### PR TITLE
zfb-init-islands: islands runtime — "use client" AST scan, esbuild bundling, hydration, <Island>

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ worktrees/
 # Bundled third-party binaries (populated by release engineering, never committed)
 crates/zfb/binaries/tailwindcss-v4
 crates/zfb/binaries/esbuild/esbuild
+
+# Ephemeral / temp files (e.g. agent prompts, review diffs)
+__inbox/

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ worktrees/
 
 # Bundled third-party binaries (populated by release engineering, never committed)
 crates/zfb/binaries/tailwindcss-v4
+crates/zfb/binaries/esbuild/esbuild

--- a/crates/zfb-islands/Cargo.toml
+++ b/crates/zfb-islands/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "zfb-islands"
+version = "0.0.0"
+edition = "2021"
+license = "MIT"
+description = "zfb islands: AST scanner, hydration HTML emit, and ClientBundler trait"
+
+[lib]
+
+[dependencies]
+# Workspace-shared helpers.
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/zfb-islands/Cargo.toml
+++ b/crates/zfb-islands/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "zfb-islands"
+version = "0.0.0"
+edition = "2021"
+license = "MIT"
+description = "zfb islands runtime: 'use client' AST scan, esbuild subprocess bundler, hydration emit"
+
+[lib]
+
+[dependencies]
+# Workspace-shared helpers.
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+tempfile = { workspace = true }
+walkdir = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Hashing for the bundle asset filename suffix. Mirrors zfb-css::pipeline.
+sha2 = "0.10"
+hex = "0.4"
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/zfb-islands/Cargo.toml
+++ b/crates/zfb-islands/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "zfb-islands"
+version = "0.0.0"
+edition = "2021"
+license = "MIT"
+description = "zfb islands: \"use client\" AST scanner + ClientBundler trait (esbuild subprocess swap-in)"
+
+[lib]
+
+[dependencies]
+# Workspace-shared helpers.
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# SWC parsing only — no transforms or codegen. Subset of zfb-render's flags.
+swc_core = { version = "64", features = [
+    "common",
+    "ecma_ast",
+    "ecma_parser",
+    "ecma_parser_typescript",
+] }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/zfb-islands/README.md
+++ b/crates/zfb-islands/README.md
@@ -1,0 +1,66 @@
+# `zfb-islands`
+
+Islands runtime pipeline for `zfb`. Scans for `"use client"` components,
+bundles them via the esbuild CLI subprocess into a single hashed JS asset,
+and emits the hydration markup + runtime glue.
+
+> This README currently documents the **esbuild version pin** for Sub 2 of
+> [issue #6](https://github.com/Takazudo/zudo-front-builder/issues/6).
+> Crate-level documentation (architecture, `ClientBundler` trait, public
+> API) lives in `src/lib.rs` rustdoc and will be expanded by Subs 1 and 3.
+
+## esbuild Version
+
+This crate invokes the **esbuild standalone CLI** as a subprocess.
+
+| Field                | Value                                                          |
+| -------------------- | -------------------------------------------------------------- |
+| Pinned version       | **`0.24.0`**                                                   |
+| Major line           | esbuild 0.24.x                                                 |
+| Distribution         | Standalone CLI binary (Go-built; no Node.js required)          |
+| Expected binary path | `crates/zfb/binaries/esbuild` (in the release tarball)         |
+| Upstream             | <https://github.com/evanw/esbuild/releases>                    |
+
+> The pin **must be reviewed and refreshed before each `zfb` release**.
+> Bump `0.24.0` to whatever the latest stable esbuild 0.x is at
+> release-cut time, and re-run the release-engineering binary-fetch step
+> (future epic) to materialize the matching binary.
+
+### Why a pinned version
+
+- **Reproducible builds.** A fixed esbuild version means the same source
+  tree produces byte-identical bundles regardless of when or where it is
+  built — the SHA-256 hash that drives `islands-{hash}.js` depends on this.
+- **Bundled binary.** The release tarball ships the exact binary
+  `zfb-islands` expects — no `npx`, no `node_modules`, no network calls at
+  user build time.
+- **Subprocess contract.** The CLI flags this crate calls (`--bundle`,
+  `--format=esm`, `--splitting=false`, `--minify`, `--tree-shaking=true`,
+  `--sourcemap=linked`, `--outfile`) are the 0.x surface area; locking the
+  version prevents flag drift from breaking the wrapper.
+
+### Why a subprocess wrapper (and not a Rust-native bundler)
+
+esbuild ships only as a Go-built CLI today. There is no production-ready
+drop-in Rust-native bundler for our needs (swc-bundler is close but not
+turnkey for our entry-point pattern). Until one exists (or until we build
+one), invoking the official CLI as a subprocess is the lowest-risk way to
+get correct, up-to-date bundling output.
+
+To keep us free to swap implementations later, the subprocess call lives
+behind an internal `ClientBundler` trait. The esbuild binary is one
+implementation; a hypothetical Rust-native crate would be another, with no
+changes required at call sites. See `src/native_bundler.rs` for the stub.
+
+### Why the binary lives at `crates/zfb/binaries/esbuild`
+
+The `zfb` CLI is the single user-facing executable; bundled tooling needs
+to sit in a path the `zfb` runtime can locate relative to its own
+executable. Placing the binary inside `crates/zfb/` keeps the
+release-tarball layout colocated with the crate that owns the runtime
+contract. See `crates/zfb/binaries/README.md` for the slot-level details
+(this slot mirrors the Tailwind v4 slot reserved by Epic 4 / Sub 4).
+
+The binary file itself is **not** committed to git — `.gitignore` excludes
+it, and release engineering (a future, separate epic) is responsible for
+populating the slot before tarball assembly.

--- a/crates/zfb-islands/npm/package.json
+++ b/crates/zfb-islands/npm/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@zfb/islands-runtime",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "zfb client-side hydration runtime walked by [data-zfb-island] elements",
+  "license": "MIT",
+  "exports": {
+    ".": "./src/hydrate.ts"
+  },
+  "scripts": {
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "happy-dom": "^15.11.7",
+    "typescript": "^5.7.3",
+    "vitest": "^2.1.9"
+  }
+}

--- a/crates/zfb-islands/npm/package.json
+++ b/crates/zfb-islands/npm/package.json
@@ -11,6 +11,9 @@
   "scripts": {
     "test": "vitest run"
   },
+  "dependencies": {
+    "zfb": "workspace:*"
+  },
   "devDependencies": {
     "happy-dom": "^15.11.7",
     "typescript": "^5.7.3",

--- a/crates/zfb-islands/npm/src/hydrate.ts
+++ b/crates/zfb-islands/npm/src/hydrate.ts
@@ -16,7 +16,13 @@
 //   <script type="module" src="…runtime.js" data-zfb-bundle="…/islands-{hash}.js"></script>
 // It walks every [data-zfb-island] element, decodes data-props, dispatches on
 // data-when (load|idle|visible), and calls the adapter shim's hydrateIsland.
+//
+// The data-when dispatch is delegated to scheduleHydrate from "zfb/runtime"
+// so the wrapper (Sub 4) and the runtime (Sub 3) share one source of truth
+// for visible|idle|load semantics.
 // =============================================================================
+
+import { scheduleHydrate } from "zfb/runtime";
 
 /** Public surface so the bundle entry can re-export this if needed. */
 export interface HydrateIslandFn {
@@ -111,44 +117,12 @@ function hydrateOne(bundle: IslandsBundle, el: Element): void {
  *   idle    → requestIdleCallback (fallback: setTimeout 0)
  *   visible → IntersectionObserver
  *
- * The actual unit tests for idle and visible live with Sub 4, where the
- * <Island> wrapper sets data-when. We keep the dispatch table here because
- * the runtime owns the values.
+ * The dispatch table lives in scheduleHydrate from "zfb/runtime" so this
+ * runtime and the <Island> wrapper share the same When semantics. We just
+ * adapt the (target, when, fire) signature here.
  */
 function schedule(when: When, el: Element, run: (el: Element) => void): void {
-  if (when === "load") {
-    run(el);
-    return;
-  }
-  if (when === "idle") {
-    const ric = (
-      globalThis as unknown as {
-        requestIdleCallback?: (cb: () => void) => number;
-      }
-    ).requestIdleCallback;
-    if (typeof ric === "function") {
-      ric(() => run(el));
-    } else {
-      setTimeout(() => run(el), 0);
-    }
-    return;
-  }
-  // visible
-  if (typeof IntersectionObserver === "undefined") {
-    // No IO support: hydrate immediately rather than never.
-    run(el);
-    return;
-  }
-  const io = new IntersectionObserver((entries, obs) => {
-    for (const entry of entries) {
-      if (entry.isIntersecting) {
-        obs.unobserve(entry.target);
-        obs.disconnect();
-        run(entry.target);
-      }
-    }
-  });
-  io.observe(el);
+  scheduleHydrate(el, when, () => run(el));
 }
 
 /**

--- a/crates/zfb-islands/npm/src/hydrate.ts
+++ b/crates/zfb-islands/npm/src/hydrate.ts
@@ -1,0 +1,195 @@
+// =============================================================================
+// zfb islands hydration runtime
+// -----------------------------------------------------------------------------
+// Size budget: ~3 KB before gzip (the issue body's "naive ~3 KB" target).
+// React's bundled hydration glue can balloon this to ~30 KB; that growth lives
+// in the framework code itself, not here. The cost we control is THIS file.
+// To hold the budget:
+//
+//   * No try/catch wrapping that swallows errors — let them surface.
+//   * No legacy-browser polyfills (no IE, no SystemJS).
+//   * No framework-specific branches: all framework calls go through the
+//     adapter shim's hydrateIsland(Component, props, element) export.
+//   * No third-party deps. Plain DOM + dynamic import().
+//
+// The runtime is a single module loaded via:
+//   <script type="module" src="…runtime.js" data-zfb-bundle="…/islands-{hash}.js"></script>
+// It walks every [data-zfb-island] element, decodes data-props, dispatches on
+// data-when (load|idle|visible), and calls the adapter shim's hydrateIsland.
+// =============================================================================
+
+/** Public surface so the bundle entry can re-export this if needed. */
+export interface HydrateIslandFn {
+  (Component: unknown, props: unknown, element: Element): void;
+}
+
+/**
+ * Shape of the islands bundle that the data-zfb-bundle URL resolves to.
+ *
+ * Components are exposed as named exports; `hydrateIsland` is the
+ * framework-specific shim contributed by zfb-render's adapter (Preact uses
+ * `h`+`hydrate`; React uses `hydrateRoot` from `react-dom/client`).
+ *
+ * The bundler (Sub 2) is responsible for arranging both pieces in the same
+ * module so this single dynamic import resolves everything.
+ */
+type IslandsBundle = {
+  hydrateIsland: HydrateIslandFn;
+  // Other named exports are the islands themselves, keyed by component name.
+  [componentName: string]: unknown;
+};
+
+/** Recognised values for data-when. Absent ⇒ "load". */
+const WHEN_VALUES = ["load", "idle", "visible"] as const;
+type When = (typeof WHEN_VALUES)[number];
+
+/** Pull the islands-bundle URL off the runtime's own <script> tag. */
+function readBundleUrl(): string {
+  // currentScript only works during initial parse, so we also accept any
+  // script tag carrying the data-zfb-bundle attribute as a fallback for
+  // late-loaded module scripts.
+  const fromCurrent = document.currentScript as HTMLScriptElement | null;
+  const url =
+    fromCurrent?.dataset?.zfbBundle ??
+    document.querySelector<HTMLScriptElement>("script[data-zfb-bundle]")?.dataset.zfbBundle;
+  if (!url) {
+    throw new Error("zfb-islands: no <script data-zfb-bundle> found; cannot locate islands bundle");
+  }
+  return url;
+}
+
+/** Coerce a data-when string into the supported set. */
+function readWhen(el: Element): When {
+  const raw = (el as HTMLElement).dataset.when;
+  if (raw == null || raw === "") return "load";
+  if ((WHEN_VALUES as readonly string[]).includes(raw)) return raw as When;
+  // Unknown value: fall back to immediate. Surfacing a warning beats
+  // pretending we understood it; the build pipeline should have caught
+  // misspellings already.
+  // eslint-disable-next-line no-console
+  console.warn(`zfb-islands: unknown data-when="${raw}" on island; defaulting to "load"`);
+  return "load";
+}
+
+/** Parse data-props as JSON. Empty/missing ⇒ {}. */
+function readProps(el: Element): unknown {
+  const raw = (el as HTMLElement).dataset.props;
+  if (raw == null || raw === "") return {};
+  return JSON.parse(raw);
+}
+
+/** Read the component name. Returns null if missing/empty. */
+function readComponentName(el: Element): string | null {
+  const name = (el as HTMLElement).dataset.zfbIsland;
+  if (name == null || name === "") return null;
+  return name;
+}
+
+/**
+ * Hydrate one island. Looks up Component from the loaded bundle by name,
+ * decodes props, and delegates to the adapter's hydrateIsland.
+ */
+function hydrateOne(bundle: IslandsBundle, el: Element): void {
+  const name = readComponentName(el);
+  if (name === null) {
+    // No name ⇒ no work to do; surface a clear error so the build pipeline
+    // can catch missing data-zfb-island wiring early.
+    throw new Error("zfb-islands: element has no data-zfb-island component name");
+  }
+  const Component = bundle[name];
+  if (Component === undefined) {
+    throw new Error(`zfb-islands: islands bundle has no export "${name}"`);
+  }
+  const props = readProps(el);
+  bundle.hydrateIsland(Component, props, el);
+}
+
+/**
+ * Schedule hydrateOne according to the element's data-when hint.
+ *
+ *   load    → run synchronously (immediate)
+ *   idle    → requestIdleCallback (fallback: setTimeout 0)
+ *   visible → IntersectionObserver
+ *
+ * The actual unit tests for idle and visible live with Sub 4, where the
+ * <Island> wrapper sets data-when. We keep the dispatch table here because
+ * the runtime owns the values.
+ */
+function schedule(when: When, el: Element, run: (el: Element) => void): void {
+  if (when === "load") {
+    run(el);
+    return;
+  }
+  if (when === "idle") {
+    const ric = (
+      globalThis as unknown as {
+        requestIdleCallback?: (cb: () => void) => number;
+      }
+    ).requestIdleCallback;
+    if (typeof ric === "function") {
+      ric(() => run(el));
+    } else {
+      setTimeout(() => run(el), 0);
+    }
+    return;
+  }
+  // visible
+  if (typeof IntersectionObserver === "undefined") {
+    // No IO support: hydrate immediately rather than never.
+    run(el);
+    return;
+  }
+  const io = new IntersectionObserver((entries, obs) => {
+    for (const entry of entries) {
+      if (entry.isIntersecting) {
+        obs.unobserve(entry.target);
+        obs.disconnect();
+        run(entry.target);
+      }
+    }
+  });
+  io.observe(el);
+}
+
+/**
+ * Entry point. Exported so callers / tests can drive the runtime
+ * deterministically. The default behaviour (auto-start on module load)
+ * happens at the bottom of this file.
+ */
+export async function hydrateAll(opts?: {
+  /** Override the bundle URL. Defaults to reading data-zfb-bundle. */
+  bundleUrl?: string;
+  /** Override which root to scan. Defaults to document. */
+  root?: ParentNode;
+  /**
+   * Override the bundle import. Lets tests inject a fake without going
+   * through dynamic import resolution. When unset, dynamic import() is used.
+   */
+  importBundle?: (url: string) => Promise<IslandsBundle>;
+}): Promise<void> {
+  const root = opts?.root ?? document;
+  const elements = root.querySelectorAll<HTMLElement>("[data-zfb-island]");
+  if (elements.length === 0) return;
+
+  const url = opts?.bundleUrl ?? readBundleUrl();
+  const importer =
+    opts?.importBundle ?? ((u: string) => import(/* @vite-ignore */ u) as Promise<IslandsBundle>);
+  const bundle = await importer(url);
+  if (typeof bundle.hydrateIsland !== "function") {
+    throw new Error("zfb-islands: bundle has no hydrateIsland export (adapter shim missing)");
+  }
+
+  for (const el of elements) {
+    const when = readWhen(el);
+    schedule(when, el, (target) => hydrateOne(bundle, target));
+  }
+}
+
+// Auto-start. Skipped during unit tests by guarding on a marker attribute the
+// test harness sets on the DOM before importing the module — but the simpler
+// guard is "no [data-zfb-island] in the document" which the test environment
+// can arrange. Tests that exercise hydrateAll call it directly.
+if (typeof document !== "undefined" && document.querySelector("[data-zfb-island]")) {
+  // Fire and forget; errors propagate to window.onerror.
+  void hydrateAll();
+}

--- a/crates/zfb-islands/npm/test/hydrate.test.ts
+++ b/crates/zfb-islands/npm/test/hydrate.test.ts
@@ -264,7 +264,10 @@ describe("hydrateAll — data-when=visible", () => {
       { unobserve, disconnect } as unknown as IntersectionObserver,
     );
 
-    expect(unobserve).toHaveBeenCalledTimes(1);
+    // Implementation detail: scheduleHydrate from "zfb/runtime" calls
+    // disconnect() on the observer (which also stops further callbacks);
+    // it does not call unobserve() separately. The outcome is the same:
+    // hydration runs exactly once for this island.
     expect(disconnect).toHaveBeenCalledTimes(1);
     expect(calls).toHaveLength(1);
   });

--- a/crates/zfb-islands/npm/test/hydrate.test.ts
+++ b/crates/zfb-islands/npm/test/hydrate.test.ts
@@ -1,0 +1,271 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { hydrateAll } from "../src/hydrate.ts";
+
+// Each test reaches into the `happy-dom` document. Reset between tests.
+afterEach(() => {
+  document.body.innerHTML = "";
+  document.head.innerHTML = "";
+});
+
+/** Build a fake islands bundle exposing two named components + adapter shim. */
+function makeBundle() {
+  const calls: Array<{
+    name: string;
+    Component: unknown;
+    props: unknown;
+    element: Element;
+  }> = [];
+  const bundle = {
+    Counter: { __id: "counter" },
+    Banner: { __id: "banner" },
+    hydrateIsland(Component: unknown, props: unknown, element: Element) {
+      const named = Object.entries(bundle).find(([, v]) => v === Component) ?? ["?", Component];
+      calls.push({
+        name: named[0],
+        Component,
+        props,
+        element,
+      });
+    },
+  };
+  return { bundle, calls };
+}
+
+describe("hydrateAll — happy path", () => {
+  it("registers a single load island and calls hydrateIsland once", async () => {
+    document.body.innerHTML = `
+      <div data-zfb-island="Counter" data-props='{"start":3}'>
+        <button>3</button>
+      </div>
+    `;
+    const { bundle, calls } = makeBundle();
+    await hydrateAll({
+      bundleUrl: "/dist/assets/islands-x.js",
+      importBundle: async () => bundle,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.name).toBe("Counter");
+    expect(calls[0]!.props).toEqual({ start: 3 });
+    expect(calls[0]!.element).toBeInstanceOf(Element);
+  });
+
+  it("treats absent data-when as load (immediate hydration)", async () => {
+    document.body.innerHTML = `
+      <div data-zfb-island="Banner" data-props="{}"></div>
+    `;
+    const { bundle, calls } = makeBundle();
+    await hydrateAll({
+      bundleUrl: "/x.js",
+      importBundle: async () => bundle,
+    });
+    // No microtask gymnastics needed: load is synchronous.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.name).toBe("Banner");
+  });
+
+  it("explicitly honours data-when=load the same as absent", async () => {
+    document.body.innerHTML = `
+      <div data-zfb-island="Banner" data-props="{}" data-when="load"></div>
+    `;
+    const { bundle, calls } = makeBundle();
+    await hydrateAll({
+      bundleUrl: "/x.js",
+      importBundle: async () => bundle,
+    });
+    expect(calls).toHaveLength(1);
+  });
+
+  it("hydrates multiple islands in document order", async () => {
+    document.body.innerHTML = `
+      <div data-zfb-island="Counter" data-props='{"n":1}'></div>
+      <div data-zfb-island="Banner" data-props='{"n":2}'></div>
+    `;
+    const { bundle, calls } = makeBundle();
+    await hydrateAll({
+      bundleUrl: "/x.js",
+      importBundle: async () => bundle,
+    });
+    expect(calls.map((c) => c.name)).toEqual(["Counter", "Banner"]);
+  });
+
+  it("decodes HTML-escaped JSON in data-props (& and quote)", async () => {
+    // The Rust rewriter encodes `"` as `&quot;` and `&` as `&amp;` so the
+    // attribute survives serialization. Going through innerHTML (the
+    // browser's parser) decodes those entities back to the original JSON
+    // string. hydrateAll then JSON.parses the decoded value.
+    document.body.innerHTML =
+      `<div data-zfb-island="Counter" ` +
+      `data-props="{&quot;label&quot;:&quot;A &amp; B&quot;}"></div>`;
+    const { bundle, calls } = makeBundle();
+    await hydrateAll({
+      bundleUrl: "/x.js",
+      importBundle: async () => bundle,
+    });
+    expect(calls[0]!.props).toEqual({ label: "A & B" });
+  });
+});
+
+describe("hydrateAll — error paths", () => {
+  it("throws when an island has no data-zfb-island name", async () => {
+    document.body.innerHTML = `<div data-zfb-island="" data-props="{}"></div>`;
+    const { bundle } = makeBundle();
+    await expect(
+      hydrateAll({
+        bundleUrl: "/x.js",
+        importBundle: async () => bundle,
+      }),
+    ).rejects.toThrow(/no data-zfb-island component name/);
+  });
+
+  it("throws when the named component is not exported by the bundle", async () => {
+    document.body.innerHTML = `
+      <div data-zfb-island="Mystery" data-props="{}"></div>
+    `;
+    const { bundle } = makeBundle();
+    await expect(
+      hydrateAll({
+        bundleUrl: "/x.js",
+        importBundle: async () => bundle,
+      }),
+    ).rejects.toThrow(/no export "Mystery"/);
+  });
+
+  it("throws when the bundle has no hydrateIsland export", async () => {
+    document.body.innerHTML = `
+      <div data-zfb-island="Counter" data-props="{}"></div>
+    `;
+    await expect(
+      hydrateAll({
+        bundleUrl: "/x.js",
+        importBundle: async () =>
+          ({ Counter: {} }) as unknown as Parameters<typeof hydrateAll>[0] extends infer _
+            ? never
+            : never,
+      }),
+    ).rejects.toThrow(/no hydrateIsland export/);
+  });
+
+  it("throws when no [data-zfb-bundle] script and no override is supplied", async () => {
+    document.body.innerHTML = `
+      <div data-zfb-island="Counter" data-props="{}"></div>
+    `;
+    await expect(hydrateAll()).rejects.toThrow(/no <script data-zfb-bundle>/);
+  });
+
+  it("does nothing when no islands are present (no bundle import)", async () => {
+    const importBundle = vi.fn();
+    await hydrateAll({
+      bundleUrl: "/x.js",
+      importBundle,
+    });
+    expect(importBundle).not.toHaveBeenCalled();
+  });
+});
+
+describe("hydrateAll — data-when=idle", () => {
+  it("runs hydration via requestIdleCallback when available", async () => {
+    document.body.innerHTML = `
+      <div data-zfb-island="Counter" data-props="{}" data-when="idle"></div>
+    `;
+    const ric = vi.fn((cb: () => void) => {
+      cb();
+      return 1;
+    });
+    (
+      globalThis as unknown as {
+        requestIdleCallback: typeof ric;
+      }
+    ).requestIdleCallback = ric;
+
+    const { bundle, calls } = makeBundle();
+    await hydrateAll({
+      bundleUrl: "/x.js",
+      importBundle: async () => bundle,
+    });
+    expect(ric).toHaveBeenCalledTimes(1);
+    expect(calls).toHaveLength(1);
+    delete (
+      globalThis as unknown as {
+        requestIdleCallback?: unknown;
+      }
+    ).requestIdleCallback;
+  });
+
+  it("falls back to setTimeout when requestIdleCallback is missing", async () => {
+    document.body.innerHTML = `
+      <div data-zfb-island="Counter" data-props="{}" data-when="idle"></div>
+    `;
+    const stOriginal = globalThis.setTimeout;
+    const st = vi.fn((cb: () => void) => {
+      cb();
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    });
+    (globalThis as unknown as { setTimeout: typeof st }).setTimeout = st;
+    delete (globalThis as unknown as { requestIdleCallback?: unknown }).requestIdleCallback;
+    const { bundle, calls } = makeBundle();
+    await hydrateAll({
+      bundleUrl: "/x.js",
+      importBundle: async () => bundle,
+    });
+    expect(st).toHaveBeenCalledTimes(1);
+    expect(calls).toHaveLength(1);
+    (globalThis as unknown as { setTimeout: typeof stOriginal }).setTimeout = stOriginal;
+  });
+});
+
+describe("hydrateAll — data-when=visible", () => {
+  it("waits for IntersectionObserver intersection before hydrating", async () => {
+    document.body.innerHTML = `
+      <div data-zfb-island="Counter" data-props="{}" data-when="visible"></div>
+    `;
+    let savedCallback: IntersectionObserverCallback | null = null;
+    let savedTarget: Element | null = null;
+    const observe = vi.fn((target: Element) => {
+      savedTarget = target;
+    });
+    const unobserve = vi.fn();
+    const disconnect = vi.fn();
+    class FakeIO {
+      constructor(cb: IntersectionObserverCallback) {
+        savedCallback = cb;
+      }
+      observe = observe;
+      unobserve = unobserve;
+      disconnect = disconnect;
+      takeRecords = () => [] as IntersectionObserverEntry[];
+      readonly root = null;
+      readonly rootMargin = "0px";
+      readonly thresholds: ReadonlyArray<number> = [0];
+    }
+    (globalThis as unknown as { IntersectionObserver: typeof FakeIO }).IntersectionObserver =
+      FakeIO;
+
+    const { bundle, calls } = makeBundle();
+    await hydrateAll({
+      bundleUrl: "/x.js",
+      importBundle: async () => bundle,
+    });
+
+    // Before intersection: observe was registered but hydrate has not run.
+    expect(observe).toHaveBeenCalledTimes(1);
+    expect(calls).toHaveLength(0);
+
+    // Simulate the element scrolling into view.
+    savedCallback!(
+      [
+        {
+          isIntersecting: true,
+          target: savedTarget!,
+        } as IntersectionObserverEntry,
+      ],
+      // The runtime calls obs.unobserve / obs.disconnect on the second
+      // argument; pass an object that exposes them.
+      { unobserve, disconnect } as unknown as IntersectionObserver,
+    );
+
+    expect(unobserve).toHaveBeenCalledTimes(1);
+    expect(disconnect).toHaveBeenCalledTimes(1);
+    expect(calls).toHaveLength(1);
+  });
+});

--- a/crates/zfb-islands/npm/tsconfig.json
+++ b/crates/zfb-islands/npm/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "verbatimModuleSyntax": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/crates/zfb-islands/npm/vitest.config.ts
+++ b/crates/zfb-islands/npm/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "happy-dom",
+    globals: false,
+    include: ["test/**/*.test.ts"],
+  },
+});

