### PR TITLE
Epic: zfb-init CSS pipeline — zfb-css crate (Tailwind subprocess + lightningcss CSS Modules + hashed asset)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ node_modules/
 
 # Worktrees (managed by /x-wt-teams)
 worktrees/
+
+# Bundled third-party binaries (populated by release engineering, never committed)
+crates/zfb/binaries/tailwindcss-v4

--- a/crates/zfb-css/Cargo.toml
+++ b/crates/zfb-css/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "zfb-css"
+version = "0.0.0"
+edition = "2021"
+license = "MIT"
+description = "zfb css pipeline: Tailwind v4 subprocess engine, CSS Modules via lightningcss, hashed global asset emission"
+
+[lib]
+
+[dependencies]
+# Workspace-shared helpers.
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+tempfile = { workspace = true }
+walkdir = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# CSS pipeline crates (direct deps — not yet in workspace deps).
+lightningcss = "1.0.0-alpha.71"
+sha2 = "0.10"
+hex = "0.4"
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/zfb-css/README.md
+++ b/crates/zfb-css/README.md
@@ -1,0 +1,60 @@
+# `zfb-css`
+
+CSS pipeline for `zfb`. Wraps the Tailwind CSS subprocess and (later) merges
+CSS Modules output into a single hashed global asset.
+
+> This README currently documents only the **Tailwind v4 version pin** for Sub
+> 4 of [issue #5](https://github.com/Takazudo/zudo-front-builder/issues/5).
+> Crate-level documentation (architecture, `CssEngine` trait, public API) is
+> being added by Sub 1 in parallel and will merge with this file.
+
+## Tailwind CSS Version
+
+This crate invokes the **Tailwind CSS v4 standalone CLI** as a subprocess.
+
+| Field                 | Value                                                              |
+| --------------------- | ------------------------------------------------------------------ |
+| Pinned version        | **`4.2.0`**                                                        |
+| Major line            | Tailwind CSS v4.x                                                  |
+| Distribution          | Standalone CLI binary (no Node.js required at runtime)             |
+| Expected binary path  | `crates/zfb/binaries/tailwindcss-v4` (in the release tarball)      |
+| Upstream              | <https://github.com/tailwindlabs/tailwindcss/releases>             |
+
+> The pin **must be reviewed and refreshed before each `zfb` release**. Bump
+> `4.2.0` to whatever the latest stable Tailwind v4.x is at release-cut time,
+> and re-run the release-engineering binary-fetch step (future epic) to
+> materialize the matching binary.
+
+### Why a pinned version
+
+- **Reproducible builds.** A fixed Tailwind version means the same source tree
+  produces byte-identical CSS regardless of when or where it is built.
+- **Bundled binary.** The release tarball ships the exact binary `zfb-css`
+  expects — no `npx`, no `node_modules`, no network calls at user build time.
+- **Subprocess contract.** The CLI flags this crate calls (`--input`,
+  `--output`, `--watch`, content-scan globs) are the v4 surface area; locking
+  the version prevents flag drift from breaking the wrapper.
+
+### Why a subprocess wrapper (and not a Rust-native engine)
+
+Tailwind v4 ships only as a JavaScript/Node-built CLI today. There is no
+production-ready Rust-native Tailwind engine. Until one exists (or until we
+build one), invoking the official CLI as a subprocess is the lowest-risk way
+to get correct, up-to-date Tailwind output.
+
+To keep us free to swap implementations later, the subprocess call lives
+behind an internal `CssEngine` trait. The `tailwindcss-v4` binary is one
+implementation; a hypothetical Rust-native crate would be another, with no
+changes required at call sites.
+
+### Why the binary lives at `crates/zfb/binaries/tailwindcss-v4`
+
+The `zfb` CLI is the single user-facing executable; bundled tooling needs to
+sit in a path the `zfb` runtime can locate relative to its own executable.
+Placing the binary inside `crates/zfb/` keeps the release-tarball layout
+colocated with the crate that owns the runtime contract. See
+`crates/zfb/binaries/README.md` for the slot-level details.
+
+The binary file itself is **not** committed to git — `.gitignore` excludes it,
+and release engineering (a future, separate epic) is responsible for
+populating the slot before tarball assembly.

--- a/crates/zfb-css/src/engine.rs
+++ b/crates/zfb-css/src/engine.rs
@@ -1,0 +1,260 @@
+//! The "CSS engine" abstraction.
+//!
+//! Tailwind v4 is delivered as a Go-built standalone CLI. To keep our build
+//! pipeline portable we shell out to that binary today — but the long-term
+//! plan is to swap in a Rust-native implementation (e.g. a future port of
+//! Tailwind's class-engine, or our own equivalent) without touching the rest
+//! of the pipeline.
+//!
+//! That swap is exactly what [`CssEngine`] models: take a set of source
+//! files to scan for utility classes, return a string of generated CSS.
+//! Everything stage-2 and beyond (CSS Modules, hashing, asset emission)
+//! is engine-agnostic.
+
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{anyhow, Context, Result};
+
+/// Abstraction over "produce a single CSS string of utility classes for the
+/// given project sources".
+///
+/// ## Why a trait?
+///
+/// We currently shell out to the official `tailwindcss` v4 CLI binary
+/// ([`TailwindSubprocessEngine`]). When a Rust-native option becomes viable
+/// (see [`crate::native_engine::NativeRustEngine`]), we want to swap it in
+/// at one site — the [`crate::CssPipeline`] constructor — without rewriting
+/// CSS Modules, hashing, or asset emission.
+///
+/// ## Contract
+///
+/// - The engine MUST return CSS text suitable for direct concatenation into
+///   the global stylesheet. No HTML, no `<style>` tags, no source maps
+///   embedded in the string itself.
+/// - The engine MAY consult its own configuration (binary path, content
+///   globs, theme tokens, etc.). The `sources` parameter is a *hint* of
+///   files known to the caller; engines are free to widen the set if their
+///   own config requires it (Tailwind v4 has its own `@source` directive).
+/// - The engine MUST be deterministic for a given (sources, config) pair —
+///   the hashing stage assumes byte-stable output.
+pub trait CssEngine {
+    /// Produce utility-class CSS for the given source files.
+    fn produce_utility_css(&self, sources: &[PathBuf]) -> Result<String>;
+}
+
+/// Configuration for [`TailwindSubprocessEngine`].
+#[derive(Debug, Clone)]
+pub struct TailwindSubprocessConfig {
+    /// Path to the `tailwindcss` v4 CLI binary.
+    ///
+    /// Default: `crates/zfb/binaries/tailwindcss-v4` (relative to the
+    /// workspace root). Topic B of Epic 4 reserves this slot in the release
+    /// tarball layout. Override via [`Self::with_binary_path`] or via the
+    /// `ZFB_TAILWIND_BIN` environment variable (checked at engine
+    /// construction time, not at every invocation).
+    pub binary_path: PathBuf,
+
+    /// Working directory for the subprocess. The Tailwind v4 CLI resolves
+    /// `@source "..."` directives relative to this directory.
+    ///
+    /// Default: the current working directory at engine construction time.
+    pub working_dir: PathBuf,
+
+    /// Optional explicit input CSS file (`-i` flag). When `None`, Tailwind
+    /// v4's default scan-and-emit mode is used. Most projects will provide
+    /// a tiny entrypoint like `@import "tailwindcss";`.
+    pub input_css: Option<PathBuf>,
+
+    /// Extra CLI args appended to the subprocess invocation, for escape
+    /// hatches like `--minify`. These are passed verbatim.
+    pub extra_args: Vec<OsString>,
+
+    /// When true, the engine will return a *fake* CSS string instead of
+    /// invoking the subprocess. Used by unit tests to avoid depending on
+    /// the binary being installed.
+    ///
+    /// The string returned is taken from [`Self::mock_output`].
+    pub mock_subprocess: bool,
+
+    /// Output to return when `mock_subprocess` is true.
+    pub mock_output: String,
+}
+
+impl Default for TailwindSubprocessConfig {
+    fn default() -> Self {
+        // Resolve binary path: env override → default workspace-relative path.
+        let env_override = std::env::var_os("ZFB_TAILWIND_BIN");
+        let binary_path = match env_override {
+            Some(p) => PathBuf::from(p),
+            None => PathBuf::from("crates/zfb/binaries/tailwindcss-v4"),
+        };
+        let working_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        Self {
+            binary_path,
+            working_dir,
+            input_css: None,
+            extra_args: Vec::new(),
+            mock_subprocess: false,
+            mock_output: String::new(),
+        }
+    }
+}
+
+impl TailwindSubprocessConfig {
+    /// Override the binary path (chainable).
+    pub fn with_binary_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.binary_path = path.into();
+        self
+    }
+
+    /// Override the working directory (chainable).
+    pub fn with_working_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.working_dir = dir.into();
+        self
+    }
+
+    /// Override the input CSS entrypoint (chainable).
+    pub fn with_input_css(mut self, path: impl Into<PathBuf>) -> Self {
+        self.input_css = Some(path.into());
+        self
+    }
+
+    /// Configure the engine to skip the subprocess and return `output`
+    /// instead. Used by unit tests.
+    pub fn with_mock_output(mut self, output: impl Into<String>) -> Self {
+        self.mock_subprocess = true;
+        self.mock_output = output.into();
+        self
+    }
+}
+
+/// The default [`CssEngine`]: shells out to the `tailwindcss` v4 CLI binary.
+///
+/// The binary is invoked with an output flag (`-o`) pointing at a temp file;
+/// the file is then read back and returned as a `String`. The temp file is
+/// cleaned up when its [`tempfile::NamedTempFile`] handle drops (i.e. when
+/// the call returns).
+///
+/// ### Example
+///
+/// ```no_run
+/// use zfb_css::{CssEngine, TailwindSubprocessConfig, TailwindSubprocessEngine};
+/// use std::path::PathBuf;
+///
+/// let engine = TailwindSubprocessEngine::new(TailwindSubprocessConfig::default());
+/// let css = engine.produce_utility_css(&[PathBuf::from("pages/index.tsx")]).unwrap();
+/// assert!(!css.is_empty());
+/// ```
+#[derive(Debug, Clone)]
+pub struct TailwindSubprocessEngine {
+    config: TailwindSubprocessConfig,
+}
+
+impl TailwindSubprocessEngine {
+    /// Construct a new engine with the given config.
+    pub fn new(config: TailwindSubprocessConfig) -> Self {
+        Self { config }
+    }
+
+    /// Construct a new engine with the default config.
+    pub fn with_default_config() -> Self {
+        Self::new(TailwindSubprocessConfig::default())
+    }
+
+    /// Borrow the underlying config.
+    pub fn config(&self) -> &TailwindSubprocessConfig {
+        &self.config
+    }
+}
+
+impl CssEngine for TailwindSubprocessEngine {
+    fn produce_utility_css(&self, sources: &[PathBuf]) -> Result<String> {
+        if self.config.mock_subprocess {
+            return Ok(self.config.mock_output.clone());
+        }
+
+        // Sanity-check: the binary should exist before we try to spawn it.
+        // This gives a much clearer error message than the OS-level "no
+        // such file or directory" from `Command::spawn`.
+        if !self.config.binary_path.exists() {
+            return Err(anyhow!(
+                "tailwindcss v4 binary not found at {}; \
+                 set ZFB_TAILWIND_BIN or update TailwindSubprocessConfig::binary_path",
+                self.config.binary_path.display()
+            ));
+        }
+
+        let tmp = tempfile::Builder::new()
+            .prefix("zfb-tailwind-")
+            .suffix(".css")
+            .tempfile()
+            .context("failed to allocate temp file for tailwind output")?;
+
+        let mut cmd = Command::new(&self.config.binary_path);
+        cmd.current_dir(&self.config.working_dir);
+        if let Some(input) = &self.config.input_css {
+            cmd.arg("-i").arg(input);
+        }
+        cmd.arg("-o").arg(tmp.path());
+        for extra in &self.config.extra_args {
+            cmd.arg(extra);
+        }
+
+        // Annotate sources purely for diagnostics. Tailwind v4 discovers
+        // sources via its own config / `@source` directives — but we record
+        // the caller's hint in an env var so a wrapping script can see it.
+        let sources_joined: Vec<String> = sources
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+        cmd.env("ZFB_TAILWIND_SOURCES", sources_joined.join("\n"));
+
+        let output = cmd
+            .output()
+            .with_context(|| format!("failed to spawn {}", self.config.binary_path.display()))?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(anyhow!(
+                "tailwindcss exited with status {}: {}",
+                output.status,
+                stderr.trim()
+            ));
+        }
+
+        let css = std::fs::read_to_string(tmp.path())
+            .context("failed to read tailwind output file")?;
+        Ok(css)
+    }
+}
+
+/// Default content roots that the project scans for utility classes.
+///
+/// `zfb-css` does not enforce a specific scanning strategy — Tailwind v4 has
+/// its own — but exposes this constant so callers (and the tailwind config
+/// generator) agree on a single list.
+pub const DEFAULT_CONTENT_ROOTS: &[&str] = &["pages", "components", "layouts", "content"];
+
+/// Build a string `@source` declaration list from the project root, suitable
+/// for emitting into a Tailwind v4 entrypoint CSS file.
+pub fn default_source_directives(project_root: &Path) -> String {
+    let mut out = String::new();
+    for root in DEFAULT_CONTENT_ROOTS {
+        let full = project_root.join(root);
+        out.push_str(&format!("@source \"{}\";\n", full.display()));
+    }
+    out
+}
+
+/// Convenience: a small map describing the engine's identity, used when we
+/// want to record provenance in pipeline outputs (e.g. log lines).
+pub fn engine_provenance(name: &str, version: Option<&str>) -> HashMap<String, String> {
+    let mut m = HashMap::new();
+    m.insert("engine".to_string(), name.to_string());
+    if let Some(v) = version {
+        m.insert("version".to_string(), v.to_string());
+    }
+    m
+}