--- a/crates/zfb-islands/src/bundler.rs
+++ b/crates/zfb-islands/src/bundler.rs
@@ -1,0 +1,247 @@
+//! [`ClientBundler`] trait and shared types.
+//!
+//! Sub 2 of Epic #6 implements the production `EsbuildSubprocessBundler` —
+//! today that means shelling out to the esbuild CLI binary. The trait below
+//! is the seam between scanning ([`crate::scanner`]) and bundling: anything
+//! handed an islands set and a [`BundleConfig`] can produce a
+//! `dist/assets/islands-{hash}.js` asset.
+//!
+//! ## Why a trait?
+//!
+//! esbuild is delivered as a Go-built CLI. To keep the build pipeline
+//! portable we shell out today, but the long-term plan is to swap in a
+//! Rust-native bundler (e.g. `oxc_minifier` on `oxc_resolver`, or
+//! `rolldown`, or whichever lands first) without touching the scanner or
+//! the render orchestrator. See [`crate::future_rust_native`] for the
+//! placeholder bundler that documents the swap path.
+//!
+//! ## Contract
+//!
+//! - The bundler MUST be deterministic: the same `(islands, config)` pair
+//!   must produce the same asset path and module-id list. Downstream
+//!   hashing assumes byte-stable bundle output.
+//! - The output asset filename convention is `islands-{hash}.js` under
+//!   `{outdir}/assets/` — mirror of `zfb_css`'s `styles-{hash}.css` layout.
+//! - `module_ids` returns the bundled module identifiers (typically the
+//!   `component_name` of each entry; bundlers MAY widen the list to also
+//!   include shared chunks). Order MUST be stable across runs.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+
+/// Stable identifier of a bundled module emitted by [`ClientBundler::bundle`].
+///
+/// Today this is just the component name; reserved as a type alias so future
+/// bundlers can carry richer info (chunk index, original specifier, …)
+/// without breaking call sites.
+pub type ModuleId = String;
+
+/// One `"use client"` component selected for hydration.
+///
+/// Two islands are equal iff their `(source_path, component_name)` pair is
+/// equal — this is the stable component-name identity the scanner promises.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Island {
+    /// Exported component name from the source file. For default exports
+    /// this is the literal string `"default"`.
+    pub component_name: String,
+    /// Path to the .tsx/.ts/.jsx/.js source that carried the
+    /// `"use client"` directive. Whatever form the scanner returned —
+    /// typically the resolver's resolved-path representation.
+    pub source_path: PathBuf,
+}
+
+impl Island {
+    /// Construct a new island.
+    ///
+    /// No path canonicalisation is done here; callers building islands by
+    /// hand should pass the same path representation that the bundler's
+    /// resolver expects so dedup keys line up with the rest of the
+    /// pipeline.
+    pub fn new(component_name: impl Into<String>, source_path: impl Into<PathBuf>) -> Self {
+        Self {
+            component_name: component_name.into(),
+            source_path: source_path.into(),
+        }
+    }
+}
+
+/// Bundle configuration handed to [`ClientBundler::bundle`].
+#[derive(Debug, Clone)]
+pub struct BundleConfig {
+    /// Minify the output. Production: `true`. Dev: `false`.
+    pub minify: bool,
+
+    /// Emit a sourcemap alongside the asset (and, for esbuild, a
+    /// `//# sourceMappingURL=` comment). Production: `false`. Dev: `true`.
+    pub sourcemap: bool,
+
+    /// Output root. The asset lands at
+    /// `{outdir}/assets/islands-{hash}.js`.
+    /// Default: `dist/`.
+    pub outdir: PathBuf,
+
+    /// Public base URL prefix used by [`bundle_link_href`].
+    /// Default: `"/"`.
+    pub base_url: String,
+}
+
+impl Default for BundleConfig {
+    fn default() -> Self {
+        Self {
+            minify: false,
+            sourcemap: true,
+            outdir: PathBuf::from("dist"),
+            base_url: "/".to_string(),
+        }
+    }
+}
+
+impl BundleConfig {
+    /// Production preset: minify on, sourcemap off.
+    pub fn production() -> Self {
+        Self {
+            minify: true,
+            sourcemap: false,
+            ..Self::default()
+        }
+    }
+
+    /// Dev preset: minify off, sourcemap on. Same as [`Default`].
+    pub fn dev() -> Self {
+        Self::default()
+    }
+
+    /// Override the output directory (chainable).
+    pub fn with_outdir(mut self, outdir: impl Into<PathBuf>) -> Self {
+        self.outdir = outdir.into();
+        self
+    }
+
+    /// Override the public base URL (chainable).
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = base_url.into();
+        self
+    }
+
+    /// Toggle minification (chainable).
+    pub fn with_minify(mut self, minify: bool) -> Self {
+        self.minify = minify;
+        self
+    }
+
+    /// Toggle sourcemap emission (chainable).
+    pub fn with_sourcemap(mut self, sourcemap: bool) -> Self {
+        self.sourcemap = sourcemap;
+        self
+    }
+}
+
+/// Result of a successful [`ClientBundler::bundle`] call.
+#[derive(Debug, Clone)]
+pub struct BundleOutput {
+    /// Output file path on disk, e.g. `dist/assets/islands-abc12345.js`.
+    pub asset_path: PathBuf,
+
+    /// Public URL the renderer should reference, e.g.
+    /// `/assets/islands-abc12345.js`. Computed via [`bundle_link_href`]
+    /// from the asset path and the `base_url` in [`BundleConfig`].
+    pub asset_url: String,
+
+    /// Identifiers of the modules included in the bundle. Order is stable
+    /// across runs for a given input.
+    pub module_ids: Vec<ModuleId>,
+}
+
+/// Abstraction over "bundle this islands set into a single browser-ready
+/// JS asset".
+///
+/// See the module-level docs for the swap-in story behind the trait.
+pub trait ClientBundler {
+    /// Bundle `islands` according to `config`. Must be deterministic for a
+    /// given `(islands, config)` pair.
+    fn bundle(&self, islands: &[Island], config: &BundleConfig) -> Result<BundleOutput>;
+}
+
+/// Build the public URL for the islands JS asset.
+///
+/// Mirrors `zfb_css::link_href` exactly — we don't depend on `zfb-css`,
+/// but the behaviour is intentionally identical so the renderer can reach
+/// for either helper interchangeably.
+///
+/// Examples:
+/// ```
+/// use std::path::PathBuf;
+/// use zfb_islands::bundle_link_href;
+///
+/// let p = PathBuf::from("dist/assets/islands-abc12345.js");
+/// assert_eq!(bundle_link_href("/", &p), "/assets/islands-abc12345.js");
+/// assert_eq!(
+///     bundle_link_href("https://cdn.example.com", &p),
+///     "https://cdn.example.com/assets/islands-abc12345.js",
+/// );
+/// ```
+pub fn bundle_link_href(base_url: &str, asset_path: &Path) -> String {
+    let filename = asset_path
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let trimmed = base_url.trim_end_matches('/');
+    format!("{trimmed}/assets/{filename}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn island_equality_uses_path_and_name() {
+        let a = Island::new("Counter", "/abs/components/Counter.tsx");
+        let b = Island::new("Counter", "/abs/components/Counter.tsx");
+        let c = Island::new("Counter", "/abs/components/Other.tsx");
+        let d = Island::new("Other", "/abs/components/Counter.tsx");
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+        assert_ne!(a, d);
+    }
+
+    #[test]
+    fn bundle_config_presets() {
+        let prod = BundleConfig::production();
+        assert!(prod.minify);
+        assert!(!prod.sourcemap);
+
+        let dev = BundleConfig::dev();
+        assert!(!dev.minify);
+        assert!(dev.sourcemap);
+    }
+
+    #[test]
+    fn bundle_config_chainable() {
+        let cfg = BundleConfig::production()
+            .with_outdir("build")
+            .with_base_url("https://cdn.example.com/")
+            .with_minify(false)
+            .with_sourcemap(true);
+        assert_eq!(cfg.outdir, PathBuf::from("build"));
+        assert_eq!(cfg.base_url, "https://cdn.example.com/");
+        assert!(!cfg.minify);
+        assert!(cfg.sourcemap);
+    }
+
+    #[test]
+    fn link_href_normalises_trailing_slash() {
+        let p = PathBuf::from("dist/assets/islands-deadbeef.js");
+        assert_eq!(bundle_link_href("/", &p), "/assets/islands-deadbeef.js");
+        assert_eq!(bundle_link_href("", &p), "/assets/islands-deadbeef.js");
+        assert_eq!(
+            bundle_link_href("https://cdn.example.com/", &p),
+            "https://cdn.example.com/assets/islands-deadbeef.js"
+        );
+        assert_eq!(
+            bundle_link_href("https://cdn.example.com", &p),
+            "https://cdn.example.com/assets/islands-deadbeef.js"
+        );
+    }
+}

--- a/crates/zfb-islands/src/bundler.rs
+++ b/crates/zfb-islands/src/bundler.rs
@@ -14,14 +14,13 @@
 //!
 //! ## Coordination with Sub 1
 //!
-//! The [`Island`] / [`BundleConfig`] / [`BundleOutput`] / [`ClientBundler`]
-//! types are drafted here so Sub 2 can be exercised in isolation. Sub 1
-//! (topic-ast-scanner) populates the islands set; if Sub 1 lands a refined
-//! `Island` shape (e.g. distinguishing `exported_name` from
-//! `component_name`), the bundler only needs `source_path` for esbuild
-//! entry points — the rest is read-through.
+//! The [`Island`] / [`BundleConfig`] / [`BundleOutput`] / [`ModuleId`] /
+//! [`ClientBundler`] types and the [`bundle_link_href`] helper are drafted
+//! here so Sub 2 can be exercised in isolation. Sub 1 (topic-ast-scanner)
+//! owns the canonical scanner population of [`Island`]; the trait shape
+//! here mirrors what Sub 1 published so the team-lead's merge is a no-op
+//! aside from de-duplication.
 
-use std::collections::BTreeMap;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -29,18 +28,22 @@ use std::process::Command;
 use anyhow::{anyhow, Context, Result};
 use sha2::{Digest, Sha256};
 
+/// String alias for an exported module id inside the bundled JS asset.
+/// One per island; the order matches the order of the islands slice that
+/// produced the bundle.
+pub type ModuleId = String;
+
 /// A single island: one component flagged with `"use client"` that the
 /// scanner found in the project sources. Bundler entry points are derived
 /// from `source_path`; `component_name` is recorded in the bundle's
-/// `module_ids` map so the hydration runtime can look up an export by name.
+/// `module_ids` list so the hydration runtime can correlate a DOM marker
+/// to its hydratable export.
 ///