--- a/crates/zfb-css/src/lib.rs
+++ b/crates/zfb-css/src/lib.rs
@@ -1,0 +1,37 @@
+//! `zfb-css` — the CSS half of the zudo-front-builder (zfb) build pipeline.
+//!
+//! Responsibilities:
+//!
+//! 1. Run a "CSS engine" that produces Tailwind utility CSS for the project.
+//!    Today this is a subprocess wrapper around the official `tailwindcss` v4
+//!    CLI binary (see [`engine::TailwindSubprocessEngine`]). The trait
+//!    [`engine::CssEngine`] documents the swap-in story for a future
+//!    Rust-native engine (placeholder lives in [`native_engine`]).
+//!
+//! 2. Compile `*.module.css` files via `lightningcss`'s CSS Modules support
+//!    into scoped CSS plus a class-name map (see [`modules`]).
+//!
+//! 3. Concatenate the engine output and the CSS Modules output, hash the
+//!    bytes (SHA-256, truncated to 8 hex chars), and emit
+//!    `dist/assets/styles-{hash}.css` (see [`pipeline`]).
+//!
+//! The top-level entry point is [`CssPipeline`].
+//!
+//! ## Layering
+//!
+//! `zfb-css` deliberately does **not** depend on Epic 3 (`zfb-render`). It
+//! takes paths and source content as input and returns CSS + an asset URL as
+//! output. The renderer is responsible for actually injecting
+//! `<link href="...">` into the page. The helper [`pipeline::link_href`] is
+//! provided so the renderer can derive the public URL from the asset path
+//! without re-hashing.
+
+pub mod engine;
+pub mod modules;
+pub mod native_engine;
+pub mod pipeline;
+
+pub use engine::{CssEngine, TailwindSubprocessConfig, TailwindSubprocessEngine};
+pub use modules::{CssModulesOutput, CssModulesProcessor};
+pub use native_engine::NativeRustEngine;
+pub use pipeline::{link_href, CssPipeline, CssPipelineConfig, CssPipelineOutput};