-/// Sub 1 owns the canonical population of this type; Sub 2 only consumes it.
-/// Field names are deliberately conservative — if Sub 1 needs to extend
-/// (e.g. add `exported_name`), additive fields are fine.
+/// Sub 1 owns the canonical population of this type. Default exports
+/// surface as the literal string `"default"` for `component_name`.
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Island {
     /// The exported component name as it appears in the source file.
-    /// Used as the lookup key in [`BundleOutput::module_ids`].
     pub component_name: String,
 
     /// Absolute or workspace-relative path to the TS/TSX source file that
@@ -54,80 +57,96 @@ pub struct Island {
 /// per-engine config struct — see [`EsbuildSubprocessConfig`].
 #[derive(Debug, Clone)]
 pub struct BundleConfig {
-    /// Where to write the bundle asset. The pipeline emits
-    /// `{output_root}/assets/islands-{hash}.js` under this directory.
-    /// Default: `dist/`.
-    pub output_root: PathBuf,
-
-    /// Public base URL prefix for the asset, e.g. `"/"` (default) or
-    /// `"https://cdn.example.com/"`. Used by [`link_href`].
-    pub base_url: String,
-
     /// Production minification: maps to esbuild's `--minify`.
     pub minify: bool,
-
-    /// Tree-shaking: maps to esbuild's `--tree-shaking=true`. Esbuild
-    /// tree-shakes by default for ESM bundles, but we set the flag
-    /// explicitly so the contract is visible at the call site.
-    pub tree_shaking: bool,
 
     /// Source maps: maps to esbuild's `--sourcemap=linked`. Recommended on
     /// in dev builds, off in production.
     pub sourcemap: bool,
+
+    /// Where to write the bundle asset. The pipeline emits
+    /// `{outdir}/assets/islands-{hash}.js` under this directory.
+    /// Default: `dist/`.
+    pub outdir: PathBuf,
+
+    /// Public base URL prefix for the asset, e.g. `"/"` (default) or
+    /// `"https://cdn.example.com/"`. Used by [`bundle_link_href`].
+    pub base_url: String,
 }
 
 impl Default for BundleConfig {
+    /// Dev-equivalent default: minify off, sourcemap on, outdir `dist/`,
+    /// base_url `/`.
     fn default() -> Self {
         Self {
-            output_root: PathBuf::from("dist"),
-            base_url: "/".to_string(),
             minify: false,
-            tree_shaking: true,
-            sourcemap: false,
+            sourcemap: true,
+            outdir: PathBuf::from("dist"),
+            base_url: "/".to_string(),
         }
     }
 }
 
 impl BundleConfig {
-    /// Production preset: minify on, tree-shaking on, sourcemap off.
+    /// Production preset: minify on, sourcemap off.
     pub fn production() -> Self {
         Self {
             minify: true,
-            tree_shaking: true,
             sourcemap: false,
             ..Self::default()
         }
     }
 
-    /// Development preset: minify off, tree-shaking on, sourcemap on.
-    pub fn development() -> Self {
-        Self {
-            minify: false,
-            tree_shaking: true,
-            sourcemap: true,
-            ..Self::default()
-        }
+    /// Development preset: same as [`Self::default`].
+    pub fn dev() -> Self {
+        Self::default()
+    }
+
+    /// Override the output root directory (chainable).
+    pub fn with_outdir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.outdir = dir.into();
+        self
+    }
+
+    /// Override the public base URL prefix (chainable).
+    pub fn with_base_url(mut self, url: impl Into<String>) -> Self {
+        self.base_url = url.into();
+        self
+    }
+
+    /// Override the minify flag (chainable).
+    pub fn with_minify(mut self, on: bool) -> Self {
+        self.minify = on;
+        self
+    }
+
+    /// Override the sourcemap flag (chainable).
+    pub fn with_sourcemap(mut self, on: bool) -> Self {
+        self.sourcemap = on;
+        self
     }
 }
 
 /// Result of running [`ClientBundler::bundle`].
+///
+/// `asset_path` and `asset_url` are derived from the same hash; the
+/// renderer (Sub 3) typically uses `asset_url` directly for the
+/// `<script type="module" src="...">` tag.
 #[derive(Debug, Clone)]
 pub struct BundleOutput {
-    /// 8-character hex hash (first 8 chars of SHA-256 of the bundled JS).
-    /// Mirrors the hash style from `zfb-css::pipeline::hash_8`.
-    pub hash: String,
-
-    /// Absolute or output-root-relative path the asset was written to.
-    /// Convention: `{output_root}/assets/islands-{hash}.js`.
+    /// Absolute or `outdir`-relative path the asset was written to.
+    /// Convention: `{outdir}/assets/islands-{hash}.js`.
     pub asset_path: PathBuf,
 
-    /// Map of `component_name → exported module id` inside the bundle.
-    /// The hydration runtime (Sub 3) uses this to resolve an island element
-    /// to its hydratable export. Empty when no islands were bundled.
-    ///
-    /// Stored as a `BTreeMap` so iteration order — and therefore the
-    /// downstream hash inputs that consume it — is deterministic.
-    pub module_ids: BTreeMap<String, String>,
+    /// Public URL for the asset, derived via [`bundle_link_href`].
+    /// Convention: `{base_url}/assets/islands-{hash}.js` (slash-normalised).
+    pub asset_url: String,
+
+    /// Per-island module ids exported by the bundle, in the same order as
+    /// the islands slice passed to [`ClientBundler::bundle`].
+    /// Hydration glue uses this to look up the hydratable export for each
+    /// island's DOM marker.
+    pub module_ids: Vec<ModuleId>,
 }
 
 /// Abstraction over "bundle these island entry points into a single hashed
@@ -137,17 +156,17 @@ pub struct BundleOutput {
 ///
 /// We currently shell out to the official esbuild CLI binary
 /// ([`EsbuildSubprocessBundler`]). When a Rust-native option becomes viable
-/// (see [`crate::native_bundler::NativeRustBundler`]), we want to swap it in
-/// at one site without rewriting hashing, asset emission, or hydration
-/// glue.
+/// (see [`crate::future_rust_native::NativeRustBundler`]), we want to swap
+/// it in at one site without rewriting hashing, asset emission, or
+/// hydration glue.
 ///
 /// ## Contract
 ///
 /// - The bundler MUST return a [`BundleOutput`] whose `asset_path` is
 ///   present on disk by the time `bundle` returns.
-/// - The bundler MUST be deterministic for a given (islands, config) pair —
-///   the same inputs must produce byte-identical bundle bytes (and thus an
-///   identical 8-char hash).
+/// - The bundler MUST be deterministic for a given (islands, config) pair
+///   — the same inputs must produce byte-identical bundle bytes (and thus
+///   an identical 8-char hash).
 /// - The bundler MAY widen the bundle's contents beyond the listed entry
 ///   points (transitive imports are expected). It MUST NOT silently drop
 ///   listed entry points.
@@ -236,10 +255,13 @@ impl EsbuildSubprocessConfig {
 
 /// The default [`ClientBundler`]: shells out to the esbuild CLI binary.
 ///
-/// The binary is invoked with each island's `source_path` as an entry point,
-/// `--bundle --format=esm --splitting=false`, and writes to a temp file
-/// (`-o`). The file is read back, hashed, and written to its final location
-/// at `{output_root}/assets/islands-{hash}.js`.
+/// The binary is invoked with each island's `source_path` as an entry
+/// point, plus `--bundle --format=esm --splitting=false
+/// --tree-shaking=true` (esbuild tree-shakes ESM by default but we set the
+/// flag explicitly so the contract is visible). `--minify` and
+/// `--sourcemap=linked` are appended per [`BundleConfig`]. The payload is
+/// written to a temp file (`--outfile=`), read back, hashed, and written
+/// to its final location at `{outdir}/assets/islands-{hash}.js`.
 ///
 /// ### Example
 ///
@@ -256,7 +278,7 @@ impl EsbuildSubprocessConfig {
 ///     source_path: PathBuf::from("components/counter.tsx"),
 /// }];
 /// let out = bundler.bundle(&islands, &BundleConfig::production()).unwrap();
-/// assert_eq!(out.hash.len(), 8);
+/// assert!(out.asset_url.starts_with("/assets/islands-"));
 /// ```
 #[derive(Debug, Clone)]
 pub struct EsbuildSubprocessBundler {
@@ -309,9 +331,9 @@ impl EsbuildSubprocessBundler {
         cmd.arg("--bundle");
         cmd.arg("--format=esm");
         cmd.arg("--splitting=false");
-        if config.tree_shaking {
-            cmd.arg("--tree-shaking=true");
-        }
+        // Tree-shaking is on by default for ESM in esbuild; we set the
+        // flag explicitly so the contract is visible at the call site.
+        cmd.arg("--tree-shaking=true");
         if config.minify {
             cmd.arg("--minify");
         }
@@ -350,7 +372,7 @@ impl ClientBundler for EsbuildSubprocessBundler {
 
         let hash = hash_8(&js);
         let asset_path = config
-            .output_root
+            .outdir
             .join("assets")
             .join(format!("islands-{hash}.js"));
 
@@ -361,19 +383,19 @@ impl ClientBundler for EsbuildSubprocessBundler {
         std::fs::write(&asset_path, js.as_bytes())
             .with_context(|| format!("failed to write {}", asset_path.display()))?;
 
-        // Default `module_ids` mapping: component_name → component_name.
-        // Sub 1's scanner is the source of truth for the canonical mapping
-        // (e.g. when `exported_name` differs from `component_name`); until
-        // it lands a richer Island shape, the identity mapping is the right
+        let asset_url = bundle_link_href(&config.base_url, &asset_path);
+
+        // Default `module_ids` mapping: identity per-island. Sub 1's
+        // scanner is the source of truth for the canonical mapping (e.g.
+        // when the exported name differs from the component name); until
+        // it lands a richer Island shape, `component_name` is the right
         // contract for the hydration runtime to assume.
-        let module_ids = islands
-            .iter()
-            .map(|i| (i.component_name.clone(), i.component_name.clone()))
-            .collect::<BTreeMap<_, _>>();
+        let module_ids: Vec<ModuleId> =
+            islands.iter().map(|i| i.component_name.clone()).collect();
 
         Ok(BundleOutput {
-            hash,
             asset_path,
+            asset_url,
             module_ids,
         })
     }
@@ -397,20 +419,21 @@ pub fn hash_8(js: &str) -> String {
 ///
 /// `base_url` is concatenated with the asset path's filename portion under
 /// an `assets/` segment. `base_url` is normalised to drop any trailing `/`.
+/// Exact mirror of `zfb_css::link_href`.
 ///
 /// Examples:
 /// ```
 /// use std::path::PathBuf;
-/// use zfb_islands::link_href;
+/// use zfb_islands::bundle_link_href;
 ///
 /// let p = PathBuf::from("dist/assets/islands-abc12345.js");
-/// assert_eq!(link_href("/", &p), "/assets/islands-abc12345.js");
+/// assert_eq!(bundle_link_href("/", &p), "/assets/islands-abc12345.js");
 /// assert_eq!(
-///     link_href("https://cdn.example.com", &p),
+///     bundle_link_href("https://cdn.example.com", &p),
 ///     "https://cdn.example.com/assets/islands-abc12345.js",
 /// );
 /// ```
-pub fn link_href(base_url: &str, asset_path: &Path) -> String {
+pub fn bundle_link_href(base_url: &str, asset_path: &Path) -> String {
     let filename = asset_path
         .file_name()
         .map(|s| s.to_string_lossy().into_owned())
@@ -439,31 +462,48 @@ mod tests {
     }
 
     #[test]
-    fn link_href_normalises_trailing_slash() {
+    fn bundle_link_href_normalises_trailing_slash() {
         let p = PathBuf::from("dist/assets/islands-deadbeef.js");
-        assert_eq!(link_href("/", &p), "/assets/islands-deadbeef.js");
-        assert_eq!(link_href("", &p), "/assets/islands-deadbeef.js");
+        assert_eq!(bundle_link_href("/", &p), "/assets/islands-deadbeef.js");
+        assert_eq!(bundle_link_href("", &p), "/assets/islands-deadbeef.js");
         assert_eq!(
-            link_href("https://cdn.example.com/", &p),
+            bundle_link_href("https://cdn.example.com/", &p),
             "https://cdn.example.com/assets/islands-deadbeef.js"
         );
         assert_eq!(
-            link_href("https://cdn.example.com", &p),
+            bundle_link_href("https://cdn.example.com", &p),
             "https://cdn.example.com/assets/islands-deadbeef.js"
         );
     }
 
     #[test]
-    fn bundle_config_presets_set_expected_flags() {
+    fn bundle_config_dev_default_matches_default() {
+        let dev = BundleConfig::dev();
+        let default = BundleConfig::default();
+        assert_eq!(dev.minify, default.minify);
+        assert_eq!(dev.sourcemap, default.sourcemap);
+        assert_eq!(dev.outdir, default.outdir);
+        assert_eq!(dev.base_url, default.base_url);
+    }
+
+    #[test]
+    fn bundle_config_production_flips_minify_and_sourcemap() {
         let prod = BundleConfig::production();
         assert!(prod.minify);
-        assert!(prod.tree_shaking);
         assert!(!prod.sourcemap);
+    }
 
-        let dev = BundleConfig::development();
-        assert!(!dev.minify);
-        assert!(dev.tree_shaking);
-        assert!(dev.sourcemap);
+    #[test]
+    fn bundle_config_chainable_setters() {
+        let cfg = BundleConfig::default()
+            .with_outdir("custom-dist")
+            .with_base_url("https://cdn.example.com/")
+            .with_minify(true)
+            .with_sourcemap(false);
+        assert_eq!(cfg.outdir, PathBuf::from("custom-dist"));
+        assert_eq!(cfg.base_url, "https://cdn.example.com/");
+        assert!(cfg.minify);
+        assert!(!cfg.sourcemap);
     }
 
     #[test]

--- a/crates/zfb-islands/src/bundler.rs
+++ b/crates/zfb-islands/src/bundler.rs
@@ -1,0 +1,484 @@
+//! The "client bundler" abstraction.
+//!
+//! esbuild is delivered as a Go-built standalone CLI. To keep our build
+//! pipeline portable we shell out to that binary today — but the long-term
+//! plan is to swap in a Rust-native implementation (e.g. swc-bundler,
+//! turbopack-style, or our own equivalent) without touching the rest of the
+//! pipeline.
+//!
+//! That swap is exactly what [`ClientBundler`] models: take a set of island
+//! entry points (collected by Sub 1's AST scanner), return a single hashed
+//! JS asset that the hydration runtime (Sub 3) can `import()` from.
+//! Everything stage-2 and beyond (hashing, asset emission, URL derivation)
+//! is engine-agnostic.
+//!
+//! ## Coordination with Sub 1
+//!
+//! The [`Island`] / [`BundleConfig`] / [`BundleOutput`] / [`ClientBundler`]
+//! types are drafted here so Sub 2 can be exercised in isolation. Sub 1
+//! (topic-ast-scanner) populates the islands set; if Sub 1 lands a refined
+//! `Island` shape (e.g. distinguishing `exported_name` from
+//! `component_name`), the bundler only needs `source_path` for esbuild
+//! entry points — the rest is read-through.
+
+use std::collections::BTreeMap;
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use anyhow::{anyhow, Context, Result};
+use sha2::{Digest, Sha256};
+
+/// A single island: one component flagged with `"use client"` that the
+/// scanner found in the project sources. Bundler entry points are derived
+/// from `source_path`; `component_name` is recorded in the bundle's
+/// `module_ids` map so the hydration runtime can look up an export by name.
+///
+/// Sub 1 owns the canonical population of this type; Sub 2 only consumes it.
+/// Field names are deliberately conservative — if Sub 1 needs to extend
+/// (e.g. add `exported_name`), additive fields are fine.
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Island {
+    /// The exported component name as it appears in the source file.
+    /// Used as the lookup key in [`BundleOutput::module_ids`].
+    pub component_name: String,
+
+    /// Absolute or workspace-relative path to the TS/TSX source file that
+    /// contains the component. Used as the esbuild entry point.
+    pub source_path: PathBuf,
+}
+
+/// Engine-agnostic bundling configuration.
+///
+/// Engine-specific knobs (binary path, extra CLI args) live on a sibling
+/// per-engine config struct — see [`EsbuildSubprocessConfig`].
+#[derive(Debug, Clone)]
+pub struct BundleConfig {
+    /// Where to write the bundle asset. The pipeline emits
+    /// `{output_root}/assets/islands-{hash}.js` under this directory.
+    /// Default: `dist/`.
+    pub output_root: PathBuf,
+
+    /// Public base URL prefix for the asset, e.g. `"/"` (default) or
+    /// `"https://cdn.example.com/"`. Used by [`link_href`].
+    pub base_url: String,
+
+    /// Production minification: maps to esbuild's `--minify`.
+    pub minify: bool,
+
+    /// Tree-shaking: maps to esbuild's `--tree-shaking=true`. Esbuild
+    /// tree-shakes by default for ESM bundles, but we set the flag
+    /// explicitly so the contract is visible at the call site.
+    pub tree_shaking: bool,
+
+    /// Source maps: maps to esbuild's `--sourcemap=linked`. Recommended on
+    /// in dev builds, off in production.
+    pub sourcemap: bool,
+}
+
+impl Default for BundleConfig {
+    fn default() -> Self {
+        Self {
+            output_root: PathBuf::from("dist"),
+            base_url: "/".to_string(),
+            minify: false,
+            tree_shaking: true,
+            sourcemap: false,
+        }
+    }
+}
+
+impl BundleConfig {
+    /// Production preset: minify on, tree-shaking on, sourcemap off.
+    pub fn production() -> Self {
+        Self {
+            minify: true,
+            tree_shaking: true,
+            sourcemap: false,
+            ..Self::default()
+        }
+    }
+
+    /// Development preset: minify off, tree-shaking on, sourcemap on.
+    pub fn development() -> Self {
+        Self {
+            minify: false,
+            tree_shaking: true,
+            sourcemap: true,
+            ..Self::default()
+        }
+    }
+}
+
+/// Result of running [`ClientBundler::bundle`].
+#[derive(Debug, Clone)]
+pub struct BundleOutput {
+    /// 8-character hex hash (first 8 chars of SHA-256 of the bundled JS).
+    /// Mirrors the hash style from `zfb-css::pipeline::hash_8`.
+    pub hash: String,
+
+    /// Absolute or output-root-relative path the asset was written to.
+    /// Convention: `{output_root}/assets/islands-{hash}.js`.
+    pub asset_path: PathBuf,
+
+    /// Map of `component_name → exported module id` inside the bundle.
+    /// The hydration runtime (Sub 3) uses this to resolve an island element
+    /// to its hydratable export. Empty when no islands were bundled.
+    ///
+    /// Stored as a `BTreeMap` so iteration order — and therefore the
+    /// downstream hash inputs that consume it — is deterministic.
+    pub module_ids: BTreeMap<String, String>,
+}
+
+/// Abstraction over "bundle these island entry points into a single hashed
+/// JS asset".
+///
+/// ## Why a trait?
+///
+/// We currently shell out to the official esbuild CLI binary
+/// ([`EsbuildSubprocessBundler`]). When a Rust-native option becomes viable
+/// (see [`crate::native_bundler::NativeRustBundler`]), we want to swap it in
+/// at one site without rewriting hashing, asset emission, or hydration
+/// glue.
+///
+/// ## Contract
+///
+/// - The bundler MUST return a [`BundleOutput`] whose `asset_path` is
+///   present on disk by the time `bundle` returns.
+/// - The bundler MUST be deterministic for a given (islands, config) pair —
+///   the same inputs must produce byte-identical bundle bytes (and thus an
+///   identical 8-char hash).
+/// - The bundler MAY widen the bundle's contents beyond the listed entry
+///   points (transitive imports are expected). It MUST NOT silently drop
+///   listed entry points.
+/// - The bundler SHOULD emit ESM with code-splitting disabled in v0 so the
+///   hydration runtime only ever resolves a single asset URL.
+pub trait ClientBundler {
+    /// Bundle the given island entry points.
+    fn bundle(&self, islands: &[Island], config: &BundleConfig) -> Result<BundleOutput>;
+}
+
+/// Configuration for [`EsbuildSubprocessBundler`].
+#[derive(Debug, Clone)]
+pub struct EsbuildSubprocessConfig {
+    /// Path to the esbuild CLI binary.
+    ///
+    /// Default: `crates/zfb/binaries/esbuild/esbuild` (relative to the
+    /// workspace root). Sub 2 reserves the parent `esbuild/` directory in
+    /// the release tarball layout (mirroring the Tailwind v4 slot pattern;
+    /// the directory shape gives release tooling room to drop sidecars
+    /// like a checksum manifest next to the binary). Override via
+    /// [`Self::with_binary_path`] or via the `ZFB_ESBUILD_BIN` environment
+    /// variable (checked at engine construction time, not at every
+    /// invocation).
+    pub binary_path: PathBuf,
+
+    /// Working directory for the subprocess. esbuild resolves entry points
+    /// and `node_modules` lookups relative to this directory.
+    ///
+    /// Default: the current working directory at engine construction time.
+    pub working_dir: PathBuf,
+
+    /// Extra CLI args appended to the subprocess invocation, for escape
+    /// hatches like `--define:process.env.NODE_ENV='production'`. Passed
+    /// verbatim.
+    pub extra_args: Vec<OsString>,
+
+    /// When true, the bundler will return a *fake* JS payload instead of
+    /// invoking the subprocess. Used by unit tests to avoid depending on
+    /// the binary being installed. The string returned is taken from
+    /// [`Self::mock_output`].
+    pub mock_subprocess: bool,
+
+    /// Output to return when `mock_subprocess` is true.
+    pub mock_output: String,
+}
+
+impl Default for EsbuildSubprocessConfig {
+    fn default() -> Self {
+        let env_override = std::env::var_os("ZFB_ESBUILD_BIN");
+        let binary_path = match env_override {
+            Some(p) => PathBuf::from(p),
+            None => PathBuf::from("crates/zfb/binaries/esbuild/esbuild"),
+        };
+        let working_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        Self {
+            binary_path,
+            working_dir,
+            extra_args: Vec::new(),
+            mock_subprocess: false,
+            mock_output: String::new(),
+        }
+    }
+}
+
+impl EsbuildSubprocessConfig {
+    /// Override the binary path (chainable).
+    pub fn with_binary_path(mut self, path: impl Into<PathBuf>) -> Self {
+        self.binary_path = path.into();
+        self
+    }
+
+    /// Override the working directory (chainable).
+    pub fn with_working_dir(mut self, dir: impl Into<PathBuf>) -> Self {
+        self.working_dir = dir.into();
+        self
+    }
+
+    /// Configure the bundler to skip the subprocess and return `output`
+    /// instead. Used by unit tests.
+    pub fn with_mock_output(mut self, output: impl Into<String>) -> Self {
+        self.mock_subprocess = true;
+        self.mock_output = output.into();
+        self
+    }
+}
+
+/// The default [`ClientBundler`]: shells out to the esbuild CLI binary.
+///
+/// The binary is invoked with each island's `source_path` as an entry point,
+/// `--bundle --format=esm --splitting=false`, and writes to a temp file
+/// (`-o`). The file is read back, hashed, and written to its final location
+/// at `{output_root}/assets/islands-{hash}.js`.
+///
+/// ### Example
+///
+/// ```no_run
+/// use zfb_islands::{
+///     BundleConfig, ClientBundler, EsbuildSubprocessBundler,
+///     EsbuildSubprocessConfig, Island,
+/// };
+/// use std::path::PathBuf;
+///
+/// let bundler = EsbuildSubprocessBundler::new(EsbuildSubprocessConfig::default());
+/// let islands = vec![Island {
+///     component_name: "Counter".into(),
+///     source_path: PathBuf::from("components/counter.tsx"),
+/// }];
+/// let out = bundler.bundle(&islands, &BundleConfig::production()).unwrap();
+/// assert_eq!(out.hash.len(), 8);
+/// ```
+#[derive(Debug, Clone)]
+pub struct EsbuildSubprocessBundler {
+    config: EsbuildSubprocessConfig,
+}
+
+impl EsbuildSubprocessBundler {
+    /// Construct a new bundler with the given config.
+    pub fn new(config: EsbuildSubprocessConfig) -> Self {
+        Self { config }
+    }
+
+    /// Construct a new bundler with the default config.
+    pub fn with_default_config() -> Self {
+        Self::new(EsbuildSubprocessConfig::default())
+    }
+
+    /// Borrow the underlying config.
+    pub fn config(&self) -> &EsbuildSubprocessConfig {
+        &self.config
+    }
+
+    /// Internal: produce the JS payload for the given islands. Split out so
+    /// tests can drive it directly without going through `bundle`'s
+    /// asset-write step.
+    fn produce_bundle_js(&self, islands: &[Island], config: &BundleConfig) -> Result<String> {
+        if self.config.mock_subprocess {
+            return Ok(self.config.mock_output.clone());
+        }
+
+        if !self.config.binary_path.exists() {
+            return Err(anyhow!(
+                "esbuild binary not found at {}; \
+                 set ZFB_ESBUILD_BIN or update EsbuildSubprocessConfig::binary_path",
+                self.config.binary_path.display()
+            ));
+        }
+
+        // Allocate a temp file in this engine's working dir so esbuild's
+        // `--outfile` can be a relative path resolvable from the subprocess
+        // cwd. Drop happens when we return — file vanishes after read.
+        let tmp = tempfile::Builder::new()
+            .prefix("zfb-esbuild-")
+            .suffix(".js")
+            .tempfile()
+            .context("failed to allocate temp file for esbuild output")?;
+
+        let mut cmd = Command::new(&self.config.binary_path);
+        cmd.current_dir(&self.config.working_dir);
+        cmd.arg("--bundle");
+        cmd.arg("--format=esm");
+        cmd.arg("--splitting=false");
+        if config.tree_shaking {
+            cmd.arg("--tree-shaking=true");
+        }
+        if config.minify {
+            cmd.arg("--minify");
+        }
+        if config.sourcemap {
+            cmd.arg("--sourcemap=linked");
+        }
+        cmd.arg(format!("--outfile={}", tmp.path().display()));
+        for extra in &self.config.extra_args {
+            cmd.arg(extra);
+        }
+        for island in islands {
+            cmd.arg(&island.source_path);
+        }
+
+        let output = cmd
+            .output()
+            .with_context(|| format!("failed to spawn {}", self.config.binary_path.display()))?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(anyhow!(
+                "esbuild exited with status {}: {}",
+                output.status,
+                stderr.trim()
+            ));
+        }
+
+        let js = std::fs::read_to_string(tmp.path())
+            .context("failed to read esbuild output file")?;
+        Ok(js)
+    }
+}
+
+impl ClientBundler for EsbuildSubprocessBundler {
+    fn bundle(&self, islands: &[Island], config: &BundleConfig) -> Result<BundleOutput> {
+        let js = self.produce_bundle_js(islands, config)?;
+
+        let hash = hash_8(&js);
+        let asset_path = config
+            .output_root
+            .join("assets")
+            .join(format!("islands-{hash}.js"));
+
+        if let Some(parent) = asset_path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
+        std::fs::write(&asset_path, js.as_bytes())
+            .with_context(|| format!("failed to write {}", asset_path.display()))?;
+
+        // Default `module_ids` mapping: component_name → component_name.
+        // Sub 1's scanner is the source of truth for the canonical mapping
+        // (e.g. when `exported_name` differs from `component_name`); until
+        // it lands a richer Island shape, the identity mapping is the right
+        // contract for the hydration runtime to assume.
+        let module_ids = islands
+            .iter()
+            .map(|i| (i.component_name.clone(), i.component_name.clone()))
+            .collect::<BTreeMap<_, _>>();
+
+        Ok(BundleOutput {
+            hash,
+            asset_path,
+            module_ids,
+        })
+    }
+}
+
+/// Compute the 8-char hex hash for the given bundle bytes.
+///
+/// The hash is the first 8 characters of `sha256(js)` in lowercase hex.
+/// Mirrors `zfb-css::pipeline::hash_8` (which folds two halves via a `\n`
+/// separator) — for islands there is only one byte stream so no separator
+/// is needed.
+pub fn hash_8(js: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(js.as_bytes());
+    let digest = hasher.finalize();
+    let full = hex::encode(digest);
+    full[..8].to_string()
+}
+
+/// Build the public URL for the islands JS asset.
+///
+/// `base_url` is concatenated with the asset path's filename portion under
+/// an `assets/` segment. `base_url` is normalised to drop any trailing `/`.
+///
+/// Examples:
+/// ```
+/// use std::path::PathBuf;
+/// use zfb_islands::link_href;
+///
+/// let p = PathBuf::from("dist/assets/islands-abc12345.js");
+/// assert_eq!(link_href("/", &p), "/assets/islands-abc12345.js");
+/// assert_eq!(
+///     link_href("https://cdn.example.com", &p),
+///     "https://cdn.example.com/assets/islands-abc12345.js",
+/// );
+/// ```
+pub fn link_href(base_url: &str, asset_path: &Path) -> String {
+    let filename = asset_path
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let trimmed = base_url.trim_end_matches('/');
+    format!("{trimmed}/assets/{filename}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_is_stable_for_identical_inputs() {
+        let a = hash_8("export const x = 1;");
+        let b = hash_8("export const x = 1;");
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 8);
+    }
+
+    #[test]
+    fn hash_changes_when_payload_changes() {
+        let before = hash_8("export const x = 1;");
+        let after = hash_8("export const x = 2;");
+        assert_ne!(before, after);
+    }
+
+    #[test]
+    fn link_href_normalises_trailing_slash() {
+        let p = PathBuf::from("dist/assets/islands-deadbeef.js");
+        assert_eq!(link_href("/", &p), "/assets/islands-deadbeef.js");
+        assert_eq!(link_href("", &p), "/assets/islands-deadbeef.js");
+        assert_eq!(
+            link_href("https://cdn.example.com/", &p),
+            "https://cdn.example.com/assets/islands-deadbeef.js"
+        );
+        assert_eq!(
+            link_href("https://cdn.example.com", &p),
+            "https://cdn.example.com/assets/islands-deadbeef.js"
+        );
+    }
+
+    #[test]
+    fn bundle_config_presets_set_expected_flags() {
+        let prod = BundleConfig::production();
+        assert!(prod.minify);
+        assert!(prod.tree_shaking);
+        assert!(!prod.sourcemap);
+
+        let dev = BundleConfig::development();
+        assert!(!dev.minify);
+        assert!(dev.tree_shaking);
+        assert!(dev.sourcemap);
+    }
+
+    #[test]
+    fn esbuild_subprocess_config_env_override_is_honoured() {
+        // Snapshot, mutate, restore.
+        let prev = std::env::var_os("ZFB_ESBUILD_BIN");
+        std::env::set_var("ZFB_ESBUILD_BIN", "/tmp/zfb-esbuild-overridden");
+        let cfg = EsbuildSubprocessConfig::default();
+        assert_eq!(
+            cfg.binary_path,
+            PathBuf::from("/tmp/zfb-esbuild-overridden")
+        );
+        match prev {
+            Some(v) => std::env::set_var("ZFB_ESBUILD_BIN", v),
+            None => std::env::remove_var("ZFB_ESBUILD_BIN"),
+        }
+    }
+}

--- a/crates/zfb-islands/src/esbuild.rs
+++ b/crates/zfb-islands/src/esbuild.rs
@@ -44,7 +44,14 @@ pub struct EsbuildSubprocessConfig {
 
     /// Extra CLI args appended to the subprocess invocation, for escape
     /// hatches like `--define:process.env.NODE_ENV='production'`. Passed
-    /// verbatim.
+    /// verbatim — each element becomes a separate `argv` entry, so shell
+    /// quoting is not needed and shell injection is not possible.
+    ///
+    /// **Trust boundary**: callers are expected to assemble these from
+    /// build configuration (zfb.config.ts, env vars under operator
+    /// control), NOT from end-user input. The same caveat applies to
+    /// island `source_path`s — they come from project-local source files
+    /// the scanner has identified, not from user-supplied data.
     pub extra_args: Vec<OsString>,
 
     /// When true, the bundler will return a *fake* JS payload instead of

--- a/crates/zfb-islands/src/esbuild.rs
+++ b/crates/zfb-islands/src/esbuild.rs
@@ -259,12 +259,6 @@ pub fn hash_8(js: &str) -> String {
     full[..8].to_string()
 }
 
-/// Build the public URL for the islands JS asset.
-///
-/// `base_url` is concatenated with the asset path's filename portion under
-/// an `assets/` segment. `base_url` is normalised to drop any trailing `/`.
-/// Exact mirror of `zfb_css::link_href`.
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/zfb-islands/src/future_rust_native.rs
+++ b/crates/zfb-islands/src/future_rust_native.rs
@@ -21,6 +21,10 @@
 //! Until then, this stub guards the API surface against drift: if someone
 //! widens [`crate::ClientBundler`] without updating both bundlers, the
 //! build breaks here, not in production.
+//!
+//! Module name mirrors `zfb_css::native_engine` — Sub 1 named the same
+//! analog `future_rust_native` here, so that name is canonical for
+//! `zfb_islands`.
 
 use anyhow::{anyhow, Result};
 
@@ -46,7 +50,7 @@ impl ClientBundler for NativeRustBundler {
     fn bundle(&self, _islands: &[Island], _config: &BundleConfig) -> Result<BundleOutput> {
         Err(anyhow!(
             "NativeRustBundler: not yet implemented. \
-             Use EsbuildSubprocessBundler for now; see crate::native_bundler for the roadmap."
+             Use EsbuildSubprocessBundler for now; see crate::future_rust_native for the roadmap."
         ))
     }
 }

--- a/crates/zfb-islands/src/future_rust_native.rs
+++ b/crates/zfb-islands/src/future_rust_native.rs
@@ -62,8 +62,7 @@ mod tests {
         let bundler = NativeRustBundler::new();
         let err = bundler
             .bundle(&[], &BundleConfig::default())
-            .err()
-            .expect("must return an error");
+            .expect_err("must return an error");
         let msg = format!("{err}");
         assert!(msg.contains("not yet implemented"), "msg = {msg}");
     }

--- a/crates/zfb-islands/src/future_rust_native.rs
+++ b/crates/zfb-islands/src/future_rust_native.rs
@@ -1,0 +1,70 @@
+//! Placeholder Rust-native islands bundler.
+//!
+//! This module exists so the [`crate::ClientBundler`] swap-in story is
+//! visible in code, not just in docs. [`NativeRustBundler`] implements the
+//! trait — but every method returns a "not yet implemented" error.
+//!
+//! ## Roadmap
+//!
+//! esbuild ships as a Go-built CLI. A pure-Rust port (oxc_minifier on top
+//! of oxc_resolver, rolldown, mako, …) is out of scope for the v0 build
+//! pipeline (Epic 6 / Sub 2). When one becomes viable, we want the swap
+//! to be a one-line change at the call site:
+//!
+//! ```ignore
+//! // before:
+//! let bundler = EsbuildSubprocessBundler::with_default_config();
+//! // after:
+//! let bundler = NativeRustBundler::default();
+//! ```
+//!
+//! Until then, this stub guards the API surface against drift: if someone
+//! widens [`crate::ClientBundler`] without updating both bundlers, the
+//! build breaks here, not in production. (Same rationale as
+//! `zfb_css::native_engine::NativeRustEngine`.)
+
+use anyhow::{anyhow, Result};
+
+use crate::bundler::{BundleConfig, BundleOutput, ClientBundler, Island};
+
+/// A non-functional placeholder for a future pure-Rust islands bundler.
+/// Construction succeeds; every method returns an error.
+///
+/// See the module-level docs for the swap-in story.
+#[derive(Debug, Default, Clone)]
+pub struct NativeRustBundler {
+    _private: (),
+}
+
+impl NativeRustBundler {
+    /// Construct a new instance. (Cheap: this bundler carries no state.)
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl ClientBundler for NativeRustBundler {
+    fn bundle(&self, _islands: &[Island], _config: &BundleConfig) -> Result<BundleOutput> {
+        Err(anyhow!(
+            "NativeRustBundler: not yet implemented. \
+             Use EsbuildSubprocessBundler (Sub 2) for now; \
+             see crate::future_rust_native for the roadmap."
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_not_implemented_error() {
+        let bundler = NativeRustBundler::new();
+        let err = bundler
+            .bundle(&[], &BundleConfig::default())
+            .err()
+            .expect("must return an error");
+        let msg = format!("{err}");
+        assert!(msg.contains("not yet implemented"), "msg = {msg}");
+    }
+}

--- a/crates/zfb-islands/src/hydration.rs
+++ b/crates/zfb-islands/src/hydration.rs
@@ -1,0 +1,418 @@
+//! Hydration HTML emit.
+//!
+//! Given a page's server-rendered HTML and a set of *islands* that were
+//! actually used by that page, rewrite each island's outer markup so it
+//! carries the metadata the client-side hydration runtime walks.
+//!
+//! Output shape per island:
+//!
+//! ```html
+//! <div data-zfb-island="ComponentName"
+//!      data-props="<json-encoded props, html-escaped>"
+//!      data-when="visible|idle|load">
+//!   …server-output…
+//! </div>
+//! ```
+//!
+//! ## Locating islands in the rendered HTML
+//!
+//! Locating an island deterministically inside an opaque HTML blob is the
+//! tricky bit. There are two reasonable approaches:
+//!
+//! 1. **Marker-based.** The renderer wraps each island's server output with
+//!    a sentinel pair (here: HTML comments shaped like
+//!    `<!--zfb-island:KEY-->…<!--/zfb-island:KEY-->`). Sub 3 owns the
+//!    rewriter; the renderer in `zfb-render` and the `<Island>` wrapper in
+//!    Sub 4 are expected to emit markers as they integrate.
+//!
+//! 2. **AST-based.** Parse the rendered HTML and locate islands structurally.
+//!    This is more robust against hand-authored markup but adds an HTML parse
+//!    on every render and is overkill while the renderer is the only thing
+//!    producing islands.
+//!
+//! We pick **option 1** for now and keep the rewriter narrow enough that we
+//! can swap in an AST-based locator later behind the same public surface
+//! ([`rewrite_islands`]) without touching callers. The marker shape is
+//! intentionally a plain string so the renderer can emit it without dragging
+//! in this crate as a dependency.
+//!
+//! ### Follow-up: marker emission in the renderer
+//!
+//! The renderer in `zfb-render` does not yet emit these markers. That work
+//! belongs with the `<Island>` wrapper (Sub 4) and is tracked there. Until
+//! the renderer emits markers, the rewriter is exercised only by tests in
+//! this crate.
+
+use serde::Serialize;
+use thiserror::Error;
+
+/// One island actually used by a rendered page.
+///
+/// Field semantics:
+/// - [`component_name`](Self::component_name): stable identifier the runtime
+///   uses to pick the right component out of the islands bundle. Must match
+///   the export name produced by Sub 1's scanner.
+/// - [`props_json`](Self::props_json): the serialised props passed to the
+///   component at server-render time. Must already be valid JSON; the
+///   rewriter does not validate it (the renderer is expected to obtain it
+///   via `serde_json::to_string` on the same `JsonValue` it handed to the
+///   component).
+/// - [`marker_key`](Self::marker_key): the unique key the renderer used in
+///   the surrounding `<!--zfb-island:KEY-->` / `<!--/zfb-island:KEY-->`
+///   sentinel pair. Each key is expected to appear at most once per page.
+/// - [`when`](Self::when): optional `data-when` hydration hint. `None`
+///   means no attribute is emitted; the runtime treats the absent case as
+///   `"load"` (immediate hydration).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct IslandDescriptor {
+    /// Component export name as produced by the islands AST scanner.
+    pub component_name: String,
+    /// Pre-serialised props JSON. Must be valid JSON; rewriter does not
+    /// validate.
+    pub props_json: String,
+    /// The unique key used in the renderer's `<!--zfb-island:KEY-->` /
+    /// `<!--/zfb-island:KEY-->` sentinel pair around this island's server
+    /// output.
+    pub marker_key: String,
+    /// Optional `data-when` hint (`"visible"` / `"idle"` / `"load"`).
+    /// Owned by Sub 4's `<Island>` wrapper. `None` ⇒ omit the attribute.
+    pub when: Option<String>,
+}
+
+impl IslandDescriptor {
+    /// Build a descriptor with no `data-when` hint (immediate hydration).
+    pub fn new(
+        component_name: impl Into<String>,
+        props_json: impl Into<String>,
+        marker_key: impl Into<String>,
+    ) -> Self {
+        Self {
+            component_name: component_name.into(),
+            props_json: props_json.into(),
+            marker_key: marker_key.into(),
+            when: None,
+        }
+    }
+
+    /// Set a `data-when` hint. Caller is responsible for using one of the
+    /// runtime-recognised values (`"visible"`, `"idle"`, `"load"`).
+    pub fn with_when(mut self, when: impl Into<String>) -> Self {
+        self.when = Some(when.into());
+        self
+    }
+}
+
+/// Errors the rewriter surfaces when the input HTML and the descriptors are
+/// inconsistent. Callers should propagate these as build-time render errors;
+/// each variant points at the descriptor whose marker is at fault.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum IslandRewriteError {
+    /// The opening `<!--zfb-island:KEY-->` sentinel was not found in the
+    /// rendered HTML. Either the renderer skipped emitting it for this
+    /// island or the key is wrong.
+    #[error("opening marker not found for island `{component}` (key `{key}`)")]
+    OpenMarkerMissing {
+        /// Component name from the descriptor.
+        component: String,
+        /// Marker key from the descriptor.
+        key: String,
+    },
+    /// The closing `<!--/zfb-island:KEY-->` sentinel was missing or not
+    /// after the opening marker. Indicates a renderer bug.
+    #[error("closing marker not found for island `{component}` (key `{key}`)")]
+    CloseMarkerMissing {
+        /// Component name from the descriptor.
+        component: String,
+        /// Marker key from the descriptor.
+        key: String,
+    },
+    /// Two descriptors used the same `marker_key`. Each island must have a
+    /// distinct key per page; this is otherwise a silent footgun (the
+    /// rewriter would only match the first occurrence).
+    #[error("duplicate marker key `{key}`")]
+    DuplicateKey {
+        /// The duplicated marker key.
+        key: String,
+    },
+}
+
+/// Rewrite each island's marker-bracketed server output into the
+/// `<div data-zfb-island="…" data-props="…">…</div>` wrapper.
+///
+/// This is the swappable seam for the marker-based vs. AST-based approach
+/// described in the module docs. The signature is deliberately kept narrow
+/// (HTML in, HTML out, errors out) so the implementation can be replaced
+/// without touching call sites.
+///
+/// # Errors
+///
+/// - [`IslandRewriteError::DuplicateKey`] if two descriptors share a
+///   `marker_key`.
+/// - [`IslandRewriteError::OpenMarkerMissing`] /
+///   [`IslandRewriteError::CloseMarkerMissing`] if the renderer's sentinel
+///   pair for a descriptor is not present in the input HTML.
+pub fn rewrite_islands(
+    html: &str,
+    islands: &[IslandDescriptor],
+) -> Result<String, IslandRewriteError> {
+    // Reject duplicate keys up front. Duplicates would otherwise rewrite
+    // only the first occurrence and silently corrupt the page.
+    {
+        let mut seen: Vec<&str> = Vec::with_capacity(islands.len());
+        for d in islands {
+            if seen.contains(&d.marker_key.as_str()) {
+                return Err(IslandRewriteError::DuplicateKey {
+                    key: d.marker_key.clone(),
+                });
+            }
+            seen.push(&d.marker_key);
+        }
+    }
+
+    let mut out = String::from(html);
+    for d in islands {
+        let open = format!("<!--zfb-island:{}-->", d.marker_key);
+        let close = format!("<!--/zfb-island:{}-->", d.marker_key);
+
+        let open_idx = out
+            .find(&open)
+            .ok_or_else(|| IslandRewriteError::OpenMarkerMissing {
+                component: d.component_name.clone(),
+                key: d.marker_key.clone(),
+            })?;
+        let after_open = open_idx + open.len();
+        let close_rel = out[after_open..].find(&close).ok_or_else(|| {
+            IslandRewriteError::CloseMarkerMissing {
+                component: d.component_name.clone(),
+                key: d.marker_key.clone(),
+            }
+        })?;
+        let close_idx = after_open + close_rel;
+        let inner = &out[after_open..close_idx];
+
+        let replacement = render_wrapper(d, inner);
+
+        let end_idx = close_idx + close.len();
+        let mut rebuilt = String::with_capacity(out.len() + replacement.len());
+        rebuilt.push_str(&out[..open_idx]);
+        rebuilt.push_str(&replacement);
+        rebuilt.push_str(&out[end_idx..]);
+        out = rebuilt;
+    }
+    Ok(out)
+}
+
+/// Build the `<div data-zfb-island="…" …>…</div>` wrapper for a single
+/// island. Internal helper; tests cover the attribute-escaping rules.
+fn render_wrapper(d: &IslandDescriptor, inner: &str) -> String {
+    let mut s = String::with_capacity(inner.len() + 96);
+    s.push_str("<div data-zfb-island=\"");
+    s.push_str(&escape_attr(&d.component_name));
+    s.push_str("\" data-props=\"");
+    s.push_str(&escape_attr(&d.props_json));
+    s.push('"');
+    if let Some(when) = &d.when {
+        s.push_str(" data-when=\"");
+        s.push_str(&escape_attr(when));
+        s.push('"');
+    }
+    s.push('>');
+    s.push_str(inner);
+    s.push_str("</div>");
+    s
+}
+
+/// HTML-escape a value for use inside a double-quoted attribute. We escape
+/// the four characters that can break out of an attribute (`&`, `<`, `>`,
+/// `"`) and leave everything else verbatim. JSON in `data-props` contains
+/// double quotes routinely, so this step is load-bearing.
+fn escape_attr(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for c in value.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// Build the `<script type="module" …>` tag the renderer drops into the
+/// page's `<head>` (or end-of-`<body>`) so the hydration runtime can find
+/// the islands bundle.
+///
+/// Two attributes are set:
+/// - `src` — the runtime script URL (the small ~3 KB hydration runtime).
+/// - `data-zfb-bundle` — the islands bundle URL (`dist/assets/islands-{hash}.js`),
+///   which the runtime reads off its own `<script>` element via
+///   `document.currentScript` (or by querying the attribute).
+///
+/// Both URLs are HTML-attribute-escaped.
+pub fn hydration_script_tag(runtime_url: &str, bundle_url: &str) -> String {
+    format!(
+        "<script type=\"module\" src=\"{runtime}\" data-zfb-bundle=\"{bundle}\"></script>",
+        runtime = escape_attr(runtime_url),
+        bundle = escape_attr(bundle_url),
+    )
+}
+
+/// Build a marker-pair the renderer can emit around a server-rendered
+/// island's HTML. Exposed so renderer code can construct the same shape
+/// the rewriter consumes without re-deriving it.
+pub fn island_marker_pair(key: &str) -> (String, String) {
+    (
+        format!("<!--zfb-island:{key}-->"),
+        format!("<!--/zfb-island:{key}-->"),
+    )
+}
+
+/// Wrap `inner` in the marker pair for `key`. Test helper / convenience.
+#[doc(hidden)]
+pub fn wrap_with_markers(key: &str, inner: &str) -> String {
+    let (open, close) = island_marker_pair(key);
+    let mut s = String::with_capacity(open.len() + inner.len() + close.len());
+    s.push_str(&open);
+    s.push_str(inner);
+    s.push_str(&close);
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn page_with(inner: &str) -> String {
+        format!("<html><body><h1>Page</h1>{inner}<footer>fin</footer></body></html>")
+    }
+
+    #[test]
+    fn rewrites_single_island_into_data_attribute_wrapper() {
+        let inner = wrap_with_markers("counter#0", "<button>3</button>");
+        let html = page_with(&inner);
+        let d = IslandDescriptor::new("Counter", r#"{"start":3}"#, "counter#0");
+        let out = rewrite_islands(&html, &[d]).unwrap();
+        assert!(
+            out.contains(
+                r#"<div data-zfb-island="Counter" data-props="{&quot;start&quot;:3}"><button>3</button></div>"#
+            ),
+            "actual: {out}"
+        );
+        // Markers are gone from the output.
+        assert!(!out.contains("<!--zfb-island:"));
+        assert!(!out.contains("<!--/zfb-island:"));
+    }
+
+    #[test]
+    fn emits_data_when_attribute_only_when_present() {
+        let inner = wrap_with_markers("k", "<x/>");
+        let html = page_with(&inner);
+        let d = IslandDescriptor::new("Foo", "{}", "k").with_when("visible");
+        let out = rewrite_islands(&html, &[d]).unwrap();
+        assert!(out.contains(r#"data-when="visible""#));
+
+        let inner = wrap_with_markers("k", "<x/>");
+        let html = page_with(&inner);
+        let d = IslandDescriptor::new("Foo", "{}", "k");
+        let out = rewrite_islands(&html, &[d]).unwrap();
+        assert!(!out.contains("data-when="));
+    }
+
+    #[test]
+    fn handles_multiple_islands_in_order() {
+        let mut html = String::from("<html><body>");
+        html.push_str(&wrap_with_markers("a", "<i>1</i>"));
+        html.push_str("<hr>");
+        html.push_str(&wrap_with_markers("b", "<i>2</i>"));
+        html.push_str("</body></html>");
+
+        let descriptors = vec![
+            IslandDescriptor::new("A", "{}", "a"),
+            IslandDescriptor::new("B", r#"{"x":1}"#, "b"),
+        ];
+        let out = rewrite_islands(&html, &descriptors).unwrap();
+        let pos_a = out.find(r#"data-zfb-island="A""#).unwrap();
+        let pos_b = out.find(r#"data-zfb-island="B""#).unwrap();
+        assert!(pos_a < pos_b);
+        assert!(out.contains("<i>1</i>"));
+        assert!(out.contains("<i>2</i>"));
+    }
+
+    #[test]
+    fn errors_when_open_marker_is_missing() {
+        let html = page_with("<span>plain</span>");
+        let d = IslandDescriptor::new("Foo", "{}", "missing");
+        let err = rewrite_islands(&html, &[d]).unwrap_err();
+        assert!(matches!(err, IslandRewriteError::OpenMarkerMissing { .. }));
+    }
+
+    #[test]
+    fn errors_when_close_marker_is_missing() {
+        let html = "<html><body><!--zfb-island:k--><span>x</span></body></html>";
+        let d = IslandDescriptor::new("Foo", "{}", "k");
+        let err = rewrite_islands(html, &[d]).unwrap_err();
+        assert!(matches!(err, IslandRewriteError::CloseMarkerMissing { .. }));
+    }
+
+    #[test]
+    fn errors_on_duplicate_marker_keys() {
+        let html = page_with(&wrap_with_markers("k", "<x/>"));
+        let descriptors = vec![
+            IslandDescriptor::new("A", "{}", "k"),
+            IslandDescriptor::new("B", "{}", "k"),
+        ];
+        let err = rewrite_islands(&html, &descriptors).unwrap_err();
+        assert!(matches!(err, IslandRewriteError::DuplicateKey { .. }));
+    }
+
+    #[test]
+    fn escapes_attributes_correctly() {
+        // Component name and props with `<`, `&`, `"`, `>` all need
+        // attribute escaping. Using realistic JSON props makes the test
+        // closer to production.
+        let inner = wrap_with_markers("k", "<i>x</i>");
+        let html = page_with(&inner);
+        let props = r#"{"text":"<a & \"b\">"}"#;
+        let d = IslandDescriptor::new("My&Comp", props, "k");
+        let out = rewrite_islands(&html, &[d]).unwrap();
+        assert!(out.contains(r#"data-zfb-island="My&amp;Comp""#));
+        assert!(out.contains("&quot;"));
+        assert!(out.contains("&lt;"));
+        assert!(out.contains("&gt;"));
+        // The literal raw `"` from props_json must NOT appear inside the
+        // attribute (it would break out of the attribute).
+        let attr_start = out.find("data-props=\"").unwrap() + "data-props=\"".len();
+        let attr_end = out[attr_start..].find('"').unwrap() + attr_start;
+        let attr_value = &out[attr_start..attr_end];
+        assert!(!attr_value.contains('"'));
+    }
+
+    #[test]
+    fn hydration_script_tag_escapes_urls() {
+        let tag = hydration_script_tag(
+            "/runtime?v=1&t=2",
+            "/dist/assets/islands-deadbeef.js?\"oops",
+        );
+        assert!(tag.starts_with("<script type=\"module\""));
+        assert!(tag.contains(r#"src="/runtime?v=1&amp;t=2""#));
+        // Bundle URL `"` must be escaped.
+        assert!(tag.contains("&quot;oops"));
+        assert!(tag.contains("data-zfb-bundle="));
+    }
+
+    #[test]
+    fn island_marker_pair_shape_is_stable() {
+        let (o, c) = island_marker_pair("counter#3");
+        assert_eq!(o, "<!--zfb-island:counter#3-->");
+        assert_eq!(c, "<!--/zfb-island:counter#3-->");
+    }
+
+    #[test]
+    fn no_descriptors_is_a_no_op() {
+        let html = page_with("<span>plain</span>");
+        let out = rewrite_islands(&html, &[]).unwrap();
+        assert_eq!(out, html);
+    }
+}

--- a/crates/zfb-islands/src/hydration.rs
+++ b/crates/zfb-islands/src/hydration.rs
@@ -222,10 +222,12 @@ fn render_wrapper(d: &IslandDescriptor, inner: &str) -> String {
     s
 }
 
-/// HTML-escape a value for use inside a double-quoted attribute. We escape
-/// the four characters that can break out of an attribute (`&`, `<`, `>`,
-/// `"`) and leave everything else verbatim. JSON in `data-props` contains
-/// double quotes routinely, so this step is load-bearing.
+/// HTML-escape a value for use inside an attribute value. We escape the
+/// five characters that can break out of an attribute or change its
+/// meaning (`&`, `<`, `>`, `"`, `'`) and leave everything else verbatim.
+/// Single-quote escaping is defence-in-depth: today the rewriter only
+/// emits double-quoted attributes, but consumers / downstream rewriters
+/// may not, and `&#39;` is cheap.
 fn escape_attr(value: &str) -> String {
     let mut out = String::with_capacity(value.len());
     for c in value.chars() {
@@ -234,6 +236,7 @@ fn escape_attr(value: &str) -> String {
             '<' => out.push_str("&lt;"),
             '>' => out.push_str("&gt;"),
             '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&#39;"),
             other => out.push(other),
         }
     }

--- a/crates/zfb-islands/src/hydration.rs
+++ b/crates/zfb-islands/src/hydration.rs
@@ -240,6 +240,99 @@ fn escape_attr(value: &str) -> String {
     out
 }
 
+/// Errors the attribute-skeleton bridge ([`rewrite_islands_in_attr_skeleton`])
+/// surfaces when the rendered HTML and the descriptors do not match up.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum IslandSkeletonRewriteError {
+    /// The number of empty `data-zfb-island=""` skeletons in the rendered
+    /// HTML does not equal the number of descriptors. Indicates an
+    /// orchestration bug in the renderer.
+    #[error(
+        "skeleton/descriptor count mismatch: {skeletons} skeletons but {descriptors} descriptors"
+    )]
+    CountMismatch {
+        /// Number of `data-zfb-island=""` skeletons found in the input HTML.
+        skeletons: usize,
+        /// Number of descriptors passed in.
+        descriptors: usize,
+    },
+}
+
+/// Bridge rewriter for HTML emitted by Sub 4's `<Island when="…">` JSX
+/// wrapper, which produces `<div data-zfb-island="" data-when="…">…</div>`
+/// skeletons at server-render time.
+///
+/// Pairs each empty-`data-zfb-island` skeleton with one descriptor in
+/// document order: the Nth skeleton receives the Nth descriptor. The
+/// renderer is responsible for ordering descriptors to match the order in
+/// which `<Island>` instances are encountered when walking the rendered
+/// page (depth-first, left-to-right — the natural JSX traversal order).
+///
+/// Each skeleton's `data-zfb-island=""` is replaced with
+/// `data-zfb-island="ComponentName"`, and `data-props="…json…"` is
+/// inserted alongside. The skeleton's existing `data-when` attribute, set
+/// by the wrapper, is left untouched. If the descriptor's `when` field is
+/// `Some(_)`, it is **not** used here — Sub 4's wrapper is the source of
+/// truth for `data-when` whenever a skeleton is present.
+///
+/// This function is the "bridge B" agreed by topic-hydration-emit (Sub 3)
+/// and topic-island-wrapper (Sub 4): the marker-comment path in
+/// [`rewrite_islands`] stays untouched for renderer code paths that emit
+/// sentinel comments around server output, and this skeleton path handles
+/// the JSX wrapper case directly.
+///
+/// # Errors
+///
+/// - [`IslandSkeletonRewriteError::CountMismatch`] if the skeleton count
+///   in the input HTML does not equal the descriptor count.
+pub fn rewrite_islands_in_attr_skeleton(
+    html: &str,
+    islands: &[IslandDescriptor],
+) -> Result<String, IslandSkeletonRewriteError> {
+    // Find every empty data-zfb-island="" attribute occurrence. Match on
+    // the literal attribute pair (with a leading space so we don't match
+    // a non-data-zfb-island prefix).
+    const NEEDLE: &str = " data-zfb-island=\"\"";
+
+    let mut positions: Vec<usize> = Vec::new();
+    {
+        let mut search_from = 0;
+        while let Some(rel) = html[search_from..].find(NEEDLE) {
+            let abs = search_from + rel;
+            positions.push(abs);
+            search_from = abs + NEEDLE.len();
+        }
+    }
+
+    if positions.len() != islands.len() {
+        return Err(IslandSkeletonRewriteError::CountMismatch {
+            skeletons: positions.len(),
+            descriptors: islands.len(),
+        });
+    }
+
+    // Walk in reverse order so earlier positions remain valid indices into
+    // the buffer as we splice in longer replacement strings.
+    let mut out = String::from(html);
+    for (i, &pos) in positions.iter().enumerate().rev() {
+        let d = &islands[i];
+        let mut replacement = String::with_capacity(NEEDLE.len() + d.props_json.len() + 64);
+        replacement.push_str(" data-zfb-island=\"");
+        replacement.push_str(&escape_attr(&d.component_name));
+        replacement.push_str("\" data-props=\"");
+        replacement.push_str(&escape_attr(&d.props_json));
+        replacement.push('"');
+
+        let end = pos + NEEDLE.len();
+        let mut rebuilt = String::with_capacity(out.len() + replacement.len() - NEEDLE.len());
+        rebuilt.push_str(&out[..pos]);
+        rebuilt.push_str(&replacement);
+        rebuilt.push_str(&out[end..]);
+        out = rebuilt;
+    }
+    Ok(out)
+}
+
 /// Build the `<script type="module" …>` tag the renderer drops into the
 /// page's `<head>` (or end-of-`<body>`) so the hydration runtime can find
 /// the islands bundle.
@@ -413,6 +506,63 @@ mod tests {
     fn no_descriptors_is_a_no_op() {
         let html = page_with("<span>plain</span>");
         let out = rewrite_islands(&html, &[]).unwrap();
+        assert_eq!(out, html);
+    }
+
+    // ---- Bridge: rewrite_islands_in_attr_skeleton (Sub 4 wrapper output) ----
+
+    #[test]
+    fn skeleton_bridge_fills_empty_data_zfb_island() {
+        // Single skeleton emitted by Sub 4's <Island when="visible">.
+        let html = r#"<html><body><div data-zfb-island="" data-when="visible"><button>3</button></div></body></html>"#;
+        let d = IslandDescriptor::new("Counter", r#"{"start":3}"#, "k");
+        let out = rewrite_islands_in_attr_skeleton(html, &[d]).unwrap();
+        assert!(out.contains(r#"data-zfb-island="Counter""#));
+        assert!(out.contains(r#"data-props="{&quot;start&quot;:3}""#));
+        // data-when from the wrapper is preserved.
+        assert!(out.contains(r#"data-when="visible""#));
+        // Inner content is left alone.
+        assert!(out.contains("<button>3</button>"));
+    }
+
+    #[test]
+    fn skeleton_bridge_pairs_in_document_order() {
+        // Two skeletons; descriptors must match positional order.
+        let html = r#"<html><body><div data-zfb-island="" data-when="visible"><i>a</i></div><span>between</span><div data-zfb-island="" data-when="idle"><i>b</i></div></body></html>"#;
+        let descriptors = vec![
+            IslandDescriptor::new("A", "{}", "k1"),
+            IslandDescriptor::new("B", "{}", "k2"),
+        ];
+        let out = rewrite_islands_in_attr_skeleton(html, &descriptors).unwrap();
+        let pos_a = out.find(r#"data-zfb-island="A""#).unwrap();
+        let pos_b = out.find(r#"data-zfb-island="B""#).unwrap();
+        assert!(pos_a < pos_b);
+        // Both data-when values from the wrapper preserved.
+        assert!(out.contains(r#"data-when="visible""#));
+        assert!(out.contains(r#"data-when="idle""#));
+    }
+
+    #[test]
+    fn skeleton_bridge_count_mismatch_is_an_error() {
+        let html = r#"<div data-zfb-island="" data-when="load"><i>x</i></div>"#;
+        let descriptors = vec![
+            IslandDescriptor::new("A", "{}", "k1"),
+            IslandDescriptor::new("B", "{}", "k2"),
+        ];
+        let err = rewrite_islands_in_attr_skeleton(html, &descriptors).unwrap_err();
+        assert_eq!(
+            err,
+            IslandSkeletonRewriteError::CountMismatch {
+                skeletons: 1,
+                descriptors: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn skeleton_bridge_no_skeletons_no_descriptors_is_ok() {
+        let html = "<html><body><span>plain</span></body></html>";
+        let out = rewrite_islands_in_attr_skeleton(html, &[]).unwrap();
         assert_eq!(out, html);
     }
 }

--- a/crates/zfb-islands/src/lib.rs
+++ b/crates/zfb-islands/src/lib.rs
@@ -4,41 +4,41 @@
 //!
 //! 1. Scan project sources for components carrying the `"use client"`
 //!    directive and produce a deterministic islands set
-//!    (Sub 1 — owned by topic-ast-scanner; lands in `scanner` module).
+//!    (Sub 1 — owned by topic-ast-scanner; lands in the `scanner` module).
 //!
 //! 2. Bundle each island entry point into a single hashed JS asset
 //!    (`dist/assets/islands-{hash}.js`) by shelling out to the esbuild CLI
 //!    (this crate's [`bundler`] module — Sub 2). The implementation mirrors
-//!    the [`zfb-css`](../zfb_css/index.html) crate's
-//!    `TailwindSubprocessEngine` pattern: a `ClientBundler` trait, a
-//!    subprocess implementation, and a placeholder native-Rust stub for the
-//!    future swap-in (see [`native_bundler`]).
+//!    the `zfb-css` crate's `TailwindSubprocessEngine` pattern: a
+//!    `ClientBundler` trait, a subprocess implementation, and a placeholder
+//!    native-Rust stub for the future swap-in (see [`future_rust_native`]).
 //!
 //! 3. Emit hydration markup and runtime glue
-//!    (Sub 3 — owned by topic-hydration-emit; lands in `emit` module).
+//!    (Sub 3 — owned by topic-hydration-emit; lands in the `emit` module).
 //!
 //! ## Layering
 //!
 //! `zfb-islands` deliberately does **not** depend on `zfb-render`. It takes
 //! source paths in and returns asset paths plus URLs out. The renderer is
-//! responsible for actually injecting `<script type="module" src="...">` into
-//! the page. The helper [`bundler::link_href`] derives the public URL from
-//! the asset path so the renderer (and Sub 3's hydration emitter) can do so
-//! without re-hashing.
+//! responsible for actually injecting `<script type="module" src="...">`
+//! into the page. The helper [`bundler::bundle_link_href`] derives the
+//! public URL from the asset path so the renderer (and Sub 3's hydration
+//! emitter) can do so without re-hashing.
 //!
 //! ## Status
 //!
 //! Sub 2 (this commit) lands the bundler module + its native-rust stub +
-//! the binary distribution slot at `crates/zfb/binaries/esbuild`. Sub 1 will
-//! add the scanner module and may refine the `Island` / `ClientBundler`
-//! types — call sites should prefer the re-exports from this crate root so
-//! that refinement stays a single-site change.
+//! the binary distribution slot at `crates/zfb/binaries/esbuild`. Sub 1
+//! lands the `Island` / `BundleConfig` / `BundleOutput` / `ModuleId` /
+//! `ClientBundler` types and the scanner module — call sites should prefer
+//! the re-exports from this crate root so that future refinement stays a
+//! single-site change.
 
 pub mod bundler;
-pub mod native_bundler;
+pub mod future_rust_native;
 
 pub use bundler::{
-    link_href, BundleConfig, BundleOutput, ClientBundler, EsbuildSubprocessBundler,
-    EsbuildSubprocessConfig, Island,
+    bundle_link_href, BundleConfig, BundleOutput, ClientBundler, EsbuildSubprocessBundler,
+    EsbuildSubprocessConfig, Island, ModuleId,
 };
-pub use native_bundler::NativeRustBundler;
+pub use future_rust_native::NativeRustBundler;

--- a/crates/zfb-islands/src/lib.rs
+++ b/crates/zfb-islands/src/lib.rs
@@ -1,0 +1,15 @@
+//! zfb-islands: islands runtime support crate.
+//!
+//! Module slots:
+//! - [`hydration`] — server-side HTML rewrite that turns each rendered island's
+//!   marker-bracketed output into the `<div data-zfb-island="…" data-props="…">`
+//!   wrapper the client-side hydration runtime walks. Owned by Sub 3.
+//!
+//! Sub 1 is expected to add an AST scanner module here (e.g. `scanner`) and a
+//! `ClientBundler` trait module. Sub 4 will add the build-time `<Island>`
+//! wrapper transform. Each sub-task lives in its own module under this crate
+//! so the surface stays orthogonal.
+
+pub mod hydration;
+
+pub use hydration::{hydration_script_tag, rewrite_islands, IslandDescriptor, IslandRewriteError};

--- a/crates/zfb-islands/src/lib.rs
+++ b/crates/zfb-islands/src/lib.rs
@@ -39,7 +39,10 @@ pub use bundler::{
 };
 pub use esbuild::{hash_8, EsbuildSubprocessBundler, EsbuildSubprocessConfig};
 pub use future_rust_native::NativeRustBundler;
-pub use hydration::{hydration_script_tag, rewrite_islands, IslandDescriptor, IslandRewriteError};
+pub use hydration::{
+    hydration_script_tag, rewrite_islands, rewrite_islands_in_attr_skeleton, IslandDescriptor,
+    IslandRewriteError, IslandSkeletonRewriteError,
+};
 pub use scanner::{
     is_bare_specifier, normalize_path_lexical, scan_islands, FsResolver, InMemoryResolver,
     IslandsSet, Resolver, ScanError, ScanResult,

--- a/crates/zfb-islands/src/lib.rs
+++ b/crates/zfb-islands/src/lib.rs
@@ -1,0 +1,35 @@
+//! `zfb-islands` — the islands runtime half of the zudo-front-builder build
+//! pipeline.
+//!
+//! Responsibilities (this crate covers Sub 1 of Epic #6):
+//!
+//! 1. Detect React/Preact `"use client"` components reachable from page
+//!    entries and produce a deterministic, sorted islands set keyed by
+//!    stable component-name identity (file path + exported name). See
+//!    [`scanner`].
+//!
+//! 2. Define the public [`ClientBundler`] trait — the contract the islands
+//!    bundler (Sub 2) implements. The trait wraps the future esbuild
+//!    subprocess engine and documents the swap-in story for a future
+//!    Rust-native bundler (placeholder lives in [`future_rust_native`],
+//!    analog of `zfb_css::native_engine`).
+//!
+//! ## Layering
+//!
+//! Like `zfb-css`, this crate deliberately does **not** depend on
+//! `zfb-render`. It takes paths and source content as input (via a
+//! [`scanner::Resolver`] the caller supplies) and returns plain Rust types.
+//! Wiring into the full render orchestrator happens in Epic 7.
+
+pub mod bundler;
+pub mod future_rust_native;
+pub mod scanner;
+
+pub use bundler::{
+    bundle_link_href, BundleConfig, BundleOutput, ClientBundler, Island, ModuleId,
+};
+pub use future_rust_native::NativeRustBundler;
+pub use scanner::{
+    is_bare_specifier, normalize_path_lexical, scan_islands, FsResolver, InMemoryResolver,
+    IslandsSet, Resolver, ScanError, ScanResult,
+};

--- a/crates/zfb-islands/src/lib.rs
+++ b/crates/zfb-islands/src/lib.rs
@@ -1,0 +1,44 @@
+//! `zfb-islands` — the islands runtime half of the zfb build pipeline.
+//!
+//! Responsibilities (Epic 6 / issue #6):
+//!
+//! 1. Scan project sources for components carrying the `"use client"`
+//!    directive and produce a deterministic islands set
+//!    (Sub 1 — owned by topic-ast-scanner; lands in `scanner` module).
+//!
+//! 2. Bundle each island entry point into a single hashed JS asset
+//!    (`dist/assets/islands-{hash}.js`) by shelling out to the esbuild CLI
+//!    (this crate's [`bundler`] module — Sub 2). The implementation mirrors
+//!    the [`zfb-css`](../zfb_css/index.html) crate's
+//!    `TailwindSubprocessEngine` pattern: a `ClientBundler` trait, a
+//!    subprocess implementation, and a placeholder native-Rust stub for the
+//!    future swap-in (see [`native_bundler`]).
+//!
+//! 3. Emit hydration markup and runtime glue
+//!    (Sub 3 — owned by topic-hydration-emit; lands in `emit` module).
+//!
+//! ## Layering
+//!
+//! `zfb-islands` deliberately does **not** depend on `zfb-render`. It takes
+//! source paths in and returns asset paths plus URLs out. The renderer is
+//! responsible for actually injecting `<script type="module" src="...">` into
+//! the page. The helper [`bundler::link_href`] derives the public URL from
+//! the asset path so the renderer (and Sub 3's hydration emitter) can do so
+//! without re-hashing.
+//!
+//! ## Status
+//!
+//! Sub 2 (this commit) lands the bundler module + its native-rust stub +
+//! the binary distribution slot at `crates/zfb/binaries/esbuild`. Sub 1 will
+//! add the scanner module and may refine the `Island` / `ClientBundler`
+//! types — call sites should prefer the re-exports from this crate root so
+//! that refinement stays a single-site change.
+
+pub mod bundler;
+pub mod native_bundler;
+
+pub use bundler::{
+    link_href, BundleConfig, BundleOutput, ClientBundler, EsbuildSubprocessBundler,
+    EsbuildSubprocessConfig, Island,
+};
+pub use native_bundler::NativeRustBundler;

--- a/crates/zfb-islands/src/native_bundler.rs
+++ b/crates/zfb-islands/src/native_bundler.rs
@@ -1,0 +1,52 @@
+//! Placeholder Rust-native client bundler.
+//!
+//! This module exists so the [`crate::ClientBundler`] swap-in story is
+//! visible in code, not just in docs. [`NativeRustBundler`] implements the
+//! trait — but every method returns a "not yet implemented" error.
+//!
+//! ## Roadmap
+//!
+//! esbuild ships a Go-built CLI. A pure-Rust replacement (swc-bundler,
+//! turbopack-style, or our own) is out of scope for the v0 build pipeline
+//! (Epic 6) — but when one becomes viable, we want the swap to be a
+//! one-line change at the call site:
+//!
+//! ```ignore
+//! // before:
+//! let bundler = EsbuildSubprocessBundler::with_default_config();
+//! // after:
+//! let bundler = NativeRustBundler::default();
+//! ```
+//!
+//! Until then, this stub guards the API surface against drift: if someone
+//! widens [`crate::ClientBundler`] without updating both bundlers, the
+//! build breaks here, not in production.
+
+use anyhow::{anyhow, Result};
+
+use crate::bundler::{BundleConfig, BundleOutput, ClientBundler, Island};
+
+/// A non-functional placeholder for a future pure-Rust esbuild-equivalent
+/// bundler. Construction succeeds; every method returns an error.
+///
+/// See the module-level docs for the swap-in story.
+#[derive(Debug, Default, Clone)]
+pub struct NativeRustBundler {
+    _private: (),
+}
+
+impl NativeRustBundler {
+    /// Construct a new instance. (Cheap: this bundler carries no state.)
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl ClientBundler for NativeRustBundler {
+    fn bundle(&self, _islands: &[Island], _config: &BundleConfig) -> Result<BundleOutput> {
+        Err(anyhow!(
+            "NativeRustBundler: not yet implemented. \
+             Use EsbuildSubprocessBundler for now; see crate::native_bundler for the roadmap."
+        ))
+    }
+}

--- a/crates/zfb-islands/src/scanner.rs
+++ b/crates/zfb-islands/src/scanner.rs
@@ -1,0 +1,987 @@
+//! `"use client"` AST scanner.
+//!
+//! Given a list of page entry paths and a [`Resolver`], [`scan_islands`]
+//! walks every component imported (transitively) from every page and
+//! returns the deterministic, sorted islands set.
+//!
+//! ## Public-API contract
+//!
+//! - **Input**:
+//!   - `pages: &[PathBuf]` — entry paths (typically absolute) the caller
+//!     considers page roots. Whatever path representation the caller
+//!     hands in is the same representation that comes back inside
+//!     [`crate::Island::source_path`].
+//!   - `resolver: &impl Resolver` — abstracts both module resolution and
+//!     source reading. The default [`FsResolver`] hits the file system;
+//!     tests use [`InMemoryResolver`].
+//! - **Output**: an [`IslandsSet`] (`Vec<Island>`), sorted by
+//!   `(source_path, component_name)`. The order is byte-stable across runs
+//!   for a given input — downstream hashing (Sub 2) relies on this.
+//!
+//! ## "use client" detection
+//!
+//! A source file is an islands entry if and only if its leading directive
+//! prologue contains a string-literal expression statement whose value
+//! equals `"use client"` — same rule Next.js uses. The rules:
+//!
+//! - The prologue is the run of expression-statement string literals at
+//!   the top of the module. As soon as a non-string-literal-expr-stmt
+//!   appears (a real statement, an import, anything else), the prologue
+//!   ends.
+//! - Both single and double quotes are tolerated; the AST stores the
+//!   parsed value, not the source token, so quote style is invisible at
+//!   this level.
+//! - Other directives such as `"use strict"` may appear before, after, or
+//!   alongside `"use client"` in the prologue. We accept `"use client"` if
+//!   it appears anywhere in the prologue.
+//! - Comments before the directive are ignored — SWC's parser leaves them
+//!   out of the module body.
+//!
+//! ## Component identity
+//!
+//! Each `"use client"` file contributes one [`crate::Island`] per *exported
+//! binding name*. Specifically:
+//!
+//! - `export function Foo() {}` → `"Foo"`
+//! - `export class Foo {}` → `"Foo"`
+//! - `export const Foo = …` (and `let` / `var`) → `"Foo"`
+//! - `export default …` → the literal string `"default"`
+//! - `export { A, B as C }` → `"A"`, `"C"`
+//! - `export * as ns from "./mod"` → `"ns"`
+//! - `export d from "./mod"` (rare) → `"d"`
+//!
+//! The pair `(source_path, component_name)` is the stable identity used
+//! for dedup and ordering. Re-exports without a local declaration of the
+//! same component (e.g. `export { X } from "./other"`) do contribute their
+//! exported name; the bundler downstream sees the same file path and
+//! resolves the actual implementation through its own module resolver.
+//!
+//! ## Cycles and dedup
+//!
+//! The scanner tracks a visited set keyed by the resolved path the
+//! resolver returned, so cyclic imports terminate. Dedup is performed on
+//! the `(source_path, component_name)` pair via a `BTreeMap`, which also
+//! gives us the sort order on output for free.
+
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::path::{Component, Path, PathBuf};
+
+use swc_core::atoms::Wtf8Atom;
+use swc_core::common::sync::Lrc;
+use swc_core::common::{FileName, SourceMap};
+use swc_core::ecma::ast::{
+    Decl, EsVersion, Expr, ExportSpecifier, Lit, Module, ModuleDecl, ModuleExportName, ModuleItem,
+    Pat, Stmt,
+};
+use swc_core::ecma::parser::{lexer::Lexer, Parser, StringInput, Syntax, TsSyntax};
+use thiserror::Error;
+
+use crate::bundler::Island;
+
+/// Errors raised by [`scan_islands`].
+#[derive(Debug, Error)]
+pub enum ScanError {
+    /// The resolver returned an error reading the given path.
+    #[error("resolver failed for {path}: {message}")]
+    Resolver {
+        /// The path the scanner asked the resolver for.
+        path: PathBuf,
+        /// Stringified error message returned by the resolver.
+        message: String,
+    },
+    /// SWC could not parse the source as TS/TSX.
+    #[error("parse failed for {path}: {message}")]
+    Parse {
+        /// Path of the source that failed to parse.
+        path: PathBuf,
+        /// Diagnostic message from SWC.
+        message: String,
+    },
+}
+
+/// Convenience alias for scanner results.
+pub type ScanResult<T> = std::result::Result<T, ScanError>;
+
+/// The result of [`scan_islands`].
+pub type IslandsSet = Vec<Island>;
+
+/// Abstraction over module resolution + source reading.
+///
+/// The scanner doesn't know how a project lays out its files (real FS,
+/// virtual FS, an in-memory test harness) — it asks the resolver. Two
+/// methods, deliberately split:
+///
+/// - [`Resolver::resolve`] turns a `(importer_dir, specifier)` pair into a
+///   resolved path the scanner will use as both the visited-set key and
+///   the [`Island::source_path`].
+/// - [`Resolver::read`] reads a previously-resolved path back as a string.
+pub trait Resolver {
+    /// Resolve a relative `specifier` (`./foo`, `../bar/baz`) against the
+    /// importer's directory. Return `None` for bare specifiers (e.g.
+    /// `preact`, `react`, `zfb`) or unresolvable paths — the scanner will
+    /// then skip them.
+    fn resolve(&self, importer_dir: &Path, specifier: &str) -> Option<PathBuf>;
+
+    /// Read the source content for a previously-resolved path.
+    ///
+    /// The error type is `String` (rather than `std::io::Error` or a
+    /// trait-specific type) so test resolvers and FS resolvers can both
+    /// produce the same shape without lossy conversions.
+    fn read(&self, path: &Path) -> std::result::Result<String, String>;
+}
+
+/// Lexically normalise a path by collapsing `.` and `..` components
+/// without consulting the filesystem.
+///
+/// `..` is only popped when the previous component is a normal name; a
+/// `..` after a root or after another preserved `..` is left in place
+/// (so we never escape above a relative root). Useful both for the
+/// in-memory test resolver — where `/proj/pages/../components/x` must
+/// match the same key as `/proj/components/x` — and as a public helper
+/// for downstream code that wants the same dedup behaviour.
+pub fn normalize_path_lexical(p: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for comp in p.components() {
+        match comp {
+            Component::Prefix(_) | Component::RootDir => {
+                out.push(comp.as_os_str());
+            }
+            Component::CurDir => {}
+            Component::ParentDir => {
+                let last_is_normal = out
+                    .components()
+                    .next_back()
+                    .map(|c| matches!(c, Component::Normal(_)))
+                    .unwrap_or(false);
+                if last_is_normal {
+                    out.pop();
+                } else {
+                    out.push(comp.as_os_str());
+                }
+            }
+            Component::Normal(name) => out.push(name),
+        }
+    }
+    out
+}
+
+/// Whether a specifier is bare (no `./`, `../`, or `/` prefix).
+///
+/// Bare specifiers are runtime-provided by the framework adapter (see
+/// `zfb_render::loader`) and do not point at files on disk; the scanner
+/// must skip them to avoid spurious resolver errors.
+pub fn is_bare_specifier(specifier: &str) -> bool {
+    !(specifier.starts_with("./") || specifier.starts_with("../") || specifier.starts_with('/'))
+}
+
+/// Filesystem-backed [`Resolver`].
+///
+/// Probes the same extensions as `zfb_render`'s loader: `.tsx`, `.ts`,
+/// `.jsx`, `.js`, plus `index.<ext>` inside a directory.
+#[derive(Debug, Clone)]
+pub struct FsResolver {
+    /// File extensions probed for relative imports without an extension.
+    pub probe_exts: Vec<String>,
+}
+
+impl Default for FsResolver {
+    fn default() -> Self {
+        Self {
+            probe_exts: vec![
+                ".tsx".to_string(),
+                ".ts".to_string(),
+                ".jsx".to_string(),
+                ".js".to_string(),
+            ],
+        }
+    }
+}
+
+impl FsResolver {
+    /// Construct with the default extension probe order.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Resolver for FsResolver {
+    fn resolve(&self, importer_dir: &Path, specifier: &str) -> Option<PathBuf> {
+        if is_bare_specifier(specifier) {
+            return None;
+        }
+        let candidate = importer_dir.join(specifier);
+
+        // Helper: turn a found path into the canonical (symlink-resolved,
+        // `..`-collapsed) form so the visited set and Island::source_path
+        // are stable regardless of how many times the same file is reached
+        // through different specifiers.
+        let canonicalize = |p: PathBuf| p.canonicalize().unwrap_or(p);
+
+        // 1) Exact match.
+        if candidate.is_file() {
+            return Some(canonicalize(candidate));
+        }
+
+        // 2) Probe extensions.
+        for ext in &self.probe_exts {
+            let mut probe = candidate.clone();
+            let new_name = format!(
+                "{}{}",
+                probe.file_name().and_then(|s| s.to_str()).unwrap_or(""),
+                ext
+            );
+            probe.set_file_name(new_name);
+            if probe.is_file() {
+                return Some(canonicalize(probe));
+            }
+        }
+
+        // 3) `index.<ext>` inside a directory.
+        if candidate.is_dir() {
+            for ext in &self.probe_exts {
+                let probe = candidate.join(format!("index{ext}"));
+                if probe.is_file() {
+                    return Some(canonicalize(probe));
+                }
+            }
+        }
+
+        None
+    }
+
+    fn read(&self, path: &Path) -> std::result::Result<String, String> {
+        std::fs::read_to_string(path).map_err(|e| e.to_string())
+    }
+}
+
+/// In-memory [`Resolver`] for tests and integration harnesses.
+///
+/// Resolution probes the same extension list as [`FsResolver`], but
+/// against the in-memory `files` map instead of the file system.
+#[derive(Debug, Clone, Default)]
+pub struct InMemoryResolver {
+    /// Map of resolved-path → source text.
+    pub files: HashMap<PathBuf, String>,
+    /// Probe extensions; mirrors [`FsResolver::probe_exts`].
+    pub probe_exts: Vec<String>,
+}
+
+impl InMemoryResolver {
+    /// Construct a fresh resolver with the standard probe extensions.
+    pub fn new() -> Self {
+        Self {
+            files: HashMap::new(),
+            probe_exts: vec![
+                ".tsx".to_string(),
+                ".ts".to_string(),
+                ".jsx".to_string(),
+                ".js".to_string(),
+            ],
+        }
+    }
+
+    /// Insert a source file into the map (chainable).
+    pub fn with_file(mut self, path: impl Into<PathBuf>, source: impl Into<String>) -> Self {
+        self.files.insert(path.into(), source.into());
+        self
+    }
+
+    /// Insert a source file (mutating).
+    pub fn insert(&mut self, path: impl Into<PathBuf>, source: impl Into<String>) {
+        self.files.insert(path.into(), source.into());
+    }
+}
+
+impl Resolver for InMemoryResolver {
+    fn resolve(&self, importer_dir: &Path, specifier: &str) -> Option<PathBuf> {
+        if is_bare_specifier(specifier) {
+            return None;
+        }
+        // Lexically normalise the candidate so `pages/../components/x`
+        // matches the same key the test wrote with `components/x`.
+        let candidate = normalize_path_lexical(&importer_dir.join(specifier));
+
+        if self.files.contains_key(&candidate) {
+            return Some(candidate);
+        }
+
+        for ext in &self.probe_exts {
+            let mut probe = candidate.clone();
+            let new_name = format!(
+                "{}{}",
+                probe.file_name().and_then(|s| s.to_str()).unwrap_or(""),
+                ext
+            );
+            probe.set_file_name(new_name);
+            if self.files.contains_key(&probe) {
+                return Some(probe);
+            }
+        }
+
+        // `index.<ext>` probe (treat any path with a matching `index.*`
+        // child as a directory entry).
+        for ext in &self.probe_exts {
+            let probe = candidate.join(format!("index{ext}"));
+            if self.files.contains_key(&probe) {
+                return Some(probe);
+            }
+        }
+
+        None
+    }
+
+    fn read(&self, path: &Path) -> std::result::Result<String, String> {
+        self.files
+            .get(path)
+            .cloned()
+            .ok_or_else(|| format!("not found in InMemoryResolver: {}", path.display()))
+    }
+}
+
+/// Walk every page, resolve imports recursively, and collect every
+/// `"use client"` component reachable from any page.
+///
+/// `pages` should be the path representation the caller wants reflected
+/// back in [`Island::source_path`]; whatever the resolver returns from
+/// [`Resolver::resolve`] is what subsequently appears as the source path
+/// of any island found in or beyond that file.
+///
+/// The returned vector is sorted by `(source_path, component_name)` and
+/// deduped — duplicate entries (same path + name reachable through
+/// multiple chains) collapse to one.
+pub fn scan_islands<R: Resolver>(pages: &[PathBuf], resolver: &R) -> ScanResult<IslandsSet> {
+    // BTreeMap keyed by (path, name) gives us natural sort order on output
+    // and dedup for free.
+    let mut found: BTreeMap<(PathBuf, String), Island> = BTreeMap::new();
+    // Visited file set so cyclic imports terminate.
+    let mut visited: HashSet<PathBuf> = HashSet::new();
+    // DFS stack.
+    let mut stack: Vec<PathBuf> = pages.to_vec();
+
+    while let Some(current) = stack.pop() {
+        if !visited.insert(current.clone()) {
+            continue;
+        }
+
+        let source = resolver.read(&current).map_err(|message| ScanError::Resolver {
+            path: current.clone(),
+            message,
+        })?;
+
+        let module = parse_module(&current, &source)?;
+
+        if has_use_client_directive(&module) {
+            for name in exported_binding_names(&module) {
+                let key = (current.clone(), name.clone());
+                found
+                    .entry(key)
+                    .or_insert_with(|| Island::new(name, current.clone()));
+            }
+        }
+
+        // Walk imports → push resolved paths onto the stack.
+        let importer_dir = current
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."));
+        for specifier in collect_import_specifiers(&module) {
+            if is_bare_specifier(&specifier) {
+                continue;
+            }
+            if let Some(resolved) = resolver.resolve(&importer_dir, &specifier) {
+                if !visited.contains(&resolved) {
+                    stack.push(resolved);
+                }
+            }
+        }
+    }
+
+    Ok(found.into_values().collect())
+}
+
+/// Parse a single TS/TSX source string into an SWC [`Module`].
+fn parse_module(path: &Path, source: &str) -> ScanResult<Module> {
+    let cm: Lrc<SourceMap> = Default::default();
+    let fm = cm.new_source_file(
+        FileName::Real(path.to_path_buf()).into(),
+        source.to_string(),
+    );
+    let lexer = Lexer::new(
+        Syntax::Typescript(TsSyntax {
+            tsx: true,
+            decorators: false,
+            dts: false,
+            no_early_errors: false,
+            disallow_ambiguous_jsx_like: false,
+        }),
+        EsVersion::Es2022,
+        StringInput::from(&*fm),
+        None,
+    );
+    let mut parser = Parser::new_from(lexer);
+    parser.parse_module().map_err(|e| ScanError::Parse {
+        path: path.to_path_buf(),
+        message: format!("{e:?}"),
+    })
+}
+
+/// Return true iff the module's leading directive prologue contains a
+/// `"use client"` string-literal expression statement.
+///
+/// The prologue is scanned greedily: as soon as a non-string-literal
+/// expression statement appears, we stop. Other prologue directives (e.g.
+/// `"use strict"`) are tolerated.
+fn has_use_client_directive(module: &Module) -> bool {
+    for item in &module.body {
+        let ModuleItem::Stmt(Stmt::Expr(expr_stmt)) = item else {
+            // First non-stmt item ends the prologue.
+            return false;
+        };
+        let Expr::Lit(Lit::Str(s)) = &*expr_stmt.expr else {
+            // First non-string-literal expression statement ends the
+            // prologue.
+            return false;
+        };
+        if s.value == *"use client" {
+            return true;
+        }
+        // Some other directive (e.g. "use strict") — keep looking through
+        // the prologue.
+    }
+    false
+}
+
+/// Convert a [`Wtf8Atom`] (the SWC AST string type) to a plain [`String`].
+///
+/// Module specifiers, identifier names, and named-export labels are all
+/// real source-text strings that round-trip cleanly through UTF-8; the
+/// "lossy" path is only taken for the WTF-8 corner case (unpaired
+/// surrogates in JS string literals), which we never see in practice.
+fn atom_to_string(value: &Wtf8Atom) -> String {
+    value.to_atom_lossy().to_string()
+}
+
+/// Collect import-style specifiers (anything that pulls another module
+/// into the graph): plain `import`, side-effect `import "./x"`, named
+/// re-exports `export { x } from "./y"`, and `export * from "./z"`.
+fn collect_import_specifiers(module: &Module) -> Vec<String> {
+    let mut out = Vec::new();
+    for item in &module.body {
+        let ModuleItem::ModuleDecl(decl) = item else {
+            continue;
+        };
+        match decl {
+            ModuleDecl::Import(import_decl) => {
+                out.push(atom_to_string(&import_decl.src.value));
+            }
+            ModuleDecl::ExportNamed(named) => {
+                if let Some(src) = &named.src {
+                    out.push(atom_to_string(&src.value));
+                }
+            }
+            ModuleDecl::ExportAll(all) => {
+                out.push(atom_to_string(&all.src.value));
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+/// Collect the exported binding names produced by this module.
+///
+/// See the module-level "Component identity" docs for the full mapping.
+fn exported_binding_names(module: &Module) -> Vec<String> {
+    let mut out = Vec::new();
+    for item in &module.body {
+        let ModuleItem::ModuleDecl(decl) = item else {
+            continue;
+        };
+        match decl {
+            ModuleDecl::ExportDecl(ed) => match &ed.decl {
+                Decl::Class(c) => out.push(c.ident.sym.to_string()),
+                Decl::Fn(f) => out.push(f.ident.sym.to_string()),
+                Decl::Var(v) => {
+                    for d in &v.decls {
+                        if let Pat::Ident(bi) = &d.name {
+                            out.push(bi.id.sym.to_string());
+                        }
+                    }
+                }
+                _ => {}
+            },
+            ModuleDecl::ExportDefaultDecl(_) | ModuleDecl::ExportDefaultExpr(_) => {
+                out.push("default".to_string());
+            }
+            ModuleDecl::ExportNamed(named) => {
+                for spec in &named.specifiers {
+                    match spec {
+                        ExportSpecifier::Named(n) => {
+                            let pick = n.exported.as_ref().unwrap_or(&n.orig);
+                            match pick {
+                                ModuleExportName::Ident(id) => out.push(id.sym.to_string()),
+                                ModuleExportName::Str(s) => out.push(atom_to_string(&s.value)),
+                            }
+                        }
+                        ExportSpecifier::Default(d) => {
+                            out.push(d.exported.sym.to_string());
+                        }
+                        ExportSpecifier::Namespace(n) => match &n.name {
+                            ModuleExportName::Ident(id) => out.push(id.sym.to_string()),
+                            ModuleExportName::Str(s) => out.push(atom_to_string(&s.value)),
+                        },
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn root() -> PathBuf {
+        PathBuf::from("/proj")
+    }
+
+    fn paths(islands: &IslandsSet) -> Vec<(String, String)> {
+        islands
+            .iter()
+            .map(|i| {
+                (
+                    i.source_path.to_string_lossy().to_string(),
+                    i.component_name.clone(),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn detects_use_client_with_double_quotes() {
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import { Counter } from "../components/counter";
+                export default function Home() { return <Counter/>; }
+                "#,
+            )
+            .with_file(
+                root().join("components/counter.tsx"),
+                r#""use client";
+                import { useState } from "preact/hooks";
+                export function Counter() { return null; }
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert_eq!(
+            paths(&islands),
+            vec![(
+                "/proj/components/counter.tsx".to_string(),
+                "Counter".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn detects_use_client_with_single_quotes() {
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import { Counter } from "../components/counter";
+                export default function Home() {}
+                "#,
+            )
+            .with_file(
+                root().join("components/counter.tsx"),
+                r#"'use client';
+                export function Counter() {}
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert_eq!(islands.len(), 1);
+        assert_eq!(islands[0].component_name, "Counter");
+    }
+
+    #[test]
+    fn page_with_no_use_client_imports_yields_empty_set() {
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import { ServerOnly } from "../components/server-only";
+                export default function Home() { return <ServerOnly/>; }
+                "#,
+            )
+            .with_file(
+                root().join("components/server-only.tsx"),
+                r#"export function ServerOnly() { return <div/>; }
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert!(islands.is_empty(), "got {:?}", islands);
+    }
+
+    #[test]
+    fn transitive_imports_reach_use_client() {
+        // page → layout → island. The middle hop is server-only, but the
+        // scanner must traverse it.
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import { Layout } from "../layouts/main";
+                export default function Home() { return <Layout/>; }
+                "#,
+            )
+            .with_file(
+                root().join("layouts/main.tsx"),
+                r#"import { Counter } from "../components/counter";
+                export function Layout() { return <Counter/>; }
+                "#,
+            )
+            .with_file(
+                root().join("components/counter.tsx"),
+                r#""use client";
+                export function Counter() {}
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert_eq!(
+            paths(&islands),
+            vec![(
+                "/proj/components/counter.tsx".to_string(),
+                "Counter".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn use_client_module_with_multiple_exports_emits_one_island_per_name() {
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import { Foo, Bar, RenamedBaz } from "../components/cluster";
+                export default function Home() {}
+                "#,
+            )
+            .with_file(
+                root().join("components/cluster.tsx"),
+                r#""use client";
+                export function Foo() {}
+                export class Bar {}
+                const Baz = () => null;
+                export { Baz as RenamedBaz };
+                export const Qux = 1;
+                export default function Defaulted() {}
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        let names: Vec<String> = islands.iter().map(|i| i.component_name.clone()).collect();
+        // Sorted lexicographically by component name for the same source
+        // path: Bar, Foo, Qux, RenamedBaz, default.
+        assert_eq!(
+            names,
+            vec![
+                "Bar".to_string(),
+                "Foo".to_string(),
+                "Qux".to_string(),
+                "RenamedBaz".to_string(),
+                "default".to_string(),
+            ]
+        );
+        // All point at the same source path.
+        for island in &islands {
+            assert_eq!(island.source_path, root().join("components/cluster.tsx"));
+        }
+    }
+
+    #[test]
+    fn use_client_after_use_strict_in_prologue_is_accepted() {
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import { Counter } from "../components/counter";
+                export default function Home() {}
+                "#,
+            )
+            .with_file(
+                root().join("components/counter.tsx"),
+                r#""use strict";
+                "use client";
+                export function Counter() {}
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert_eq!(islands.len(), 1);
+    }
+
+    #[test]
+    fn directive_after_a_real_statement_is_not_a_directive() {
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import { Counter } from "../components/counter";
+                export default function Home() {}
+                "#,
+            )
+            .with_file(
+                root().join("components/counter.tsx"),
+                r#"const _ = 1;
+                "use client";
+                export function Counter() {}
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert!(islands.is_empty(), "got {:?}", islands);
+    }
+
+    #[test]
+    fn comments_above_use_client_are_ignored() {
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import { Counter } from "../components/counter";
+                export default function Home() {}
+                "#,
+            )
+            .with_file(
+                root().join("components/counter.tsx"),
+                r#"// SPDX-License-Identifier: MIT
+                /* This file runs in the browser. */
+                "use client";
+                export function Counter() {}
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert_eq!(islands.len(), 1);
+        assert_eq!(islands[0].component_name, "Counter");
+    }
+
+    #[test]
+    fn output_is_deterministically_sorted() {
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import { A } from "../components/zeta";
+                import { B } from "../components/alpha";
+                export default function Home() {}
+                "#,
+            )
+            .with_file(
+                root().join("components/zeta.tsx"),
+                r#""use client";
+                export function A() {}
+                "#,
+            )
+            .with_file(
+                root().join("components/alpha.tsx"),
+                r#""use client";
+                export function B() {}
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert_eq!(
+            paths(&islands),
+            vec![
+                (
+                    "/proj/components/alpha.tsx".to_string(),
+                    "B".to_string()
+                ),
+                ("/proj/components/zeta.tsx".to_string(), "A".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn cyclic_imports_terminate() {
+        // a imports b, b imports a — neither uses "use client".
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import { A } from "../components/a";
+                export default function Home() {}
+                "#,
+            )
+            .with_file(
+                root().join("components/a.tsx"),
+                r#"import { B } from "./b";
+                export const A = () => B;
+                "#,
+            )
+            .with_file(
+                root().join("components/b.tsx"),
+                r#"import { A } from "./a";
+                export const B = () => A;
+                "#,
+            );
+
+        // Should terminate (and yield no islands).
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert!(islands.is_empty());
+    }
+
+    #[test]
+    fn dedups_islands_reachable_through_multiple_chains() {
+        // page imports both A and B; both pull in the same client island.
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import { A } from "../components/a";
+                import { B } from "../components/b";
+                export default function Home() {}
+                "#,
+            )
+            .with_file(
+                root().join("components/a.tsx"),
+                r#"import { Counter } from "./counter";
+                export function A() {}
+                "#,
+            )
+            .with_file(
+                root().join("components/b.tsx"),
+                r#"import { Counter } from "./counter";
+                export function B() {}
+                "#,
+            )
+            .with_file(
+                root().join("components/counter.tsx"),
+                r#""use client";
+                export function Counter() {}
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert_eq!(islands.len(), 1, "got {:?}", islands);
+        assert_eq!(islands[0].component_name, "Counter");
+    }
+
+    #[test]
+    fn bare_specifiers_are_skipped_silently() {
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import { useState } from "preact/hooks";
+                import { Counter } from "../components/counter";
+                export default function Home() {}
+                "#,
+            )
+            .with_file(
+                root().join("components/counter.tsx"),
+                r#""use client";
+                export function Counter() {}
+                "#,
+            );
+
+        // Must not fail trying to resolve "preact/hooks".
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert_eq!(islands.len(), 1);
+    }
+
+    #[test]
+    fn re_export_from_another_module_is_followed_and_attributed() {
+        // A barrel file re-exports a "use client" component. The barrel
+        // itself is not a "use client" file — but the scanner must follow
+        // the re-export to discover the underlying island.
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import { Counter } from "../components/index";
+                export default function Home() {}
+                "#,
+            )
+            .with_file(
+                root().join("components/index.tsx"),
+                r#"export { Counter } from "./counter";
+                "#,
+            )
+            .with_file(
+                root().join("components/counter.tsx"),
+                r#""use client";
+                export function Counter() {}
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert_eq!(
+            paths(&islands),
+            vec![(
+                "/proj/components/counter.tsx".to_string(),
+                "Counter".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn fs_resolver_works_against_a_real_tempdir() {
+        use std::fs;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let pages = dir.path().join("pages");
+        let components = dir.path().join("components");
+        fs::create_dir_all(&pages).unwrap();
+        fs::create_dir_all(&components).unwrap();
+
+        fs::write(
+            pages.join("home.tsx"),
+            r#"import { Counter } from "../components/counter";
+            export default function Home() {}
+            "#,
+        )
+        .unwrap();
+        fs::write(
+            components.join("counter.tsx"),
+            r#""use client";
+            export function Counter() {}
+            "#,
+        )
+        .unwrap();
+
+        let resolver = FsResolver::new();
+        let islands = scan_islands(&[pages.join("home.tsx")], &resolver).unwrap();
+        assert_eq!(islands.len(), 1);
+        assert_eq!(islands[0].component_name, "Counter");
+        // FsResolver canonicalises (resolves symlinks like macOS's
+        // `/var` → `/private/var`), so compare against the canonical form
+        // of the expected path rather than the join-produced one.
+        let expected = components
+            .join("counter.tsx")
+            .canonicalize()
+            .expect("canonicalize");
+        assert_eq!(islands[0].source_path, expected);
+    }
+
+    #[test]
+    fn parse_error_surfaces_with_path_context() {
+        let resolver = InMemoryResolver::new().with_file(
+            root().join("pages/broken.tsx"),
+            // Stray `}`: real syntax error.
+            r#"export default function() }"#,
+        );
+        let err = scan_islands(&[root().join("pages/broken.tsx")], &resolver).unwrap_err();
+        match err {
+            ScanError::Parse { path, .. } => {
+                assert_eq!(path, root().join("pages/broken.tsx"));
+            }
+            other => panic!("expected Parse error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn is_bare_specifier_recognises_relative_and_absolute_paths() {
+        assert!(is_bare_specifier("preact"));
+        assert!(is_bare_specifier("preact/hooks"));
+        assert!(is_bare_specifier("zfb"));
+        assert!(!is_bare_specifier("./layout"));
+        assert!(!is_bare_specifier("../components/counter"));
+        assert!(!is_bare_specifier("/abs/path"));
+    }
+}

--- a/crates/zfb-islands/src/scanner.rs
+++ b/crates/zfb-islands/src/scanner.rs
@@ -258,6 +258,13 @@ impl Resolver for FsResolver {
 ///
 /// Resolution probes the same extension list as [`FsResolver`], but
 /// against the in-memory `files` map instead of the file system.
+///
+/// Note on path normalization: where [`FsResolver`] uses
+/// `std::fs::canonicalize` (which also resolves symlinks), this resolver
+/// only collapses `.` / `..` lexically via [`normalize_path_lexical`].
+/// That's enough for the tests' synthetic paths but is intentionally
+/// less powerful than the real-FS path; production code should always
+/// use [`FsResolver`].
 #[derive(Debug, Clone, Default)]
 pub struct InMemoryResolver {
     /// Map of resolved-path → source text.

--- a/crates/zfb-islands/tests/integration.rs
+++ b/crates/zfb-islands/tests/integration.rs
@@ -3,13 +3,14 @@
 //! These exercise the bundler trait, the subprocess engine, and the URL
 //! helper. Tests that need the real esbuild binary are gated by `#[ignore]`
 //! and a comment — they will be enabled in a release-engineering follow-up
-//! once the binary is materialised at `crates/zfb/binaries/esbuild` (Sub 2
-//! reserves the slot but does not download the binary).
+//! once the binary is materialised at
+//! `crates/zfb/binaries/esbuild/esbuild` (Sub 2 reserves the slot but does
+//! not download the binary).
 
 use std::path::{Path, PathBuf};
 
 use zfb_islands::{
-    link_href, BundleConfig, BundleOutput, ClientBundler, EsbuildSubprocessBundler,
+    bundle_link_href, BundleConfig, BundleOutput, ClientBundler, EsbuildSubprocessBundler,
     EsbuildSubprocessConfig, Island, NativeRustBundler,
 };
 
@@ -44,26 +45,24 @@ fn subprocess_bundler_mock_short_circuits_command() {
     let cfg = EsbuildSubprocessConfig::default()
         .with_mock_output("export const Counter = () => null;\n");
     let bundler = EsbuildSubprocessBundler::new(cfg);
-    let bundle_cfg = BundleConfig {
-        output_root: tmp.path().to_path_buf(),
-        ..BundleConfig::default()
-    };
+    let bundle_cfg = BundleConfig::default().with_outdir(tmp.path());
     let out: BundleOutput = bundler
         .bundle(
             &[island("Counter", "components/counter.tsx")],
             &bundle_cfg,
         )
         .expect("mock bundler should succeed");
-    assert_eq!(out.hash.len(), 8);
     assert!(
         out.asset_path.starts_with(tmp.path()),
-        "asset must land under output_root: {}",
+        "asset must land under outdir: {}",
         out.asset_path.display()
     );
     assert!(out.asset_path.exists(), "asset must be written to disk");
     let on_disk = std::fs::read_to_string(&out.asset_path).expect("read asset");
     assert!(on_disk.contains("Counter"));
-    assert_eq!(out.module_ids.get("Counter").map(String::as_str), Some("Counter"));
+    assert_eq!(out.module_ids, vec!["Counter".to_string()]);
+    assert!(out.asset_url.starts_with("/assets/islands-"));
+    assert!(out.asset_url.ends_with(".js"));
 }
 
 #[test]
@@ -85,10 +84,7 @@ fn bundle_hash_is_deterministic_across_runs() {
     let make = |root: &Path| {
         let cfg = EsbuildSubprocessConfig::default().with_mock_output(payload);
         let bundler = EsbuildSubprocessBundler::new(cfg);
-        let bundle_cfg = BundleConfig {
-            output_root: root.to_path_buf(),
-            ..BundleConfig::default()
-        };
+        let bundle_cfg = BundleConfig::default().with_outdir(root);
         bundler
             .bundle(&[island("X", "components/x.tsx")], &bundle_cfg)
             .expect("bundle")
@@ -98,12 +94,12 @@ fn bundle_hash_is_deterministic_across_runs() {
     let tmp2 = tempfile::tempdir().expect("tempdir");
     let a = make(tmp1.path());
     let b = make(tmp2.path());
-    assert_eq!(a.hash, b.hash, "identical payload must produce identical hash");
     assert_eq!(
         a.asset_path.file_name(),
         b.asset_path.file_name(),
-        "filename suffix derives from hash"
+        "filename suffix derives from hash; identical payload must yield identical filename"
     );
+    assert_eq!(a.asset_url, b.asset_url);
 }
 
 #[test]
@@ -111,10 +107,7 @@ fn bundle_hash_changes_when_payload_changes() {
     let make = |payload: &str, root: &Path| {
         let cfg = EsbuildSubprocessConfig::default().with_mock_output(payload);
         let bundler = EsbuildSubprocessBundler::new(cfg);
-        let bundle_cfg = BundleConfig {
-            output_root: root.to_path_buf(),
-            ..BundleConfig::default()
-        };
+        let bundle_cfg = BundleConfig::default().with_outdir(root);
         bundler
             .bundle(&[island("X", "components/x.tsx")], &bundle_cfg)
             .expect("bundle")
@@ -123,7 +116,11 @@ fn bundle_hash_changes_when_payload_changes() {
     let tmp2 = tempfile::tempdir().expect("tempdir");
     let a = make("export const X = 1;\n", tmp1.path());
     let b = make("export const X = 2;\n", tmp2.path());
-    assert_ne!(a.hash, b.hash, "different payload must change the hash");
+    assert_ne!(
+        a.asset_path.file_name(),
+        b.asset_path.file_name(),
+        "different payload must change the hash → change the filename"
+    );
 }
 
 #[test]
@@ -131,41 +128,50 @@ fn bundle_output_layout_is_assets_islands_hash_js() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let cfg = EsbuildSubprocessConfig::default().with_mock_output("export {};\n");
     let bundler = EsbuildSubprocessBundler::new(cfg);
-    let bundle_cfg = BundleConfig {
-        output_root: tmp.path().to_path_buf(),
-        ..BundleConfig::default()
-    };
+    let bundle_cfg = BundleConfig::default().with_outdir(tmp.path());
     let out = bundler
         .bundle(&[island("X", "x.tsx")], &bundle_cfg)
         .expect("bundle");
 
-    // Path layout: {output_root}/assets/islands-{hash}.js
-    let expected = tmp
-        .path()
-        .join("assets")
-        .join(format!("islands-{}.js", out.hash));
-    assert_eq!(out.asset_path, expected);
+    // Path layout: {outdir}/assets/islands-{hash}.js
+    let parent = out
+        .asset_path
+        .parent()
+        .expect("asset path has a parent")
+        .to_path_buf();
+    assert_eq!(parent, tmp.path().join("assets"));
+    let filename = out
+        .asset_path
+        .file_name()
+        .expect("asset path has a filename")
+        .to_string_lossy()
+        .into_owned();
+    assert!(filename.starts_with("islands-"));
+    assert!(filename.ends_with(".js"));
+    // hash is the 8-char hex segment between the prefix and suffix
+    let hash = filename
+        .strip_prefix("islands-")
+        .and_then(|s| s.strip_suffix(".js"))
+        .expect("filename has the islands-{hash}.js shape");
+    assert_eq!(hash.len(), 8);
 }
 
 #[test]
-fn link_href_derives_public_url_from_asset_path() {
+fn bundle_link_href_derives_public_url_from_asset_path() {
     let p = PathBuf::from("dist/assets/islands-abc12345.js");
-    assert_eq!(link_href("/", &p), "/assets/islands-abc12345.js");
+    assert_eq!(bundle_link_href("/", &p), "/assets/islands-abc12345.js");
     assert_eq!(
-        link_href("https://cdn.example.com", &p),
+        bundle_link_href("https://cdn.example.com", &p),
         "https://cdn.example.com/assets/islands-abc12345.js"
     );
 }
 
 #[test]
-fn module_ids_map_is_populated_from_islands() {
+fn module_ids_list_preserves_island_order() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let cfg = EsbuildSubprocessConfig::default().with_mock_output("export {};\n");
     let bundler = EsbuildSubprocessBundler::new(cfg);
-    let bundle_cfg = BundleConfig {
-        output_root: tmp.path().to_path_buf(),
-        ..BundleConfig::default()
-    };
+    let bundle_cfg = BundleConfig::default().with_outdir(tmp.path());
     let out = bundler
         .bundle(
             &[
@@ -175,13 +181,29 @@ fn module_ids_map_is_populated_from_islands() {
             &bundle_cfg,
         )
         .expect("bundle");
-    assert_eq!(out.module_ids.len(), 2);
-    assert!(out.module_ids.contains_key("Counter"));
-    assert!(out.module_ids.contains_key("Tabs"));
+    assert_eq!(out.module_ids, vec!["Counter".to_string(), "Tabs".to_string()]);
 }
 
 #[test]
-#[ignore = "Requires the real esbuild binary at crates/zfb/binaries/esbuild. \
+fn asset_url_uses_configured_base_url() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let cfg = EsbuildSubprocessConfig::default().with_mock_output("export {};\n");
+    let bundler = EsbuildSubprocessBundler::new(cfg);
+    let bundle_cfg = BundleConfig::default()
+        .with_outdir(tmp.path())
+        .with_base_url("https://cdn.example.com");
+    let out = bundler
+        .bundle(&[island("X", "x.tsx")], &bundle_cfg)
+        .expect("bundle");
+    assert!(
+        out.asset_url.starts_with("https://cdn.example.com/assets/islands-"),
+        "got: {}",
+        out.asset_url
+    );
+}
+
+#[test]
+#[ignore = "Requires the real esbuild binary at crates/zfb/binaries/esbuild/esbuild. \
             Will be enabled in a release-engineering follow-up."]
 fn subprocess_bundler_against_real_binary() {
     let bundler = EsbuildSubprocessBundler::with_default_config();
@@ -192,10 +214,7 @@ fn subprocess_bundler_against_real_binary() {
     let entry = tmp.path().join("entry.js");
     std::fs::write(&entry, "export const Counter = () => null;\n").expect("write entry");
 
-    let bundle_cfg = BundleConfig {
-        output_root: tmp.path().to_path_buf(),
-        ..BundleConfig::production()
-    };
+    let bundle_cfg = BundleConfig::production().with_outdir(tmp.path());
     let out = bundler
         .bundle(
             &[Island {

--- a/crates/zfb-islands/tests/integration.rs
+++ b/crates/zfb-islands/tests/integration.rs
@@ -1,0 +1,209 @@
+//! Integration-style tests for the public surface of `zfb-islands` (Sub 2).
+//!
+//! These exercise the bundler trait, the subprocess engine, and the URL
+//! helper. Tests that need the real esbuild binary are gated by `#[ignore]`
+//! and a comment — they will be enabled in a release-engineering follow-up
+//! once the binary is materialised at `crates/zfb/binaries/esbuild` (Sub 2
+//! reserves the slot but does not download the binary).
+
+use std::path::{Path, PathBuf};
+
+use zfb_islands::{
+    link_href, BundleConfig, BundleOutput, ClientBundler, EsbuildSubprocessBundler,
+    EsbuildSubprocessConfig, Island, NativeRustBundler,
+};
+
+fn island(name: &str, path: &str) -> Island {
+    Island {
+        component_name: name.to_string(),
+        source_path: PathBuf::from(path),
+    }
+}
+
+#[test]
+fn native_bundler_returns_not_implemented_error() {
+    let bundler = NativeRustBundler::new();
+    let err = bundler
+        .bundle(
+            &[island("Counter", "components/counter.tsx")],
+            &BundleConfig::default(),
+        )
+        .expect_err("NativeRustBundler must return an error");
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("not yet implemented"),
+        "expected 'not yet implemented' in error, got: {msg}"
+    );
+}
+
+#[test]
+fn subprocess_bundler_mock_short_circuits_command() {
+    // Use the mock-output escape hatch so this test does not require the
+    // esbuild binary to be present.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let cfg = EsbuildSubprocessConfig::default()
+        .with_mock_output("export const Counter = () => null;\n");
+    let bundler = EsbuildSubprocessBundler::new(cfg);
+    let bundle_cfg = BundleConfig {
+        output_root: tmp.path().to_path_buf(),
+        ..BundleConfig::default()
+    };
+    let out: BundleOutput = bundler
+        .bundle(
+            &[island("Counter", "components/counter.tsx")],
+            &bundle_cfg,
+        )
+        .expect("mock bundler should succeed");
+    assert_eq!(out.hash.len(), 8);
+    assert!(
+        out.asset_path.starts_with(tmp.path()),
+        "asset must land under output_root: {}",
+        out.asset_path.display()
+    );
+    assert!(out.asset_path.exists(), "asset must be written to disk");
+    let on_disk = std::fs::read_to_string(&out.asset_path).expect("read asset");
+    assert!(on_disk.contains("Counter"));
+    assert_eq!(out.module_ids.get("Counter").map(String::as_str), Some("Counter"));
+}
+
+#[test]
+fn subprocess_bundler_reports_missing_binary_clearly() {
+    let cfg = EsbuildSubprocessConfig::default()
+        .with_binary_path("/nonexistent/zfb-esbuild-please-do-not-create");
+    let bundler = EsbuildSubprocessBundler::new(cfg);
+    let err = bundler
+        .bundle(&[], &BundleConfig::default())
+        .expect_err("missing binary must error");
+    let msg = format!("{err}");
+    assert!(msg.contains("not found"), "got: {msg}");
+}
+
+#[test]
+fn bundle_hash_is_deterministic_across_runs() {
+    let payload = "export const X = 1;\n";
+
+    let make = |root: &Path| {
+        let cfg = EsbuildSubprocessConfig::default().with_mock_output(payload);
+        let bundler = EsbuildSubprocessBundler::new(cfg);
+        let bundle_cfg = BundleConfig {
+            output_root: root.to_path_buf(),
+            ..BundleConfig::default()
+        };
+        bundler
+            .bundle(&[island("X", "components/x.tsx")], &bundle_cfg)
+            .expect("bundle")
+    };
+
+    let tmp1 = tempfile::tempdir().expect("tempdir");
+    let tmp2 = tempfile::tempdir().expect("tempdir");
+    let a = make(tmp1.path());
+    let b = make(tmp2.path());
+    assert_eq!(a.hash, b.hash, "identical payload must produce identical hash");
+    assert_eq!(
+        a.asset_path.file_name(),
+        b.asset_path.file_name(),
+        "filename suffix derives from hash"
+    );
+}
+
+#[test]
+fn bundle_hash_changes_when_payload_changes() {
+    let make = |payload: &str, root: &Path| {
+        let cfg = EsbuildSubprocessConfig::default().with_mock_output(payload);
+        let bundler = EsbuildSubprocessBundler::new(cfg);
+        let bundle_cfg = BundleConfig {
+            output_root: root.to_path_buf(),
+            ..BundleConfig::default()
+        };
+        bundler
+            .bundle(&[island("X", "components/x.tsx")], &bundle_cfg)
+            .expect("bundle")
+    };
+    let tmp1 = tempfile::tempdir().expect("tempdir");
+    let tmp2 = tempfile::tempdir().expect("tempdir");
+    let a = make("export const X = 1;\n", tmp1.path());
+    let b = make("export const X = 2;\n", tmp2.path());
+    assert_ne!(a.hash, b.hash, "different payload must change the hash");
+}
+
+#[test]
+fn bundle_output_layout_is_assets_islands_hash_js() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let cfg = EsbuildSubprocessConfig::default().with_mock_output("export {};\n");
+    let bundler = EsbuildSubprocessBundler::new(cfg);
+    let bundle_cfg = BundleConfig {
+        output_root: tmp.path().to_path_buf(),
+        ..BundleConfig::default()
+    };
+    let out = bundler
+        .bundle(&[island("X", "x.tsx")], &bundle_cfg)
+        .expect("bundle");
+
+    // Path layout: {output_root}/assets/islands-{hash}.js
+    let expected = tmp
+        .path()
+        .join("assets")
+        .join(format!("islands-{}.js", out.hash));
+    assert_eq!(out.asset_path, expected);
+}
+
+#[test]
+fn link_href_derives_public_url_from_asset_path() {
+    let p = PathBuf::from("dist/assets/islands-abc12345.js");
+    assert_eq!(link_href("/", &p), "/assets/islands-abc12345.js");
+    assert_eq!(
+        link_href("https://cdn.example.com", &p),
+        "https://cdn.example.com/assets/islands-abc12345.js"
+    );
+}
+
+#[test]
+fn module_ids_map_is_populated_from_islands() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let cfg = EsbuildSubprocessConfig::default().with_mock_output("export {};\n");
+    let bundler = EsbuildSubprocessBundler::new(cfg);
+    let bundle_cfg = BundleConfig {
+        output_root: tmp.path().to_path_buf(),
+        ..BundleConfig::default()
+    };
+    let out = bundler
+        .bundle(
+            &[
+                island("Counter", "components/counter.tsx"),
+                island("Tabs", "components/tabs.tsx"),
+            ],
+            &bundle_cfg,
+        )
+        .expect("bundle");
+    assert_eq!(out.module_ids.len(), 2);
+    assert!(out.module_ids.contains_key("Counter"));
+    assert!(out.module_ids.contains_key("Tabs"));
+}
+
+#[test]
+#[ignore = "Requires the real esbuild binary at crates/zfb/binaries/esbuild. \
+            Will be enabled in a release-engineering follow-up."]
+fn subprocess_bundler_against_real_binary() {
+    let bundler = EsbuildSubprocessBundler::with_default_config();
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    // The caller would normally pass real island source paths here. For
+    // the gated smoke test we ship a one-line ESM file in a temp dir.
+    let entry = tmp.path().join("entry.js");
+    std::fs::write(&entry, "export const Counter = () => null;\n").expect("write entry");
+
+    let bundle_cfg = BundleConfig {
+        output_root: tmp.path().to_path_buf(),
+        ..BundleConfig::production()
+    };
+    let out = bundler
+        .bundle(
+            &[Island {
+                component_name: "Counter".into(),
+                source_path: entry,
+            }],
+            &bundle_cfg,
+        )
+        .expect("real esbuild binary should produce a bundle");
+    assert!(out.asset_path.exists());
+}

--- a/crates/zfb-render/src/adapters/mod.rs
+++ b/crates/zfb-render/src/adapters/mod.rs
@@ -8,7 +8,7 @@
 //! portable component must follow and for the gotchas that arise from
 //! this two-track design.
 //!
-//! An [`Adapter`] is responsible for three things and three things only:
+//! An [`Adapter`] is responsible for four things and four things only:
 //!
 //! 1. Telling the SWC pipeline which JSX import source to inject
 //!    (see [`Adapter::jsx_import_source`]).
@@ -19,9 +19,34 @@
 //!    `render.rs` can call `__zfbRenderToString(vnode)` without caring
 //!    which framework is active
 //!    (see [`Adapter::pre_render_setup`]).
+//! 4. Exposing a tiny client-side **hydration shim** that the islands
+//!    bundler folds into the islands bundle's entry. The shim exports a
+//!    single `hydrateIsland(Component, props, element)` function so the
+//!    framework-agnostic hydration runtime (`zfb-islands` JS, Sub 3) can
+//!    hydrate any island without branching on the framework
+//!    (see [`Adapter::hydrate_shim_specifier`] and
+//!    [`Adapter::hydrate_shim_source`]).
 //!
-//! Anything beyond that — hook semantics, signal interop, hydration
-//! strategy — is intentionally out of scope. ADR-002 documents why.
+//! ## Hydration: per-adapter shim, not per-call JS expression
+//!
+//! For Sub 3 we considered two designs:
+//!
+//! - **`hydrate_call()` returning a JS expression string** that the
+//!   runtime would template into a per-page generated module.
+//! - **A per-adapter shim module** that the islands bundler includes as
+//!   the islands-bundle entry; the hydration runtime imports a uniform
+//!   `hydrateIsland(Component, props, element)`.
+//!
+//! We pick the shim. It keeps the Rust ↔ JS boundary expressed purely
+//! as static strings (no JS-expression concatenation in Rust, no `eval`
+//! in the runtime), it keeps tree-shaking honest because the shim is a
+//! real module the bundler sees, and it leaves the hydration runtime
+//! adapter-agnostic — the same JS file ships whether the project picked
+//! Preact or React.
+//!
+//! Anything beyond these four hooks — hook semantics, signal interop,
+//! event delegation strategy — is intentionally out of scope. ADR-002
+//! documents why.
 
 use crate::{RenderError, RenderHost};
 
@@ -48,8 +73,9 @@ pub enum Framework {
 
 /// The portable adapter contract.
 ///
-/// All four methods are pure (`name`, `jsx_import_source`,
-/// `render_to_string_module`) or side-effecting only on the host
+/// Methods are pure (`name`, `jsx_import_source`,
+/// `render_to_string_module`, `hydrate_shim_specifier`,
+/// `hydrate_shim_source`) or side-effecting only on the host
 /// (`pre_render_setup`). Adapters MUST NOT carry per-render state — a
 /// single adapter instance is reused across every page render.
 pub trait Adapter {
@@ -72,6 +98,26 @@ pub trait Adapter {
     /// orchestrator in `render.rs` can call into the framework
     /// uniformly.
     fn pre_render_setup(&self, host: &mut dyn RenderHost) -> Result<(), RenderError>;
+
+    /// Synthetic module specifier the islands bundler uses to write the
+    /// hydration shim into the bundle. Conventionally lives under the
+    /// `zfb:internal/adapters/` namespace so it cannot collide with a
+    /// user-authored module. The bundler is free to substitute its own
+    /// path; this value exists primarily to give the bundler a stable
+    /// default and to give the shim source a recognisable display name.
+    fn hydrate_shim_specifier(&self) -> &'static str;
+
+    /// JS module source the islands bundler folds into the islands
+    /// bundle as the framework-specific hydration entry.
+    ///
+    /// Contract: the module MUST export a function named `hydrateIsland`
+    /// with signature
+    /// `hydrateIsland(Component, props, element)` and MUST hydrate
+    /// `Component` against `element` using `props`. The hydration
+    /// runtime in `zfb-islands` calls this function for every
+    /// `[data-zfb-island]` element in the DOM, so the function MUST be
+    /// safe to call repeatedly with different elements.
+    fn hydrate_shim_source(&self) -> &'static str;
 }
 
 /// Construct the boxed adapter for a given [`Framework`].
@@ -127,5 +173,41 @@ mod tests {
             make_adapter(Framework::React).render_to_string_module(),
             "react-dom/server"
         );
+    }
+
+    #[test]
+    fn hydrate_shim_sources_export_hydrate_island() {
+        // Both adapters must expose a `hydrateIsland` export. The
+        // hydration runtime imports this name, not the framework's
+        // native API, so a typo here would silently break every page.
+        for adapter in [
+            make_adapter(Framework::Preact),
+            make_adapter(Framework::React),
+        ] {
+            let src = adapter.hydrate_shim_source();
+            assert!(
+                src.contains("hydrateIsland"),
+                "{} shim does not export hydrateIsland: {src}",
+                adapter.name()
+            );
+        }
+    }
+
+    #[test]
+    fn hydrate_shim_specifiers_are_internal_namespace() {
+        // Specifiers must live under zfb:internal/ so they can never
+        // collide with a user-authored module path.
+        for adapter in [
+            make_adapter(Framework::Preact),
+            make_adapter(Framework::React),
+        ] {
+            assert!(
+                adapter
+                    .hydrate_shim_specifier()
+                    .starts_with("zfb:internal/"),
+                "{} specifier escaped zfb:internal/",
+                adapter.name()
+            );
+        }
     }
 }

--- a/crates/zfb-render/src/adapters/preact.rs
+++ b/crates/zfb-render/src/adapters/preact.rs
@@ -35,6 +35,21 @@ const PREACT_SETUP_SOURCE: &str = r#"import { renderToString } from "preact-rend
 globalThis.__zfbRenderToString = renderToString;
 "#;
 
+/// Synthetic module specifier under which the islands bundler folds the
+/// per-adapter hydration shim into the islands bundle entry.
+const PREACT_HYDRATE_SHIM_SPECIFIER: &str = "zfb:internal/adapters/preact-hydrate.mjs";
+
+/// Per-adapter hydration shim. Exports the uniform
+/// `hydrateIsland(Component, props, element)` the framework-agnostic
+/// hydration runtime in `zfb-islands` calls to drive Preact. Uses `h` +
+/// `hydrate` from bare `preact` (not `preact/compat`) because zfb's
+/// portable-component contract targets bare Preact — see ADR-002.
+const PREACT_HYDRATE_SHIM_SOURCE: &str = r#"import { h, hydrate } from "preact";
+export function hydrateIsland(Component, props, element) {
+  hydrate(h(Component, props), element);
+}
+"#;
+
 impl Adapter for PreactAdapter {
     fn name(&self) -> &'static str {
         "preact"
@@ -51,9 +66,15 @@ impl Adapter for PreactAdapter {
     fn pre_render_setup(&self, host: &mut dyn RenderHost) -> Result<(), RenderError> {
         host.execute_module(PREACT_SETUP_SPECIFIER, PREACT_SETUP_SOURCE)
             .map(|_handle| ())
-            .map_err(|e| {
-                RenderError::Adapter(format!("preact pre-render setup failed: {e}"))
-            })
+            .map_err(|e| RenderError::Adapter(format!("preact pre-render setup failed: {e}")))
+    }
+
+    fn hydrate_shim_specifier(&self) -> &'static str {
+        PREACT_HYDRATE_SHIM_SPECIFIER
+    }
+
+    fn hydrate_shim_source(&self) -> &'static str {
+        PREACT_HYDRATE_SHIM_SOURCE
     }
 }
 
@@ -78,8 +99,7 @@ mod tests {
             name: &str,
             source: &str,
         ) -> Result<ModuleHandle, RenderError> {
-            self.calls
-                .push((name.to_owned(), source.to_owned()));
+            self.calls.push((name.to_owned(), source.to_owned()));
             if let Some(msg) = &self.fail_with {
                 return Err(RenderError::Adapter(msg.clone()));
             }
@@ -120,6 +140,21 @@ mod tests {
         assert_eq!(specifier, PREACT_SETUP_SPECIFIER);
         assert!(source.contains("preact-render-to-string"));
         assert!(source.contains("__zfbRenderToString"));
+    }
+
+    #[test]
+    fn hydrate_shim_imports_bare_preact_and_exports_hydrate_island() {
+        let a = PreactAdapter;
+        let src = a.hydrate_shim_source();
+        // Imports `h` and `hydrate` from bare `preact`. Importing from
+        // `preact/compat` would silently pull in React-shim semantics
+        // we explicitly do not want.
+        assert!(src.contains(r#"from "preact""#));
+        assert!(!src.contains("preact/compat"));
+        assert!(src.contains("hydrateIsland"));
+        // Specifier lives under zfb:internal/ so user code cannot collide.
+        assert_eq!(a.hydrate_shim_specifier(), PREACT_HYDRATE_SHIM_SPECIFIER);
+        assert!(a.hydrate_shim_specifier().starts_with("zfb:internal/"));
     }
 
     #[test]

--- a/crates/zfb-render/src/adapters/react.rs
+++ b/crates/zfb-render/src/adapters/react.rs
@@ -46,6 +46,25 @@ const REACT_SETUP_SOURCE: &str = r#"import { renderToString } from "react-dom/se
 globalThis.__zfbRenderToString = renderToString;
 "#;
 
+/// Synthetic module specifier under which the islands bundler folds the
+/// per-adapter hydration shim into the islands bundle entry.
+const REACT_HYDRATE_SHIM_SPECIFIER: &str = "zfb:internal/adapters/react-hydrate.mjs";
+
+/// Per-adapter hydration shim. Exports the uniform
+/// `hydrateIsland(Component, props, element)` the framework-agnostic
+/// hydration runtime in `zfb-islands` calls to drive React 18+. We pull
+/// `hydrateRoot` from `react-dom/client` (the React 18 client API);
+/// the legacy `react-dom`'s `hydrate` is intentionally not used because
+/// React 19 removes it. Argument order differs from Preact: React's
+/// `hydrateRoot(container, element)` takes the container first, then
+/// the element.
+const REACT_HYDRATE_SHIM_SOURCE: &str = r#"import { createElement } from "react";
+import { hydrateRoot } from "react-dom/client";
+export function hydrateIsland(Component, props, element) {
+  hydrateRoot(element, createElement(Component, props));
+}
+"#;
+
 impl Adapter for ReactAdapter {
     fn name(&self) -> &'static str {
         "react"
@@ -62,9 +81,15 @@ impl Adapter for ReactAdapter {
     fn pre_render_setup(&self, host: &mut dyn RenderHost) -> Result<(), RenderError> {
         host.execute_module(REACT_SETUP_SPECIFIER, REACT_SETUP_SOURCE)
             .map(|_handle| ())
-            .map_err(|e| {
-                RenderError::Adapter(format!("react pre-render setup failed: {e}"))
-            })
+            .map_err(|e| RenderError::Adapter(format!("react pre-render setup failed: {e}")))
+    }
+
+    fn hydrate_shim_specifier(&self) -> &'static str {
+        REACT_HYDRATE_SHIM_SPECIFIER
+    }
+
+    fn hydrate_shim_source(&self) -> &'static str {
+        REACT_HYDRATE_SHIM_SOURCE
     }
 }
 
@@ -89,8 +114,7 @@ mod tests {
             name: &str,
             source: &str,
         ) -> Result<ModuleHandle, RenderError> {
-            self.calls
-                .push((name.to_owned(), source.to_owned()));
+            self.calls.push((name.to_owned(), source.to_owned()));
             if let Some(msg) = &self.fail_with {
                 return Err(RenderError::Adapter(msg.clone()));
             }
@@ -142,6 +166,21 @@ mod tests {
         // matching benefit.
         assert!(!REACT_SETUP_SOURCE.contains("renderToReadableStream"));
         assert!(!REACT_SETUP_SOURCE.contains("renderToPipeableStream"));
+    }
+
+    #[test]
+    fn hydrate_shim_uses_hydrate_root_from_client() {
+        let a = ReactAdapter;
+        let src = a.hydrate_shim_source();
+        // React 18+: hydrateRoot from react-dom/client. Legacy
+        // `hydrate` from react-dom is removed in React 19, so guard
+        // against accidentally regressing to it.
+        assert!(src.contains(r#"from "react-dom/client""#));
+        assert!(src.contains("hydrateRoot"));
+        assert!(!src.contains(r#"from "react-dom""#));
+        assert!(src.contains("hydrateIsland"));
+        assert_eq!(a.hydrate_shim_specifier(), REACT_HYDRATE_SHIM_SPECIFIER);
+        assert!(a.hydrate_shim_specifier().starts_with("zfb:internal/"));
     }
 
     #[test]

--- a/crates/zfb/binaries/README.md
+++ b/crates/zfb/binaries/README.md
@@ -18,8 +18,12 @@ with the crate that owns the runtime contract.
 | Path                              | Purpose                                                       | Owner crate     |
 | --------------------------------- | ------------------------------------------------------------- | --------------- |
 | `tailwindcss-v4`                  | Tailwind CSS v4 standalone CLI binary (subprocess invocation) | `zfb-css`       |
+| `esbuild/esbuild`                 | esbuild standalone CLI binary (subprocess invocation)         | `zfb-islands`   |
 
 See `crates/zfb-css/README.md` for the pinned Tailwind version and rationale.
+See `crates/zfb-islands/README.md` for the pinned esbuild version and rationale,
+and `crates/zfb/binaries/esbuild/README.md` for the slot-shape rationale
+(the esbuild slot uses a subdirectory rather than a single file path).
 
 ## Why no binaries are committed
 

--- a/crates/zfb/binaries/esbuild/README.md
+++ b/crates/zfb/binaries/esbuild/README.md
@@ -1,0 +1,60 @@
+# `crates/zfb/binaries/esbuild/` — esbuild binary slot
+
+This directory reserves placement for the **esbuild standalone CLI binary**
+that the `zfb-islands` crate invokes as a subprocess (see
+`crates/zfb-islands/README.md` for the version pin).
+
+## Slot layout
+
+The release-tarball layout looks like this:
+
+```text
+zfb/                      # release tarball root
+├── zfb                   # the user-facing CLI executable
+└── binaries/
+    ├── tailwindcss-v4    # bundled Tailwind v4 CLI (zfb-css)
+    └── esbuild/          # this directory
+        └── esbuild       # bundled esbuild CLI (zfb-islands)
+```
+
+The `esbuild` binary file itself is **never** committed to this repo.
+`.gitignore` excludes the actual binary path; this directory is preserved
+in git via `.gitkeep`.
+
+## Why a subdirectory rather than a single file slot
+
+`crates/zfb/binaries/tailwindcss-v4` is a single-file slot because Tailwind
+ships exactly one CLI binary per platform. esbuild also ships a single CLI
+binary per platform — a subdirectory is used here so that platform-specific
+release tooling (a future epic) has room to drop a sidecar (e.g. a checksum
+manifest or a `LICENSE.md`) without polluting the parent `binaries/`
+namespace. The runtime path the subprocess code resolves to is
+`crates/zfb/binaries/esbuild` — that path is interpreted as the *binary
+file itself*, not as a directory; see the override env var
+`ZFB_ESBUILD_BIN`.
+
+> If the subdirectory shape proves to be unnecessary at release-engineering
+> time, this slot may be flattened back to a single file path. The
+> subprocess code reads the path verbatim, so the call site is unaffected.
+
+## Why this slot is reserved now
+
+Sub 2 of [issue #6](https://github.com/Takazudo/zudo-front-builder/issues/6)
+implements the subprocess wrapper. The wrapper needs a deterministic
+default path for the binary so that user code can construct an
+`EsbuildSubprocessConfig::default()` without environment fiddling. The
+binary itself will be downloaded and verified by a future
+release-engineering epic — this sub-task only **reserves the slot**.
+
+## Runtime resolution
+
+The `EsbuildSubprocessConfig::default()` constructor resolves the binary
+path as follows:
+
+1. If the `ZFB_ESBUILD_BIN` env var is set, use that path verbatim.
+2. Otherwise, default to `crates/zfb/binaries/esbuild/esbuild` (i.e. the
+   `esbuild` executable file inside this slot directory; relative to the
+   current working directory at engine construction time).
+
+A clear error message is returned if the binary is not present at the
+resolved path.

--- a/packages/zfb/README.md
+++ b/packages/zfb/README.md
@@ -1,0 +1,113 @@
+# zfb
+
+Public SDK module for [zudo-front-builder][zfb-repo]. User pages reach this
+package through the bare specifier `"zfb"` — the `zfb-render` runtime
+loader registers the source under that name at build time so user TSX can
+write:
+
+```tsx
+import { Island } from "zfb";
+```
+
+[zfb-repo]: https://github.com/Takazudo/zudo-front-builder
+
+## What lives here
+
+This package is the canonical TypeScript source for the `zfb` SDK
+surface. Today it covers:
+
+- `<Island when="visible|idle|load">` — JSX wrapper that marks a region
+  for client-side hydration.
+- `scheduleHydrate(target, when, fire)` — the runtime branching helper
+  consumed by the hydration runtime (Sub 3).
+- `When`, `WHEN_VALUES`, `DEFAULT_WHEN`, `isWhen`, `resolveWhen` — type
+  and runtime utilities pinning the spelling of the three modes.
+
+The package is JSX-runtime-agnostic: the `Island` component does not
+import preact or react, so it works under either framework adapter
+without bundling the wrong runtime.
+
+## Usage
+
+```tsx
+import { Island } from "zfb";
+import { Counter } from "../components/Counter.tsx"; // a "use client" component
+
+export default function Page() {
+  return (
+    <>
+      <h1>Welcome</h1>
+
+      {/* Hydrate immediately on page load (default). */}
+      <Island>
+        <Counter />
+      </Island>
+
+      {/* Hydrate during the next idle callback. */}
+      <Island when="idle">
+        <Counter />
+      </Island>
+
+      {/* Hydrate only when the island first scrolls into view. */}
+      <Island when="visible">
+        <Counter />
+      </Island>
+    </>
+  );
+}
+```
+
+## The three `when=` modes
+
+| `when`      | Trigger                                                         | Fallback                                       |
+| ----------- | --------------------------------------------------------------- | ---------------------------------------------- |
+| `"load"`    | Synchronous, immediate fire after registration. **Default.**    | n/a                                            |
+| `"idle"`    | `requestIdleCallback`                                           | `setTimeout(0)` when not available             |
+| `"visible"` | `IntersectionObserver`, threshold 0, first intersection only    | Immediate fire when `IntersectionObserver` is missing |
+
+Unknown values produce a `console.warn` in development builds and fall
+back to `"load"`.
+
+## Build-time output
+
+The wrapper is intentionally type-erased at the JSX boundary. At the
+call site, `<Island when="visible">{children}</Island>` renders as:
+
+```html
+<div data-zfb-island data-when="visible"><!-- children --></div>
+```
+
+The `data-zfb-island` attribute is empty here. The hydration emit step
+(`zfb-render` runtime, Sub 3) walks rendered HTML and replaces it with
+`data-zfb-island="ComponentName"` so the client-side hydration runtime
+can look up the right module to call.
+
+## Runtime helper
+
+The hydration runtime imports (or inlines) `scheduleHydrate` from this
+package:
+
+```ts
+import { scheduleHydrate } from "zfb/runtime";
+
+for (const el of document.querySelectorAll<HTMLElement>("[data-zfb-island]")) {
+  const when = el.getAttribute("data-when") ?? "load";
+  scheduleHydrate(el, when, () => hydrateOne(el));
+}
+```
+
+`scheduleHydrate` returns a `cancel` function that aborts the schedule
+if hydration has not fired yet. After firing, calling `cancel` is a
+no-op.
+
+## Tests
+
+```sh
+pnpm --filter zfb test
+```
+
+The tests run under [vitest][vitest] with [happy-dom][happy-dom] as the
+DOM implementation; no real browser is required.
+
+[vitest]: https://vitest.dev/
+[happy-dom]: https://github.com/capricorn86/happy-dom

--- a/packages/zfb/package.json
+++ b/packages/zfb/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "zfb",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "zfb public SDK — Island JSX wrapper and hydration scheduling helpers",
+  "license": "MIT",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./runtime": {
+      "types": "./src/runtime.ts",
+      "default": "./src/runtime.ts"
+    }
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "happy-dom": "^15.7.4",
+    "typescript": "^5.9.0",
+    "vitest": "^2.1.9"
+  }
+}

--- a/packages/zfb/src/__tests__/island.test.ts
+++ b/packages/zfb/src/__tests__/island.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Island, resolveWhen } from "../island.js";
+import { DEFAULT_WHEN, isWhen, WHEN_VALUES } from "../types.js";
+
+describe("Island JSX wrapper", () => {
+  it("renders a div with data-zfb-island marker and data-when='load' by default", () => {
+    const node = Island({ children: "hello" });
+    expect(node.type).toBe("div");
+    expect(node.props["data-zfb-island"]).toBe("");
+    expect(node.props["data-when"]).toBe("load");
+    expect(node.props.children).toBe("hello");
+  });
+
+  it("forwards a valid `when` value to data-when", () => {
+    for (const value of WHEN_VALUES) {
+      const node = Island({ when: value, children: null });
+      expect(node.props["data-when"]).toBe(value);
+    }
+  });
+
+  it("does not set data-zfb-island to a component name (Sub 3 fills that in)", () => {
+    const node = Island({ when: "visible", children: null });
+    // The marker exists but holds an empty value at the build-time wrapper
+    // stage. The hydration emit step (Sub 3) replaces it with the
+    // component-name string when it walks rendered HTML.
+    expect(node.props["data-zfb-island"]).toBe("");
+  });
+
+  it("preserves children verbatim, including arrays", () => {
+    const children = ["a", "b", { type: "span", props: {}, key: null }];
+    const node = Island({ when: "idle", children });
+    expect(node.props.children).toBe(children);
+  });
+});
+
+describe("resolveWhen", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it("returns the default when input is undefined", () => {
+    expect(resolveWhen(undefined)).toBe(DEFAULT_WHEN);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns the input unchanged when valid", () => {
+    expect(resolveWhen("visible")).toBe("visible");
+    expect(resolveWhen("idle")).toBe("idle");
+    expect(resolveWhen("load")).toBe("load");
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("warns and falls back to load for unknown strings (in development)", () => {
+    const original = process.env["NODE_ENV"];
+    process.env["NODE_ENV"] = "development";
+    try {
+      expect(resolveWhen("eager")).toBe(DEFAULT_WHEN);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const msg = String(warnSpy.mock.calls[0]?.[0] ?? "");
+      expect(msg).toContain("eager");
+      expect(msg).toContain("load");
+    } finally {
+      if (original === undefined) {
+        delete process.env["NODE_ENV"];
+      } else {
+        process.env["NODE_ENV"] = original;
+      }
+    }
+  });
+
+  it("does not warn in production builds", () => {
+    const original = process.env["NODE_ENV"];
+    process.env["NODE_ENV"] = "production";
+    try {
+      expect(resolveWhen("eager")).toBe(DEFAULT_WHEN);
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      if (original === undefined) {
+        delete process.env["NODE_ENV"];
+      } else {
+        process.env["NODE_ENV"] = original;
+      }
+    }
+  });
+});
+
+describe("isWhen", () => {
+  it("accepts the three valid strings only", () => {
+    expect(isWhen("visible")).toBe(true);
+    expect(isWhen("idle")).toBe(true);
+    expect(isWhen("load")).toBe(true);
+    expect(isWhen("eager")).toBe(false);
+    expect(isWhen("")).toBe(false);
+    expect(isWhen(undefined)).toBe(false);
+    expect(isWhen(null)).toBe(false);
+    expect(isWhen(0)).toBe(false);
+  });
+});

--- a/packages/zfb/src/__tests__/runtime.test.ts
+++ b/packages/zfb/src/__tests__/runtime.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
+
+import { scheduleHydrate } from "../runtime.js";
+
+type IntersectionCallback = (
+  entries: Array<{ isIntersecting: boolean; target: Element }>,
+  observer: { disconnect(): void; observe(el: Element): void },
+) => void;
+
+interface FakeObserverInstance {
+  disconnect: ReturnType<typeof vi.fn>;
+  observe: ReturnType<typeof vi.fn>;
+  unobserve: ReturnType<typeof vi.fn>;
+  trigger: (target: Element, isIntersecting: boolean) => void;
+  options: { threshold?: number | number[] } | undefined;
+}
+
+describe("scheduleHydrate", () => {
+  let target: HTMLElement;
+
+  beforeEach(() => {
+    target = document.createElement("div");
+    document.body.appendChild(target);
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  describe("when='load'", () => {
+    it("fires synchronously and returns a no-op cancel", () => {
+      const fire = vi.fn();
+      const cancel = scheduleHydrate(target, "load", fire);
+      expect(fire).toHaveBeenCalledTimes(1);
+      // Calling cancel after fire is safe and a no-op.
+      expect(() => cancel()).not.toThrow();
+      expect(fire).toHaveBeenCalledTimes(1);
+    });
+
+    it("treats omitted `when` as load (default)", () => {
+      const fire = vi.fn();
+      scheduleHydrate(target, undefined, fire);
+      expect(fire).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("when='idle'", () => {
+    it("uses requestIdleCallback when available", () => {
+      const calls: Array<() => void> = [];
+      const ric = vi.fn((cb: () => void) => {
+        calls.push(cb);
+        return 42;
+      });
+      const cic = vi.fn();
+      vi.stubGlobal("requestIdleCallback", ric);
+      vi.stubGlobal("cancelIdleCallback", cic);
+
+      const fire = vi.fn();
+      scheduleHydrate(target, "idle", fire);
+
+      expect(ric).toHaveBeenCalledTimes(1);
+      expect(fire).not.toHaveBeenCalled();
+
+      // Drain the queued idle callback.
+      calls[0]?.();
+      expect(fire).toHaveBeenCalledTimes(1);
+    });
+
+    it("falls back to setTimeout(0) when requestIdleCallback is absent", async () => {
+      // Make sure happy-dom does not expose it.
+      vi.stubGlobal("requestIdleCallback", undefined);
+
+      vi.useFakeTimers();
+      try {
+        const fire = vi.fn();
+        scheduleHydrate(target, "idle", fire);
+        expect(fire).not.toHaveBeenCalled();
+        vi.advanceTimersByTime(0);
+        expect(fire).toHaveBeenCalledTimes(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("cancel() prevents the idle callback from firing", () => {
+      const calls: Array<() => void> = [];
+      const ric = vi.fn((cb: () => void) => {
+        calls.push(cb);
+        return 7;
+      });
+      const cic = vi.fn();
+      vi.stubGlobal("requestIdleCallback", ric);
+      vi.stubGlobal("cancelIdleCallback", cic);
+
+      const fire = vi.fn();
+      const cancel = scheduleHydrate(target, "idle", fire);
+      cancel();
+      // Even if the runtime delivers the callback, `fire` is gated by the
+      // cancellation flag.
+      calls[0]?.();
+      expect(fire).not.toHaveBeenCalled();
+      expect(cic).toHaveBeenCalledWith(7);
+    });
+  });
+
+  describe("when='visible'", () => {
+    let observers: FakeObserverInstance[];
+    let ObserverSpy: MockInstance<
+      (cb: IntersectionCallback, options?: { threshold?: number | number[] }) => unknown
+    >;
+
+    beforeEach(() => {
+      observers = [];
+      function FakeObserver(
+        cb: IntersectionCallback,
+        options?: { threshold?: number | number[] },
+      ): FakeObserverInstance {
+        const instance: FakeObserverInstance = {
+          options,
+          disconnect: vi.fn(),
+          observe: vi.fn(),
+          unobserve: vi.fn(),
+          trigger(t: Element, isIntersecting: boolean) {
+            cb([{ isIntersecting, target: t }], {
+              disconnect: instance.disconnect,
+              observe: instance.observe,
+            });
+          },
+        };
+        observers.push(instance);
+        return instance;
+      }
+      ObserverSpy = vi.fn(FakeObserver) as unknown as typeof ObserverSpy;
+      vi.stubGlobal("IntersectionObserver", ObserverSpy);
+    });
+
+    it("does not hydrate before intersection, hydrates on first intersection, then disconnects", () => {
+      const fire = vi.fn();
+      scheduleHydrate(target, "visible", fire);
+
+      expect(ObserverSpy).toHaveBeenCalledTimes(1);
+      const inst = observers[0];
+      if (!inst) throw new Error("expected observer instance");
+      expect(inst.observe).toHaveBeenCalledWith(target);
+      expect(inst.options?.threshold).toBe(0);
+      expect(fire).not.toHaveBeenCalled();
+
+      // Non-intersecting entry is ignored.
+      inst.trigger(target, false);
+      expect(fire).not.toHaveBeenCalled();
+      expect(inst.disconnect).not.toHaveBeenCalled();
+
+      // First intersecting entry fires and disconnects.
+      inst.trigger(target, true);
+      expect(fire).toHaveBeenCalledTimes(1);
+      expect(inst.disconnect).toHaveBeenCalledTimes(1);
+
+      // Subsequent intersections do not re-fire.
+      inst.trigger(target, true);
+      expect(fire).toHaveBeenCalledTimes(1);
+    });
+
+    it("cancel() disconnects the observer and prevents firing", () => {
+      const fire = vi.fn();
+      const cancel = scheduleHydrate(target, "visible", fire);
+      const inst = observers[0];
+      if (!inst) throw new Error("expected observer instance");
+      cancel();
+      expect(inst.disconnect).toHaveBeenCalledTimes(1);
+      // Even if a stale entry is delivered, fire is gated.
+      inst.trigger(target, true);
+      expect(fire).not.toHaveBeenCalled();
+    });
+
+    it("falls back to immediate fire when IntersectionObserver is missing", () => {
+      vi.stubGlobal("IntersectionObserver", undefined);
+      const fire = vi.fn();
+      scheduleHydrate(target, "visible", fire);
+      expect(fire).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("unknown when=", () => {
+    it("warns and falls back to load (immediate)", () => {
+      const original = process.env["NODE_ENV"];
+      process.env["NODE_ENV"] = "development";
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const fire = vi.fn();
+        scheduleHydrate(target, "eager", fire);
+        expect(fire).toHaveBeenCalledTimes(1);
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+      } finally {
+        warnSpy.mockRestore();
+        if (original === undefined) {
+          delete process.env["NODE_ENV"];
+        } else {
+          process.env["NODE_ENV"] = original;
+        }
+      }
+    });
+  });
+});

--- a/packages/zfb/src/index.ts
+++ b/packages/zfb/src/index.ts
@@ -1,0 +1,10 @@
+// Public entry point for the "zfb" package.
+//
+// User TSX pages reach this module via `import { Island } from "zfb"`.
+// The hydration runtime (Sub 3) reaches the helper via
+// `import { scheduleHydrate } from "zfb/runtime"` (or by inlining the
+// same logic; coordinated separately).
+
+export { Island, resolveWhen, type IslandProps } from "./island.js";
+export { scheduleHydrate } from "./runtime.js";
+export { DEFAULT_WHEN, isWhen, WHEN_VALUES, type When } from "./types.js";

--- a/packages/zfb/src/island.ts
+++ b/packages/zfb/src/island.ts
@@ -1,0 +1,84 @@
+// Build-time `<Island when="...">` JSX wrapper.
+//
+// The wrapper is intentionally JSX-runtime-agnostic: it does not import
+// preact or react and never calls h() / createElement directly. Instead it
+// returns a plain object with a fixed shape that both Preact's and React's
+// jsx-runtime accept when the JSX transform turns the call site into a
+// jsx(Island, props) invocation.
+//
+// At build time:
+//   <Island when="visible">{children}</Island>
+// renders as:
+//   <div data-zfb-island data-when="visible">{children}</div>
+//
+// The component-name attribute (data-zfb-island="ComponentName") is filled
+// in by the hydration emit step (Sub 3) when it walks rendered HTML and
+// rewrites server output. This wrapper only sets the marker presence and
+// data-when.
+//
+// When validation: in development we console.warn for unknown `when`
+// values and fall back to the default. In production we silently fall
+// back to keep the bundle path small.
+
+import type { ReactNode } from "./jsx-types.js";
+import { DEFAULT_WHEN, isWhen, type When } from "./types.js";
+
+/** Props for `<Island>`. */
+export interface IslandProps {
+  /** Hydration scheduling strategy. Defaults to `"load"`. */
+  when?: When;
+  /** Server-rendered children, hydrated client-side once `when` fires. */
+  children?: ReactNode;
+}
+
+/**
+ * Resolve the validated `when` value, warning in development for unknown
+ * inputs. Exported so tests can pin the warning behavior.
+ */
+export function resolveWhen(when: unknown): When {
+  if (when === undefined) return DEFAULT_WHEN;
+  if (isWhen(when)) return when;
+  if (typeof process !== "undefined" && process.env && process.env["NODE_ENV"] !== "production") {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[zfb] <Island when="${String(when)}"> is not a valid value. ` +
+        `Expected "visible" | "idle" | "load". Falling back to "${DEFAULT_WHEN}".`,
+    );
+  }
+  return DEFAULT_WHEN;
+}
+
+/**
+ * `<Island>` JSX wrapper.
+ *
+ * Returns a JSX element shape compatible with both Preact and React. The
+ * runtime tag is `"div"` and the only props set on it are
+ * `data-zfb-island` (always present, value empty until Sub 3 fills in
+ * the component name) and `data-when` (the resolved scheduling strategy).
+ *
+ * This function is intentionally untyped at the JSX-element-shape boundary:
+ * Preact and React expose subtly different VNode shapes, but both renderers
+ * accept the form `{ type, props, key }` produced by their jsx-runtime
+ * transforms when called via `jsx(Island, props)`. Runtime test coverage
+ * verifies the rendered DOM is correct for at least one renderer.
+ */
+export function Island(props: IslandProps): {
+  type: "div";
+  props: {
+    "data-zfb-island": string;
+    "data-when": When;
+    children: ReactNode;
+  };
+  key: null;
+} {
+  const when = resolveWhen(props.when);
+  return {
+    type: "div",
+    props: {
+      "data-zfb-island": "",
+      "data-when": when,
+      children: props.children as ReactNode,
+    },
+    key: null,
+  };
+}

--- a/packages/zfb/src/jsx-types.ts
+++ b/packages/zfb/src/jsx-types.ts
@@ -1,0 +1,18 @@
+// Lightweight ambient JSX types so the public Island wrapper does not
+// hard-depend on either preact or react as a runtime/types dependency.
+//
+// Both Preact and React's `children` accept this minimal union; the build
+// is type-erased so the actual rendering happens in the user's app under
+// whichever framework adapter they chose.
+
+export type ReactNode =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined
+  | bigint
+  | ReactNodeArray
+  | { readonly [key: string]: unknown };
+
+export interface ReactNodeArray extends ReadonlyArray<ReactNode> {}

--- a/packages/zfb/src/runtime.ts
+++ b/packages/zfb/src/runtime.ts
@@ -1,0 +1,134 @@
+// Hydration scheduling helper consumed by the hydration runtime (Sub 3).
+//
+// Sub 3 owns the hydration runtime that walks the DOM, finds elements
+// marked with `data-zfb-island`, and dispatches each one through this
+// helper to decide *when* to fire the actual hydrate() call. The helper
+// itself does not know how to hydrate — it only schedules the supplied
+// `fire` callback.
+//
+// The branching matches the `When` union exactly:
+//   "visible" → IntersectionObserver, threshold 0.0, hydrate on first
+//                intersection, then disconnect.
+//   "idle"    → requestIdleCallback if available, otherwise setTimeout(0).
+//   "load"    → immediate, synchronous fire.
+//
+// Anything else is treated as "load" (with a console.warn in development).
+// The helper is environment-tolerant: callers can run it in jsdom /
+// happy-dom or bare Node, and the absence of `IntersectionObserver` /
+// `requestIdleCallback` is handled gracefully.
+
+import { resolveWhen } from "./island.js";
+import type { When } from "./types.js";
+
+/** Window-shaped subset that the helper actually uses. */
+type IdleWindow = typeof globalThis & {
+  requestIdleCallback?: (
+    cb: (deadline: { didTimeout: boolean; timeRemaining: () => number }) => void,
+    options?: { timeout?: number },
+  ) => number;
+};
+
+/**
+ * Schedule a hydration `fire` callback for `target` according to `when`.
+ *
+ * Returns a `cancel` function that aborts the scheduling if it has not
+ * fired yet. After firing, calling `cancel` is a no-op. If the helper
+ * cannot find the relevant browser API (e.g. running in pure Node with no
+ * polyfill), it falls back to firing synchronously so server-side smoke
+ * tests still observe the call.
+ */
+export function scheduleHydrate(
+  target: Element,
+  when: When | string | undefined,
+  fire: () => void,
+): () => void {
+  const resolved = resolveWhen(when);
+
+  if (resolved === "load") {
+    fire();
+    return noop;
+  }
+
+  if (resolved === "idle") {
+    return scheduleIdle(fire);
+  }
+
+  // "visible"
+  return scheduleVisible(target, fire);
+}
+
+function noop(): void {
+  // intentionally empty
+}
+
+function scheduleIdle(fire: () => void): () => void {
+  const w = globalThis as IdleWindow;
+  let cancelled = false;
+  let fired = false;
+  const wrapped = (): void => {
+    if (cancelled || fired) return;
+    fired = true;
+    fire();
+  };
+
+  if (typeof w.requestIdleCallback === "function") {
+    const handle = w.requestIdleCallback(wrapped);
+    return () => {
+      if (fired) return;
+      cancelled = true;
+      const cancelIdle = (
+        globalThis as typeof globalThis & {
+          cancelIdleCallback?: (handle: number) => void;
+        }
+      ).cancelIdleCallback;
+      if (typeof cancelIdle === "function") cancelIdle(handle);
+    };
+  }
+
+  const handle = setTimeout(wrapped, 0);
+  return () => {
+    if (fired) return;
+    cancelled = true;
+    clearTimeout(handle);
+  };
+}
+
+function scheduleVisible(target: Element, fire: () => void): () => void {
+  const Observer = (
+    globalThis as typeof globalThis & {
+      IntersectionObserver?: typeof IntersectionObserver;
+    }
+  ).IntersectionObserver;
+
+  // No IntersectionObserver (e.g. very old browsers, bare Node) — fail
+  // open and hydrate immediately so the island is at least functional.
+  if (typeof Observer !== "function") {
+    fire();
+    return noop;
+  }
+
+  let fired = false;
+  let cancelled = false;
+  const observer = new Observer(
+    (entries, obs) => {
+      if (cancelled || fired) return;
+      for (const entry of entries) {
+        if (entry.isIntersecting) {
+          fired = true;
+          obs.disconnect();
+          fire();
+          return;
+        }
+      }
+    },
+    { threshold: 0 },
+  );
+
+  observer.observe(target);
+
+  return () => {
+    if (fired) return;
+    cancelled = true;
+    observer.disconnect();
+  };
+}

--- a/packages/zfb/src/types.ts
+++ b/packages/zfb/src/types.ts
@@ -1,0 +1,29 @@
+// Public type surface for the zfb island system.
+//
+// `When` is the string-literal union of allowed `data-when` values. The
+// hydration runtime (Sub 3) reads the same attribute and dispatches on the
+// same set of strings. Keep these in sync; the unit tests pin the spelling.
+
+/**
+ * Hydration scheduling strategy.
+ *
+ * - `"visible"` — hydrate when the island first intersects the viewport
+ *   (IntersectionObserver, threshold 0). Cheapest deferral for content the
+ *   user has not scrolled to yet.
+ * - `"idle"` — hydrate during the next idle callback. Falls back to a
+ *   `setTimeout(0)` on platforms without `requestIdleCallback`.
+ * - `"load"` — hydrate immediately and synchronously. Default when
+ *   `when` is omitted.
+ */
+export type When = "visible" | "idle" | "load";
+
+/** Public set of allowed `When` values, useful for runtime validation. */
+export const WHEN_VALUES: readonly When[] = ["visible", "idle", "load"];
+
+/** Default `when` strategy applied when `when` is omitted. */
+export const DEFAULT_WHEN: When = "load";
+
+/** Type guard for `When`. */
+export function isWhen(value: unknown): value is When {
+  return typeof value === "string" && (WHEN_VALUES as readonly string[]).includes(value);
+}

--- a/packages/zfb/tsconfig.json
+++ b/packages/zfb/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "jsx": "preserve",
+    "types": ["node"],
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/zfb/vitest.config.ts
+++ b/packages/zfb/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "happy-dom",
+    include: ["src/**/__tests__/**/*.test.ts"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,18 @@ importers:
         specifier: ^4.85.0
         version: 4.85.0
 
+  crates/zfb-islands/npm:
+    devDependencies:
+      happy-dom:
+        specifier: ^15.11.7
+        version: 15.11.7
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@22.19.17)(happy-dom@15.11.7)(lightningcss@1.32.0)
+
   docs:
     dependencies:
       '@astrojs/mdx':
@@ -335,6 +347,12 @@ packages:
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
@@ -353,6 +371,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
@@ -369,6 +393,12 @@ packages:
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.12':
@@ -389,6 +419,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
@@ -407,6 +443,12 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
@@ -423,6 +465,12 @@ packages:
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.12':
@@ -443,6 +491,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
@@ -459,6 +513,12 @@ packages:
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -479,6 +539,12 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
@@ -495,6 +561,12 @@ packages:
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.12':
@@ -515,6 +587,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
@@ -531,6 +609,12 @@ packages:
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.12':
@@ -551,6 +635,12 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
@@ -567,6 +657,12 @@ packages:
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -587,6 +683,12 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
@@ -605,6 +707,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
@@ -621,6 +729,12 @@ packages:
     resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.12':
@@ -659,6 +773,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
@@ -693,6 +813,12 @@ packages:
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -731,6 +857,12 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
@@ -748,6 +880,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
@@ -767,6 +905,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.12':
     resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
@@ -783,6 +927,12 @@ packages:
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.12':
@@ -1495,6 +1645,35 @@ packages:
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
   '@volar/kit@2.4.28':
     resolution: {integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==}
     peerDependencies:
@@ -1578,6 +1757,10 @@ packages:
   array-iterate@2.0.1:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
@@ -1622,6 +1805,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   camelcase@8.0.0:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
     engines: {node: '>=16'}
@@ -1631,6 +1818,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
 
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
@@ -1647,6 +1838,10 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chevrotain-allstar@0.4.1:
     resolution: {integrity: sha512-PvVJm3oGqrveUVW2Vt/eZGeiAIsJszYweUcYwcskg9e+IubNYKKD+rHHem7A6XVO22eDAL+inxNIGAzZ/VIWlA==}
@@ -1929,6 +2124,10 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
@@ -2019,6 +2218,11 @@ packages:
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
 
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
@@ -2073,6 +2277,10 @@ packages:
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
@@ -2139,6 +2347,10 @@ packages:
 
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
+  happy-dom@15.11.7:
+    resolution: {integrity: sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==}
+    engines: {node: '>=18.0.0'}
 
   hast-util-from-html@2.0.3:
     resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
@@ -2446,6 +2658,9 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
@@ -2763,8 +2978,15 @@ packages:
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   piccolore@0.1.3:
     resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
@@ -2965,6 +3187,9 @@ packages:
   shiki@3.23.0:
     resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   simple-code-frame@1.3.0:
     resolution: {integrity: sha512-MB4pQmETUBlNs62BBeRjIFGeuy/x6gGKh7+eRUemn1rCFhqo7K+4slPqsyizCbcbYLnaYqaoZ2FWsZ/jN06D8w==}
 
@@ -2992,6 +3217,12 @@ packages:
   stack-trace@1.0.0-pre2:
     resolution: {integrity: sha512-2ztBJRek8IVofG9DBJqdy2N5kulaacX30Nz7xmkYF6ale9WBVmIy6mFBchvGX7Vx/MyjBhx+Rcxqrj+dbOnQ6A==}
     engines: {node: '>=16'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -3044,6 +3275,12 @@ packages:
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
@@ -3051,6 +3288,18 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -3226,10 +3475,46 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite-prerender-plugin@0.5.13:
     resolution: {integrity: sha512-IKSpYkzDBsKAxa05naRbj7GvNVMSdww/Z/E89oO3xndz+gWnOBOKOAbEXv7qDhktY/j3vHgJmoV1pPzqU2tx9g==}
     peerDependencies:
       vite: 5.x || 6.x || 7.x || 8.x
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
 
   vite@6.4.2:
     resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
@@ -3277,6 +3562,31 @@ packages:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       vite:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   volar-service-css@0.0.70:
@@ -3374,9 +3684,22 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
     engines: {node: '>=4'}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   widest-line@5.0.0:
     resolution: {integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==}
@@ -3827,6 +4150,9 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
@@ -3834,6 +4160,9 @@ snapshots:
     optional: true
 
   '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
@@ -3845,6 +4174,9 @@ snapshots:
   '@esbuild/android-arm64@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.25.12':
     optional: true
 
@@ -3852,6 +4184,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
@@ -3863,6 +4198,9 @@ snapshots:
   '@esbuild/android-x64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
@@ -3870,6 +4208,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
@@ -3881,6 +4222,9 @@ snapshots:
   '@esbuild/darwin-x64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
@@ -3888,6 +4232,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -3899,6 +4246,9 @@ snapshots:
   '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
@@ -3906,6 +4256,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
@@ -3917,6 +4270,9 @@ snapshots:
   '@esbuild/linux-arm@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
@@ -3924,6 +4280,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
@@ -3935,6 +4294,9 @@ snapshots:
   '@esbuild/linux-loong64@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
@@ -3942,6 +4304,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -3953,6 +4318,9 @@ snapshots:
   '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
@@ -3962,6 +4330,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
@@ -3969,6 +4340,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -3989,6 +4363,9 @@ snapshots:
   '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
@@ -4005,6 +4382,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -4025,6 +4405,9 @@ snapshots:
   '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
@@ -4032,6 +4415,9 @@ snapshots:
     optional: true
 
   '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
@@ -4043,6 +4429,9 @@ snapshots:
   '@esbuild/win32-arm64@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
@@ -4050,6 +4439,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
@@ -4688,6 +5080,46 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.17)(lightningcss@1.32.0))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
   '@volar/kit@2.4.28(typescript@5.9.3)':
     dependencies:
       '@volar/language-service': 2.4.28
@@ -4783,6 +5215,8 @@ snapshots:
   aria-query@5.3.2: {}
 
   array-iterate@2.0.1: {}
+
+  assertion-error@2.0.1: {}
 
   astring@1.9.0: {}
 
@@ -4923,11 +5357,21 @@ snapshots:
       node-releases: 2.0.38
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  cac@6.7.14: {}
+
   camelcase@8.0.0: {}
 
   caniuse-lite@1.0.30001790: {}
 
   ccount@2.0.1: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
 
   chalk@5.6.2: {}
 
@@ -4938,6 +5382,8 @@ snapshots:
   character-entities@2.0.2: {}
 
   character-reference-invalid@2.0.1: {}
+
+  check-error@2.1.3: {}
 
   chevrotain-allstar@0.4.1(chevrotain@12.0.0):
     dependencies:
@@ -5232,6 +5678,8 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  deep-eql@5.0.2: {}
+
   defu@6.1.7: {}
 
   delaunator@5.1.0:
@@ -5319,6 +5767,32 @@ snapshots:
       acorn: 8.16.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -5450,6 +5924,8 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  expect-type@1.3.0: {}
+
   extend-shallow@2.0.1:
     dependencies:
       is-extendable: 0.1.1
@@ -5507,6 +5983,12 @@ snapshots:
       uncrypto: 0.1.3
 
   hachure-fill@0.5.2: {}
+
+  happy-dom@15.11.7:
+    dependencies:
+      entities: 4.5.0
+      webidl-conversions: 7.0.0
+      whatwg-mimetype: 3.0.0
 
   hast-util-from-html@2.0.3:
     dependencies:
@@ -5830,6 +6312,8 @@ snapshots:
   lodash-es@4.18.1: {}
 
   longest-streak@3.1.0: {}
+
+  loupe@3.2.1: {}
 
   lru-cache@11.3.5: {}
 
@@ -6477,7 +6961,11 @@ snapshots:
 
   path-to-regexp@6.3.0: {}
 
+  pathe@1.1.2: {}
+
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   piccolore@0.1.3: {}
 
@@ -6798,6 +7286,8 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  siginfo@2.0.0: {}
+
   simple-code-frame@1.3.0:
     dependencies:
       kolorist: 1.8.0
@@ -6815,6 +7305,10 @@ snapshots:
   sprintf-js@1.0.3: {}
 
   stack-trace@1.0.0-pre2: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -6871,12 +7365,22 @@ snapshots:
 
   tiny-inflate@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyexec@1.1.1: {}
 
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   trim-lines@3.0.1: {}
 
@@ -7011,6 +7515,24 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@2.1.9(@types/node@22.19.17)(lightningcss@1.32.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-prerender-plugin@0.5.13(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)):
     dependencies:
       kolorist: 1.8.0
@@ -7020,6 +7542,16 @@ snapshots:
       source-map: 0.7.6
       stack-trace: 1.0.0-pre2
       vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+
+  vite@5.4.21(@types/node@22.19.17)(lightningcss@1.32.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.10
+      rollup: 4.60.2
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3
+      lightningcss: 1.32.0
 
   vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3):
     dependencies:
@@ -7039,6 +7571,42 @@ snapshots:
   vitefu@1.1.3(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)):
     optionalDependencies:
       vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+
+  vitest@2.1.9(@types/node@22.19.17)(happy-dom@15.11.7)(lightningcss@1.32.0):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.17)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)
+      vite-node: 2.1.9(@types/node@22.19.17)(lightningcss@1.32.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+      happy-dom: 15.11.7
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   volar-service-css@0.0.70(@volar/language-service@2.4.28):
     dependencies:
@@ -7139,7 +7707,16 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
+  webidl-conversions@7.0.0: {}
+
+  whatwg-mimetype@3.0.0: {}
+
   which-pm-runs@1.1.0: {}
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   widest-line@5.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,21 @@ importers:
         specifier: ^5.9.0
         version: 5.9.3
 
+  packages/zfb:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      happy-dom:
+        specifier: ^15.7.4
+        version: 15.11.7
+      typescript:
+        specifier: ^5.9.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@22.19.17)(happy-dom@15.11.7)(lightningcss@1.32.0)
+
 packages:
 
   '@antfu/install-pkg@1.1.0':
@@ -335,6 +350,12 @@ packages:
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
@@ -353,6 +374,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
@@ -369,6 +396,12 @@ packages:
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.12':
@@ -389,6 +422,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
@@ -407,6 +446,12 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
@@ -423,6 +468,12 @@ packages:
     resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.12':
@@ -443,6 +494,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
@@ -459,6 +516,12 @@ packages:
     resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -479,6 +542,12 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
@@ -495,6 +564,12 @@ packages:
     resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.12':
@@ -515,6 +590,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
@@ -531,6 +612,12 @@ packages:
     resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.12':
@@ -551,6 +638,12 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
@@ -567,6 +660,12 @@ packages:
     resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -587,6 +686,12 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
@@ -605,6 +710,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
@@ -621,6 +732,12 @@ packages:
     resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.12':
@@ -659,6 +776,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
@@ -693,6 +816,12 @@ packages:
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -731,6 +860,12 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
@@ -748,6 +883,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
@@ -767,6 +908,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.12':
     resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
@@ -783,6 +930,12 @@ packages:
     resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.12':
@@ -1495,6 +1648,35 @@ packages:
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
   '@volar/kit@2.4.28':
     resolution: {integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==}
     peerDependencies:
@@ -1578,6 +1760,10 @@ packages:
   array-iterate@2.0.1:
     resolution: {integrity: sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
@@ -1622,6 +1808,10 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   camelcase@8.0.0:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
     engines: {node: '>=16'}
@@ -1631,6 +1821,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
 
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
@@ -1647,6 +1841,10 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chevrotain-allstar@0.4.1:
     resolution: {integrity: sha512-PvVJm3oGqrveUVW2Vt/eZGeiAIsJszYweUcYwcskg9e+IubNYKKD+rHHem7A6XVO22eDAL+inxNIGAzZ/VIWlA==}
@@ -1929,6 +2127,10 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
@@ -2019,6 +2221,11 @@ packages:
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
 
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
@@ -2073,6 +2280,10 @@ packages:
 
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
@@ -2139,6 +2350,10 @@ packages:
 
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
+  happy-dom@15.11.7:
+    resolution: {integrity: sha512-KyrFvnl+J9US63TEzwoiJOQzZBJY7KgBushJA8X61DMbNsH+2ONkDuLDnCnwUiPTF42tLoEmrPyoqbenVA5zrg==}
+    engines: {node: '>=18.0.0'}
 
   hast-util-from-html@2.0.3:
     resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
@@ -2446,6 +2661,9 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
@@ -2763,8 +2981,15 @@ packages:
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   piccolore@0.1.3:
     resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
@@ -2965,6 +3190,9 @@ packages:
   shiki@3.23.0:
     resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   simple-code-frame@1.3.0:
     resolution: {integrity: sha512-MB4pQmETUBlNs62BBeRjIFGeuy/x6gGKh7+eRUemn1rCFhqo7K+4slPqsyizCbcbYLnaYqaoZ2FWsZ/jN06D8w==}
 
@@ -2992,6 +3220,12 @@ packages:
   stack-trace@1.0.0-pre2:
     resolution: {integrity: sha512-2ztBJRek8IVofG9DBJqdy2N5kulaacX30Nz7xmkYF6ale9WBVmIy6mFBchvGX7Vx/MyjBhx+Rcxqrj+dbOnQ6A==}
     engines: {node: '>=16'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -3044,6 +3278,12 @@ packages:
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
@@ -3051,6 +3291,18 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -3226,10 +3478,46 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite-prerender-plugin@0.5.13:
     resolution: {integrity: sha512-IKSpYkzDBsKAxa05naRbj7GvNVMSdww/Z/E89oO3xndz+gWnOBOKOAbEXv7qDhktY/j3vHgJmoV1pPzqU2tx9g==}
     peerDependencies:
       vite: 5.x || 6.x || 7.x || 8.x
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
 
   vite@6.4.2:
     resolution: {integrity: sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==}
@@ -3277,6 +3565,31 @@ packages:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       vite:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   volar-service-css@0.0.70:
@@ -3374,9 +3687,22 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
     engines: {node: '>=4'}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   widest-line@5.0.0:
     resolution: {integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==}
@@ -3827,6 +4153,9 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
@@ -3834,6 +4163,9 @@ snapshots:
     optional: true
 
   '@esbuild/aix-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
@@ -3845,6 +4177,9 @@ snapshots:
   '@esbuild/android-arm64@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.25.12':
     optional: true
 
@@ -3852,6 +4187,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
@@ -3863,6 +4201,9 @@ snapshots:
   '@esbuild/android-x64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
@@ -3870,6 +4211,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
@@ -3881,6 +4225,9 @@ snapshots:
   '@esbuild/darwin-x64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
@@ -3888,6 +4235,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -3899,6 +4249,9 @@ snapshots:
   '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
@@ -3906,6 +4259,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
@@ -3917,6 +4273,9 @@ snapshots:
   '@esbuild/linux-arm@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
@@ -3924,6 +4283,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
@@ -3935,6 +4297,9 @@ snapshots:
   '@esbuild/linux-loong64@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
@@ -3942,6 +4307,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-mips64el@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -3953,6 +4321,9 @@ snapshots:
   '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
@@ -3962,6 +4333,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
@@ -3969,6 +4343,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -3989,6 +4366,9 @@ snapshots:
   '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
@@ -4005,6 +4385,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -4025,6 +4408,9 @@ snapshots:
   '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
@@ -4032,6 +4418,9 @@ snapshots:
     optional: true
 
   '@esbuild/sunos-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
@@ -4043,6 +4432,9 @@ snapshots:
   '@esbuild/win32-arm64@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
@@ -4050,6 +4442,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-ia32@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
@@ -4688,6 +5083,46 @@ snapshots:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.17)(lightningcss@1.32.0))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
   '@volar/kit@2.4.28(typescript@5.9.3)':
     dependencies:
       '@volar/language-service': 2.4.28
@@ -4783,6 +5218,8 @@ snapshots:
   aria-query@5.3.2: {}
 
   array-iterate@2.0.1: {}
+
+  assertion-error@2.0.1: {}
 
   astring@1.9.0: {}
 
@@ -4923,11 +5360,21 @@ snapshots:
       node-releases: 2.0.38
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
+  cac@6.7.14: {}
+
   camelcase@8.0.0: {}
 
   caniuse-lite@1.0.30001790: {}
 
   ccount@2.0.1: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
 
   chalk@5.6.2: {}
 
@@ -4938,6 +5385,8 @@ snapshots:
   character-entities@2.0.2: {}
 
   character-reference-invalid@2.0.1: {}
+
+  check-error@2.1.3: {}
 
   chevrotain-allstar@0.4.1(chevrotain@12.0.0):
     dependencies:
@@ -5232,6 +5681,8 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
+  deep-eql@5.0.2: {}
+
   defu@6.1.7: {}
 
   delaunator@5.1.0:
@@ -5319,6 +5770,32 @@ snapshots:
       acorn: 8.16.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -5450,6 +5927,8 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  expect-type@1.3.0: {}
+
   extend-shallow@2.0.1:
     dependencies:
       is-extendable: 0.1.1
@@ -5507,6 +5986,12 @@ snapshots:
       uncrypto: 0.1.3
 
   hachure-fill@0.5.2: {}
+
+  happy-dom@15.11.7:
+    dependencies:
+      entities: 4.5.0
+      webidl-conversions: 7.0.0
+      whatwg-mimetype: 3.0.0
 
   hast-util-from-html@2.0.3:
     dependencies:
@@ -5830,6 +6315,8 @@ snapshots:
   lodash-es@4.18.1: {}
 
   longest-streak@3.1.0: {}
+
+  loupe@3.2.1: {}
 
   lru-cache@11.3.5: {}
 
@@ -6477,7 +6964,11 @@ snapshots:
 
   path-to-regexp@6.3.0: {}
 
+  pathe@1.1.2: {}
+
   pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
 
   piccolore@0.1.3: {}
 
@@ -6798,6 +7289,8 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
+  siginfo@2.0.0: {}
+
   simple-code-frame@1.3.0:
     dependencies:
       kolorist: 1.8.0
@@ -6815,6 +7308,10 @@ snapshots:
   sprintf-js@1.0.3: {}
 
   stack-trace@1.0.0-pre2: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   string-width@4.2.3:
     dependencies:
@@ -6871,12 +7368,22 @@ snapshots:
 
   tiny-inflate@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyexec@1.1.1: {}
 
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   trim-lines@3.0.1: {}
 
@@ -7011,6 +7518,24 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
+  vite-node@2.1.9(@types/node@22.19.17)(lightningcss@1.32.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-prerender-plugin@0.5.13(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)):
     dependencies:
       kolorist: 1.8.0
@@ -7020,6 +7545,16 @@ snapshots:
       source-map: 0.7.6
       stack-trace: 1.0.0-pre2
       vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+
+  vite@5.4.21(@types/node@22.19.17)(lightningcss@1.32.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.10
+      rollup: 4.60.2
+    optionalDependencies:
+      '@types/node': 22.19.17
+      fsevents: 2.3.3
+      lightningcss: 1.32.0
 
   vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3):
     dependencies:
@@ -7039,6 +7574,42 @@ snapshots:
   vitefu@1.1.3(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)):
     optionalDependencies:
       vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
+
+  vitest@2.1.9(@types/node@22.19.17)(happy-dom@15.11.7)(lightningcss@1.32.0):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.17)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)
+      vite-node: 2.1.9(@types/node@22.19.17)(lightningcss@1.32.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.17
+      happy-dom: 15.11.7
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   volar-service-css@0.0.70(@volar/language-service@2.4.28):
     dependencies:
@@ -7139,7 +7710,16 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
+  webidl-conversions@7.0.0: {}
+
+  whatwg-mimetype@3.0.0: {}
+
   which-pm-runs@1.1.0: {}
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   widest-line@5.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,10 @@ importers:
         version: 4.85.0
 
   crates/zfb-islands/npm:
+    dependencies:
+      zfb:
+        specifier: workspace:*
+        version: link:../../../packages/zfb
     devDependencies:
       happy-dom:
         specifier: ^15.11.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,8 @@
 packages:
   - "docs"
+  # packages/* — first-party JS/TS packages that ship as part of the zfb
+  # public surface (e.g. the "zfb" SDK with the <Island> wrapper).
+  - "packages/*"
   # crates/*/npm — for future per-crate npm tooling exports (e.g., a Rust crate that
   # also publishes a tiny npm package for JS-side helpers). None exist today; the
   # glob is reserved so adding one later requires no workspace-config change.


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/6
- super-epic
    - https://github.com/Takazudo/zudo-front-builder/issues/2

---

## Summary

Implements Epic #6 of the zfb-init super-epic: the islands runtime sub-system. Adds the new `zfb-islands` Rust crate (use-client AST scanner, ClientBundler trait, esbuild subprocess bundler, hydration HTML rewriter), the `zfb` public JS SDK with `<Island when=...>`, and the `@zfb/islands-runtime` client-side hydration glue. Extends the `zfb-render` Adapter trait with hydrate-shim accessors so the per-framework hydration call is portable. Built in parallel by 4 child worktree agents and reconciled at merge with two integration bridges (locator-protocol + scheduleHydrate dedup).

## Changes

### Sub 1 — `crates/zfb-islands/` (AST scanner + ClientBundler trait)

- New workspace crate, layered like `zfb-css` (no dep on `zfb-render`).
- `ClientBundler` trait + shared types: `Island { component_name, source_path }`, `BundleConfig` (minify / sourcemap / outdir / base_url with chainable setters and dev / production presets), `BundleOutput { asset_path, asset_url, module_ids }`, `ModuleId`, `bundle_link_href`.
- SWC-based scanner (`swc_core` v64 — `common`, `ecma_ast`, `ecma_parser`, `ecma_parser_typescript`) that walks every component imported (transitively) from every page entry, detects a top-of-file `"use client"` directive, and returns a deterministic `IslandsSet` keyed by file-path + exported name.
- `Resolver` interface with `FsResolver` and `InMemoryResolver` impls.
- `NativeRustBundler` stub in `future_rust_native` mirrors `zfb_css::native_engine`'s swap-in story.

### Sub 2 — `crates/zfb-islands/src/esbuild.rs` (esbuild subprocess engine)

- `EsbuildSubprocessBundler` implements `ClientBundler` via a subprocess shell-out to the esbuild CLI (`--bundle --format=esm --splitting=false --tree-shaking=true`, plus `--minify` / `--sourcemap=linked` per `BundleConfig`).
- `EsbuildSubprocessConfig` with binary-path env override (`ZFB_ESBUILD_BIN`), working dir, `extra_args`, and a `mock_subprocess` test injection point.
- `hash_8(js)` — first 8 hex chars of `sha256(js)`. Asset path follows `{outdir}/assets/islands-{hash}.js`.
- `crates/zfb/binaries/esbuild/` slot reserved (mirror of the Tailwind v4 binary slot pattern); runtime binary path added to `.gitignore`.

### Sub 3 — `crates/zfb-islands/src/hydration.rs` + `crates/zfb-islands/npm/`

- `rewrite_islands(html, descriptors)` — server-side HTML rewrite that finds `<!--zfb-island:KEY-->...<!--/zfb-island:KEY-->` sentinel pairs and replaces each with `<div data-zfb-island="ComponentName" data-props="..." data-when="...">...server-output...</div>`.
- `IslandDescriptor`, `IslandRewriteError`, `island_marker_pair(key)`, `hydration_script_tag(runtime_url, bundle_url)` helpers.
- `crates/zfb-islands/npm/` — `@zfb/islands-runtime` package with `src/hydrate.ts` (~3 KB hydration runtime). Walks `[data-zfb-island]` elements, decodes `data-props`, dynamic-imports the bundle from `data-zfb-bundle`, and calls the bundle's `hydrateIsland` adapter shim. Vitest under happy-dom.
- Adapter trait extension in `crates/zfb-render/src/adapters/`: `hydrate_shim_specifier()` + `hydrate_shim_source()` on the `Adapter` trait, with per-framework shims for Preact (`h` + `hydrate` from `"preact"`) and React (`hydrateRoot` from `"react-dom/client"`). Module-level docs justify the per-adapter-shim choice over a JS-expression accessor.

### Sub 4 — `packages/zfb/`

- New pnpm workspace package `zfb` (added to `pnpm-workspace.yaml`).
- `<Island when="visible|idle|load">` JSX wrapper, jsx-runtime-agnostic — no preact / react import.
- Build-time output: `<div data-zfb-island="" data-when="...">{children}</div>` (the wrapper sets only the marker presence; the rewriter fills `data-zfb-island="ComponentName"`).
- `scheduleHydrate(target, when, fire)` runtime helper: `visible` → IntersectionObserver (threshold 0, disconnect on first hit), `idle` → `requestIdleCallback` with `setTimeout(0)` fallback, `load` → synchronous fire. Returns a cancel function. Unknown `when` warns in dev and falls back to load.
- `When` string-literal union (`"visible" | "idle" | "load"`), `DEFAULT_WHEN`, `isWhen` type guard, `WHEN_VALUES` array. README with usage examples.

### Cross-sub integration (added at merge)

- **Locator-protocol bridge (Bridge B)** — `rewrite_islands_in_attr_skeleton(html, descriptors)` in `hydration.rs`. Renderers that emit Sub 4's attribute-skeleton output instead of comment sentinels can pair descriptors with `<div data-zfb-island="" ...>` placeholders in document order. New `IslandSkeletonRewriteError::CountMismatch` for skeleton/descriptor count mismatches. Marker-comment path stays untouched.
- **scheduleHydrate dedup** — `@zfb/islands-runtime` now `import { scheduleHydrate } from "zfb/runtime"` (workspace dep added). The dispatch table lives in `packages/zfb/src/runtime.ts` only.
- `escape_attr` also escapes single quotes (`&#39;`) — defence-in-depth for downstream rewriters.
- `EsbuildSubprocessConfig::extra_args` docs the trust boundary (separate `argv` entries; no shell injection; callers must source from build config, not user input).

## Acceptance Criteria (issue #6)

- [x] `Counter` `"use client"` component end-to-end path: scanner detects → bundler emits → hydration rewriter wraps → runtime hydrates. Each sub has unit tests; the integration story is documented and the seams are typed and re-exported.
- [x] `<Island when="visible">` only hydrates on intersection — `scheduleHydrate` visible-path test verifies. Disconnect-after-first-hit confirmed.
- [x] `dist/assets/islands-{hash}.js` is tree-shaken (`--tree-shaking=true` set explicitly).
- [x] `ClientBundler` trait named in code with a `NativeRustBundler` stub at `future_rust_native::NativeRustBundler`.

## Test Plan

- `cargo build --workspace` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test --workspace` — 251 passing (zfb-islands: 38 unit + 9 integration + 2 doc).
- `pnpm --filter zfb test` — 18/18 vitest passing under happy-dom (Island wrapper + scheduleHydrate runtime).
- `pnpm --filter @zfb/islands-runtime test` — 13/13 vitest passing under happy-dom (hydrateAll + bundle dispatch + when-path coverage).
- `/gcoc-review` ran on the full diff; the two high-priority findings are addressed in this PR.

CI: pr-checks workflow only triggers on PRs against `main`, so no CI runs at this stack level by design — quality gates are local (cargo test / vitest / clippy) plus the gcoc-review pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)