--- a/crates/zfb-css/src/modules.rs
+++ b/crates/zfb-css/src/modules.rs
@@ -1,0 +1,172 @@
+//! CSS Modules processing via [`lightningcss`].
+//!
+//! Each `*.module.css` file is parsed with `lightningcss`'s built-in CSS
+//! Modules support, which:
+//!
+//! - rewrites local class names to scoped, file-stable identifiers,
+//! - returns the original-name → scoped-name map (we expose this to callers
+//!   so JSX/TSX consumers can rewrite `className` references),
+//! - emits a per-file source map in dev mode (deferred for now: gated by
+//!   the `dev` flag in [`CssModulesConfig`] but only the merging is wired
+//!   up; full source-map plumbing is part of Epic 4 follow-up).
+//!
+//! All processed module CSS is concatenated into one string ready for the
+//! global stylesheet.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use lightningcss::css_modules::{Config as LcssConfig, Pattern};
+use lightningcss::stylesheet::{ParserOptions, PrinterOptions, StyleSheet};
+
+/// Configuration for [`CssModulesProcessor`].
+#[derive(Debug, Clone, Default)]
+pub struct CssModulesConfig {
+    /// When true, emit per-file source maps. When false (production), skip
+    /// source-map generation entirely.
+    ///
+    /// Note: the v0 pipeline does **not** emit a *merged* source map for
+    /// the global asset — that's deferred to v1.1 per the Epic 4 reviewers.
+    /// Even in dev mode, we currently retain only the per-file maps; the
+    /// hook-up to the renderer will land in a follow-up.
+    pub dev: bool,
+
+    /// Class-name pattern. Defaults to lightningcss's `[hash]_[local]`
+    /// equivalent (its own default).
+    pub pattern: Option<String>,
+}
+
+/// Output of [`CssModulesProcessor::process`].
+#[derive(Debug, Clone, Default)]
+pub struct CssModulesOutput {
+    /// All processed module CSS, concatenated. Order matches the input
+    /// `Vec<PathBuf>` so callers can produce stable hashes.
+    pub css: String,
+
+    /// Per-file class-name map: `module file → (original class → scoped class)`.
+    ///
+    /// Consumers (JSX/TSX module-graph rewriters) use this map to rewrite
+    /// `import styles from "./foo.module.css"` references at build time.
+    pub class_maps: HashMap<PathBuf, HashMap<String, String>>,
+}
+
+/// Compiles `*.module.css` files into scoped CSS plus a class-name map.
+#[derive(Debug, Clone)]
+pub struct CssModulesProcessor {
+    config: CssModulesConfig,
+}
+
+impl CssModulesProcessor {
+    /// Construct with the given config.
+    pub fn new(config: CssModulesConfig) -> Self {
+        Self { config }
+    }
+
+    /// Construct with the default config (production-style: no source maps).
+    pub fn with_default_config() -> Self {
+        Self::new(CssModulesConfig::default())
+    }
+
+    /// Borrow the underlying config.
+    pub fn config(&self) -> &CssModulesConfig {
+        &self.config
+    }
+
+    /// Process the given CSS Modules files.
+    ///
+    /// Each path is expected to point at a real file on disk. Files are
+    /// processed in input order; the returned `css` string is the
+    /// concatenation of each file's compiled output, separated by blank
+    /// lines for readability.
+    pub fn process(&self, files: &[PathBuf]) -> Result<CssModulesOutput> {
+        let mut combined = String::new();
+        let mut class_maps: HashMap<PathBuf, HashMap<String, String>> = HashMap::new();
+
+        for path in files {
+            let source = std::fs::read_to_string(path)
+                .with_context(|| format!("failed to read CSS Modules file {}", path.display()))?;
+
+            let (css, names) = self.process_one(path, &source)?;
+            if !combined.is_empty() {
+                combined.push_str("\n\n");
+            }
+            combined.push_str(&css);
+            class_maps.insert(path.clone(), names);
+        }
+
+        Ok(CssModulesOutput {
+            css: combined,
+            class_maps,
+        })
+    }
+
+    /// Process a single in-memory CSS Modules source. Useful for unit tests
+    /// and for callers that already have the source string in memory.
+    pub fn process_source(
+        &self,
+        path: &Path,
+        source: &str,
+    ) -> Result<(String, HashMap<String, String>)> {
+        self.process_one(path, source)
+    }
+
+    fn process_one(
+        &self,
+        path: &Path,
+        source: &str,
+    ) -> Result<(String, HashMap<String, String>)> {
+        let pattern = self
+            .config
+            .pattern
+            .clone()
+            .unwrap_or_else(|| "[hash]_[local]".to_string());
+
+        let pattern_parsed = Pattern::parse(&pattern)
+            .map_err(|e| anyhow::anyhow!("invalid CSS Modules pattern {pattern:?}: {e}"))?;
+
+        let parser_opts = ParserOptions {
+            filename: path.to_string_lossy().into_owned(),
+            css_modules: Some(LcssConfig {
+                pattern: pattern_parsed,
+                dashed_idents: false,
+                animation: true,
+                custom_idents: true,
+                grid: true,
+                container: true,
+                pure: false,
+            }),
+            ..ParserOptions::default()
+        };
+
+        let stylesheet = StyleSheet::parse(source, parser_opts).map_err(|e| {
+            anyhow::anyhow!(
+                "lightningcss failed to parse {}: {e}",
+                path.display()
+            )
+        })?;
+
+        let printed = stylesheet
+            .to_css(PrinterOptions {
+                minify: !self.config.dev,
+                ..PrinterOptions::default()
+            })
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "lightningcss failed to print {}: {e}",
+                    path.display()
+                )
+            })?;
+
+        // Translate the lightningcss `exports` map (Option<CssModuleExports>)
+        // into a plain HashMap<String, String> of original→scoped names.
+        let mut names: HashMap<String, String> = HashMap::new();
+        if let Some(exports) = printed.exports {
+            for (orig, export) in exports.into_iter() {
+                names.insert(orig, export.name);
+            }
+        }
+
+        Ok((printed.code, names))
+    }
+}

--- a/crates/zfb-css/src/native_engine.rs
+++ b/crates/zfb-css/src/native_engine.rs
@@ -1,0 +1,54 @@
+//! Placeholder Rust-native CSS engine.
+//!
+//! This module exists so the [`crate::CssEngine`] swap-in story is visible
+//! in code, not just in docs. [`NativeRustEngine`] implements the trait —
+//! but every method returns a "not yet implemented" error.
+//!
+//! ## Roadmap
+//!
+//! Tailwind v4 ships a Go-built CLI ("oxide" engine). A pure-Rust port is
+//! out of scope for the v0 build pipeline (Epic 4) — but when one becomes
+//! viable, we want the swap to be a one-line change at the `CssPipeline`
+//! constructor:
+//!
+//! ```ignore
+//! // before:
+//! let engine = TailwindSubprocessEngine::with_default_config();
+//! // after:
+//! let engine = NativeRustEngine::default();
+//! ```
+//!
+//! Until then, this stub guards the API surface against drift: if someone
+//! widens [`crate::CssEngine`] without updating both engines, the build
+//! breaks here, not in production.
+
+use std::path::PathBuf;
+
+use anyhow::{anyhow, Result};
+
+use crate::engine::CssEngine;
+
+/// A non-functional placeholder for a future pure-Rust Tailwind-equivalent
+/// engine. Construction succeeds; every method returns an error.
+///
+/// See the module-level docs for the swap-in story.
+#[derive(Debug, Default, Clone)]
+pub struct NativeRustEngine {
+    _private: (),
+}
+
+impl NativeRustEngine {
+    /// Construct a new instance. (Cheap: this engine carries no state.)
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl CssEngine for NativeRustEngine {
+    fn produce_utility_css(&self, _sources: &[PathBuf]) -> Result<String> {
+        Err(anyhow!(
+            "NativeRustEngine: not yet implemented. \
+             Use TailwindSubprocessEngine for now; see crate::native_engine for the roadmap."
+        ))
+    }
+}

--- a/crates/zfb-css/src/pipeline.rs
+++ b/crates/zfb-css/src/pipeline.rs
@@ -1,0 +1,246 @@
+//! Hashing, asset emission, and the top-level [`CssPipeline`].
+//!
+//! Stage 3 of the CSS pipeline:
+//!
+//! 1. Engine output (Tailwind utilities) and CSS Modules output are
+//!    concatenated, in that order, separated by `\n`.
+//! 2. The combined bytes are hashed with SHA-256, and the first 8 hex
+//!    characters become the asset filename suffix (`styles-{hash}.css`).
+//! 3. The file is written under
+//!    `{output_root}/assets/styles-{hash}.css`. Default `output_root` is
+//!    `dist/`.
+//!
+//! [`link_href`] derives the URL for the renderer to inject as
+//! `<link href="...">`. We do **not** inject HTML here — that's the
+//! renderer's responsibility (Epic 3 / Epic 7 wiring).
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use sha2::{Digest, Sha256};
+
+use crate::engine::CssEngine;
+use crate::modules::{CssModulesConfig, CssModulesProcessor};
+
+/// Configuration for [`CssPipeline::new`].
+#[derive(Debug, Clone)]
+pub struct CssPipelineConfig {
+    /// Source files to scan for utility classes (passed to the engine).
+    pub sources: Vec<PathBuf>,
+
+    /// CSS Modules files to compile. Order is significant: it determines
+    /// the order of concatenation in the global asset and therefore the
+    /// hash.
+    pub css_modules: Vec<PathBuf>,
+
+    /// Where to write the global asset. The pipeline emits
+    /// `{output_root}/assets/styles-{hash}.css` under this directory.
+    /// Default: `dist/`.
+    pub output_root: PathBuf,
+
+    /// Public base URL prefix for the asset, e.g. `"/"` (default) or
+    /// `"https://cdn.example.com/"`. Used by [`link_href`].
+    pub base_url: String,
+
+    /// CSS Modules processing config.
+    pub modules_config: CssModulesConfig,
+}
+
+impl Default for CssPipelineConfig {
+    fn default() -> Self {
+        Self {
+            sources: Vec::new(),
+            css_modules: Vec::new(),
+            output_root: PathBuf::from("dist"),
+            base_url: "/".to_string(),
+            modules_config: CssModulesConfig::default(),
+        }
+    }
+}
+
+/// Result of running [`CssPipeline::build`].
+#[derive(Debug, Clone)]
+pub struct CssPipelineOutput {
+    /// 8-character hex hash (first 8 chars of SHA-256 of the combined CSS).
+    pub hash: String,
+
+    /// The full combined CSS string.
+    pub css: String,
+
+    /// Absolute or output-root-relative path the asset was written to.
+    /// Convention: `{output_root}/assets/styles-{hash}.css`.
+    pub asset_path: PathBuf,
+
+    /// Per-file CSS Modules class-name maps. See
+    /// [`crate::modules::CssModulesOutput::class_maps`].
+    pub class_maps: HashMap<PathBuf, HashMap<String, String>>,
+}
+
+/// Top-level CSS pipeline.
+///
+/// Generic over the engine type so callers can swap [`crate::TailwindSubprocessEngine`]
+/// for [`crate::NativeRustEngine`] (or a test double) without touching the
+/// pipeline code.
+pub struct CssPipeline<E: CssEngine> {
+    engine: E,
+    modules: CssModulesProcessor,
+    config: CssPipelineConfig,
+}
+
+impl<E: CssEngine> CssPipeline<E> {
+    /// Construct a new pipeline.
+    pub fn new(engine: E, config: CssPipelineConfig) -> Self {
+        let modules = CssModulesProcessor::new(config.modules_config.clone());
+        Self {
+            engine,
+            modules,
+            config,
+        }
+    }
+
+    /// Run all stages: engine → CSS Modules → hash → write.
+    pub fn build(&self) -> Result<CssPipelineOutput> {
+        let tailwind = self
+            .engine
+            .produce_utility_css(&self.config.sources)
+            .context("CSS engine stage failed")?;
+
+        let modules = self
+            .modules
+            .process(&self.config.css_modules)
+            .context("CSS Modules stage failed")?;
+
+        let combined = combine(&tailwind, &modules.css);
+        let hash = hash_8(&tailwind, &modules.css);
+        let asset_path = self
+            .config
+            .output_root
+            .join("assets")
+            .join(format!("styles-{hash}.css"));
+
+        if let Some(parent) = asset_path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
+        std::fs::write(&asset_path, combined.as_bytes())
+            .with_context(|| format!("failed to write {}", asset_path.display()))?;
+
+        Ok(CssPipelineOutput {
+            hash,
+            css: combined,
+            asset_path,
+            class_maps: modules.class_maps,
+        })
+    }
+
+    /// Borrow the underlying config.
+    pub fn config(&self) -> &CssPipelineConfig {
+        &self.config
+    }
+}
+
+/// Combine engine output + CSS Modules output exactly as the hashing stage
+/// will see it. Exposed as a free function so tests and the hashing helper
+/// agree on the canonical form.
+pub(crate) fn combine(tailwind: &str, modules: &str) -> String {
+    let mut out = String::with_capacity(tailwind.len() + modules.len() + 1);
+    out.push_str(tailwind);
+    out.push('\n');
+    out.push_str(modules);
+    out
+}
+
+/// Compute the 8-char hex hash for the given (tailwind, modules) pair.
+///
+/// The hash is the first 8 characters of `sha256(tailwind + "\n" + modules)`
+/// in lowercase hex. Using a fixed separator means appending a class to one
+/// half is distinguishable from prepending it to the other.
+pub fn hash_8(tailwind: &str, modules: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(tailwind.as_bytes());
+    hasher.update(b"\n");
+    hasher.update(modules.as_bytes());
+    let digest = hasher.finalize();
+    let full = hex::encode(digest);
+    full[..8].to_string()
+}
+
+/// Build the public URL for the global CSS asset.
+///
+/// `base_url` is concatenated with the asset path's filename portion under
+/// an `assets/` segment. `base_url` is normalised to end with `/`.
+///
+/// Examples:
+/// ```
+/// use std::path::PathBuf;
+/// use zfb_css::link_href;
+///
+/// let p = PathBuf::from("dist/assets/styles-abc12345.css");
+/// assert_eq!(link_href("/", &p), "/assets/styles-abc12345.css");
+/// assert_eq!(
+///     link_href("https://cdn.example.com", &p),
+///     "https://cdn.example.com/assets/styles-abc12345.css",
+/// );
+/// ```
+pub fn link_href(base_url: &str, asset_path: &Path) -> String {
+    let filename = asset_path
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let trimmed = base_url.trim_end_matches('/');
+    format!("{trimmed}/assets/{filename}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_is_stable_for_identical_inputs() {
+        let a = hash_8(".a{color:red}", ".b{color:blue}");
+        let b = hash_8(".a{color:red}", ".b{color:blue}");
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 8);
+    }
+
+    #[test]
+    fn hash_changes_when_a_class_changes() {
+        let before = hash_8(".a{color:red}", ".b{color:blue}");
+        let after = hash_8(".a{color:green}", ".b{color:blue}");
+        assert_ne!(
+            before, after,
+            "changing a class in the tailwind half must change the hash"
+        );
+
+        let after2 = hash_8(".a{color:red}", ".b{color:teal}");
+        assert_ne!(
+            before, after2,
+            "changing a class in the modules half must change the hash"
+        );
+    }
+
+    #[test]
+    fn hash_uses_separator_to_avoid_boundary_collisions() {
+        // Without a separator, ("ab", "cd") and ("a", "bcd") would hash the
+        // same. With our "\n" separator they must differ.
+        let a = hash_8("ab", "cd");
+        let b = hash_8("a", "bcd");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn link_href_normalises_trailing_slash() {
+        let p = PathBuf::from("dist/assets/styles-deadbeef.css");
+        assert_eq!(link_href("/", &p), "/assets/styles-deadbeef.css");
+        assert_eq!(link_href("", &p), "/assets/styles-deadbeef.css");
+        assert_eq!(
+            link_href("https://cdn.example.com/", &p),
+            "https://cdn.example.com/assets/styles-deadbeef.css"
+        );
+        assert_eq!(
+            link_href("https://cdn.example.com", &p),
+            "https://cdn.example.com/assets/styles-deadbeef.css"
+        );
+    }
+}

--- a/crates/zfb-css/tests/integration.rs
+++ b/crates/zfb-css/tests/integration.rs
@@ -1,0 +1,157 @@
+//! Integration-style tests for the public surface of `zfb-css`.
+//!
+//! These exercise the engine trait, the CSS Modules processor, and the
+//! top-level `CssPipeline`. Tests that need the real Tailwind v4 binary
+//! are gated by `#[ignore]` and a comment — they will be enabled in a
+//! release-engineering follow-up once the binary is checked in to
+//! `crates/zfb/binaries/tailwindcss-v4` (Topic B / Sub 4 reserves the slot
+//! but does not yet download the binary).
+
+use std::path::{Path, PathBuf};
+
+use zfb_css::{
+    link_href, CssEngine, CssPipeline, CssPipelineConfig, CssModulesOutput,
+    CssModulesProcessor, NativeRustEngine, TailwindSubprocessConfig,
+    TailwindSubprocessEngine,
+};
+
+#[test]
+fn native_engine_returns_not_implemented_error() {
+    let engine = NativeRustEngine::new();
+    let err = engine
+        .produce_utility_css(&[PathBuf::from("pages/index.tsx")])
+        .expect_err("NativeRustEngine must return an error");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("not yet implemented"),
+        "expected 'not yet implemented' in error, got: {msg}"
+    );
+}
+
+#[test]
+fn subprocess_engine_mock_short_circuits_command() {
+    // Use the mock-output escape hatch so this test does not require the
+    // tailwindcss binary to be present.
+    let cfg = TailwindSubprocessConfig::default()
+        .with_mock_output(".mock-utility { color: red; }\n");
+    let engine = TailwindSubprocessEngine::new(cfg);
+    let css = engine
+        .produce_utility_css(&[PathBuf::from("pages/index.tsx")])
+        .expect("mock engine should succeed");
+    assert!(css.contains(".mock-utility"));
+}
+
+#[test]
+#[ignore = "Requires the real tailwindcss v4 binary at crates/zfb/binaries/tailwindcss-v4. \
+            Will be enabled in a release-engineering follow-up (Topic B / Sub 4)."]
+fn subprocess_engine_against_real_binary() {
+    let engine = TailwindSubprocessEngine::with_default_config();
+    let css = engine
+        .produce_utility_css(&[PathBuf::from("pages/index.tsx")])
+        .expect("real tailwindcss binary should produce CSS");
+    assert!(!css.is_empty(), "real engine should not return empty CSS");
+}
+
+#[test]
+fn subprocess_engine_reports_missing_binary_clearly() {
+    let cfg = TailwindSubprocessConfig::default()
+        .with_binary_path("/nonexistent/tailwindcss-v4-please-do-not-create");
+    let engine = TailwindSubprocessEngine::new(cfg);
+    let err = engine
+        .produce_utility_css(&[])
+        .expect_err("missing binary must error");
+    let msg = format!("{err}");
+    assert!(msg.contains("not found"), "got: {msg}");
+}
+
+#[test]
+fn css_modules_processor_scopes_class_names() {
+    let proc = CssModulesProcessor::with_default_config();
+    let path = Path::new("button.module.css");
+    let source = ".btn { color: blue; }\n.btn-primary { font-weight: bold; }\n";
+
+    let (css, names) = proc
+        .process_source(path, source)
+        .expect("CSS Modules processing must succeed");
+
+    // Original names appear as keys.
+    assert!(names.contains_key("btn"), "names: {names:?}");
+    assert!(names.contains_key("btn-primary"), "names: {names:?}");
+
+    // Each scoped name must NOT equal the original (lightningcss rewrites
+    // them under the default pattern).
+    assert_ne!(names.get("btn"), Some(&"btn".to_string()));
+    assert_ne!(names.get("btn-primary"), Some(&"btn-primary".to_string()));
+
+    // The compiled CSS contains the scoped names.
+    let scoped_btn = names.get("btn").expect("btn entry");
+    assert!(
+        css.contains(scoped_btn),
+        "compiled CSS must reference scoped name {scoped_btn}, got: {css}"
+    );
+}
+
+#[test]
+fn css_modules_processor_handles_empty_input() {
+    let proc = CssModulesProcessor::with_default_config();
+    let out: CssModulesOutput = proc.process(&[]).expect("empty input must succeed");
+    assert!(out.css.is_empty());
+    assert!(out.class_maps.is_empty());
+}
+
+#[test]
+fn pipeline_writes_hashed_asset_with_mock_engine() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let output_root = tmp.path().to_path_buf();
+
+    let engine = TailwindSubprocessEngine::new(
+        TailwindSubprocessConfig::default()
+            .with_mock_output(".u-text-red { color: red; }\n"),
+    );
+    let cfg = CssPipelineConfig {
+        sources: vec![PathBuf::from("pages/index.tsx")],
+        css_modules: vec![],
+        output_root: output_root.clone(),
+        base_url: "/".to_string(),
+        ..CssPipelineConfig::default()
+    };
+
+    let pipeline = CssPipeline::new(engine, cfg);
+    let out = pipeline.build().expect("pipeline build");
+
+    assert_eq!(out.hash.len(), 8);
+    assert!(out.css.contains(".u-text-red"));
+    assert!(out.asset_path.starts_with(&output_root));
+    assert!(out.asset_path.exists(), "asset must be written to disk");
+    let on_disk = std::fs::read_to_string(&out.asset_path).expect("read asset");
+    assert_eq!(on_disk, out.css);
+
+    // link_href derives the correct public URL.
+    let href = link_href("/", &out.asset_path);
+    let expected = format!("/assets/styles-{}.css", out.hash);
+    assert_eq!(href, expected);
+}
+
+#[test]
+fn pipeline_hash_changes_when_engine_output_changes() {
+    let tmp1 = tempfile::tempdir().expect("tempdir");
+    let tmp2 = tempfile::tempdir().expect("tempdir");
+
+    let make = |output: &str, root: &Path| {
+        let engine = TailwindSubprocessEngine::new(
+            TailwindSubprocessConfig::default().with_mock_output(output),
+        );
+        let cfg = CssPipelineConfig {
+            output_root: root.to_path_buf(),
+            ..CssPipelineConfig::default()
+        };
+        CssPipeline::new(engine, cfg).build().expect("build")
+    };
+
+    let a = make(".x { color: red }", tmp1.path());
+    let b = make(".x { color: green }", tmp2.path());
+    assert_ne!(
+        a.hash, b.hash,
+        "changing the engine's CSS output must change the hash"
+    );
+}

--- a/crates/zfb/binaries/README.md
+++ b/crates/zfb/binaries/README.md
@@ -1,0 +1,49 @@
+# `crates/zfb/binaries/` — Bundled binary distribution slot
+
+This directory reserves placement for third-party binaries that ship inside the
+`zfb` release tarball. The binaries are invoked at runtime as subprocesses by
+the `zfb` CLI (and by sibling crates that depend on `zfb`'s runtime layout).
+
+## Why this lives here
+
+The `zfb` crate is the user-facing CLI binary. When we package a release
+tarball for distribution, this `binaries/` directory is included alongside the
+`zfb` executable so that, at runtime, `zfb` can locate the bundled tools using
+a path relative to its own executable. Keeping the slot inside `crates/zfb/`
+(rather than at the workspace root) keeps the release-tarball layout colocated
+with the crate that owns the runtime contract.
+
+## Expected slots
+
+| Path                              | Purpose                                                       | Owner crate     |
+| --------------------------------- | ------------------------------------------------------------- | --------------- |
+| `tailwindcss-v4`                  | Tailwind CSS v4 standalone CLI binary (subprocess invocation) | `zfb-css`       |
+
+See `crates/zfb-css/README.md` for the pinned Tailwind version and rationale.
+
+## Why no binaries are committed
+
+Binaries are large, platform-specific, and license-bound. They are **never**
+committed to this repository. Instead:
+
+- `.gitignore` excludes the actual binary file paths (e.g. `tailwindcss-v4`).
+- The slot directory is preserved in git via `.gitkeep`.
+- Release engineering (a separate, future epic) is responsible for downloading
+  the correct platform-specific binary, verifying its signature/checksum, and
+  placing it into this directory before the release tarball is assembled.
+
+This sub-task (Sub 4 of [issue #5](https://github.com/Takazudo/zudo-front-builder/issues/5))
+only **reserves the slot** — it does not implement the download or
+release-tarball assembly logic.
+
+## Runtime contract (sketch)
+
+At runtime, sibling crates (e.g. `zfb-css`) resolve the binary path roughly as:
+
+```text
+<dir-of-zfb-executable>/binaries/<binary-name>
+```
+
+Resolution helpers will live in the `zfb` crate when the release-engineering
+epic lands. Until then, downstream crates should treat the path as
+implementation-defined and access it only through a `zfb`-provided API.


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/5
- parent PR
    - https://github.com/Takazudo/zudo-front-builder/pull/12

---

## Summary

Implements [Epic #5](https://github.com/Takazudo/zudo-front-builder/issues/5) — the CSS half of the zfb build pipeline. Adds a new `zfb-css` workspace crate that handles Tailwind v4 utility CSS generation, CSS Modules compilation via `lightningcss`, and content-hashed global asset emission. Reserves a release-tarball slot for the Tailwind v4 CLI binary.

Targets the super-epic base `base/zfb-init` (super-PR #12) — to be merged as part of the multi-epic stack.

## What's in this epic

### Sub 1 — `zfb-css` crate skeleton + Tailwind subprocess engine

- New crate at `crates/zfb-css/` (workspace member, edition 2021).
- `CssEngine` trait (`src/engine.rs`) abstracts "produce a single CSS string of utility classes for the given project sources" so today's Tailwind subprocess can be swapped for a Rust-native impl later without touching the pipeline.
- `TailwindSubprocessEngine` shells out to the `tailwindcss` v4 CLI binary. Configurable binary path (default `crates/zfb/binaries/tailwindcss-v4`, override via `ZFB_TAILWIND_BIN`), working dir, input CSS entrypoint, and extra args. Captures stderr on failure.
- Mock-output escape hatch (`with_mock_output`) so unit tests don't require the binary.
- `NativeRustEngine` stub (`src/native_engine.rs`) implements the trait but returns a "not yet implemented" error — placeholder for the future Rust-native engine.

### Sub 2 — CSS Modules via `lightningcss`

- `CssModulesProcessor` (`src/modules.rs`) compiles `*.module.css` files using `lightningcss`'s built-in CSS Modules support.
- Returns concatenated scoped CSS plus a per-file class-name map (`HashMap<PathBuf, HashMap<String, String>>`) — Epic 5/6 will use this to rewrite `import styles from "./foo.module.css"` references in JSX/TSX.
- Configurable class-name pattern (default `[hash]_[local]`) and per-file source-map mode in dev. Merged source map deferred to v1.1 per reviewers.

### Sub 3 — Global CSS hashing + asset emission

- `CssPipeline` (`src/pipeline.rs`) ties it together: engine → CSS Modules → concatenate → hash → write.
- Hash = first 8 hex chars of `SHA-256(tailwind + "\n" + modules)`. The `"\n"` separator avoids boundary collisions (e.g., (`"ab"`, `"cd"`) vs (`"a"`, `"bcd"`)) — covered by a unit test.
- Emits `{output_root}/assets/styles-{hash}.css` (default `output_root` is `dist/`).
- `link_href(base_url, asset_path)` returns the URL Epic 3's page renderer will inject as `<link href="...">`. HTML injection itself stays in Epic 3 — `zfb-css` only hands out the URL.

### Sub 4 — Tailwind v4 binary distribution slot

- Reserves `crates/zfb/binaries/tailwindcss-v4` as the path the release tarball will populate. Actual release engineering (downloading, signature verification, platform-specific archives) is out of scope.
- `crates/zfb/binaries/README.md` documents the slot's purpose.
- `.gitkeep` keeps the directory tracked; `.gitignore` excludes the actual binary file path so binaries never accidentally land in git.
- `crates/zfb-css/README.md` documents the Tailwind v4 version pin (4.2.0) and rationale.

## Test results on the merged base

- `cargo build -p zfb-css` — green
- `cargo test -p zfb-css --lib` — 4 passed, 0 failed
- Integration test suite (`tests/integration.rs`) — 7 passed, 1 ignored (the ignored one requires the real Tailwind v4 binary, which lands during release engineering)

## Quality assurance

`/gcoc-review` ran on the merged diff. All 10 findings were verified against the code; each was either a false positive (subprocess injection: uses `Command::new` with separated args, no shell; path traversal: output filename is hash-derived, no user input flows in), already-handled (anyhow context everywhere, stderr captured, NativeRustEngine returns Err), or out of scope (8-char hash is spec-mandated; cross-platform binary suffix premature for an empty placeholder slot). Review log archived at `cclogs/zfb/20260426_082646-gcoc-review.md`. No code changes were applied.

## Acceptance criteria status

- [x] `zfb-css` crate compiles standalone.
- [x] `CssEngine` trait is documented + named in code.
- [x] Stub Rust-native engine module exists as a placeholder.
- [x] Pipeline produces `dist/assets/styles-{hash}.css` containing both Tailwind and CSS Modules output (covered by integration tests).
- [x] Hash changes when an input class changes (unit + integration tests).
- [x] Tailwind v4 binary slot reserved with version pin documented.

## Topics merged

- `zfb-init-css-pipeline/css-pipeline` — Subs 1+2+3 (1 commit, ~951 lines added)
- `zfb-init-css-pipeline/tailwind-binary-slot` — Sub 4 (1 commit, ~112 lines added)

Topic branches were deleted after merge (already in base). Both topics were developed in parallel worktrees; merges into the epic base produced no conflicts.