### PR TITLE
Epic 6: Build infrastructure (watcher + graph + build orchestrator)

### DIFF
--- a/crates/zfb-build/Cargo.toml
+++ b/crates/zfb-build/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "zfb-build"
+version = "0.0.0"
+edition = "2021"
+license = "MIT"
+description = "zfb build orchestrator: ties watcher + dependency graph + render/css/islands pipelines together for the dev loop, with atomic dist writes"
+
+[lib]
+
+[dependencies]
+zfb-watcher = { path = "../zfb-watcher" }
+zfb-graph = { path = "../zfb-graph" }
+
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { version = "1", features = ["sync", "rt", "macros", "time"] }
+tracing = "0.1"
+
+[dev-dependencies]
+tempfile = { workspace = true }
+tokio = { version = "1", features = ["sync", "rt", "macros", "time", "rt-multi-thread"] }

--- a/crates/zfb-build/README.md
+++ b/crates/zfb-build/README.md
@@ -1,0 +1,209 @@
+# zfb-build
+
+The dev-loop orchestrator for the zudo-front-builder framework.
+
+`zfb-build` ties the four moving parts of the dev pipeline together:
+
+1. [`zfb-watcher`](../zfb-watcher) for filesystem change events.
+2. [`zfb-graph`](../zfb-graph) for "given this file changed, which pages
+   need to be re-rendered?" queries.
+3. The page renderer (Epic 3 — `zfb-render` / `zfb-content` /
+   `zfb-router`).
+4. The CSS pipeline (Epic 4 — `zfb-css`) and the islands bundler
+   (Epic 5 — `zfb-islands`).
+
+The orchestrator deliberately does **not** depend on those last three
+crates. They're injected as callback functions on a `BuildContext` so:
+
+- the orchestrator's surface stays free of feature-gated dependencies
+  (notably `zfb-render`'s `deno_core_host` feature, which pulls in V8),
+  and
+- tests can plug in fakes that count invocations without spawning
+  Tailwind / esbuild subprocesses.
+
+Wiring concrete renderers / engines / bundlers happens in the bin crate
+(Epic 7's `zfb dev` command).
+
+## Public API
+
+The crate exports five top-level items:
+
+- `BuildOrchestrator<P>` — owns the watcher config, the dependency
+  graph, and an `AssetPipeline` impl.
+- `OrchestratorConfig` — `(project_root, watch_roots, policy,
+  debounce)`.
+- `AssetPipeline` trait — single-method `apply(plan, ctx) ->
+  BuildOutcome`. Production / SSR / edge builds plug in their own impl.
+- `DevAssetPipeline` — the default `zfb dev` implementation: render,
+  CSS, islands, atomic dist write, byte-cache so unchanged HTML is not
+  re-emitted.
+- `atomic_write` / `atomic_write_string` — the `write-then-rename`
+  helper any other crate can use to land bytes safely under `dist/`.
+
+```rust,ignore
+use std::sync::{Arc, Mutex};
+use zfb_build::{
+    AssetPipeline, BuildContext, BuildOrchestrator, DevAssetPipeline,
+    OrchestratorConfig, RenderedPage,
+};
+use zfb_graph::DependencyGraph;
+
+let graph = Arc::new(Mutex::new(DependencyGraph::new()));
+let pipeline = DevAssetPipeline::new();
+let orch = BuildOrchestrator::new(
+    OrchestratorConfig::new("/path/to/proj", vec!["pages".into(), "content".into()]),
+    graph,
+    pipeline,
+);
+
+let ctx = BuildContext {
+    dist_root: "/path/to/proj/dist".into(),
+    render_pages: Arc::new(|pages| {
+        // call into zfb-render here
+        Ok(vec![/* RenderedPage { … } */])
+    }),
+    run_css: None,     // wire to zfb-css when available
+    run_islands: None, // wire to zfb-islands when available
+};
+
+orch.run(ctx, |outcome| {
+    println!("rebuilt: {} page(s)", outcome.pages_rendered);
+}).await?;
+```
+
+## The `AssetPipeline` trait
+
+```rust,ignore
+pub trait AssetPipeline: Send + Sync {
+    fn apply(&self, plan: &RebuildPlan, ctx: &BuildContext) -> Result<BuildOutcome>;
+}
+```
+
+The shape is intentionally minimal:
+
+- **One method** — every implementation gets a fully-formed
+  `RebuildPlan` (the orchestrator has already folded watcher events
+  through the granularity policy and the dependency graph).
+- **No async** — pipelines do CPU + IO work but don't need to await.
+  The orchestrator's `run` loop is the async boundary; pipelines run
+  synchronously inside one tick. This keeps tests and embedded
+  use-cases simple.
+- **`Send + Sync`** — the orchestrator may be wrapped in an `Arc` and
+  shared with the dev preview server, so the pipeline must be safe to
+  call from multiple threads.
+
+Why a trait when there's only one impl today? Production / SSR / edge
+builds will need different behaviour:
+
+| Build      | Differences from dev                                      |
+| ---------- | --------------------------------------------------------- |
+| Production | Minify, fail-fast, hashed asset URLs in HTML.             |
+| SSR        | Skip writing HTML to disk; emit into a runtime bundle.    |
+| Edge       | Skip dist/ entirely; emit deno-shaped artefacts in RAM.   |
+
+Locking the orchestrator to a concrete struct now would force a
+refactor when production-build lands. Locking to a trait costs one
+virtual call per rebuild tick and keeps the door open. The trait also
+guards the contract: if a future PR adds a method to `AssetPipeline`,
+the dev impl breaks here, not in production.
+
+## Granularity policy
+
+`zfb-build` resolves the open question from issue #7 ("per-file vs.
+coarse rebuild granularity") with the following rules. They live in
+[`policy.rs`](src/policy.rs); the orchestrator
+([`orchestrator.rs`](src/orchestrator.rs)) folds them through the
+dependency graph.
+
+| Change                                         | Pages re-rendered                              | CSS rerun? | Islands rerun? |
+| ---------------------------------------------- | ---------------------------------------------- | ---------- | -------------- |
+| `zfb.config.ts` (or any `mark_global` path)    | All                                            | Yes        | Yes            |
+| `pages/foo.tsx`                                | Just `foo` (graph self-edge)                   | No         | No             |
+| `content/foo.md`                               | Pages that import the content collection entry | No         | No             |
+| `styles/main.css`                              | Pages with a recorded edge to it (usually 0)   | Yes        | No             |
+| `components/Header.tsx` (used by N pages)      | Those N pages (graph reverse-edges)            | No         | Yes (\*)       |
+| `data/site.json`                               | Pages with a recorded edge to it               | No         | No             |
+| `public/logo.svg`                              | None                                           | No         | No             |
+| Anything else (e.g. `package.json`)            | Whatever the graph says, usually nothing       | No         | No             |
+
+(\*) A change to a `.tsx`/`.ts`/`.jsx`/`.js` file under any of the
+configured **islands roots** re-bundles islands. Default islands roots
+are `components/` and `src/`; override with
+`GranularityPolicy::with_islands_roots`.
+
+We **do not** parse the file inside `zfb-build` to check for the
+`"use client"` directive. The islands sub-pipeline (Epic 5) re-runs its
+scanner on every islands-root change. Its scanner is fast, and the
+bundler re-emits the same hashed asset bytes if the islands set turns
+out to be unchanged — so the cost of a "false positive" rerun is one
+scanner pass plus a no-op bundle, which is well under the noise floor
+of a typical save-rebuild cycle.
+
+### When in doubt, rebuild more
+
+The policy errs on the side of "rebuild a bit too much" rather than
+"miss a change". A misclassified path produces a slow-but-correct
+build; an over-aggressively-narrowed path produces a stale page. We
+always pick the former. Concrete consequences:
+
+- The classifier falls back to file-extension heuristics if no known
+  root matches.
+- `Unclassified` paths still consult the graph (they may be tracked as
+  explicit deps by a power-user resolver), so an explicit edge always
+  wins over a missing pattern match.
+
+## Atomic dist write
+
+Every file the pipeline emits is written to `<final>.tmp-<pid>-<seq>` in
+the same directory and then `rename`d into place. `rename` is atomic on
+the same filesystem, so a reader (the dev preview server, an external
+fs-notify consumer, …) never observes a half-written file.
+
+The temp file lives next to the destination — never in `/tmp` — so the
+`rename` stays on the same filesystem. Cross-FS `rename` would silently
+degrade to a copy + delete, breaking the atomicity guarantee.
+
+The default `DevAssetPipeline` also keeps a tiny in-memory byte cache
+(`HashMap<dist_path, bytes>`) so unchanged HTML is *not* re-written.
+This keeps the dev preview server's WebSocket reload signal accurate:
+`BuildOutcome::pages_written` lists only the pages whose bytes
+actually moved.
+
+## Graph persistence between runs
+
+Issue #7 lists this as an open question:
+
+> Cache the graph between `zfb dev` restarts (warm start); fall through
+> to full rebuild if cache is stale or version-mismatched.
+
+**Status: deferred.** The dependency graph today is rebuilt by the
+resolver on every `zfb dev` start. Adding a serialiser
+(`postcard`/`bincode`/`serde_json` of `DependencyGraph::snapshot()`) is
+straightforward but pulls in a non-trivial chunk of "is this cache
+valid?" logic — version bytes, source-file mtimes, resolver-version
+salt — that doesn't pay for itself on the small projects we expect
+during the early dev loop.
+
+When we revisit, the storage location is `<project>/.zfb/cache/graph.bin`
+and the validity rule is "if any source file's mtime is newer than
+`graph.bin`, throw the cache away and rebuild". `DependencyGraph`
+already exposes `snapshot()` (read) and `from_pages()` / `upsert()`
+(write), so wiring is mechanical; the design tax is in the
+invalidation rules.
+
+## Tests
+
+```sh
+cargo test -p zfb-build
+```
+
+- `src/{atomic,plan,policy,pipeline,orchestrator}.rs` carry focused
+  unit tests for each module.
+- `tests/integration_dev_loop.rs` covers the four acceptance scenarios:
+  - Touching a `.md` file triggers a single-page rebuild.
+  - Editing a global CSS file triggers a CSS-only rebuild (no page
+    re-render unless a page recorded an edge).
+  - Editing a `"use client"` component re-bundles islands without a
+    full re-render.
+  - The real watcher → orchestrator → pipeline path also works
+    end-to-end (one async test using `notify`).

--- a/crates/zfb-build/src/atomic.rs
+++ b/crates/zfb-build/src/atomic.rs
@@ -57,13 +57,19 @@ pub fn atomic_write(dest: &Path, bytes: &[u8]) -> Result<()> {
             .with_context(|| format!("failed to fsync temp file {}", temp_path.display()))?;
     }
 
-    fs::rename(&temp_path, dest).with_context(|| {
-        format!(
-            "failed to rename {} -> {}",
-            temp_path.display(),
-            dest.display()
-        )
-    })?;
+    if let Err(e) = fs::rename(&temp_path, dest) {
+        // Best-effort cleanup so repeated rename failures don't accumulate
+        // sibling temp files in the destination directory. Ignore the
+        // remove error — the rename failure is the actionable signal.
+        let _ = fs::remove_file(&temp_path);
+        return Err(e).with_context(|| {
+            format!(
+                "failed to rename {} -> {}",
+                temp_path.display(),
+                dest.display()
+            )
+        });
+    }
 
     Ok(())
 }

--- a/crates/zfb-build/src/atomic.rs
+++ b/crates/zfb-build/src/atomic.rs
@@ -1,0 +1,139 @@
+//! Atomic file writes.
+//!
+//! `write-then-rename` is the canonical Unix recipe for "no reader ever
+//! sees a half-written file". Both helpers below:
+//!
+//! 1. Create the parent directory if it doesn't exist.
+//! 2. Write the bytes to a sibling temp file in the same directory.
+//! 3. `fs::rename` the temp file over the destination. This is atomic on
+//!    POSIX filesystems for files on the same filesystem.
+//!
+//! On Windows `std::fs::rename` is also atomic for replacing an existing
+//! file (`MoveFileExW` with `MOVEFILE_REPLACE_EXISTING` semantics).
+//!
+//! ## Why "same directory" matters
+//!
+//! `rename` is only atomic across the same filesystem. Putting the temp
+//! file in the same directory as the destination guarantees this — using
+//! e.g. `/tmp` would silently degrade to a copy + delete on multi-disk
+//! setups, which is not atomic.
+//!
+//! ## Naming the temp file
+//!
+//! We use `<final>.tmp-<pid>-<seq>` so:
+//!
+//! - It clearly belongs to this build (process id) — easy to spot in
+//!   `ls` output if a build crashes mid-write.
+//! - A monotonic sequence number prevents collisions when the same
+//!   destination is touched repeatedly inside one process.
+
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use anyhow::{Context, Result};
+
+static SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// Atomically write `bytes` to `dest`. See module-level docs.
+pub fn atomic_write(dest: &Path, bytes: &[u8]) -> Result<()> {
+    if let Some(parent) = dest.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
+    }
+
+    let temp_path = temp_sibling(dest);
+
+    // Scope the file handle so it's flushed and dropped before rename.
+    {
+        let mut f = fs::File::create(&temp_path)
+            .with_context(|| format!("failed to create temp file {}", temp_path.display()))?;
+        f.write_all(bytes)
+            .with_context(|| format!("failed to write temp file {}", temp_path.display()))?;
+        f.sync_all()
+            .with_context(|| format!("failed to fsync temp file {}", temp_path.display()))?;
+    }
+
+    fs::rename(&temp_path, dest).with_context(|| {
+        format!(
+            "failed to rename {} -> {}",
+            temp_path.display(),
+            dest.display()
+        )
+    })?;
+
+    Ok(())
+}
+
+/// Convenience: atomically write a `&str` to `dest`.
+pub fn atomic_write_string(dest: &Path, s: &str) -> Result<()> {
+    atomic_write(dest, s.as_bytes())
+}
+
+/// Build the sibling temp path. Pub for tests; not part of the stable API.
+fn temp_sibling(dest: &Path) -> std::path::PathBuf {
+    let pid = std::process::id();
+    let seq = SEQ.fetch_add(1, Ordering::Relaxed);
+
+    let mut name = dest
+        .file_name()
+        .map(|s| s.to_os_string())
+        .unwrap_or_else(|| std::ffi::OsString::from("zfb"));
+    name.push(format!(".tmp-{pid}-{seq}"));
+
+    let mut out = dest.parent().map(|p| p.to_path_buf()).unwrap_or_default();
+    if out.as_os_str().is_empty() {
+        out = std::path::PathBuf::from(".");
+    }
+    out.push(name);
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn writes_file_atomically() {
+        let dir = tempdir().unwrap();
+        let dest = dir.path().join("nested/output.txt");
+        atomic_write_string(&dest, "hello").unwrap();
+        assert_eq!(fs::read_to_string(&dest).unwrap(), "hello");
+    }
+
+    #[test]
+    fn overwrites_existing_file() {
+        let dir = tempdir().unwrap();
+        let dest = dir.path().join("a.txt");
+        atomic_write_string(&dest, "first").unwrap();
+        atomic_write_string(&dest, "second").unwrap();
+        assert_eq!(fs::read_to_string(&dest).unwrap(), "second");
+    }
+
+    #[test]
+    fn temp_sibling_is_in_same_dir() {
+        let dest = Path::new("/tmp/some/dir/file.html");
+        let t = temp_sibling(dest);
+        assert_eq!(t.parent(), Some(Path::new("/tmp/some/dir")));
+        let name = t.file_name().unwrap().to_string_lossy().into_owned();
+        assert!(name.starts_with("file.html.tmp-"), "got {name}");
+    }
+
+    #[test]
+    fn no_partial_temp_files_remain_after_success() {
+        let dir = tempdir().unwrap();
+        let dest = dir.path().join("a.txt");
+        atomic_write_string(&dest, "hi").unwrap();
+
+        let entries: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        // Only the destination file should exist; no leftover .tmp-* sibling.
+        assert_eq!(entries, vec!["a.txt".to_string()]);
+    }
+}

--- a/crates/zfb-build/src/lib.rs
+++ b/crates/zfb-build/src/lib.rs
@@ -1,0 +1,62 @@
+//! `zfb-build` — the dev-loop orchestrator for the zudo-front-builder
+//! framework.
+//!
+//! Wires together the four moving parts of the dev pipeline:
+//!
+//! 1. [`zfb_watcher`] for filesystem change events.
+//! 2. [`zfb_graph`] for "given this file changed, which pages need to be
+//!    re-rendered?" queries.
+//! 3. The page renderer (Epic 3 — `zfb-render` / `zfb-content` /
+//!    `zfb-router`).
+//! 4. The CSS pipeline (Epic 4 — `zfb-css`) and the islands bundler
+//!    (Epic 5 — `zfb-islands`).
+//!
+//! The orchestrator does *not* call those last three crates directly. It
+//! goes through pluggable callback functions ([`PageRenderer`],
+//! [`CssRunner`], [`IslandsRunner`]) so:
+//!
+//! - the orchestrator's surface stays free of feature-gated dependencies
+//!   (notably `zfb-render`'s `deno_core_host` feature), and
+//! - tests can plug in fakes that count invocations rather than spinning
+//!   up Tailwind/esbuild subprocesses.
+//!
+//! The whole thing is exposed via the [`AssetPipeline`] trait + the
+//! default [`DevAssetPipeline`] impl. Production / SSR / edge builds can
+//! ship their own `AssetPipeline` implementation later without rewriting
+//! the orchestrator.
+//!
+//! ## Granularity policy
+//!
+//! See [`policy`] for the full rules and rationale. In short:
+//!
+//! - Edits to the registered "global" set (e.g. `zfb.config.ts`) → full
+//!   rebuild (every page, CSS, islands).
+//! - Edits to a `content/**` source → only the consumer pages re-render.
+//! - Edits to a `styles/**` file → CSS pipeline rerun, no page re-render.
+//! - Edits to a `"use client"` component → islands re-bundle, no CSS
+//!   rerun unless its CSS also changed.
+//! - Edits to a layout/component used by N pages → those N pages
+//!   re-render (looked up via the dependency graph).
+//!
+//! ## Atomic dist write
+//!
+//! Every file the pipeline emits is written to `<final>.tmp-<rand>` in the
+//! same directory and then `rename`d into place. `rename` is atomic on the
+//! same filesystem, so a reader (the dev preview server, a fs notify
+//! consumer, …) never observes a half-written file. The pipeline ships
+//! [`atomic_write`] for crates that need the same guarantee.
+
+pub mod atomic;
+pub mod orchestrator;
+pub mod pipeline;
+pub mod plan;
+pub mod policy;
+
+pub use atomic::{atomic_write, atomic_write_string};
+pub use orchestrator::{BuildOrchestrator, OrchestratorConfig};
+pub use pipeline::{
+    AssetPipeline, BuildContext, BuildOutcome, CssRunner, DevAssetPipeline, IslandsRunner,
+    PageRenderer, RenderedPage,
+};
+pub use plan::{PageSelection, RebuildPlan};
+pub use policy::{classify_change, GranularityPolicy, PathClass};

--- a/crates/zfb-build/src/orchestrator.rs
+++ b/crates/zfb-build/src/orchestrator.rs
@@ -1,0 +1,420 @@
+//! [`BuildOrchestrator`] — the long-running glue that drives the dev loop.
+//!
+//! The orchestrator owns:
+//!
+//! - the [`zfb_watcher::Watcher`] handle (started on `run`),
+//! - the [`zfb_graph::DependencyGraph`] (shared via `Arc<Mutex<…>>` so
+//!   the resolver can update it from outside the orchestrator if needed),
+//! - the [`crate::AssetPipeline`] implementation, and
+//! - the [`crate::policy::GranularityPolicy`].
+//!
+//! ## Lifecycle
+//!
+//! 1. The bin crate (Epic 7) constructs an orchestrator with a
+//!    [`OrchestratorConfig`], the graph, the asset pipeline, and a
+//!    [`crate::pipeline::BuildContext`].
+//! 2. It calls [`BuildOrchestrator::run`] on a tokio runtime.
+//! 3. The orchestrator spawns a [`zfb_watcher::Watcher`] over the
+//!    project's source roots, then loops on its `Change` receiver.
+//! 4. For each batch of changes (drained from the channel within a tick
+//!    window), the orchestrator folds the changes through
+//!    [`crate::policy::classify_change`] + the dep graph into a single
+//!    [`crate::RebuildPlan`], hands it to the pipeline, and reports the
+//!    [`crate::pipeline::BuildOutcome`] back to the caller.
+//!
+//! ## Single-tick API
+//!
+//! [`BuildOrchestrator::plan_for_changes`] is exposed publicly because
+//! integration tests (and the eventual one-shot `zfb build` command)
+//! want to call "given this list of changed paths, what would the plan
+//! look like?" without spinning up a watcher. The dev `run` loop uses
+//! the same function internally.
+//!
+//! ## Why not a fixed tick window?
+//!
+//! The watcher already debounces (default 50ms). On top of that the
+//! orchestrator drains *every* `Change` already in the channel before
+//! invoking the pipeline — so a fast burst of saves still produces one
+//! pipeline run per natural pause. There's no extra `sleep`-based
+//! coalescing inside the orchestrator; if the watcher decides "this is
+//! one logical save", we treat it as one.
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use anyhow::Result;
+use tracing::{debug, info, warn};
+use zfb_graph::DependencyGraph;
+use zfb_watcher::{Change, Watcher};
+
+use crate::pipeline::{AssetPipeline, BuildContext, BuildOutcome};
+use crate::plan::{PageSelection, RebuildPlan};
+use crate::policy::{classify_change, GranularityPolicy, PathClass};
+
+/// Construction-time configuration for [`BuildOrchestrator`].
+#[derive(Debug, Clone)]
+pub struct OrchestratorConfig {
+    /// Project root (handed to [`zfb_watcher::Watcher::start`]).
+    pub project_root: PathBuf,
+
+    /// Relative source roots to watch. Typical: `["content", "pages",
+    /// "components", "layouts", "styles", "data", "public",
+    /// "zfb.config.ts"]`.
+    pub watch_roots: Vec<PathBuf>,
+
+    /// Granularity policy. Defaults to [`GranularityPolicy::default`].
+    pub policy: GranularityPolicy,
+
+    /// Optional override for the watcher debounce window. `None` =
+    /// `zfb_watcher::DEFAULT_DEBOUNCE` (50ms).
+    pub debounce: Option<Duration>,
+}
+
+impl OrchestratorConfig {
+    /// Convenience: build a config from `(project_root, watch_roots)`
+    /// with the default policy and debounce.
+    pub fn new(project_root: impl Into<PathBuf>, watch_roots: Vec<PathBuf>) -> Self {
+        Self {
+            project_root: project_root.into(),
+            watch_roots,
+            policy: GranularityPolicy::default(),
+            debounce: None,
+        }
+    }
+
+    /// Override the policy (chainable).
+    pub fn with_policy(mut self, policy: GranularityPolicy) -> Self {
+        self.policy = policy;
+        self
+    }
+
+    /// Override the debounce window (chainable).
+    pub fn with_debounce(mut self, debounce: Duration) -> Self {
+        self.debounce = Some(debounce);
+        self
+    }
+}
+
+/// The dev-loop orchestrator.
+///
+/// `P` is the [`AssetPipeline`] implementation (typically
+/// [`crate::DevAssetPipeline`]).
+pub struct BuildOrchestrator<P: AssetPipeline> {
+    config: OrchestratorConfig,
+    graph: Arc<Mutex<DependencyGraph>>,
+    pipeline: P,
+}
+
+impl<P: AssetPipeline> BuildOrchestrator<P> {
+    /// Construct a new orchestrator. The graph is shared via
+    /// `Arc<Mutex<…>>` so the resolver/loader can mutate it (via
+    /// `DependencyGraph::upsert`) while the orchestrator reads from it.
+    pub fn new(
+        config: OrchestratorConfig,
+        graph: Arc<Mutex<DependencyGraph>>,
+        pipeline: P,
+    ) -> Self {
+        Self {
+            config,
+            graph,
+            pipeline,
+        }
+    }
+
+    /// Borrow the underlying graph (for the resolver to mutate before /
+    /// during the run).
+    pub fn graph(&self) -> &Arc<Mutex<DependencyGraph>> {
+        &self.graph
+    }
+
+    /// Borrow the policy.
+    pub fn policy(&self) -> &GranularityPolicy {
+        &self.config.policy
+    }
+
+    /// Build a plan from a list of changed paths. Pure: does not call
+    /// the pipeline.
+    ///
+    /// This is the heart of the orchestrator — split out so tests can
+    /// exercise the policy + graph fold without spinning up a watcher.
+    pub fn plan_for_changes<I, P2>(&self, changes: I) -> RebuildPlan
+    where
+        I: IntoIterator<Item = P2>,
+        P2: Into<PathBuf>,
+    {
+        let mut plan = RebuildPlan::empty();
+        let graph = self
+            .graph
+            .lock()
+            .expect("BuildOrchestrator::graph mutex poisoned");
+
+        for change in changes {
+            let path: PathBuf = change.into();
+            plan.record_trigger(path.clone());
+
+            let class = classify_change(&path, |p| graph.is_global(p));
+
+            match class {
+                PathClass::Global => {
+                    // Nuke and pave: every page, every sub-pipeline.
+                    let mut full = RebuildPlan::full_rebuild();
+                    full.triggers = std::mem::take(&mut plan.triggers);
+                    full.triggers.push(path);
+                    return full;
+                }
+                PathClass::Page | PathClass::Module | PathClass::Content | PathClass::Data => {
+                    let dirty: PageSelection = graph.dirty_pages(&path).into();
+                    plan.mark_pages(dirty);
+
+                    // Modules under an islands root re-bundle islands.
+                    if matches!(class, PathClass::Module)
+                        && self.config.policy.is_islands_candidate(&path)
+                    {
+                        plan.mark_islands();
+                    }
+                }
+                PathClass::Style => {
+                    plan.mark_css();
+                    // CSS sources may also be referenced as deps of pages
+                    // (CSS Modules imported from a .tsx). Honour the
+                    // graph for those.
+                    let dirty: PageSelection = graph.dirty_pages(&path).into();
+                    plan.mark_pages(dirty);
+                }
+                PathClass::Asset => {
+                    // No page re-render. The orchestrator does not yet
+                    // copy `public/**` into dist/ — that's the
+                    // responsibility of the bin crate's setup step.
+                    debug!(path = %path.display(), "asset change, no rebuild needed");
+                }
+                PathClass::Unclassified => {
+                    // Defensive: maybe the graph knows about this path
+                    // via an explicit dep. If so, dirty those pages; if
+                    // not, do nothing.
+                    let dirty: PageSelection = graph.dirty_pages(&path).into();
+                    plan.mark_pages(dirty);
+                }
+            }
+        }
+
+        plan
+    }
+
+    /// Resolve [`PageSelection::All`] to an explicit page list using the
+    /// graph's known pages. Required before handing the plan to a
+    /// pipeline.
+    fn resolve_all(&self, plan: &mut RebuildPlan) {
+        if plan.pages.is_all() {
+            let graph = self
+                .graph
+                .lock()
+                .expect("BuildOrchestrator::graph mutex poisoned");
+            let pages: std::collections::BTreeSet<_> = graph.pages().into_iter().collect();
+            plan.pages = PageSelection::Specific(pages);
+        }
+    }
+
+    /// One-shot tick: take an iterator of changes, build a plan,
+    /// resolve "All" against the graph, hand to the pipeline, return
+    /// the outcome.
+    ///
+    /// Returns `Ok(None)` if the plan was a no-op.
+    pub fn tick<I, P2>(&self, changes: I, ctx: &BuildContext) -> Result<Option<BuildOutcome>>
+    where
+        I: IntoIterator<Item = P2>,
+        P2: Into<PathBuf>,
+    {
+        let mut plan = self.plan_for_changes(changes);
+        if plan.is_noop() {
+            return Ok(None);
+        }
+        self.resolve_all(&mut plan);
+        // After resolution an `All` plan can become an empty plan (the
+        // graph has zero pages). Treat that as a no-op rather than
+        // erroring out of the pipeline.
+        if plan.pages.is_empty() && !plan.rerun_css && !plan.rerun_islands {
+            return Ok(None);
+        }
+        let outcome = self.pipeline.apply(&plan, ctx)?;
+        Ok(Some(outcome))
+    }
+
+    /// Long-running dev loop: spawn a watcher, drain change events, and
+    /// invoke the pipeline once per debounced burst.
+    ///
+    /// `on_outcome` is called after every non-noop tick — typically the
+    /// dev preview server uses this to push a websocket reload signal.
+    pub async fn run<F>(self, ctx: BuildContext, mut on_outcome: F) -> Result<()>
+    where
+        F: FnMut(&BuildOutcome) + Send + 'static,
+    {
+        let (watcher, mut rx) = match self.config.debounce {
+            Some(d) => Watcher::start_with_debounce(
+                &self.config.project_root,
+                self.config.watch_roots.iter().map(|p| p.as_path()),
+                d,
+            )?,
+            None => Watcher::start(
+                &self.config.project_root,
+                self.config.watch_roots.iter().map(|p| p.as_path()),
+            )?,
+        };
+
+        info!(
+            project_root = %self.config.project_root.display(),
+            "build orchestrator running"
+        );
+
+        // Drain loop: wait for the first event, then drain everything
+        // currently in the channel so we coalesce concurrent bursts
+        // into one tick.
+        while let Some(first) = rx.recv().await {
+            let mut batch: Vec<Change> = vec![first];
+            while let Ok(c) = rx.try_recv() {
+                batch.push(c);
+            }
+
+            let paths: Vec<PathBuf> = batch.iter().map(|c| c.path.clone()).collect();
+            match self.tick(paths, &ctx) {
+                Ok(Some(outcome)) => on_outcome(&outcome),
+                Ok(None) => {
+                    debug!("rebuild tick was a no-op");
+                }
+                Err(e) => {
+                    warn!(error = %e, "rebuild tick failed; watcher staying alive");
+                }
+            }
+        }
+
+        // Channel closed = watcher dropped from elsewhere. Returning Ok
+        // lets the caller decide whether to re-spawn or exit.
+        drop(watcher);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::pipeline::BuildOutcome;
+    use std::collections::BTreeSet;
+    use std::path::PathBuf;
+    use zfb_graph::{DepKind, PageDeps, PageId};
+
+    /// Test pipeline that records what it was asked to do.
+    #[derive(Debug, Default, Clone)]
+    struct CountingPipeline {
+        applies: Arc<Mutex<Vec<RebuildPlan>>>,
+    }
+
+    impl AssetPipeline for CountingPipeline {
+        fn apply(&self, plan: &RebuildPlan, _ctx: &BuildContext) -> Result<BuildOutcome> {
+            self.applies.lock().unwrap().push(plan.clone());
+            Ok(BuildOutcome::default())
+        }
+    }
+
+    fn pid(s: &str) -> PageId {
+        PageId::new(PathBuf::from(s))
+    }
+
+    fn make_graph() -> Arc<Mutex<DependencyGraph>> {
+        let mut g = DependencyGraph::new();
+        g.upsert(PageDeps::new(
+            pid("/proj/pages/a.tsx"),
+            vec![(PathBuf::from("/proj/components/Header.tsx"), DepKind::Module)],
+        ));
+        g.upsert(PageDeps::new(
+            pid("/proj/pages/b.tsx"),
+            vec![(PathBuf::from("/proj/components/Header.tsx"), DepKind::Module)],
+        ));
+        g.upsert(PageDeps::new(
+            pid("/proj/pages/c.tsx"),
+            vec![(PathBuf::from("/proj/content/post.md"), DepKind::Content)],
+        ));
+        g.mark_global(PathBuf::from("/proj/zfb.config.ts"));
+        Arc::new(Mutex::new(g))
+    }
+
+    fn make_orch<P: AssetPipeline>(pipeline: P) -> BuildOrchestrator<P> {
+        BuildOrchestrator::new(
+            OrchestratorConfig::new(
+                "/proj",
+                vec![PathBuf::from("pages"), PathBuf::from("content")],
+            ),
+            make_graph(),
+            pipeline,
+        )
+    }
+
+    #[test]
+    fn page_change_dirties_only_that_page() {
+        let orch = make_orch(CountingPipeline::default());
+        let plan = orch.plan_for_changes(vec![PathBuf::from("/proj/pages/a.tsx")]);
+        match plan.pages {
+            PageSelection::Specific(s) => {
+                assert!(s.contains(&pid("/proj/pages/a.tsx")));
+                assert!(!s.contains(&pid("/proj/pages/b.tsx")));
+            }
+            _ => panic!(),
+        }
+        assert!(!plan.rerun_css);
+        assert!(!plan.rerun_islands);
+    }
+
+    #[test]
+    fn shared_component_dirties_all_consumers() {
+        let orch = make_orch(CountingPipeline::default());
+        let plan = orch.plan_for_changes(vec![PathBuf::from("/proj/components/Header.tsx")]);
+        match plan.pages {
+            PageSelection::Specific(s) => {
+                assert!(s.contains(&pid("/proj/pages/a.tsx")));
+                assert!(s.contains(&pid("/proj/pages/b.tsx")));
+                assert!(!s.contains(&pid("/proj/pages/c.tsx")));
+            }
+            _ => panic!(),
+        }
+        // components/ is in default islands roots -> islands rerun.
+        assert!(plan.rerun_islands);
+        assert!(!plan.rerun_css);
+    }
+
+    #[test]
+    fn css_change_triggers_css_pipeline_only() {
+        let orch = make_orch(CountingPipeline::default());
+        let plan = orch.plan_for_changes(vec![PathBuf::from("/proj/styles/main.css")]);
+        assert!(plan.rerun_css);
+        assert!(!plan.rerun_islands);
+        // No pages depend on this CSS file directly.
+        assert!(plan.pages.is_empty());
+    }
+
+    #[test]
+    fn global_change_promotes_to_full_rebuild() {
+        let orch = make_orch(CountingPipeline::default());
+        let plan = orch.plan_for_changes(vec![PathBuf::from("/proj/zfb.config.ts")]);
+        assert!(plan.pages.is_all());
+        assert!(plan.rerun_css);
+        assert!(plan.rerun_islands);
+    }
+
+    #[test]
+    fn content_change_dirties_consumer_pages() {
+        let orch = make_orch(CountingPipeline::default());
+        let plan = orch.plan_for_changes(vec![PathBuf::from("/proj/content/post.md")]);
+        match plan.pages {
+            PageSelection::Specific(s) => {
+                assert_eq!(s, BTreeSet::from([pid("/proj/pages/c.tsx")]));
+            }
+            _ => panic!(),
+        }
+    }
+
+    #[test]
+    fn unclassified_change_with_no_consumers_is_noop() {
+        let orch = make_orch(CountingPipeline::default());
+        let plan = orch.plan_for_changes(vec![PathBuf::from("/proj/some-random-thing")]);
+        assert!(plan.is_noop());
+    }
+}

--- a/crates/zfb-build/src/pipeline.rs
+++ b/crates/zfb-build/src/pipeline.rs
@@ -1,0 +1,428 @@
+//! [`AssetPipeline`] trait + [`DevAssetPipeline`] (the default impl for
+//! `zfb dev`).
+//!
+//! Production / SSR / edge builds will eventually plug in their own
+//! [`AssetPipeline`] implementations here. The trait is the contract:
+//! given a [`crate::RebuildPlan`] and a [`BuildContext`], execute the
+//! plan and return a [`BuildOutcome`].
+//!
+//! ## Why a trait when there's only one impl today?
+//!
+//! The orchestrator has a fairly opinionated lifecycle: receive a plan,
+//! call into renderer/CSS/islands in some order, atomically write
+//! everything to `dist/`. That lifecycle is the same shape across dev,
+//! production, and edge — but the details differ:
+//!
+//! - **Dev**: don't minify, watch the graph, error on first failure but
+//!   keep the watcher alive.
+//! - **Production**: minify, fail-fast on first error, generate
+//!   sourcemaps separately, optionally post-process for hashed asset
+//!   filenames in HTML.
+//! - **SSR / edge**: skip writing HTML to disk; emit it into a deno-
+//!   shaped runtime bundle.
+//!
+//! Locking the orchestrator to a concrete struct now would force a
+//! refactor when production-build lands. Locking to a trait costs a
+//! single virtual call per rebuild tick and keeps the door open.
+//!
+//! ## Why callbacks for renderer / css / islands?
+//!
+//! The orchestrator deliberately doesn't depend on `zfb-render`,
+//! `zfb-css`, or `zfb-islands` directly:
+//!
+//! - `zfb-render` requires the `deno_core_host` feature (gigabytes of V8
+//!   build artefacts) for a working host. The orchestrator must compile
+//!   without that feature flag flipped on.
+//! - The CSS / islands crates ship trait-based plug points
+//!   (`CssEngine`, `ClientBundler`) plus subprocess wrappers around
+//!   third-party CLIs (Tailwind, esbuild). Pulling them in transitively
+//!   would force every consumer of `zfb-build` to pay that cost.
+//! - Tests need fakes that count invocations without spawning binaries.
+//!
+//! So the public API takes function-typed inputs. The bin crate
+//! (Epic 7's `zfb dev` command) will instantiate concrete renderers /
+//! engines and pass closures here.
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use anyhow::Result;
+use zfb_graph::PageId;
+
+use crate::atomic::atomic_write_string;
+use crate::plan::{PageSelection, RebuildPlan};
+
+/// One rendered page's HTML output.
+///
+/// The pipeline writes `html` to `<dist_root>/<output_path>` atomically.
+/// `output_path` should be relative to the dist root and must be a safe
+/// subpath (no `..`). Producers typically derive this from the page's
+/// route template — e.g. `/blog/foo` → `blog/foo/index.html`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenderedPage {
+    /// The page id this output belongs to. Echoed back verbatim from
+    /// the [`PageSelection`] so callers can correlate inputs/outputs.
+    pub page: PageId,
+
+    /// Path under the dist root, in URL-style forward-slash form. The
+    /// pipeline joins this onto its `dist_root` and writes the HTML
+    /// atomically.
+    pub output_path: PathBuf,
+
+    /// HTML to write.
+    pub html: String,
+}
+
+/// Function that renders a batch of pages to HTML.
+///
+/// Boxed-trait-object alias: each rebuild tick may select N pages, and
+/// the renderer can decide to render them serially (cheap, dev) or in
+/// parallel (production). Errors abort the tick — the watcher stays
+/// alive but the rebuild is reported as failed.
+pub type PageRenderer =
+    Arc<dyn Fn(&[PageId]) -> Result<Vec<RenderedPage>> + Send + Sync + 'static>;
+
+/// Function that runs the CSS pipeline once and returns whether the
+/// emitted asset is new (i.e. whether the asset URL changed).
+///
+/// `true` here triggers a re-render of any page that embeds the CSS asset
+/// URL — but the orchestrator does *not* automatically schedule that
+/// re-render in this version. Production builds that need URL stability
+/// in HTML will manage that explicitly.
+pub type CssRunner = Arc<dyn Fn() -> Result<bool> + Send + Sync + 'static>;
+
+/// Function that runs the islands bundler once and returns whether the
+/// emitted asset is new. Same semantics as [`CssRunner`].
+pub type IslandsRunner = Arc<dyn Fn() -> Result<bool> + Send + Sync + 'static>;
+
+/// Per-build-tick context handed to [`AssetPipeline::apply`].
+///
+/// Holds the absolute `dist_root` (where output HTML and assets land)
+/// plus the closures the dev pipeline calls to render pages, run CSS,
+/// and bundle islands.
+#[derive(Clone)]
+pub struct BuildContext {
+    /// Absolute path to the dist directory. The pipeline writes
+    /// `<dist_root>/<rendered_page.output_path>` atomically.
+    pub dist_root: PathBuf,
+
+    /// Page renderer callback.
+    pub render_pages: PageRenderer,
+
+    /// CSS pipeline callback. Optional: if `None`, CSS reruns are
+    /// silently skipped. Used by tests that don't care about CSS.
+    pub run_css: Option<CssRunner>,
+
+    /// Islands bundler callback. Optional: if `None`, islands reruns are
+    /// silently skipped.
+    pub run_islands: Option<IslandsRunner>,
+}
+
+impl std::fmt::Debug for BuildContext {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BuildContext")
+            .field("dist_root", &self.dist_root)
+            .field("render_pages", &"<callback>")
+            .field("run_css", &self.run_css.as_ref().map(|_| "<callback>"))
+            .field(
+                "run_islands",
+                &self.run_islands.as_ref().map(|_| "<callback>"),
+            )
+            .finish()
+    }
+}
+
+/// What an [`AssetPipeline::apply`] call did for the tick.
+///
+/// Counters mostly — handy for tests and for dev-server status logging
+/// (`rendered N pages, CSS rerun, islands rerun`).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BuildOutcome {
+    /// Number of pages re-rendered this tick.
+    pub pages_rendered: usize,
+
+    /// Whether the CSS pipeline ran.
+    pub css_rerun: bool,
+
+    /// Whether the CSS pipeline reported a new asset (only meaningful
+    /// when `css_rerun` is true).
+    pub css_changed: bool,
+
+    /// Whether the islands bundler ran.
+    pub islands_rerun: bool,
+
+    /// Whether the islands bundler reported a new asset (only
+    /// meaningful when `islands_rerun` is true).
+    pub islands_changed: bool,
+
+    /// Pages whose HTML was actually written (the file was new or the
+    /// bytes changed). Useful for the dev preview server's WebSocket
+    /// reload path.
+    pub pages_written: Vec<PageId>,
+}
+
+/// The contract every asset pipeline implementation must satisfy.
+///
+/// `apply` is called once per rebuild tick, after the orchestrator has
+/// folded watcher events through the granularity policy and dependency
+/// graph into a [`RebuildPlan`].
+///
+/// Implementations should:
+///
+/// - Run only the sub-pipelines the plan requests.
+/// - Fail fast on the first error inside a sub-pipeline (caller decides
+///   whether to keep the watcher alive).
+/// - Write outputs atomically (use [`crate::atomic_write`] or roll your
+///   own equivalent).
+pub trait AssetPipeline: Send + Sync {
+    /// Apply `plan` against `ctx`. See module-level docs for the
+    /// expected behaviour.
+    fn apply(&self, plan: &RebuildPlan, ctx: &BuildContext) -> Result<BuildOutcome>;
+}
+
+/// The default `zfb dev`-mode asset pipeline.
+///
+/// - Calls `ctx.render_pages` for every selected page (or "all known
+///   pages" if the plan is `PageSelection::All` — but the orchestrator
+///   resolves "All" before handing the plan in, so this impl just
+///   handles `Specific`).
+/// - Calls `ctx.run_css` if the plan asks for it.
+/// - Calls `ctx.run_islands` if the plan asks for it.
+/// - Writes each `RenderedPage.html` atomically under `ctx.dist_root`.
+/// - Tracks bytes-changed-or-not so [`BuildOutcome::pages_written`]
+///   reflects only pages whose bytes actually moved (cheap reload signal
+///   for the dev server's WebSocket).
+#[derive(Debug, Default)]
+pub struct DevAssetPipeline {
+    // Last-known bytes per output path, used to skip writes when the
+    // renderer is deterministic and re-emits the same HTML. Wrapped in
+    // a Mutex so &self.apply() can mutate it; the lock is held for the
+    // duration of one tick which is fine for dev.
+    last_bytes: Mutex<std::collections::HashMap<PathBuf, Vec<u8>>>,
+}
+
+impl DevAssetPipeline {
+    /// Construct a fresh pipeline with no last-bytes cache.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Forget the last-bytes cache. Useful when the dist root is wiped
+    /// from outside the orchestrator and the caller wants the next
+    /// rebuild to re-emit every page.
+    pub fn reset_cache(&self) {
+        self.last_bytes
+            .lock()
+            .expect("DevAssetPipeline::last_bytes lock poisoned")
+            .clear();
+    }
+}
+
+impl AssetPipeline for DevAssetPipeline {
+    fn apply(&self, plan: &RebuildPlan, ctx: &BuildContext) -> Result<BuildOutcome> {
+        let mut outcome = BuildOutcome::default();
+
+        // 1. Pages.
+        let pages: Vec<PageId> = match &plan.pages {
+            PageSelection::All => {
+                // The orchestrator should have resolved this. If we still
+                // see All here it means the caller bypassed the
+                // orchestrator — surface it as an error rather than
+                // silently no-op'ing.
+                return Err(anyhow::anyhow!(
+                    "DevAssetPipeline: PageSelection::All must be resolved to a concrete page list \
+                     by the orchestrator before reaching the pipeline"
+                ));
+            }
+            PageSelection::Specific(s) => s.iter().cloned().collect(),
+        };
+
+        if !pages.is_empty() {
+            let rendered = (ctx.render_pages)(&pages)?;
+            outcome.pages_rendered = rendered.len();
+
+            for r in rendered {
+                let dest = ctx.dist_root.join(&r.output_path);
+                let new_bytes = r.html.into_bytes();
+
+                let changed = {
+                    let mut cache = self
+                        .last_bytes
+                        .lock()
+                        .expect("DevAssetPipeline::last_bytes lock poisoned");
+                    match cache.get(&dest) {
+                        Some(prev) if prev == &new_bytes => false,
+                        _ => {
+                            cache.insert(dest.clone(), new_bytes.clone());
+                            true
+                        }
+                    }
+                };
+
+                if changed {
+                    atomic_write_string(&dest, std::str::from_utf8(&new_bytes).unwrap_or(""))?;
+                    outcome.pages_written.push(r.page);
+                }
+            }
+        }
+
+        // 2. CSS.
+        if plan.rerun_css {
+            outcome.css_rerun = true;
+            if let Some(run) = &ctx.run_css {
+                outcome.css_changed = run()?;
+            }
+        }
+
+        // 3. Islands.
+        if plan.rerun_islands {
+            outcome.islands_rerun = true;
+            if let Some(run) = &ctx.run_islands {
+                outcome.islands_changed = run()?;
+            }
+        }
+
+        Ok(outcome)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tempfile::tempdir;
+
+    fn pid(s: &str) -> PageId {
+        PageId::new(PathBuf::from(s))
+    }
+
+    fn ctx_with_renderer(
+        dist_root: PathBuf,
+        rendered: Vec<RenderedPage>,
+        invocations: Arc<AtomicUsize>,
+    ) -> BuildContext {
+        BuildContext {
+            dist_root,
+            render_pages: Arc::new(move |_pages: &[PageId]| {
+                invocations.fetch_add(1, Ordering::SeqCst);
+                Ok(rendered.clone())
+            }),
+            run_css: None,
+            run_islands: None,
+        }
+    }
+
+    #[test]
+    fn writes_rendered_pages_atomically() {
+        let dir = tempdir().unwrap();
+        let pipeline = DevAssetPipeline::new();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let ctx = ctx_with_renderer(
+            dir.path().to_path_buf(),
+            vec![RenderedPage {
+                page: pid("/p/a.tsx"),
+                output_path: PathBuf::from("a/index.html"),
+                html: "<h1>A</h1>".into(),
+            }],
+            calls.clone(),
+        );
+
+        let mut sel = BTreeSet::new();
+        sel.insert(pid("/p/a.tsx"));
+        let plan = RebuildPlan {
+            pages: PageSelection::Specific(sel),
+            rerun_css: false,
+            rerun_islands: false,
+            triggers: vec![],
+        };
+
+        let outcome = pipeline.apply(&plan, &ctx).unwrap();
+        assert_eq!(outcome.pages_rendered, 1);
+        assert_eq!(outcome.pages_written, vec![pid("/p/a.tsx")]);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("a/index.html")).unwrap(),
+            "<h1>A</h1>"
+        );
+    }
+
+    #[test]
+    fn skips_write_when_html_unchanged() {
+        let dir = tempdir().unwrap();
+        let pipeline = DevAssetPipeline::new();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let rendered = vec![RenderedPage {
+            page: pid("/p/a.tsx"),
+            output_path: PathBuf::from("a.html"),
+            html: "<p>same</p>".into(),
+        }];
+        let ctx = ctx_with_renderer(dir.path().to_path_buf(), rendered, calls);
+
+        let mut sel = BTreeSet::new();
+        sel.insert(pid("/p/a.tsx"));
+        let plan = RebuildPlan {
+            pages: PageSelection::Specific(sel),
+            rerun_css: false,
+            rerun_islands: false,
+            triggers: vec![],
+        };
+
+        let first = pipeline.apply(&plan, &ctx).unwrap();
+        assert_eq!(first.pages_written.len(), 1);
+
+        let second = pipeline.apply(&plan, &ctx).unwrap();
+        // Bytes are the same — nothing new to write.
+        assert_eq!(second.pages_written.len(), 0);
+        assert_eq!(second.pages_rendered, 1, "renderer still ran");
+    }
+
+    #[test]
+    fn css_rerun_invokes_callback() {
+        let pipeline = DevAssetPipeline::new();
+        let dir = tempdir().unwrap();
+        let css_calls = Arc::new(AtomicUsize::new(0));
+        let css_calls_cb = css_calls.clone();
+        let ctx = BuildContext {
+            dist_root: dir.path().to_path_buf(),
+            render_pages: Arc::new(|_| Ok(vec![])),
+            run_css: Some(Arc::new(move || {
+                css_calls_cb.fetch_add(1, Ordering::SeqCst);
+                Ok(true)
+            })),
+            run_islands: None,
+        };
+
+        let plan = RebuildPlan {
+            pages: PageSelection::none(),
+            rerun_css: true,
+            rerun_islands: false,
+            triggers: vec![],
+        };
+
+        let outcome = pipeline.apply(&plan, &ctx).unwrap();
+        assert!(outcome.css_rerun);
+        assert!(outcome.css_changed);
+        assert_eq!(css_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn all_must_be_resolved_before_reaching_pipeline() {
+        let pipeline = DevAssetPipeline::new();
+        let dir = tempdir().unwrap();
+        let ctx = BuildContext {
+            dist_root: dir.path().to_path_buf(),
+            render_pages: Arc::new(|_| Ok(vec![])),
+            run_css: None,
+            run_islands: None,
+        };
+        let plan = RebuildPlan {
+            pages: PageSelection::All,
+            rerun_css: false,
+            rerun_islands: false,
+            triggers: vec![],
+        };
+        assert!(pipeline.apply(&plan, &ctx).is_err());
+    }
+}

--- a/crates/zfb-build/src/plan.rs
+++ b/crates/zfb-build/src/plan.rs
@@ -1,0 +1,191 @@
+//! [`RebuildPlan`] — what the orchestrator decided needs to happen for a
+//! given burst of filesystem changes.
+//!
+//! The plan is the only thing the orchestrator hands to an
+//! [`crate::AssetPipeline`]. Pipelines never see raw filesystem events;
+//! they consume a plan and act on it. This keeps the granularity policy
+//! in one place ([`crate::policy`]) and lets the pipeline focus on
+//! "given this plan, run the right sub-pipelines and write output
+//! atomically".
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+use zfb_graph::{DirtySet, PageId};
+
+/// What the orchestrator wants the asset pipeline to do for the next
+/// rebuild tick.
+///
+/// Construction is via [`RebuildPlan::empty`] + the `mark_*` helpers, or
+/// via [`RebuildPlan::full_rebuild`] which sets every flag.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RebuildPlan {
+    /// Pages whose HTML must be re-rendered.
+    pub pages: PageSelection,
+
+    /// Whether the CSS pipeline should run again.
+    pub rerun_css: bool,
+
+    /// Whether the islands bundler should run again.
+    pub rerun_islands: bool,
+
+    /// The raw paths that triggered this plan, kept around purely for
+    /// diagnostics. Not consumed by the pipeline.
+    pub triggers: Vec<PathBuf>,
+}
+
+/// Which pages to re-render this tick.
+///
+/// Mirrors [`zfb_graph::DirtySet`] but is owned by `zfb-build`; we don't
+/// re-export the graph variant directly so future plans can carry richer
+/// per-page info (e.g. force flag, props override) without rippling
+/// through the graph crate.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PageSelection {
+    /// Re-render every page (e.g. after a global change).
+    All,
+    /// Re-render exactly this set. Empty means "no pages need re-render
+    /// this tick" — common when only CSS or only assets changed.
+    Specific(BTreeSet<PageId>),
+}
+
+impl PageSelection {
+    /// Empty (no pages). Convenience constructor.
+    pub fn none() -> Self {
+        PageSelection::Specific(BTreeSet::new())
+    }
+
+    /// True iff this is the [`PageSelection::All`] sentinel.
+    pub fn is_all(&self) -> bool {
+        matches!(self, PageSelection::All)
+    }
+
+    /// True iff no pages are selected. Returns false for `All` since
+    /// `All` covers every page.
+    pub fn is_empty(&self) -> bool {
+        matches!(self, PageSelection::Specific(s) if s.is_empty())
+    }
+
+    /// Merge `other` into self. `All` absorbs everything.
+    pub fn merge(&mut self, other: PageSelection) {
+        match (&mut *self, other) {
+            (PageSelection::All, _) => {}
+            (slot, PageSelection::All) => *slot = PageSelection::All,
+            (PageSelection::Specific(a), PageSelection::Specific(b)) => a.extend(b),
+        }
+    }
+}
+
+impl From<DirtySet> for PageSelection {
+    fn from(d: DirtySet) -> Self {
+        match d {
+            DirtySet::All => PageSelection::All,
+            DirtySet::Specific(s) => PageSelection::Specific(s),
+        }
+    }
+}
+
+impl RebuildPlan {
+    /// An empty plan — nothing to do.
+    pub fn empty() -> Self {
+        Self {
+            pages: PageSelection::none(),
+            rerun_css: false,
+            rerun_islands: false,
+            triggers: Vec::new(),
+        }
+    }
+
+    /// A plan that does everything: every page, every sub-pipeline.
+    pub fn full_rebuild() -> Self {
+        Self {
+            pages: PageSelection::All,
+            rerun_css: true,
+            rerun_islands: true,
+            triggers: Vec::new(),
+        }
+    }
+
+    /// Add `path` to the diagnostics trigger list.
+    pub fn record_trigger(&mut self, path: PathBuf) {
+        self.triggers.push(path);
+    }
+
+    /// Mark these pages dirty. Combines with what's already in `pages`.
+    pub fn mark_pages(&mut self, pages: PageSelection) {
+        self.pages.merge(pages);
+    }
+
+    /// Mark CSS as needing a rerun.
+    pub fn mark_css(&mut self) {
+        self.rerun_css = true;
+    }
+
+    /// Mark islands as needing a rerun.
+    pub fn mark_islands(&mut self) {
+        self.rerun_islands = true;
+    }
+
+    /// True iff the plan would do nothing — no pages, no CSS, no
+    /// islands. The orchestrator skips empty plans.
+    pub fn is_noop(&self) -> bool {
+        !self.rerun_css && !self.rerun_islands && self.pages.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn pid(s: &str) -> PageId {
+        PageId::new(PathBuf::from(s))
+    }
+
+    #[test]
+    fn empty_plan_is_noop() {
+        assert!(RebuildPlan::empty().is_noop());
+    }
+
+    #[test]
+    fn full_rebuild_is_not_noop() {
+        let p = RebuildPlan::full_rebuild();
+        assert!(!p.is_noop());
+        assert!(p.pages.is_all());
+        assert!(p.rerun_css);
+        assert!(p.rerun_islands);
+    }
+
+    #[test]
+    fn merging_specific_into_all_stays_all() {
+        let mut sel = PageSelection::All;
+        let mut s = BTreeSet::new();
+        s.insert(pid("/p/a.tsx"));
+        sel.merge(PageSelection::Specific(s));
+        assert!(sel.is_all());
+    }
+
+    #[test]
+    fn merging_all_into_specific_promotes() {
+        let mut sel = PageSelection::Specific(BTreeSet::new());
+        sel.merge(PageSelection::All);
+        assert!(sel.is_all());
+    }
+
+    #[test]
+    fn merging_specifics_unions() {
+        let mut a = BTreeSet::new();
+        a.insert(pid("/p/a.tsx"));
+        let mut b = BTreeSet::new();
+        b.insert(pid("/p/b.tsx"));
+        let mut sel = PageSelection::Specific(a);
+        sel.merge(PageSelection::Specific(b));
+        match sel {
+            PageSelection::Specific(s) => {
+                assert!(s.contains(&pid("/p/a.tsx")));
+                assert!(s.contains(&pid("/p/b.tsx")));
+            }
+            _ => panic!(),
+        }
+    }
+}

--- a/crates/zfb-build/src/policy.rs
+++ b/crates/zfb-build/src/policy.rs
@@ -1,0 +1,325 @@
+//! Granularity policy: how a single filesystem change maps to a rebuild
+//! plan.
+//!
+//! See the crate-level docs for a summary. This module turns a raw
+//! [`zfb_watcher::Change`] path into a [`PathClass`], and the
+//! [`GranularityPolicy`] then folds that class into a [`crate::RebuildPlan`].
+//!
+//! The policy is deliberately *defensive* — when in doubt we err on the
+//! side of "rebuild more, not less". A misclassified path produces a
+//! correct (if slower) build; an over-aggressively-narrowed path produces
+//! a stale page. Of those two failure modes we prefer the former.
+//!
+//! ## Rationale (defensible-policy short version)
+//!
+//! - **Pages and components live in the dependency graph.** For these
+//!   paths we trust the graph: a change to `components/Header.tsx` dirties
+//!   exactly the pages that import it (plus the implicit self-edge, so
+//!   editing a page source dirties that page).
+//! - **Content lives in the graph too.** `content/foo.md` is reached via
+//!   a content collection, which the resolver records as a dep. So
+//!   editing one markdown file also routes through the graph and only
+//!   touches its consumer page(s).
+//! - **CSS sources are treated separately.** A CSS source change does not
+//!   re-render pages — the renderer's HTML doesn't change, only the
+//!   hashed asset URL might. If the CSS pipeline's hash changes and
+//!   pages embed that URL, the orchestrator rewrites only the affected
+//!   pages on the *next* render — but in this version we keep things
+//!   simple and re-render dirty pages whenever CSS-source hash changes
+//!   are reflected back into the graph (a future micro-optimisation).
+//! - **Islands components are treated separately too.** Editing a
+//!   `"use client"` component triggers an islands re-bundle. It does not
+//!   trigger a full re-render: the rendered HTML embeds the bundle URL,
+//!   not the bundle bytes, and the URL only changes when the islands set
+//!   itself changes (add/remove a `"use client"`, or any of the bundled
+//!   modules' bytes change).
+//! - **Globals are nuclear.** `zfb.config.ts` and the like force a full
+//!   rebuild. The dependency graph already exposes this via
+//!   `DependencyGraph::is_global`.
+//!
+//! ## Classification heuristic
+//!
+//! Path classification is purely *path-pattern based* — it does not read
+//! file contents. The orchestrator combines this with the dependency
+//! graph (which *does* know real edges) to produce the final plan. So:
+//!
+//! - We do **not** decide here whether a `.tsx` is an islands component;
+//!   we decide whether it's *inside the islands source roots* and let
+//!   the orchestrator/graph decide whether the islands set actually
+//!   changed.
+//! - We do **not** decide here whether a `.tsx` is a page; we let the
+//!   graph answer that via `dirty_pages`.
+
+use std::path::{Component, Path, PathBuf};
+
+/// Coarse-grained classification of a changed file. Drives which
+/// sub-pipelines the orchestrator considers running.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PathClass {
+    /// Registered as a "global" file in the dependency graph (e.g.
+    /// `zfb.config.ts`). Forces a full rebuild.
+    Global,
+
+    /// A page source under `pages/**` — re-render this page (the graph's
+    /// self-edge will surface it as dirty).
+    Page,
+
+    /// A `.md` / `.mdx` content entry under `content/**`. The graph's
+    /// content-collection edges decide which pages re-render.
+    Content,
+
+    /// A non-page TSX / TS / JSX / JS file (layout, component, lib).
+    /// The graph decides which pages re-render. May also be an islands
+    /// component — that decision is made by the islands sub-pipeline.
+    Module,
+
+    /// A CSS source under `styles/**` (or anywhere with a `.css`
+    /// extension). Trigger CSS pipeline rerun.
+    Style,
+
+    /// A static data file (JSON / TOML / YAML under `data/**`). Treated
+    /// like a `Module`: the graph's data-edges decide consumers.
+    Data,
+
+    /// A static asset under `public/**`. Doesn't dirty any page on its
+    /// own — the asset pipeline copies it into `dist/` directly, and the
+    /// HTML reference is by URL not by content.
+    Asset,
+
+    /// Path didn't match any known root. Defensively, the orchestrator
+    /// treats this as "consult the graph anyway" — many editors write to
+    /// project-relative paths we didn't classify (`tsconfig.json`,
+    /// `package.json`, …) but the graph will return an empty dirty set
+    /// and nothing happens.
+    Unclassified,
+}
+
+/// Classify a path against the standard zfb project layout.
+///
+/// Pattern-based, not content-based. The lookup is purely about the path
+/// shape so it stays cheap and predictable.
+///
+/// `is_global` is consulted first: it lets the dependency graph extend
+/// the global set at runtime without changing this function.
+pub fn classify_change(path: &Path, is_global: impl FnOnce(&Path) -> bool) -> PathClass {
+    if is_global(path) {
+        return PathClass::Global;
+    }
+
+    // Find the project-relative segment leadership. We look at the path
+    // components in order and match against known roots. Absolute paths
+    // are common (notify hands them back), so we walk components from
+    // the start and find the first known-root component.
+    let mut comps = path.components().peekable();
+
+    // Skip leading `/` / drive prefixes / `RootDir` components.
+    while let Some(c) = comps.peek() {
+        if matches!(c, Component::Prefix(_) | Component::RootDir) {
+            comps.next();
+        } else {
+            break;
+        }
+    }
+
+    // Walk components looking for the first root we recognise.
+    for comp in comps {
+        let s = match comp {
+            Component::Normal(s) => s.to_string_lossy().into_owned(),
+            _ => continue,
+        };
+        match s.as_str() {
+            "pages" => return PathClass::Page,
+            "content" => return PathClass::Content,
+            "styles" => return PathClass::Style,
+            "data" => return PathClass::Data,
+            "public" => return PathClass::Asset,
+            "components" | "layouts" | "lib" | "src" => return PathClass::Module,
+            _ => {}
+        }
+    }
+
+    // Fall back to extension sniffing.
+    match path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("css") => PathClass::Style,
+        Some("md") | Some("mdx") => PathClass::Content,
+        Some("ts") | Some("tsx") | Some("js") | Some("jsx") => PathClass::Module,
+        Some("json") | Some("toml") | Some("yaml") | Some("yml") => PathClass::Data,
+        _ => PathClass::Unclassified,
+    }
+}
+
+/// The granularity policy combines a [`PathClass`] with the dependency
+/// graph to decide what sub-pipelines run.
+///
+/// This is a thin record of decisions; see [`crate::RebuildPlan`] for the
+/// shape it folds into.
+#[derive(Debug, Clone)]
+pub struct GranularityPolicy {
+    /// Treat any change under this list of relative roots as triggering
+    /// the islands re-bundle. Defaults to `["components", "src"]` —
+    /// callers can override with [`GranularityPolicy::with_islands_roots`].
+    pub islands_roots: Vec<PathBuf>,
+}
+
+impl Default for GranularityPolicy {
+    fn default() -> Self {
+        Self {
+            islands_roots: vec![PathBuf::from("components"), PathBuf::from("src")],
+        }
+    }
+}
+
+impl GranularityPolicy {
+    /// Override the islands source roots. Used when the project's
+    /// `"use client"` components live somewhere non-standard.
+    pub fn with_islands_roots<I, P>(mut self, roots: I) -> Self
+    where
+        I: IntoIterator<Item = P>,
+        P: Into<PathBuf>,
+    {
+        self.islands_roots = roots.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Decide whether a `Module` change is inside an islands root.
+    ///
+    /// We do not parse the file here to check for the `"use client"`
+    /// directive — that's the islands sub-pipeline's job (and it is
+    /// stable enough to be re-run unconditionally on any module change
+    /// inside an islands root: the scanner is fast and the bundler
+    /// re-emits the same hashed asset if the islands set is unchanged).
+    pub fn is_islands_candidate(&self, path: &Path) -> bool {
+        for root in &self.islands_roots {
+            if path_starts_with_segment(path, root) {
+                return true;
+            }
+        }
+        false
+    }
+}
+
+/// True iff `path` contains `segment` as one of its components.
+///
+/// We don't require an absolute prefix match because filesystem watcher
+/// events come back as absolute paths and the policy's "roots" are
+/// project-relative.
+fn path_starts_with_segment(path: &Path, segment: &Path) -> bool {
+    let segment_components: Vec<_> = segment.components().collect();
+    if segment_components.is_empty() {
+        return false;
+    }
+
+    let path_components: Vec<_> = path.components().collect();
+    if path_components.len() < segment_components.len() {
+        return false;
+    }
+
+    // Slide the segment over path looking for a contiguous match.
+    for start in 0..=path_components.len() - segment_components.len() {
+        if path_components[start..start + segment_components.len()] == segment_components[..] {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn never_global(_: &Path) -> bool {
+        false
+    }
+
+    #[test]
+    fn classifies_pages() {
+        assert_eq!(
+            classify_change(Path::new("/proj/pages/index.tsx"), never_global),
+            PathClass::Page
+        );
+    }
+
+    #[test]
+    fn classifies_content() {
+        assert_eq!(
+            classify_change(Path::new("/proj/content/post.md"), never_global),
+            PathClass::Content
+        );
+    }
+
+    #[test]
+    fn classifies_styles() {
+        assert_eq!(
+            classify_change(Path::new("/proj/styles/main.css"), never_global),
+            PathClass::Style
+        );
+        assert_eq!(
+            classify_change(Path::new("/proj/some/loose.css"), never_global),
+            PathClass::Style
+        );
+    }
+
+    #[test]
+    fn classifies_modules() {
+        assert_eq!(
+            classify_change(Path::new("/proj/components/X.tsx"), never_global),
+            PathClass::Module
+        );
+        assert_eq!(
+            classify_change(Path::new("/proj/layouts/Y.tsx"), never_global),
+            PathClass::Module
+        );
+    }
+
+    #[test]
+    fn classifies_data_and_assets() {
+        assert_eq!(
+            classify_change(Path::new("/proj/data/config.json"), never_global),
+            PathClass::Data
+        );
+        assert_eq!(
+            classify_change(Path::new("/proj/public/logo.svg"), never_global),
+            PathClass::Asset
+        );
+    }
+
+    #[test]
+    fn unknown_root_falls_back_to_extension() {
+        assert_eq!(
+            classify_change(Path::new("/proj/whatever/x.css"), never_global),
+            PathClass::Style
+        );
+        assert_eq!(
+            classify_change(Path::new("/proj/whatever/x.tsx"), never_global),
+            PathClass::Module
+        );
+        assert_eq!(
+            classify_change(Path::new("/proj/whatever/x.md"), never_global),
+            PathClass::Content
+        );
+        assert_eq!(
+            classify_change(Path::new("/proj/whatever/x.bin"), never_global),
+            PathClass::Unclassified
+        );
+    }
+
+    #[test]
+    fn global_wins() {
+        let p = Path::new("/proj/zfb.config.ts");
+        let cls = classify_change(p, |q| q == p);
+        assert_eq!(cls, PathClass::Global);
+    }
+
+    #[test]
+    fn islands_candidate_matches_components_root() {
+        let pol = GranularityPolicy::default();
+        assert!(pol.is_islands_candidate(Path::new("/proj/components/Counter.tsx")));
+        assert!(!pol.is_islands_candidate(Path::new("/proj/pages/index.tsx")));
+        assert!(!pol.is_islands_candidate(Path::new("/proj/content/x.md")));
+    }
+}

--- a/crates/zfb-build/tests/integration_dev_loop.rs
+++ b/crates/zfb-build/tests/integration_dev_loop.rs
@@ -1,0 +1,369 @@
+//! End-to-end integration tests for `zfb-build`.
+//!
+//! Each test sets up a small project fixture in a temp dir, builds an
+//! orchestrator, and exercises the dev loop with synthetic file changes
+//! (via the orchestrator's `tick` method — no watcher spin-up needed,
+//! which keeps these tests fast and deterministic).
+//!
+//! The renderer / CSS / islands callbacks are fakes that record what
+//! they were asked to do. The orchestrator + plan + atomic-write path
+//! are all real.
+
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tempfile::tempdir;
+use zfb_build::{
+    AssetPipeline, BuildContext, BuildOrchestrator, DevAssetPipeline, OrchestratorConfig,
+    PageSelection, RebuildPlan, RenderedPage,
+};
+use zfb_graph::{DepKind, DependencyGraph, PageDeps, PageId};
+use zfb_watcher::Watcher;
+
+fn pid(p: PathBuf) -> PageId {
+    PageId::new(p)
+}
+
+fn make_graph_with_md_page(project_root: &std::path::Path) -> Arc<Mutex<DependencyGraph>> {
+    // One page (`pages/post.tsx`) consumes one markdown content file
+    // (`content/post.md`).
+    let page_src = project_root.join("pages/post.tsx");
+    let md_src = project_root.join("content/post.md");
+
+    let mut g = DependencyGraph::new();
+    g.upsert(PageDeps::new(
+        pid(page_src.clone()),
+        vec![(md_src, DepKind::Content)],
+    ));
+    Arc::new(Mutex::new(g))
+}
+
+#[test]
+fn touching_a_md_file_only_rerenders_its_page() {
+    let dir = tempdir().unwrap();
+    let project = dir.path();
+
+    // Set up the fixture project tree.
+    std::fs::create_dir_all(project.join("pages")).unwrap();
+    std::fs::create_dir_all(project.join("content")).unwrap();
+    std::fs::write(project.join("pages/post.tsx"), "// page\n").unwrap();
+    std::fs::write(project.join("content/post.md"), "# hello\n").unwrap();
+    std::fs::create_dir_all(project.join("dist")).unwrap();
+
+    let graph = make_graph_with_md_page(project);
+    let render_calls: Arc<Mutex<Vec<Vec<PageId>>>> = Arc::new(Mutex::new(Vec::new()));
+    let render_calls_for_cb = render_calls.clone();
+
+    let pipeline = DevAssetPipeline::new();
+    let orch = BuildOrchestrator::new(
+        OrchestratorConfig::new(project, vec![PathBuf::from("content")]),
+        graph,
+        pipeline,
+    );
+
+    let project_path = project.to_path_buf();
+    let ctx = BuildContext {
+        dist_root: project.join("dist"),
+        render_pages: Arc::new(move |pages: &[PageId]| {
+            render_calls_for_cb.lock().unwrap().push(pages.to_vec());
+            Ok(pages
+                .iter()
+                .map(|p| {
+                    let stem = p
+                        .path()
+                        .file_stem()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or("idx");
+                    RenderedPage {
+                        page: p.clone(),
+                        output_path: PathBuf::from(format!("{stem}.html")),
+                        html: format!("<h1>{stem}</h1>"),
+                    }
+                })
+                .collect())
+        }),
+        run_css: None,
+        run_islands: None,
+    };
+
+    // Tick: the markdown file changed.
+    let outcome = orch
+        .tick(vec![project_path.join("content/post.md")], &ctx)
+        .expect("tick succeeded")
+        .expect("non-noop");
+
+    assert_eq!(outcome.pages_rendered, 1, "exactly one page re-rendered");
+    assert_eq!(outcome.pages_written.len(), 1);
+    assert_eq!(
+        outcome.pages_written[0],
+        pid(project_path.join("pages/post.tsx"))
+    );
+    assert!(!outcome.css_rerun);
+    assert!(!outcome.islands_rerun);
+
+    // The renderer was called with exactly one page.
+    let calls = render_calls.lock().unwrap();
+    assert_eq!(calls.len(), 1);
+    assert_eq!(calls[0].len(), 1);
+
+    // The post.html exists on disk.
+    let post_html = project.join("dist/post.html");
+    assert!(post_html.exists(), "post.html should exist");
+    assert_eq!(std::fs::read_to_string(&post_html).unwrap(), "<h1>post</h1>");
+}
+
+#[test]
+fn editing_a_global_css_file_triggers_css_only_rebuild() {
+    let dir = tempdir().unwrap();
+    let project = dir.path();
+
+    std::fs::create_dir_all(project.join("styles")).unwrap();
+    std::fs::create_dir_all(project.join("pages")).unwrap();
+    std::fs::write(project.join("styles/main.css"), ".x{}").unwrap();
+    std::fs::write(project.join("pages/index.tsx"), "// page\n").unwrap();
+
+    // Graph has one page that does NOT depend on the CSS file directly.
+    let mut g = DependencyGraph::new();
+    g.upsert(PageDeps::new(
+        pid(project.join("pages/index.tsx")),
+        vec![],
+    ));
+    let graph = Arc::new(Mutex::new(g));
+
+    let css_runs = Arc::new(AtomicUsize::new(0));
+    let css_runs_cb = css_runs.clone();
+    let render_runs = Arc::new(AtomicUsize::new(0));
+    let render_runs_cb = render_runs.clone();
+    let islands_runs = Arc::new(AtomicUsize::new(0));
+    let islands_runs_cb = islands_runs.clone();
+
+    let pipeline = DevAssetPipeline::new();
+    let orch = BuildOrchestrator::new(
+        OrchestratorConfig::new(project, vec![PathBuf::from("styles")]),
+        graph,
+        pipeline,
+    );
+
+    let ctx = BuildContext {
+        dist_root: project.join("dist"),
+        render_pages: Arc::new(move |_| {
+            render_runs_cb.fetch_add(1, Ordering::SeqCst);
+            Ok(vec![])
+        }),
+        run_css: Some(Arc::new(move || {
+            css_runs_cb.fetch_add(1, Ordering::SeqCst);
+            Ok(true)
+        })),
+        run_islands: Some(Arc::new(move || {
+            islands_runs_cb.fetch_add(1, Ordering::SeqCst);
+            Ok(false)
+        })),
+    };
+
+    let outcome = orch
+        .tick(vec![project.join("styles/main.css")], &ctx)
+        .expect("tick succeeded")
+        .expect("non-noop");
+
+    assert!(outcome.css_rerun, "css must run");
+    assert!(outcome.css_changed, "css callback returned true");
+    assert!(!outcome.islands_rerun, "islands must NOT run");
+    assert_eq!(
+        outcome.pages_rendered, 0,
+        "no pages depend on this CSS file → no render"
+    );
+
+    assert_eq!(css_runs.load(Ordering::SeqCst), 1);
+    assert_eq!(islands_runs.load(Ordering::SeqCst), 0);
+    assert_eq!(render_runs.load(Ordering::SeqCst), 0);
+}
+
+#[test]
+fn editing_a_use_client_component_re_bundles_islands_without_full_rerender() {
+    let dir = tempdir().unwrap();
+    let project = dir.path();
+
+    std::fs::create_dir_all(project.join("components")).unwrap();
+    std::fs::create_dir_all(project.join("pages")).unwrap();
+    std::fs::write(
+        project.join("components/Counter.tsx"),
+        "\"use client\"\nexport default function Counter(){}",
+    )
+    .unwrap();
+    std::fs::write(project.join("pages/a.tsx"), "// a").unwrap();
+    std::fs::write(project.join("pages/b.tsx"), "// b").unwrap();
+
+    // Graph: only page a imports Counter; page b does not. So editing
+    // Counter.tsx should re-render exactly page a (graph) AND re-bundle
+    // islands (policy: components/ is an islands root).
+    let mut g = DependencyGraph::new();
+    g.upsert(PageDeps::new(
+        pid(project.join("pages/a.tsx")),
+        vec![(project.join("components/Counter.tsx"), DepKind::Module)],
+    ));
+    g.upsert(PageDeps::new(pid(project.join("pages/b.tsx")), vec![]));
+    let graph = Arc::new(Mutex::new(g));
+
+    let render_calls: Arc<Mutex<Vec<Vec<PageId>>>> = Arc::new(Mutex::new(Vec::new()));
+    let render_calls_cb = render_calls.clone();
+    let islands_runs = Arc::new(AtomicUsize::new(0));
+    let islands_runs_cb = islands_runs.clone();
+    let css_runs = Arc::new(AtomicUsize::new(0));
+    let css_runs_cb = css_runs.clone();
+
+    let pipeline = DevAssetPipeline::new();
+    let orch = BuildOrchestrator::new(
+        OrchestratorConfig::new(project, vec![PathBuf::from("components")]),
+        graph,
+        pipeline,
+    );
+
+    let ctx = BuildContext {
+        dist_root: project.join("dist"),
+        render_pages: Arc::new(move |pages: &[PageId]| {
+            render_calls_cb.lock().unwrap().push(pages.to_vec());
+            Ok(pages
+                .iter()
+                .map(|p| RenderedPage {
+                    page: p.clone(),
+                    output_path: PathBuf::from(format!(
+                        "{}.html",
+                        p.path().file_stem().unwrap().to_string_lossy()
+                    )),
+                    html: "<p>x</p>".into(),
+                })
+                .collect())
+        }),
+        run_css: Some(Arc::new(move || {
+            css_runs_cb.fetch_add(1, Ordering::SeqCst);
+            Ok(false)
+        })),
+        run_islands: Some(Arc::new(move || {
+            islands_runs_cb.fetch_add(1, Ordering::SeqCst);
+            Ok(true)
+        })),
+    };
+
+    let outcome = orch
+        .tick(vec![project.join("components/Counter.tsx")], &ctx)
+        .expect("tick succeeded")
+        .expect("non-noop");
+
+    assert!(outcome.islands_rerun, "islands must rerun");
+    assert!(!outcome.css_rerun, "css must NOT rerun");
+    assert_eq!(outcome.pages_rendered, 1, "only page a re-rendered");
+
+    let calls = render_calls.lock().unwrap();
+    assert_eq!(calls.len(), 1);
+    let rendered_pages: BTreeSet<_> = calls[0].iter().cloned().collect();
+    assert!(rendered_pages.contains(&pid(project.join("pages/a.tsx"))));
+    assert!(!rendered_pages.contains(&pid(project.join("pages/b.tsx"))));
+
+    assert_eq!(css_runs.load(Ordering::SeqCst), 0, "css callback not called");
+    assert_eq!(islands_runs.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+async fn touching_md_via_real_watcher_triggers_one_page_rebuild() {
+    // Same as the first test, but driven by the real watcher rather
+    // than a synthetic `tick`. Validates the watcher → orchestrator →
+    // pipeline path end-to-end. Uses a generous (200ms) debounce so
+    // the test is robust against jittery filesystems on CI.
+    let dir = tempdir().unwrap();
+    let project = dir.path();
+
+    std::fs::create_dir_all(project.join("pages")).unwrap();
+    std::fs::create_dir_all(project.join("content")).unwrap();
+    std::fs::write(project.join("pages/post.tsx"), "// page\n").unwrap();
+    let md_path = project.join("content/post.md");
+    std::fs::write(&md_path, "# v1\n").unwrap();
+
+    let graph = make_graph_with_md_page(project);
+    let render_calls: Arc<Mutex<Vec<Vec<PageId>>>> = Arc::new(Mutex::new(Vec::new()));
+    let render_calls_cb = render_calls.clone();
+
+    let orch = BuildOrchestrator::new(
+        OrchestratorConfig::new(project, vec![PathBuf::from("content")])
+            .with_debounce(Duration::from_millis(50)),
+        graph.clone(),
+        TestPipeline {
+            inner: DevAssetPipeline::new(),
+            applied: Arc::new(Mutex::new(0)),
+        },
+    );
+
+    let ctx = BuildContext {
+        dist_root: project.join("dist"),
+        render_pages: Arc::new(move |pages: &[PageId]| {
+            render_calls_cb.lock().unwrap().push(pages.to_vec());
+            Ok(pages
+                .iter()
+                .map(|p| RenderedPage {
+                    page: p.clone(),
+                    output_path: PathBuf::from("post.html"),
+                    html: "<h1>v2</h1>".into(),
+                })
+                .collect())
+        }),
+        run_css: None,
+        run_islands: None,
+    };
+
+    // Spawn watcher manually so the test can observe the channel and
+    // then drive a single tick. We do NOT call `orch.run` here because
+    // the test wants explicit control over when the rebuild happens.
+    let (handle, mut rx) = Watcher::start_with_debounce(
+        project,
+        ["content"],
+        Duration::from_millis(50),
+    )
+    .expect("watcher start");
+
+    // Wait briefly for the watcher to install its inotify on the dir,
+    // then change the file.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    std::fs::write(&md_path, "# v2\n").unwrap();
+
+    // Wait for the change to propagate.
+    let change = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("watcher emitted within 2s")
+        .expect("channel still open");
+
+    let outcome = orch
+        .tick(vec![change.path], &ctx)
+        .expect("tick ok")
+        .expect("non-noop");
+    assert_eq!(outcome.pages_rendered, 1);
+    assert_eq!(outcome.pages_written.len(), 1);
+
+    let html_path = project.join("dist/post.html");
+    assert!(html_path.exists());
+    assert_eq!(std::fs::read_to_string(&html_path).unwrap(), "<h1>v2</h1>");
+
+    drop(handle);
+}
+
+/// Wrapper pipeline that delegates to `DevAssetPipeline` but counts
+/// `apply` calls so async tests can verify the pipeline really ran.
+struct TestPipeline {
+    inner: DevAssetPipeline,
+    applied: Arc<Mutex<usize>>,
+}
+
+impl AssetPipeline for TestPipeline {
+    fn apply(
+        &self,
+        plan: &RebuildPlan,
+        ctx: &BuildContext,
+    ) -> anyhow::Result<zfb_build::BuildOutcome> {
+        *self.applied.lock().unwrap() += 1;
+        self.inner.apply(plan, ctx)
+    }
+}
+
+#[allow(dead_code)]
+fn _ensure_unused_imports_used(_: PageSelection) {}

--- a/crates/zfb-content/tests/error_messages.rs
+++ b/crates/zfb-content/tests/error_messages.rs
@@ -1,0 +1,143 @@
+//! Cross-crate "error-quality" acceptance test for `zfb-content`.
+//!
+//! Pins the user-facing error produced when a markdown file in a content
+//! collection has invalid YAML frontmatter. Bar:
+//!
+//! - file path
+//! - line/col of the YAML error (provided by serde_yaml)
+//! - what went wrong
+//! - what was expected
+//!
+//! Companion to `zfb-render/tests/error_messages.rs`. The
+//! `getCollection("doesnotexist")` failure mode and the `zfb.config.ts`
+//! failure mode are tracked separately — see the Sub 4 log for the
+//! "no surface yet" follow-up.
+
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+use zfb_content::collection::{walk_collection, CollectionError, Entry};
+
+#[derive(Debug, Deserialize, garde::Validate)]
+#[allow(dead_code)]
+struct PostSchema {
+    #[garde(length(min = 1))]
+    title: String,
+}
+
+// ---------------------------------------------------------------------------
+// Failure mode 2 — invalid YAML frontmatter in a collection entry.
+// ---------------------------------------------------------------------------
+
+/// A `.md` file with malformed YAML frontmatter must surface an error that
+/// includes the offending file path **and** a line/column from the YAML
+/// parser.
+#[test]
+fn malformed_frontmatter_error_points_at_file_and_yaml_location() {
+    let tmp = mk_tmp("bad-yaml");
+    let bad = tmp.path.join("bad.md");
+    // An unterminated flow sequence — serde_yaml rejects it and reports the
+    // line/column of the failure.
+    std::fs::write(
+        &bad,
+        "---\ntitle: [unclosed, broken\nother: ok\n---\nbody\n",
+    )
+    .unwrap();
+
+    let err =
+        walk_collection::<PostSchema>(&tmp.path).expect_err("malformed frontmatter should fail");
+
+    let CollectionError::Multiple { errors, .. } = &err else {
+        panic!("expected Multiple aggregate, got {err:?}");
+    };
+    assert_eq!(errors.len(), 1, "expected a single aggregated error");
+
+    let inner = &errors[0];
+    let CollectionError::Frontmatter { path, message } = inner else {
+        panic!("expected Frontmatter variant, got {inner:?}");
+    };
+
+    assert_eq!(path, &bad, "error must carry the offending file path");
+
+    // serde_yaml's stringified error always says "at line N column M" when it
+    // has a Location, which it does for syntactic errors like this one.
+    assert!(
+        message.contains("line"),
+        "expected serde_yaml line/col context in error message, got: {message}",
+    );
+    assert!(
+        message.contains("column"),
+        "expected serde_yaml column in error message, got: {message}",
+    );
+
+    // Top-level Display of the aggregated error must also include the file
+    // path so build logs are actionable without unwrapping the variant.
+    let top_msg = err.to_string();
+    assert!(
+        top_msg.contains(bad.to_string_lossy().as_ref()),
+        "top-level error message should include file path, got: {top_msg}",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Failure mode 4 — getCollection("doesnotexist"): SKIPPED.
+//
+// `zfb-content` exposes the static `walk_collection<T>` API and
+// `emit_types_dts` for the TypeScript surface; there is no runtime
+// `getCollection(name)` lookup that takes a name string and validates it
+// against the registered collections yet. When that surface lands, this
+// test should call it with an unknown name and assert the error includes
+// the call site, the requested name, and the list of available names.
+// Tracked in the Sub 4 log as a follow-up.
+// ---------------------------------------------------------------------------
+
+/// Mark the gap explicitly so a future regression — i.e. someone *adds* the
+/// surface but forgets to wire the file-pointing error — is at least
+/// surfaced as a failing-but-`#[ignore]`d test that future work flips on.
+#[test]
+#[ignore = "no runtime getCollection() surface yet — see Sub 4 log follow-up"]
+fn unknown_collection_name_lists_available_collections() {
+    // Once a `get_collection(name: &str)` (or equivalent) surface exists,
+    // call it with `"doesnotexist"` and assert that:
+    //   - the error mentions the call site (file path)
+    //   - the error mentions the bad name
+    //   - the error lists the names that *are* registered
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+struct TmpDir {
+    path: PathBuf,
+}
+
+impl Drop for TmpDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn mk_tmp(label: &str) -> TmpDir {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let dir = std::env::temp_dir().join(format!(
+        "zfb-content-error-quality-{label}-{nanos}-{n}-{pid}",
+        pid = std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).expect("create tmp dir");
+    TmpDir { path: dir }
+}
+
+#[allow(dead_code)]
+fn ensure_entry_unused() {
+    // Touch types so unused-import warnings stay quiet on stable.
+    let _: Option<Entry<PostSchema>> = None;
+}

--- a/crates/zfb-graph/Cargo.toml
+++ b/crates/zfb-graph/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "zfb-graph"
+version = "0.0.0"
+edition = "2021"
+license = "MIT"
+description = "zfb dependency graph: tracks which pages depend on which sources and computes the minimal set of dirty pages on file change"
+
+[lib]
+
+[dependencies]
+thiserror = { workspace = true }

--- a/crates/zfb-graph/README.md
+++ b/crates/zfb-graph/README.md
@@ -1,0 +1,91 @@
+# zfb-graph
+
+Page dependency graph for the zfb framework. Tracks which pages depend on
+which sources (content collections, layouts, components, styles, data
+modules) and answers: "given this file changed, which pages need to be
+re-rendered?"
+
+This crate is part of Epic 6 (build infrastructure) and is consumed by
+`zfb-build`. It is a pure in-memory data structure with no IO.
+
+## Public API
+
+### Types
+
+- `PageId` — newtype wrapping a `PathBuf`, identifying a page by its source
+  `.tsx` path. Lines up with `zfb_router::Route::source_path` semantically
+  without taking a hard dependency on the router crate.
+- `DepKind` — informational tag for an edge: `Module`, `Content`, `Style`,
+  `Data`, `Asset`, `Other`. The graph itself does not branch on kind — every
+  recorded edge invalidates its owning page — but the build orchestrator can
+  use the tag to decide which sub-pipeline (CSS, islands, etc.) to re-run.
+- `PageDeps` — input record: `{ page, deps: Vec<(PathBuf, DepKind)> }`.
+- `DependencyGraph` — the graph itself.
+- `DirtySet` — return shape of `dirty_pages`. Either `All` (sentinel meaning
+  "rebuild every page") or `Specific(BTreeSet<PageId>)`.
+
+### Construction
+
+```rust
+let g = DependencyGraph::from_pages([
+    PageDeps::new(PageId::new("/proj/pages/a.tsx"), vec![
+        (PathBuf::from("/proj/layouts/main.tsx"), DepKind::Module),
+    ]),
+]);
+```
+
+Or build empty and `upsert` page-by-page as the resolver finishes each one.
+
+### Methods
+
+- `dirty_pages(&path) -> DirtySet` — minimal set of pages whose output is
+  affected by changing `path`. Read-only. Returns `DirtySet::All` for files
+  registered as global, an empty `DirtySet::Specific` for unknown paths.
+- `add_node(path) -> bool` — register a brand-new file (e.g., a fresh
+  markdown entry). Returns `true` if newly added. The graph cannot infer
+  consumers; the caller should re-resolve affected pages and feed the new
+  edges back via `upsert`.
+- `remove_node(&path) -> BTreeSet<PageId>` — drop a file. Returns the set of
+  former consumers; these pages need rebuilding. If `path` was a page itself
+  the page is deleted from the graph.
+- `upsert(record)` — install or replace the dep set for a single page.
+  Idempotent and stale-edge-safe: removes prior reverse edges from this page
+  before installing the new ones.
+- `mark_global(path) / unmark_global(&path) / is_global(&path)` — manage the
+  set of files whose change forces `DirtySet::All`.
+- `pages() / page_count() / deps_of(&page) / consumers_of(&path) / snapshot()`
+  — diagnostics + introspection helpers.
+
+## Coarse-rebuild policy
+
+Some files affect every page (`zfb.config.ts`, top-level `_app.tsx`, etc.).
+Rather than enumerating per-page edges for these, register them via
+`mark_global` and the next `dirty_pages` call returns `DirtySet::All` — a
+sentinel that the orchestrator treats as "rebuild everything". This keeps
+the graph small (no synthetic edges from every page to the config file) and
+makes the policy explicit at registration time.
+
+The graph does not auto-register any path as global. The caller decides.
+
+## Self-edge
+
+Every page is implicitly its own dependency: changing
+`/proj/pages/index.tsx` dirties `/proj/pages/index.tsx`. `upsert` adds this
+self-edge automatically so callers do not need to remember.
+
+## Deletion semantics
+
+A deleted file invalidates all of its former consumers — they imported a
+thing that no longer exists. `remove_node` returns exactly that consumer
+set so the orchestrator can rebuild those pages and surface the missing-
+import error per-page.
+
+## Tests
+
+Unit tests in `src/lib.rs`. Integration test in `tests/dirty_pages.rs`
+builds a small fixture graph and exercises edit / add / delete / global
+flows.
+
+```sh
+cargo test -p zfb-graph
+```

--- a/crates/zfb-graph/src/error.rs
+++ b/crates/zfb-graph/src/error.rs
@@ -1,0 +1,16 @@
+//! Crate-wide error type.
+//!
+//! The graph itself is a pure in-memory data structure that does not perform
+//! IO, so today's error surface is small. The type is reserved as a stable
+//! public name so future fallible operations (graph persistence, cycle checks
+//! against an external resolver, etc.) can fit without a breaking API change.
+
+/// Errors produced by `zfb-graph`.
+#[derive(Debug, thiserror::Error)]
+pub enum GraphError {
+    /// Reserved variant. Currently no operation produces this; reserved so the
+    /// enum is non-empty and downstream `match` arms can be exhaustive once
+    /// fallible APIs are added (e.g., persistence, cross-resolver validation).
+    #[error("internal graph error: {0}")]
+    Internal(String),
+}

--- a/crates/zfb-graph/src/lib.rs
+++ b/crates/zfb-graph/src/lib.rs
@@ -1,0 +1,669 @@
+//! zfb-graph: page dependency graph.
+//!
+//! Tracks which pages depend on which sources (content collections, layouts,
+//! components, styles, data modules) and answers: "given this file changed,
+//! which pages need to be re-rendered?"
+//!
+//! Consumes the resolved-dep output of Epic 3's module resolver
+//! ([`zfb_render::loader::ModuleLoader`]). The exact resolver output type is
+//! not yet shared as a public struct, so this crate is intentionally
+//! structurally-typed: it accepts any iterable of `(page, deps)` tuples whose
+//! page is identified by its source path and whose deps are absolute paths.
+//!
+//! ## Public surface
+//!
+//! - [`PageId`] — newtype around a page's source `PathBuf` (matches
+//!   [`zfb_router::Route::source_path`] semantically without a hard dep).
+//! - [`DepKind`] — informational tag for a dependency edge.
+//! - [`PageDeps`] — input record: a page plus its resolved dependencies.
+//! - [`DependencyGraph`] — the graph itself.
+//! - [`DirtySet`] — return shape of [`DependencyGraph::dirty_pages`]; either a
+//!   specific set of pages or the [`DirtySet::All`] sentinel meaning "rebuild
+//!   every page" (used for global files like `zfb.config.ts`).
+//!
+//! ## Coarse-rebuild policy
+//!
+//! Some files affect every page (the framework config, top-level `_app.tsx`,
+//! etc.). The graph treats these as **global**. A change to a global path
+//! returns [`DirtySet::All`], not the union of all per-page edges. Callers
+//! should treat this as a "rebuild everything" sentinel rather than iterating
+//! over a giant `Vec<PageId>`.
+//!
+//! `zfb.config.ts` is registered as global by default. Add more via
+//! [`DependencyGraph::mark_global`].
+
+pub mod error;
+
+pub use error::GraphError;
+
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+/// Identifier for a page in the graph. Wraps the source `.tsx` path so it can
+/// be compared cheaply and printed in diagnostics.
+///
+/// We use a newtype rather than a bare `PathBuf` so future migrations (e.g.
+/// switching to a content-hash key) do not ripple through callers.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct PageId(PathBuf);
+
+impl PageId {
+    /// Build a page id from its source path. The path is stored as-is (no
+    /// canonicalisation) — callers are expected to feed in absolute paths
+    /// matching what the resolver emits.
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self(path.into())
+    }
+
+    /// Borrow the underlying path.
+    pub fn path(&self) -> &Path {
+        &self.0
+    }
+
+    /// Consume self and return the inner `PathBuf`.
+    pub fn into_path(self) -> PathBuf {
+        self.0
+    }
+}
+
+impl From<PathBuf> for PageId {
+    fn from(p: PathBuf) -> Self {
+        Self(p)
+    }
+}
+
+impl From<&Path> for PageId {
+    fn from(p: &Path) -> Self {
+        Self(p.to_path_buf())
+    }
+}
+
+/// Informational tag for a dependency edge. The graph itself does not branch
+/// on kind — every edge invalidates its owning page — but downstream tooling
+/// (build orchestrator, diagnostics) can use the kind to decide which sub-
+/// pipeline to re-run (CSS only, islands only, etc.).
+///
+/// Kept deliberately small: the resolver exposes raw paths today, so
+/// classification is the consumer's job. Add variants conservatively.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum DepKind {
+    /// A `.tsx` / `.ts` / `.jsx` / `.js` module imported from the page graph.
+    Module,
+    /// A markdown / MDX entry consumed via a content collection.
+    Content,
+    /// A CSS / global stylesheet.
+    Style,
+    /// A static data module (JSON, TS-as-data, etc.).
+    Data,
+    /// A static asset under `public/` referenced by the page.
+    Asset,
+    /// Catch-all for edges whose flavour is not yet classified.
+    Other,
+}
+
+/// One page plus its resolved dependencies. Input record consumed by
+/// [`DependencyGraph::from_pages`] and [`DependencyGraph::upsert`].
+#[derive(Debug, Clone)]
+pub struct PageDeps {
+    /// The page itself.
+    pub page: PageId,
+    /// Absolute paths the page depends on, paired with their kind.
+    pub deps: Vec<(PathBuf, DepKind)>,
+}
+
+impl PageDeps {
+    /// Convenience constructor.
+    pub fn new(page: impl Into<PageId>, deps: Vec<(PathBuf, DepKind)>) -> Self {
+        Self {
+            page: page.into(),
+            deps,
+        }
+    }
+}
+
+/// The result of [`DependencyGraph::dirty_pages`].
+///
+/// A change to a globally-scoped file (see [`DependencyGraph::mark_global`])
+/// returns [`DirtySet::All`]. Every other change returns
+/// [`DirtySet::Specific`] with the (possibly empty) set of affected pages.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DirtySet {
+    /// Rebuild every page. Triggered by changes to global files (e.g.
+    /// `zfb.config.ts`) or by file deletions whose former consumers cannot
+    /// be enumerated reliably.
+    All,
+    /// Rebuild this specific set of pages. May be empty when the changed file
+    /// is unknown to the graph (no consumer recorded).
+    Specific(BTreeSet<PageId>),
+}
+
+impl DirtySet {
+    /// Convenience: collect the specific pages into a sorted `Vec` if this is
+    /// a [`DirtySet::Specific`] — returns `None` for [`DirtySet::All`].
+    pub fn as_pages(&self) -> Option<Vec<PageId>> {
+        match self {
+            DirtySet::All => None,
+            DirtySet::Specific(set) => Some(set.iter().cloned().collect()),
+        }
+    }
+
+    /// `true` iff this is the [`DirtySet::All`] sentinel.
+    pub fn is_all(&self) -> bool {
+        matches!(self, DirtySet::All)
+    }
+}
+
+/// Page dependency graph.
+///
+/// Internally maintains:
+///
+/// - `forward[page] -> {dep, kind}` — what each page depends on (kept so
+///   `upsert` and `remove_node` can clean the reverse index).
+/// - `reverse[dep] -> {pages}` — what pages depend on this file (the index
+///   used by [`DependencyGraph::dirty_pages`]).
+/// - `pages` — the canonical set of known pages.
+/// - `globals` — paths whose change forces [`DirtySet::All`].
+pub struct DependencyGraph {
+    forward: HashMap<PageId, Vec<(PathBuf, DepKind)>>,
+    reverse: HashMap<PathBuf, HashSet<PageId>>,
+    pages: HashSet<PageId>,
+    globals: HashSet<PathBuf>,
+}
+
+impl Default for DependencyGraph {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DependencyGraph {
+    /// Build an empty graph. The default global set is empty; the caller
+    /// should register their `zfb.config.ts` (and any other always-invalidates
+    /// paths) via [`Self::mark_global`].
+    pub fn new() -> Self {
+        Self {
+            forward: HashMap::new(),
+            reverse: HashMap::new(),
+            pages: HashSet::new(),
+            globals: HashSet::new(),
+        }
+    }
+
+    /// Build a graph from an initial batch of `(page, deps)` records — this
+    /// is the typical entry point right after the module resolver finishes.
+    pub fn from_pages(records: impl IntoIterator<Item = PageDeps>) -> Self {
+        let mut g = Self::new();
+        for r in records {
+            g.upsert(r);
+        }
+        g
+    }
+
+    /// Number of pages currently tracked.
+    pub fn page_count(&self) -> usize {
+        self.pages.len()
+    }
+
+    /// All currently-known pages, sorted for deterministic iteration.
+    pub fn pages(&self) -> Vec<PageId> {
+        let mut v: Vec<PageId> = self.pages.iter().cloned().collect();
+        v.sort();
+        v
+    }
+
+    /// Mark `path` as a global file: any change to it returns
+    /// [`DirtySet::All`] regardless of recorded edges.
+    ///
+    /// Typical examples: `zfb.config.ts`, `pages/_app.tsx`,
+    /// `pages/_document.tsx`. The graph does not auto-register any of these —
+    /// the caller decides the policy.
+    pub fn mark_global(&mut self, path: impl Into<PathBuf>) {
+        self.globals.insert(path.into());
+    }
+
+    /// Stop treating `path` as a global file. No-op if it was not marked.
+    pub fn unmark_global(&mut self, path: &Path) {
+        self.globals.remove(path);
+    }
+
+    /// Whether `path` is currently registered as a global file.
+    pub fn is_global(&self, path: &Path) -> bool {
+        self.globals.contains(path)
+    }
+
+    /// Insert or replace the dep set for a single page. Cleans up stale
+    /// reverse-index entries so callers can hand in the latest resolver
+    /// output without bookkeeping.
+    pub fn upsert(&mut self, record: PageDeps) {
+        let page = record.page;
+
+        // Remove any prior reverse edges from this page so a re-resolve does
+        // not leave dangling entries.
+        if let Some(prior) = self.forward.remove(&page) {
+            for (dep, _) in prior {
+                if let Some(consumers) = self.reverse.get_mut(&dep) {
+                    consumers.remove(&page);
+                    if consumers.is_empty() {
+                        self.reverse.remove(&dep);
+                    }
+                }
+            }
+        }
+
+        // Install fresh forward + reverse edges. A page is always a consumer
+        // of itself — changing the page source obviously dirties the page —
+        // so we add a self-edge unconditionally.
+        let mut deps = record.deps;
+        let self_edge = (page.path().to_path_buf(), DepKind::Module);
+        if !deps.iter().any(|(p, _)| p == &self_edge.0) {
+            deps.push(self_edge);
+        }
+
+        for (dep, _) in &deps {
+            self.reverse
+                .entry(dep.clone())
+                .or_default()
+                .insert(page.clone());
+        }
+
+        self.pages.insert(page.clone());
+        self.forward.insert(page, deps);
+    }
+
+    /// Add a brand-new node to the graph.
+    ///
+    /// - If `path` is a page (a `pages/**/*.tsx` source), prefer
+    ///   [`Self::upsert`] with an empty (or freshly-resolved) dep list —
+    ///   `add_node` is for non-page sources discovered later (e.g., a new
+    ///   markdown file in a content collection).
+    /// - If `path` is already known as a dep or page, this is a no-op (we
+    ///   keep existing edges intact).
+    ///
+    /// Returns `true` if the call introduced a new entry, `false` if the path
+    /// was already present.
+    ///
+    /// Note: a freshly-added file has no recorded consumers yet, so the next
+    /// [`Self::dirty_pages`] call for that path will return an empty
+    /// [`DirtySet::Specific`]. Callers that need "consumers might appear
+    /// imminently" semantics should re-resolve and call [`Self::upsert`] on
+    /// affected pages.
+    pub fn add_node(&mut self, path: impl Into<PathBuf>) -> bool {
+        let path = path.into();
+        if self.reverse.contains_key(&path) {
+            return false;
+        }
+        // We only need an entry if something later adds an edge — but we
+        // insert an empty consumer set so callers can distinguish "known but
+        // unused" from "totally unknown" via reverse-index introspection.
+        self.reverse.entry(path).or_default();
+        true
+    }
+
+    /// Remove a node from the graph and return its former consumers.
+    ///
+    /// - If `path` was a page, the page is dropped and its reverse-index
+    ///   entries are cleaned up. The returned set contains just that page id.
+    /// - If `path` was a non-page dep, every page that depended on it loses
+    ///   that edge. The returned set is the former consumer list — these
+    ///   pages should be rebuilt.
+    /// - If `path` was unknown, returns an empty set.
+    ///
+    /// A removed file invalidates all of its former consumers (they imported
+    /// something that no longer exists), so the returned set is exactly the
+    /// pages that need rebuilding.
+    pub fn remove_node(&mut self, path: &Path) -> BTreeSet<PageId> {
+        let mut affected: BTreeSet<PageId> = BTreeSet::new();
+
+        // Case 1: removing a page.
+        let page_id = PageId::new(path.to_path_buf());
+        if self.pages.remove(&page_id) {
+            if let Some(deps) = self.forward.remove(&page_id) {
+                for (dep, _) in deps {
+                    if let Some(consumers) = self.reverse.get_mut(&dep) {
+                        consumers.remove(&page_id);
+                        if consumers.is_empty() {
+                            self.reverse.remove(&dep);
+                        }
+                    }
+                }
+            }
+            affected.insert(page_id);
+            return affected;
+        }
+
+        // Case 2: removing a non-page dep. Collect consumers, clear edges.
+        if let Some(consumers) = self.reverse.remove(path) {
+            for page in &consumers {
+                if let Some(forward_deps) = self.forward.get_mut(page) {
+                    forward_deps.retain(|(p, _)| p != path);
+                }
+            }
+            affected.extend(consumers);
+        }
+
+        affected
+    }
+
+    /// The minimal set of pages whose output is affected by changing `path`.
+    ///
+    /// - For a global file (see [`Self::mark_global`]) → [`DirtySet::All`].
+    /// - For a page or dep with recorded consumers → [`DirtySet::Specific`]
+    ///   with that consumer set.
+    /// - For an unknown path → empty [`DirtySet::Specific`].
+    ///
+    /// This method is read-only; it does not mutate the graph. For deletions
+    /// use [`Self::remove_node`], which both returns the affected set and
+    /// updates the index.
+    pub fn dirty_pages(&self, path: &Path) -> DirtySet {
+        if self.globals.contains(path) {
+            return DirtySet::All;
+        }
+
+        let mut out: BTreeSet<PageId> = BTreeSet::new();
+
+        // The file is itself a page → it is dirty.
+        let page_id = PageId::new(path.to_path_buf());
+        if self.pages.contains(&page_id) {
+            out.insert(page_id);
+        }
+
+        // Anything that imported this path is dirty.
+        if let Some(consumers) = self.reverse.get(path) {
+            for c in consumers {
+                out.insert(c.clone());
+            }
+        }
+
+        DirtySet::Specific(out)
+    }
+
+    /// Lookup helper: every recorded dep of a page (kind included), sorted by
+    /// path. Returns an empty `Vec` for unknown pages.
+    pub fn deps_of(&self, page: &PageId) -> Vec<(PathBuf, DepKind)> {
+        let mut v = self
+            .forward
+            .get(page)
+            .cloned()
+            .unwrap_or_default();
+        v.sort_by(|a, b| a.0.cmp(&b.0));
+        v
+    }
+
+    /// Lookup helper: every page that depends on `path`, sorted. Returns
+    /// `None` if the path is not known to the graph at all (versus
+    /// `Some(empty)` for a known-but-unused dep registered via
+    /// [`Self::add_node`]).
+    pub fn consumers_of(&self, path: &Path) -> Option<Vec<PageId>> {
+        self.reverse.get(path).map(|set| {
+            let mut v: Vec<PageId> = set.iter().cloned().collect();
+            v.sort();
+            v
+        })
+    }
+
+    /// Snapshot for diagnostics: every (dep -> sorted consumers) pair, keyed
+    /// for deterministic ordering. Mostly useful in tests.
+    pub fn snapshot(&self) -> BTreeMap<PathBuf, Vec<PageId>> {
+        let mut out: BTreeMap<PathBuf, Vec<PageId>> = BTreeMap::new();
+        for (dep, consumers) in &self.reverse {
+            let mut v: Vec<PageId> = consumers.iter().cloned().collect();
+            v.sort();
+            out.insert(dep.clone(), v);
+        }
+        out
+    }
+}
+
+// -----------------------------------------------------------------------------
+// tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn p(s: &str) -> PathBuf {
+        PathBuf::from(s)
+    }
+
+    fn pid(s: &str) -> PageId {
+        PageId::new(p(s))
+    }
+
+    #[test]
+    fn empty_graph_returns_empty_specific_set() {
+        let g = DependencyGraph::new();
+        let d = g.dirty_pages(&p("/x"));
+        assert_eq!(d, DirtySet::Specific(BTreeSet::new()));
+        assert!(!d.is_all());
+    }
+
+    #[test]
+    fn page_self_dirties_on_change_to_its_own_source() {
+        let mut g = DependencyGraph::new();
+        g.upsert(PageDeps::new(pid("/pages/index.tsx"), vec![]));
+        let d = g.dirty_pages(&p("/pages/index.tsx"));
+        match d {
+            DirtySet::Specific(set) => {
+                assert_eq!(set.len(), 1);
+                assert!(set.contains(&pid("/pages/index.tsx")));
+            }
+            DirtySet::All => panic!("expected specific set, got All"),
+        }
+    }
+
+    #[test]
+    fn shared_layout_dirties_all_consumers() {
+        let mut g = DependencyGraph::new();
+        g.upsert(PageDeps::new(
+            pid("/pages/a.tsx"),
+            vec![(p("/layouts/main.tsx"), DepKind::Module)],
+        ));
+        g.upsert(PageDeps::new(
+            pid("/pages/b.tsx"),
+            vec![(p("/layouts/main.tsx"), DepKind::Module)],
+        ));
+        g.upsert(PageDeps::new(
+            pid("/pages/c.tsx"),
+            vec![(p("/layouts/other.tsx"), DepKind::Module)],
+        ));
+
+        let d = g.dirty_pages(&p("/layouts/main.tsx"));
+        let pages = d.as_pages().expect("specific");
+        assert_eq!(pages, vec![pid("/pages/a.tsx"), pid("/pages/b.tsx")]);
+    }
+
+    #[test]
+    fn unique_dep_dirties_only_one_page() {
+        let mut g = DependencyGraph::new();
+        g.upsert(PageDeps::new(
+            pid("/pages/a.tsx"),
+            vec![(p("/components/only-a.tsx"), DepKind::Module)],
+        ));
+        g.upsert(PageDeps::new(
+            pid("/pages/b.tsx"),
+            vec![(p("/components/only-b.tsx"), DepKind::Module)],
+        ));
+
+        let d = g.dirty_pages(&p("/components/only-a.tsx"));
+        assert_eq!(d.as_pages().unwrap(), vec![pid("/pages/a.tsx")]);
+    }
+
+    #[test]
+    fn unknown_path_returns_empty_specific() {
+        let mut g = DependencyGraph::new();
+        g.upsert(PageDeps::new(pid("/pages/a.tsx"), vec![]));
+        let d = g.dirty_pages(&p("/totally/unrelated.css"));
+        assert_eq!(d, DirtySet::Specific(BTreeSet::new()));
+    }
+
+    #[test]
+    fn global_file_returns_all() {
+        let mut g = DependencyGraph::new();
+        g.upsert(PageDeps::new(pid("/pages/a.tsx"), vec![]));
+        g.upsert(PageDeps::new(pid("/pages/b.tsx"), vec![]));
+        g.mark_global("/zfb.config.ts");
+
+        let d = g.dirty_pages(&p("/zfb.config.ts"));
+        assert!(d.is_all());
+        assert!(d.as_pages().is_none());
+    }
+
+    #[test]
+    fn global_overrides_recorded_edges() {
+        let mut g = DependencyGraph::new();
+        g.upsert(PageDeps::new(
+            pid("/pages/a.tsx"),
+            vec![(p("/zfb.config.ts"), DepKind::Other)],
+        ));
+        g.mark_global("/zfb.config.ts");
+        // Even though only page a recorded the edge, a global file change
+        // means "rebuild everything" — All, not just {a}.
+        let d = g.dirty_pages(&p("/zfb.config.ts"));
+        assert!(d.is_all());
+    }
+
+    #[test]
+    fn upsert_replaces_prior_deps_cleanly() {
+        let mut g = DependencyGraph::new();
+        g.upsert(PageDeps::new(
+            pid("/pages/a.tsx"),
+            vec![(p("/x.tsx"), DepKind::Module)],
+        ));
+        // Prior /x.tsx edge should disappear; new /y.tsx edge should appear.
+        g.upsert(PageDeps::new(
+            pid("/pages/a.tsx"),
+            vec![(p("/y.tsx"), DepKind::Module)],
+        ));
+
+        let d_x = g.dirty_pages(&p("/x.tsx"));
+        assert_eq!(d_x.as_pages().unwrap(), Vec::<PageId>::new());
+
+        let d_y = g.dirty_pages(&p("/y.tsx"));
+        assert_eq!(d_y.as_pages().unwrap(), vec![pid("/pages/a.tsx")]);
+    }
+
+    #[test]
+    fn remove_node_for_a_page_drops_it() {
+        let mut g = DependencyGraph::new();
+        g.upsert(PageDeps::new(
+            pid("/pages/a.tsx"),
+            vec![(p("/lib/util.tsx"), DepKind::Module)],
+        ));
+        let removed = g.remove_node(&p("/pages/a.tsx"));
+        assert!(removed.contains(&pid("/pages/a.tsx")));
+        assert_eq!(g.page_count(), 0);
+        // Reverse edge for /lib/util.tsx should also be cleaned up.
+        let d = g.dirty_pages(&p("/lib/util.tsx"));
+        assert_eq!(d.as_pages().unwrap(), Vec::<PageId>::new());
+    }
+
+    #[test]
+    fn remove_node_for_a_dep_returns_consumers() {
+        let mut g = DependencyGraph::new();
+        g.upsert(PageDeps::new(
+            pid("/pages/a.tsx"),
+            vec![(p("/components/shared.tsx"), DepKind::Module)],
+        ));
+        g.upsert(PageDeps::new(
+            pid("/pages/b.tsx"),
+            vec![(p("/components/shared.tsx"), DepKind::Module)],
+        ));
+        let removed = g.remove_node(&p("/components/shared.tsx"));
+        let removed_v: Vec<PageId> = removed.into_iter().collect();
+        assert_eq!(removed_v, vec![pid("/pages/a.tsx"), pid("/pages/b.tsx")]);
+
+        // Subsequent dirty_pages for the deleted file should be empty
+        // (consumers no longer recorded under that path).
+        let d = g.dirty_pages(&p("/components/shared.tsx"));
+        assert_eq!(d.as_pages().unwrap(), Vec::<PageId>::new());
+    }
+
+    #[test]
+    fn remove_node_for_unknown_path_returns_empty() {
+        let mut g = DependencyGraph::new();
+        let removed = g.remove_node(&p("/nope"));
+        assert!(removed.is_empty());
+    }
+
+    #[test]
+    fn add_node_is_idempotent_for_known_paths() {
+        let mut g = DependencyGraph::new();
+        g.upsert(PageDeps::new(
+            pid("/pages/a.tsx"),
+            vec![(p("/x.tsx"), DepKind::Module)],
+        ));
+        // /x.tsx is already in the reverse index.
+        assert!(!g.add_node("/x.tsx"));
+        // Brand-new path → true.
+        assert!(g.add_node("/new-thing.tsx"));
+        // Second time → false.
+        assert!(!g.add_node("/new-thing.tsx"));
+    }
+
+    #[test]
+    fn pages_returns_sorted_list() {
+        let mut g = DependencyGraph::new();
+        g.upsert(PageDeps::new(pid("/pages/c.tsx"), vec![]));
+        g.upsert(PageDeps::new(pid("/pages/a.tsx"), vec![]));
+        g.upsert(PageDeps::new(pid("/pages/b.tsx"), vec![]));
+        assert_eq!(
+            g.pages(),
+            vec![pid("/pages/a.tsx"), pid("/pages/b.tsx"), pid("/pages/c.tsx")]
+        );
+    }
+
+    #[test]
+    fn deps_of_returns_sorted_with_self_edge() {
+        let mut g = DependencyGraph::new();
+        g.upsert(PageDeps::new(
+            pid("/pages/a.tsx"),
+            vec![
+                (p("/c.tsx"), DepKind::Module),
+                (p("/a.css"), DepKind::Style),
+            ],
+        ));
+        let deps = g.deps_of(&pid("/pages/a.tsx"));
+        let paths: Vec<PathBuf> = deps.iter().map(|(p, _)| p.clone()).collect();
+        // a.css, /c.tsx, and the implicit self-edge (/pages/a.tsx).
+        assert_eq!(paths.len(), 3);
+        // Sorted.
+        let mut sorted = paths.clone();
+        sorted.sort();
+        assert_eq!(paths, sorted);
+        assert!(paths.contains(&p("/pages/a.tsx")));
+    }
+
+    #[test]
+    fn consumers_of_distinguishes_unknown_from_unused() {
+        let mut g = DependencyGraph::new();
+        g.upsert(PageDeps::new(
+            pid("/pages/a.tsx"),
+            vec![(p("/x.tsx"), DepKind::Module)],
+        ));
+        assert_eq!(
+            g.consumers_of(&p("/x.tsx")),
+            Some(vec![pid("/pages/a.tsx")])
+        );
+        assert_eq!(g.consumers_of(&p("/never-seen.tsx")), None);
+
+        g.add_node("/known-but-unused.tsx");
+        assert_eq!(g.consumers_of(&p("/known-but-unused.tsx")), Some(vec![]));
+    }
+
+    #[test]
+    fn from_pages_constructor_is_equivalent_to_repeated_upsert() {
+        let recs = vec![
+            PageDeps::new(pid("/pages/a.tsx"), vec![(p("/x"), DepKind::Module)]),
+            PageDeps::new(pid("/pages/b.tsx"), vec![(p("/x"), DepKind::Module)]),
+        ];
+        let g1 = DependencyGraph::from_pages(recs.clone());
+
+        let mut g2 = DependencyGraph::new();
+        for r in recs {
+            g2.upsert(r);
+        }
+        assert_eq!(g1.snapshot(), g2.snapshot());
+    }
+}

--- a/crates/zfb-graph/tests/dirty_pages.rs
+++ b/crates/zfb-graph/tests/dirty_pages.rs
@@ -1,0 +1,184 @@
+//! Integration test: build a small fake graph that mirrors a realistic
+//! Epic-3-shaped resolver output and exercise the dirty-page query for the
+//! main edit / add / delete / global flows.
+//!
+//! The shape modelled here:
+//!
+//! ```text
+//! pages/index.tsx     → [layouts/main.tsx, components/header.tsx, styles/global.css]
+//! pages/blog.tsx      → [layouts/main.tsx, components/post-card.tsx, content/blog/hello.md]
+//! pages/about.tsx     → [layouts/main.tsx]
+//! pages/contact.tsx   → [layouts/contact.tsx, components/form.tsx]
+//! ```
+//!
+//! Plus a `zfb.config.ts` registered as global.
+
+use std::path::PathBuf;
+
+use zfb_graph::{DepKind, DependencyGraph, DirtySet, PageDeps, PageId};
+
+fn p(s: &str) -> PathBuf {
+    PathBuf::from(s)
+}
+
+fn pid(s: &str) -> PageId {
+    PageId::new(p(s))
+}
+
+fn fixture() -> DependencyGraph {
+    let mut g = DependencyGraph::from_pages([
+        PageDeps::new(
+            pid("/proj/pages/index.tsx"),
+            vec![
+                (p("/proj/layouts/main.tsx"), DepKind::Module),
+                (p("/proj/components/header.tsx"), DepKind::Module),
+                (p("/proj/styles/global.css"), DepKind::Style),
+            ],
+        ),
+        PageDeps::new(
+            pid("/proj/pages/blog.tsx"),
+            vec![
+                (p("/proj/layouts/main.tsx"), DepKind::Module),
+                (p("/proj/components/post-card.tsx"), DepKind::Module),
+                (p("/proj/content/blog/hello.md"), DepKind::Content),
+            ],
+        ),
+        PageDeps::new(
+            pid("/proj/pages/about.tsx"),
+            vec![(p("/proj/layouts/main.tsx"), DepKind::Module)],
+        ),
+        PageDeps::new(
+            pid("/proj/pages/contact.tsx"),
+            vec![
+                (p("/proj/layouts/contact.tsx"), DepKind::Module),
+                (p("/proj/components/form.tsx"), DepKind::Module),
+            ],
+        ),
+    ]);
+    g.mark_global("/proj/zfb.config.ts");
+    g
+}
+
+#[test]
+fn editing_a_unique_markdown_dirties_only_one_page() {
+    let g = fixture();
+    let d = g.dirty_pages(&p("/proj/content/blog/hello.md"));
+    assert_eq!(d.as_pages().unwrap(), vec![pid("/proj/pages/blog.tsx")]);
+}
+
+#[test]
+fn editing_the_shared_layout_dirties_three_pages() {
+    let g = fixture();
+    let d = g.dirty_pages(&p("/proj/layouts/main.tsx"));
+    assert_eq!(
+        d.as_pages().unwrap(),
+        vec![
+            pid("/proj/pages/about.tsx"),
+            pid("/proj/pages/blog.tsx"),
+            pid("/proj/pages/index.tsx"),
+        ]
+    );
+}
+
+#[test]
+fn editing_a_page_source_dirties_just_that_page() {
+    let g = fixture();
+    let d = g.dirty_pages(&p("/proj/pages/contact.tsx"));
+    assert_eq!(d.as_pages().unwrap(), vec![pid("/proj/pages/contact.tsx")]);
+}
+
+#[test]
+fn editing_an_unrelated_dep_dirties_nothing() {
+    let g = fixture();
+    let d = g.dirty_pages(&p("/proj/pages/contact.tsx"));
+    // Sanity: contact has no overlap with the index/blog/about cluster.
+    let pages = d.as_pages().unwrap();
+    assert!(!pages.contains(&pid("/proj/pages/index.tsx")));
+    assert!(!pages.contains(&pid("/proj/pages/blog.tsx")));
+    assert!(!pages.contains(&pid("/proj/pages/about.tsx")));
+}
+
+#[test]
+fn config_change_returns_all_sentinel() {
+    let g = fixture();
+    let d = g.dirty_pages(&p("/proj/zfb.config.ts"));
+    assert!(d.is_all());
+    assert!(matches!(d, DirtySet::All));
+}
+
+#[test]
+fn deleting_a_shared_dep_invalidates_all_consumers() {
+    let mut g = fixture();
+    let removed = g.remove_node(&p("/proj/layouts/main.tsx"));
+    let removed: Vec<PageId> = removed.into_iter().collect();
+    assert_eq!(
+        removed,
+        vec![
+            pid("/proj/pages/about.tsx"),
+            pid("/proj/pages/blog.tsx"),
+            pid("/proj/pages/index.tsx"),
+        ]
+    );
+    // After removal, dirtying that path again finds no consumers.
+    let d = g.dirty_pages(&p("/proj/layouts/main.tsx"));
+    assert!(d.as_pages().unwrap().is_empty());
+}
+
+#[test]
+fn deleting_a_page_drops_it_and_cleans_reverse_index() {
+    let mut g = fixture();
+    let removed = g.remove_node(&p("/proj/pages/blog.tsx"));
+    assert!(removed.contains(&pid("/proj/pages/blog.tsx")));
+    assert_eq!(g.page_count(), 3);
+
+    // The blog-only deps should no longer point to anyone.
+    let d = g.dirty_pages(&p("/proj/content/blog/hello.md"));
+    assert!(d.as_pages().unwrap().is_empty());
+
+    let d = g.dirty_pages(&p("/proj/components/post-card.tsx"));
+    assert!(d.as_pages().unwrap().is_empty());
+
+    // But the shared layout is still wired to the other two pages.
+    let d = g.dirty_pages(&p("/proj/layouts/main.tsx"));
+    assert_eq!(
+        d.as_pages().unwrap(),
+        vec![pid("/proj/pages/about.tsx"), pid("/proj/pages/index.tsx")]
+    );
+}
+
+#[test]
+fn adding_a_brand_new_dep_then_resolving_records_consumer() {
+    let mut g = fixture();
+    // Filesystem watcher reports a new file. Before the resolver re-runs,
+    // dirty_pages for that path is empty (no consumer yet).
+    assert!(g.add_node("/proj/components/new-widget.tsx"));
+    let d = g.dirty_pages(&p("/proj/components/new-widget.tsx"));
+    assert!(d.as_pages().unwrap().is_empty());
+
+    // Now the resolver re-resolves /proj/pages/index.tsx and reports the new
+    // dep. After upsert, dirty_pages returns the new consumer.
+    g.upsert(PageDeps::new(
+        pid("/proj/pages/index.tsx"),
+        vec![
+            (p("/proj/layouts/main.tsx"), DepKind::Module),
+            (p("/proj/components/header.tsx"), DepKind::Module),
+            (p("/proj/components/new-widget.tsx"), DepKind::Module),
+            (p("/proj/styles/global.css"), DepKind::Style),
+        ],
+    ));
+    let d = g.dirty_pages(&p("/proj/components/new-widget.tsx"));
+    assert_eq!(d.as_pages().unwrap(), vec![pid("/proj/pages/index.tsx")]);
+}
+
+#[test]
+fn adding_a_brand_new_page_appears_in_pages_list() {
+    let mut g = fixture();
+    g.upsert(PageDeps::new(
+        pid("/proj/pages/new.tsx"),
+        vec![(p("/proj/layouts/main.tsx"), DepKind::Module)],
+    ));
+    assert_eq!(g.page_count(), 5);
+    // And the shared layout now dirties four pages instead of three.
+    let d = g.dirty_pages(&p("/proj/layouts/main.tsx"));
+    assert_eq!(d.as_pages().unwrap().len(), 4);
+}

--- a/crates/zfb-render/src/error.rs
+++ b/crates/zfb-render/src/error.rs
@@ -18,12 +18,33 @@ pub enum RenderError {
     },
 
     /// Module resolution failure (e.g., relative import not found).
-    #[error("could not resolve `{specifier}` from `{importer}`")]
+    ///
+    /// `importer` points at the file that contains the failing import so the
+    /// error is actionable in editors (file path + optional line/col). `tried`
+    /// lists the on-disk candidates probed so the operator can see whether a
+    /// typo or missing extension is the cause.
+    #[error(
+        "could not resolve `{specifier}` imported from `{importer}`{loc}: no such module (tried: {tried_pretty})\n\
+         help: check the import path or extension; the resolver probes .tsx, .ts, .jsx, .js, and `index.<ext>` for directories",
+        loc = match (line, col) {
+            (Some(l), Some(c)) => format!(":{l}:{c}"),
+            (Some(l), None) => format!(":{l}"),
+            _ => String::new(),
+        },
+        tried_pretty = if tried.is_empty() { "<none>".to_string() } else { tried.join(", ") },
+    )]
     Resolve {
         /// The bare/relative specifier we tried to resolve.
         specifier: String,
-        /// The importer module's display name.
+        /// File-system path of the module that contains the failing import.
         importer: String,
+        /// 1-based line number of the import statement when known.
+        line: Option<u32>,
+        /// 1-based column number of the import statement when known.
+        col: Option<u32>,
+        /// Filesystem candidates probed by the resolver. Helps the operator
+        /// diagnose typos and missing extensions.
+        tried: Vec<String>,
     },
 
     /// JS runtime failure (loading, evaluating, or calling into a module).
@@ -61,11 +82,35 @@ impl RenderError {
         }
     }
 
-    /// Convenience constructor for resolve errors.
+    /// Convenience constructor for resolve errors with no probe list and no
+    /// import-statement source location. Prefer
+    /// [`RenderError::resolve_with`] when those details are available.
     pub fn resolve(specifier: impl Into<String>, importer: impl Into<String>) -> Self {
         Self::Resolve {
             specifier: specifier.into(),
             importer: importer.into(),
+            line: None,
+            col: None,
+            tried: Vec::new(),
+        }
+    }
+
+    /// Convenience constructor for resolve errors that record the candidate
+    /// paths probed by the resolver and (optionally) the line/column of the
+    /// `import` statement in the importer file.
+    pub fn resolve_with(
+        specifier: impl Into<String>,
+        importer: impl Into<String>,
+        line: Option<u32>,
+        col: Option<u32>,
+        tried: Vec<String>,
+    ) -> Self {
+        Self::Resolve {
+            specifier: specifier.into(),
+            importer: importer.into(),
+            line,
+            col,
+            tried,
         }
     }
 }

--- a/crates/zfb-render/src/loader.rs
+++ b/crates/zfb-render/src/loader.rs
@@ -57,12 +57,62 @@ impl ModuleLoader {
 
     /// Resolve a relative `specifier` against `importer_dir`, probing
     /// extensions and returning the resolved absolute path on success.
+    ///
+    /// On failure the returned [`RenderError::Resolve`] points at
+    /// `importer_dir` (no source line/column). Prefer
+    /// [`Self::resolve_relative_from_file`] when the importer's file path is
+    /// known so the error message points editors at the actual TSX file.
     pub fn resolve_relative(&self, importer_dir: &Path, specifier: &str) -> Result<PathBuf> {
+        let (result, tried) = self.try_resolve(importer_dir, specifier);
+        result.ok_or_else(|| {
+            RenderError::resolve_with(
+                specifier,
+                importer_dir.display().to_string(),
+                None,
+                None,
+                tried,
+            )
+        })
+    }
+
+    /// Resolve a relative `specifier` imported from `importer_file`. On
+    /// failure the error includes the importer's file path (and optional
+    /// line/col of the `import` statement) plus every candidate path probed.
+    pub fn resolve_relative_from_file(
+        &self,
+        importer_file: &Path,
+        specifier: &str,
+        import_line: Option<u32>,
+        import_col: Option<u32>,
+    ) -> Result<PathBuf> {
+        let importer_dir = importer_file.parent().unwrap_or(Path::new(""));
+        let (result, tried) = self.try_resolve(importer_dir, specifier);
+        result.ok_or_else(|| {
+            RenderError::resolve_with(
+                specifier,
+                importer_file.display().to_string(),
+                import_line,
+                import_col,
+                tried,
+            )
+        })
+    }
+
+    /// Internal probe loop shared by [`resolve_relative`] and
+    /// [`resolve_relative_from_file`]. Returns the resolved path (if any) and
+    /// the full list of candidates attempted, in probe order.
+    fn try_resolve(
+        &self,
+        importer_dir: &Path,
+        specifier: &str,
+    ) -> (Option<PathBuf>, Vec<String>) {
         let candidate = importer_dir.join(specifier);
+        let mut tried: Vec<String> = Vec::with_capacity(self.probe_exts.len() + 1 + self.probe_exts.len());
 
         // 1) Exact match.
+        tried.push(candidate.display().to_string());
         if candidate.is_file() {
-            return Ok(candidate);
+            return (Some(candidate), tried);
         }
 
         // 2) Probe extensions (`./layout` → `./layout.tsx` etc.).
@@ -74,8 +124,9 @@ impl ModuleLoader {
                 ext
             );
             probe.set_file_name(new_name);
+            tried.push(probe.display().to_string());
             if probe.is_file() {
-                return Ok(probe);
+                return (Some(probe), tried);
             }
         }
 
@@ -83,16 +134,14 @@ impl ModuleLoader {
         if candidate.is_dir() {
             for ext in &self.probe_exts {
                 let probe = candidate.join(format!("index{ext}"));
+                tried.push(probe.display().to_string());
                 if probe.is_file() {
-                    return Ok(probe);
+                    return (Some(probe), tried);
                 }
             }
         }
 
-        Err(RenderError::resolve(
-            specifier,
-            importer_dir.display().to_string(),
-        ))
+        (None, tried)
     }
 
     /// Compile a source string through SWC and cache it under `specifier`.

--- a/crates/zfb-render/src/paths.rs
+++ b/crates/zfb-render/src/paths.rs
@@ -48,6 +48,10 @@ pub struct ResolvedPath {
 }
 
 /// Errors produced while resolving a `paths()` export.
+///
+/// Every variant carries `route` — the route template, which by convention is
+/// the source TSX file's path relative to `pages/` (e.g. `blog/[slug].tsx`).
+/// That string lets editors / build output point at the offending file.
 #[derive(Debug, Error)]
 pub enum PathsError {
     /// A required dynamic/catch-all param was missing from a `paths()`
@@ -62,13 +66,34 @@ pub enum PathsError {
 
     /// A param value had the wrong JSON shape (e.g. number where a string
     /// was expected, empty string, etc.).
-    #[error("invalid param type for `{name}`: {reason}")]
-    InvalidParamType { name: String, reason: String },
+    #[error("invalid param type for `{name}` in route `{route}`: {reason}")]
+    InvalidParamType {
+        name: String,
+        reason: String,
+        route: String,
+    },
 
     /// The `paths()` export itself was malformed (not an array, missing
     /// `params`, etc.).
-    #[error("invalid paths() export: {reason}")]
-    InvalidPathsExport { reason: String },
+    ///
+    /// `route` points at the source file (route template) so the operator
+    /// knows which page module's `paths()` returned the wrong shape; `field`
+    /// names the bad field when known (e.g. `params`, `entry[2].params.slug`)
+    /// so they can find it inside that file. `expected` describes what the
+    /// resolver wanted to see.
+    #[error(
+        "invalid `paths()` export in `{route}`{field_note}: {reason} (expected {expected})",
+        field_note = match field {
+            Some(f) => format!(" at `{f}`"),
+            None => String::new(),
+        },
+    )]
+    InvalidPathsExport {
+        route: String,
+        field: Option<String>,
+        reason: String,
+        expected: String,
+    },
 
     /// Two entries resolved to the same URL within a single `paths()`
     /// invocation. Surfaced so the build can fail loudly rather than
@@ -145,7 +170,10 @@ pub fn resolve_paths(
     let entries = paths_export
         .as_array()
         .ok_or_else(|| PathsError::InvalidPathsExport {
-            reason: "expected an array of { params, props } objects".to_string(),
+            route: route_template.to_string(),
+            field: Some("paths()".to_string()),
+            reason: format!("got {}", value_kind(paths_export)),
+            expected: "an array of `{ params, props }` objects".to_string(),
         })?;
 
     // Required param names + whether they are catch-all.
@@ -165,18 +193,30 @@ pub fn resolve_paths(
         let entry_obj = entry
             .as_object()
             .ok_or_else(|| PathsError::InvalidPathsExport {
-                reason: format!("paths() entry at index {i} must be an object"),
+                route: route_template.to_string(),
+                field: Some(format!("entry[{i}]")),
+                reason: format!("got {}", value_kind(entry)),
+                expected: "an object with `params` (and optional `props`)".to_string(),
             })?;
 
-        let params_obj = entry_obj
-            .get("params")
-            .ok_or_else(|| PathsError::InvalidPathsExport {
-                reason: format!("paths() entry at index {i} missing `params`"),
-            })?
-            .as_object()
-            .ok_or_else(|| PathsError::InvalidPathsExport {
-                reason: format!("paths() entry at index {i} `params` must be an object"),
-            })?;
+        let params_value =
+            entry_obj
+                .get("params")
+                .ok_or_else(|| PathsError::InvalidPathsExport {
+                    route: route_template.to_string(),
+                    field: Some(format!("entry[{i}].params")),
+                    reason: "missing".to_string(),
+                    expected: "an object mapping each route param to a value".to_string(),
+                })?;
+        let params_obj =
+            params_value
+                .as_object()
+                .ok_or_else(|| PathsError::InvalidPathsExport {
+                    route: route_template.to_string(),
+                    field: Some(format!("entry[{i}].params")),
+                    reason: format!("got {}", value_kind(params_value)),
+                    expected: "an object mapping each route param to a value".to_string(),
+                })?;
 
         // Required-param check + value extraction.
         let mut params_map: HashMap<String, String> = HashMap::with_capacity(required.len());
@@ -188,9 +228,9 @@ pub fn resolve_paths(
                     route: route_template.to_string(),
                 })?;
             let resolved = if *is_catchall {
-                catchall_string(raw, name)?
+                catchall_string(raw, name, route_template)?
             } else {
-                dynamic_string(raw, name)?
+                dynamic_string(raw, name, route_template)?
             };
             params_map.insert((*name).to_string(), resolved);
         }
@@ -235,21 +275,24 @@ pub fn resolve_paths(
 
 /// Validate and extract a single-segment dynamic param value (must be a
 /// non-empty string with no `/`).
-fn dynamic_string(val: &Value, name: &str) -> Result<String, PathsError> {
+fn dynamic_string(val: &Value, name: &str, route: &str) -> Result<String, PathsError> {
     let s = val.as_str().ok_or_else(|| PathsError::InvalidParamType {
         name: name.to_string(),
         reason: format!("dynamic param must be a string, got {}", value_kind(val)),
+        route: route.to_string(),
     })?;
     if s.is_empty() {
         return Err(PathsError::InvalidParamType {
             name: name.to_string(),
             reason: "dynamic param must not be empty".to_string(),
+            route: route.to_string(),
         });
     }
     if s.contains('/') {
         return Err(PathsError::InvalidParamType {
             name: name.to_string(),
             reason: "dynamic param must not contain `/` (use a catchall `[...name]` for path-shaped values)".to_string(),
+            route: route.to_string(),
         });
     }
     Ok(s.to_string())
@@ -258,7 +301,7 @@ fn dynamic_string(val: &Value, name: &str) -> Result<String, PathsError> {
 /// Validate and extract a catch-all param value. Accepts either a single
 /// string (`"a/b/c"`) or an array of strings (`["a", "b", "c"]`); both are
 /// normalized to a slash-joined string used as one URL segment-bag.
-fn catchall_string(val: &Value, name: &str) -> Result<String, PathsError> {
+fn catchall_string(val: &Value, name: &str, route: &str) -> Result<String, PathsError> {
     match val {
         Value::String(s) => {
             let trimmed = s.trim_matches('/');
@@ -266,6 +309,7 @@ fn catchall_string(val: &Value, name: &str) -> Result<String, PathsError> {
                 return Err(PathsError::InvalidParamType {
                     name: name.to_string(),
                     reason: "catchall param string must not be empty".to_string(),
+                    route: route.to_string(),
                 });
             }
             // Reject empty inner segments: "a//b".
@@ -273,6 +317,7 @@ fn catchall_string(val: &Value, name: &str) -> Result<String, PathsError> {
                 return Err(PathsError::InvalidParamType {
                     name: name.to_string(),
                     reason: "catchall param string must not contain empty segments".to_string(),
+                    route: route.to_string(),
                 });
             }
             Ok(trimmed.to_string())
@@ -282,6 +327,7 @@ fn catchall_string(val: &Value, name: &str) -> Result<String, PathsError> {
                 return Err(PathsError::InvalidParamType {
                     name: name.to_string(),
                     reason: "catchall param array must not be empty".to_string(),
+                    route: route.to_string(),
                 });
             }
             let mut parts = Vec::with_capacity(arr.len());
@@ -292,11 +338,13 @@ fn catchall_string(val: &Value, name: &str) -> Result<String, PathsError> {
                         "catchall param array element {i} must be a string, got {}",
                         value_kind(v)
                     ),
+                    route: route.to_string(),
                 })?;
                 if s.is_empty() {
                     return Err(PathsError::InvalidParamType {
                         name: name.to_string(),
                         reason: format!("catchall param array element {i} must not be empty"),
+                        route: route.to_string(),
                     });
                 }
                 if s.contains('/') {
@@ -305,6 +353,7 @@ fn catchall_string(val: &Value, name: &str) -> Result<String, PathsError> {
                         reason: format!(
                             "catchall param array element {i} must not contain `/` (split into separate elements)"
                         ),
+                        route: route.to_string(),
                     });
                 }
                 parts.push(s.to_string());
@@ -317,6 +366,7 @@ fn catchall_string(val: &Value, name: &str) -> Result<String, PathsError> {
                 "catchall param must be a string or array of strings, got {}",
                 value_kind(val)
             ),
+            route: route.to_string(),
         }),
     }
 }

--- a/crates/zfb-render/tests/error_messages.rs
+++ b/crates/zfb-render/tests/error_messages.rs
@@ -1,0 +1,240 @@
+//! Cross-crate "error-quality" acceptance tests.
+//!
+//! These tests pin the user-facing error messages produced by the failure
+//! modes catalogued in Epic 6 / Sub 4. The bar each error must clear:
+//!
+//! - **file path** — points at the source file the user authored
+//! - **line/col** when available
+//! - **what went wrong** — concrete signal, not "something failed"
+//! - **what was expected** — actionable hint
+//!
+//! Each test asserts only the *load-bearing* substrings, never the full
+//! message string, so cosmetic phrasing tweaks don't break the suite.
+
+use std::path::PathBuf;
+
+use zfb_render::loader::ModuleLoader;
+use zfb_render::paths::{resolve_paths, PathsCache, PathsError, Segment};
+use zfb_render::swc_pipeline::JsxRuntime;
+use zfb_render::RenderError;
+
+// ---------------------------------------------------------------------------
+// Failure mode 1 — broken JS import in a TSX page.
+// ---------------------------------------------------------------------------
+
+/// The resolver should name the importer **file** (not just its dir), the
+/// missing specifier, and at least one candidate path it probed.
+#[test]
+fn broken_relative_import_points_at_importer_file_and_lists_candidates() {
+    // Construct a project tree on disk so the resolver actually walks the
+    // filesystem and reports the absolute paths it tried.
+    let tmp = mk_tmp("broken-import");
+    let pages = tmp.path.join("pages");
+    std::fs::create_dir_all(&pages).unwrap();
+    let importer = pages.join("index.tsx");
+    std::fs::write(
+        &importer,
+        "import { foo } from \"./does-not-exist\";\nexport default function P(){ return null; }\n",
+    )
+    .unwrap();
+
+    let loader = ModuleLoader::new(JsxRuntime::Preact);
+    // Pretend the parser surfaced the import on line 1, column 1.
+    let err = loader
+        .resolve_relative_from_file(&importer, "./does-not-exist", Some(1), Some(1))
+        .expect_err("resolution should fail");
+
+    let msg = err.to_string();
+    let importer_str = importer.display().to_string();
+
+    assert!(
+        msg.contains(&importer_str),
+        "expected importer file path `{importer_str}` in error, got: {msg}",
+    );
+    assert!(
+        msg.contains("does-not-exist"),
+        "expected missing specifier in error, got: {msg}",
+    );
+    assert!(
+        msg.contains(":1:1"),
+        "expected `:line:col` location marker, got: {msg}",
+    );
+    // The probe list should mention at least one extension we tried.
+    assert!(
+        msg.contains(".tsx"),
+        "expected `.tsx` candidate in `tried` list, got: {msg}",
+    );
+
+    // And the error variant is the structured one (not a stringified Other).
+    match err {
+        RenderError::Resolve {
+            specifier,
+            importer: ie,
+            line,
+            col,
+            tried,
+        } => {
+            assert_eq!(specifier, "./does-not-exist");
+            assert_eq!(ie, importer_str);
+            assert_eq!(line, Some(1));
+            assert_eq!(col, Some(1));
+            assert!(
+                !tried.is_empty(),
+                "expected the resolver to record probed candidates, got tried={tried:?}",
+            );
+        }
+        other => panic!("expected RenderError::Resolve, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Failure mode 3 — `paths()` returning the wrong shape.
+// ---------------------------------------------------------------------------
+
+/// `paths()` returning a non-array must name the route file and say what
+/// shape was expected.
+#[test]
+fn paths_export_wrong_top_level_shape_names_route_file() {
+    let mut cache = PathsCache::new();
+    let segs = vec![
+        Segment::Static("blog".to_string()),
+        Segment::Dynamic("slug".to_string()),
+    ];
+    let export = serde_json::json!({ "not": "an array" });
+
+    let err = resolve_paths(&mut cache, "blog/[slug].tsx", &segs, &export)
+        .expect_err("non-array export should fail");
+    let msg = err.to_string();
+
+    assert!(
+        msg.contains("blog/[slug].tsx"),
+        "expected route file in error, got: {msg}",
+    );
+    assert!(
+        msg.contains("expected"),
+        "expected an `expected …` clause in error, got: {msg}",
+    );
+    match err {
+        PathsError::InvalidPathsExport {
+            route,
+            field,
+            expected,
+            ..
+        } => {
+            assert_eq!(route, "blog/[slug].tsx");
+            assert!(
+                expected.contains("array"),
+                "expected `array` in expected clause, got: {expected}",
+            );
+            assert_eq!(field.as_deref(), Some("paths()"));
+        }
+        other => panic!("expected InvalidPathsExport, got {other:?}"),
+    }
+}
+
+/// `paths()` returning an entry with the wrong field shape (missing
+/// `params`) must name the route file and the bad field path.
+#[test]
+fn paths_entry_missing_params_names_field_and_route_file() {
+    let mut cache = PathsCache::new();
+    let segs = vec![
+        Segment::Static("blog".to_string()),
+        Segment::Dynamic("slug".to_string()),
+    ];
+    let export = serde_json::json!([{ "props": { "title": "no params here" } }]);
+
+    let err = resolve_paths(&mut cache, "pages/blog/[slug].tsx", &segs, &export)
+        .expect_err("missing `params` should fail");
+    let msg = err.to_string();
+
+    assert!(
+        msg.contains("pages/blog/[slug].tsx"),
+        "expected route file in error, got: {msg}",
+    );
+    assert!(
+        msg.contains("entry[0].params"),
+        "expected the bad field path in error, got: {msg}",
+    );
+    assert!(
+        msg.contains("expected"),
+        "expected an `expected …` clause in error, got: {msg}",
+    );
+}
+
+/// A `params` value with the wrong type names both the param, the route
+/// file, and (via the shared `route` field) the file context.
+#[test]
+fn paths_param_with_wrong_type_names_param_and_route() {
+    let mut cache = PathsCache::new();
+    let segs = vec![
+        Segment::Static("blog".to_string()),
+        Segment::Dynamic("slug".to_string()),
+    ];
+    // `slug` should be a string; pass a number.
+    let export = serde_json::json!([{ "params": { "slug": 42 } }]);
+
+    let err = resolve_paths(&mut cache, "blog/[slug].tsx", &segs, &export)
+        .expect_err("number slug should fail");
+    let msg = err.to_string();
+
+    assert!(
+        msg.contains("blog/[slug].tsx"),
+        "expected route file in error, got: {msg}",
+    );
+    assert!(
+        msg.contains("slug"),
+        "expected param name in error, got: {msg}",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Failure mode 5 — invalid `zfb.config.ts`: SKIPPED.
+//
+// No crate currently parses `zfb.config.ts` into a typed Rust struct (the
+// adapter / SWC pipeline references it only in doc-comments, and the
+// islands esbuild crate touches it as a marker). When the loader lands,
+// this test should produce a config file with a missing required field /
+// wrong type and assert the error includes:
+//   - the absolute path to `zfb.config.ts`
+//   - the bad field name
+//   - what was expected (e.g. `framework: "preact" | "react"`)
+// Tracked in the Sub 4 log as a follow-up.
+// ---------------------------------------------------------------------------
+#[test]
+#[ignore = "no zfb.config.ts loader exists yet — see Sub 4 log follow-up"]
+fn invalid_zfb_config_ts_points_at_field_and_file() {
+    // Once a config loader exists in zfb (or zfb-render), build a tmp
+    // config with a missing `framework` field and assert the error
+    // mentions the path, the field name, and the expected union type.
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+struct TmpDir {
+    path: PathBuf,
+}
+
+impl Drop for TmpDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+fn mk_tmp(label: &str) -> TmpDir {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let dir = std::env::temp_dir().join(format!(
+        "zfb-render-error-quality-{label}-{nanos}-{n}-{pid}",
+        pid = std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).expect("create tmp dir");
+    TmpDir { path: dir }
+}

--- a/crates/zfb-watcher/Cargo.toml
+++ b/crates/zfb-watcher/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "zfb-watcher"
+version = "0.0.0"
+edition = "2021"
+license = "MIT"
+description = "zfb dev-mode filesystem watcher: wraps `notify` and emits debounced Change events on a tokio channel"
+
+[lib]
+
+[dependencies]
+notify = "8"
+tokio = { version = "1", features = ["sync", "rt", "macros", "time"] }
+tracing = "0.1"
+
+[dev-dependencies]
+tempfile = { workspace = true }
+tokio = { version = "1", features = ["sync", "rt", "macros", "time", "rt-multi-thread"] }

--- a/crates/zfb-watcher/README.md
+++ b/crates/zfb-watcher/README.md
@@ -1,0 +1,63 @@
+# zfb-watcher
+
+Dev-mode filesystem watcher for the zfb dev server.
+
+Wraps the [`notify`](https://crates.io/crates/notify) crate's recommended
+watcher, normalises the many event kinds into a small `ChangeKind` enum,
+and emits debounced `Change` events on a `tokio::sync::mpsc::Receiver`.
+
+## Public API
+
+```rust,ignore
+use zfb_watcher::{Watcher, Change, ChangeKind};
+
+let (handle, mut rx) = Watcher::start(
+    "/path/to/project",
+    [
+        "content",
+        "pages",
+        "components",
+        "layouts",
+        "styles",
+        "data",
+        "public",
+        "zfb.config.ts",
+    ],
+)?;
+
+while let Some(Change { path, kind }) = rx.recv().await {
+    match kind {
+        ChangeKind::Created  => { /* ... */ }
+        ChangeKind::Modified => { /* ... */ }
+        ChangeKind::Removed  => { /* ... */ }
+    }
+}
+
+// Drop `handle` to stop watching.
+```
+
+## Behaviour
+
+- **Recursive watching** of every existing relative path passed in.
+- **Missing paths are skipped** with a `warn!` log — `data/` not existing
+  yet is normal and not an error.
+- **~50ms debounce window** by default (override via
+  `Watcher::start_with_debounce`). Editor "save" bursts (vim's swap-and-
+  rename, vscode's metadata-then-content sequence, etc.) collapse to a
+  single `Change` per path per burst.
+- **Three-variant `ChangeKind`** (`Created` / `Modified` / `Removed`).
+  Anything notify reports that we cannot positively classify falls into
+  `Modified` — we'd rather rebuild unnecessarily than miss a real change.
+- **Drop = stop.** Dropping the `Watcher` handle aborts the debouncer
+  task and drops the underlying notify watcher (which stops the OS-level
+  watch).
+
+## Non-goals
+
+- **Polling for re-appearance** of a top-level missing path is *not*
+  implemented. Sub-directories appearing under an already-watched parent
+  are picked up automatically by recursive watching; if `data/` itself
+  is created later the dev server is expected to restart the watcher.
+- **No "watch a single file via its parent dir" trickery** — we simply
+  call `notify::Watcher::watch` on whatever path is given. `notify`
+  handles the file-vs-dir distinction.

--- a/crates/zfb-watcher/src/lib.rs
+++ b/crates/zfb-watcher/src/lib.rs
@@ -41,7 +41,7 @@ use std::sync::mpsc as std_mpsc;
 use std::time::{Duration, Instant};
 
 use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher as NotifyWatcher};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tracing::{debug, warn};
 
@@ -73,14 +73,20 @@ pub struct Change {
 /// The watcher handle.
 ///
 /// Holds the underlying `notify` watcher (dropping stops the OS watch)
-/// and the JoinHandle for the debouncer task (also aborted on drop).
+/// and the JoinHandle for the debouncer task. Dropping the handle sends
+/// a graceful shutdown signal to the debouncer so any pending events
+/// flush to the receiver before the task exits, then aborts the task as
+/// a fallback if it does not finish promptly.
 ///
 /// Construct via [`Watcher::start`], which returns this handle plus the
 /// receiver end of the `Change` channel.
 pub struct Watcher {
     // Kept alive: dropping the notify watcher stops the OS-level watch.
     _notify: RecommendedWatcher,
-    // Aborted on drop so the debouncer task does not outlive the handle.
+    // Some(_) until Drop fires the shutdown signal.
+    shutdown: Option<oneshot::Sender<()>>,
+    // Aborted on drop as a fallback so the debouncer task does not
+    // outlive the handle indefinitely.
     debouncer: Option<JoinHandle<()>>,
 }
 
@@ -143,11 +149,13 @@ impl Watcher {
         // absorb a `git checkout` burst that survived debouncing.
         let (out_tx, out_rx) = mpsc::channel::<Change>(256);
 
-        let debouncer = tokio::spawn(debouncer_task(raw_rx, out_tx, debounce));
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let debouncer = tokio::spawn(debouncer_task(raw_rx, out_tx, debounce, shutdown_rx));
 
         Ok((
             Self {
                 _notify: notify_watcher,
+                shutdown: Some(shutdown_tx),
                 debouncer: Some(debouncer),
             },
             out_rx,
@@ -157,6 +165,14 @@ impl Watcher {
 
 impl Drop for Watcher {
     fn drop(&mut self) {
+        // Best-effort graceful shutdown: signal the debouncer to flush
+        // its pending map and exit. If we are not on a tokio runtime (or
+        // the receiver is gone), the JoinHandle::abort() below ensures
+        // the task is reaped regardless. We deliberately do NOT block
+        // here — Drop must stay non-blocking.
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
         if let Some(h) = self.debouncer.take() {
             h.abort();
         }
@@ -192,6 +208,7 @@ async fn debouncer_task(
     raw_rx: std_mpsc::Receiver<notify::Result<Event>>,
     out_tx: mpsc::Sender<Change>,
     debounce: Duration,
+    mut shutdown: oneshot::Receiver<()>,
 ) {
     // Bridge sync→async. A small bounded buffer is fine: notify will
     // back up briefly under bursts but we drain quickly.
@@ -214,6 +231,13 @@ async fn debouncer_task(
     loop {
         tokio::select! {
             biased;
+
+            // Shutdown signal from Drop: flush whatever we have and exit
+            // before the JoinHandle::abort() in Drop forcibly cancels us.
+            _ = &mut shutdown => {
+                flush_all(&mut pending, &out_tx).await;
+                break;
+            }
 
             maybe_evt = bridge_rx.recv() => {
                 let Some(res) = maybe_evt else {

--- a/crates/zfb-watcher/src/lib.rs
+++ b/crates/zfb-watcher/src/lib.rs
@@ -1,0 +1,300 @@
+//! `zfb-watcher` — dev-mode filesystem watcher for the zfb dev server.
+//!
+//! Wraps the [`notify`] crate's recommended watcher, normalises its many
+//! event kinds into a small [`ChangeKind`] enum, and emits debounced
+//! [`Change`] values on a `tokio::sync::mpsc` channel.
+//!
+//! ## Why this crate exists
+//!
+//! Editor "save" actions almost never produce a single FS event. Common
+//! patterns:
+//!
+//! - `vim` saves via "write to swap → rename over original" → multiple
+//!   `Create`/`Modify`/`Remove` events on the *same* path within ~5ms.
+//! - `vscode` and friends emit several `Modify(Metadata)` /
+//!   `Modify(Data(Content))` events back-to-back.
+//! - Bulk operations like `git checkout` produce hundreds of events at once.
+//!
+//! Downstream consumers (the dev server's rebuild loop) want **one logical
+//! change per path per burst**. So we coalesce events within a short
+//! debounce window (default 50ms) and only emit once the path has been
+//! quiet for that window.
+//!
+//! ## Design
+//!
+//! - One background `notify` watcher thread (started by `notify` itself).
+//! - One async debouncer task: receives raw events on an unbounded
+//!   `std::sync::mpsc` (sync, because that is what `notify` hands us) and
+//!   forwards normalised `Change` values on a `tokio::sync::mpsc`.
+//! - Per-path "last seen" timestamp + sleep-until-quiet logic gives us
+//!   "burst → one event" semantics with a single small loop.
+//! - Watching a non-existent path is allowed: notify rejects it, we log
+//!   and move on. (We do NOT poll for re-appearance — the higher-level
+//!   dev server is expected to restart the watcher when major project
+//!   shape changes happen. Re-appearance of a sub-directory under an
+//!   already-watched parent is handled automatically by recursive
+//!   watching.)
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::mpsc as std_mpsc;
+use std::time::{Duration, Instant};
+
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher as NotifyWatcher};
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tracing::{debug, warn};
+
+/// Default debounce window. Chosen short enough to feel instant in dev
+/// (~one frame at 60fps + a bit) but long enough to coalesce typical
+/// editor save bursts on Linux/macOS/Windows.
+pub const DEFAULT_DEBOUNCE: Duration = Duration::from_millis(50);
+
+/// Normalised filesystem change kind.
+///
+/// Collapses notify's many `EventKind` variants into the three things
+/// downstream rebuild logic actually cares about. Anything we cannot
+/// classify is treated as `Modified` — we'd rather rebuild
+/// unnecessarily than miss a real change.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChangeKind {
+    Created,
+    Modified,
+    Removed,
+}
+
+/// A debounced filesystem change.
+#[derive(Debug, Clone)]
+pub struct Change {
+    pub path: PathBuf,
+    pub kind: ChangeKind,
+}
+
+/// The watcher handle.
+///
+/// Holds the underlying `notify` watcher (dropping stops the OS watch)
+/// and the JoinHandle for the debouncer task (also aborted on drop).
+///
+/// Construct via [`Watcher::start`], which returns this handle plus the
+/// receiver end of the `Change` channel.
+pub struct Watcher {
+    // Kept alive: dropping the notify watcher stops the OS-level watch.
+    _notify: RecommendedWatcher,
+    // Aborted on drop so the debouncer task does not outlive the handle.
+    debouncer: Option<JoinHandle<()>>,
+}
+
+impl Watcher {
+    /// Start a watcher rooted at `project_root`, watching every existing
+    /// path in `relative_paths` recursively, with the default 50ms debounce.
+    ///
+    /// Missing paths are skipped with a warn-level log — this is normal
+    /// (e.g. `data/` may not exist on a fresh project).
+    ///
+    /// Returns `(handle, receiver)`. Drop the handle to stop watching.
+    pub fn start<P, I, S>(
+        project_root: P,
+        relative_paths: I,
+    ) -> notify::Result<(Self, mpsc::Receiver<Change>)>
+    where
+        P: AsRef<Path>,
+        I: IntoIterator<Item = S>,
+        S: AsRef<Path>,
+    {
+        Self::start_with_debounce(project_root, relative_paths, DEFAULT_DEBOUNCE)
+    }
+
+    /// Same as [`Watcher::start`] but with a configurable debounce window
+    /// (mainly for tests).
+    pub fn start_with_debounce<P, I, S>(
+        project_root: P,
+        relative_paths: I,
+        debounce: Duration,
+    ) -> notify::Result<(Self, mpsc::Receiver<Change>)>
+    where
+        P: AsRef<Path>,
+        I: IntoIterator<Item = S>,
+        S: AsRef<Path>,
+    {
+        let root = project_root.as_ref();
+
+        // notify hands us events on a sync channel from a thread it owns.
+        let (raw_tx, raw_rx) = std_mpsc::channel::<notify::Result<Event>>();
+        let mut notify_watcher = notify::recommended_watcher(move |res| {
+            // Best-effort send; if the receiver is gone the watcher is
+            // shutting down and we should quietly stop pushing.
+            let _ = raw_tx.send(res);
+        })?;
+
+        for rel in relative_paths {
+            let full = root.join(rel.as_ref());
+            if !full.exists() {
+                warn!(path = %full.display(), "watch target missing; skipping");
+                continue;
+            }
+            if let Err(e) = notify_watcher.watch(&full, RecursiveMode::Recursive) {
+                warn!(path = %full.display(), error = %e, "failed to watch path");
+            } else {
+                debug!(path = %full.display(), "watching");
+            }
+        }
+
+        // Outbound channel: bounded but generous. 256 should comfortably
+        // absorb a `git checkout` burst that survived debouncing.
+        let (out_tx, out_rx) = mpsc::channel::<Change>(256);
+
+        let debouncer = tokio::spawn(debouncer_task(raw_rx, out_tx, debounce));
+
+        Ok((
+            Self {
+                _notify: notify_watcher,
+                debouncer: Some(debouncer),
+            },
+            out_rx,
+        ))
+    }
+}
+
+impl Drop for Watcher {
+    fn drop(&mut self) {
+        if let Some(h) = self.debouncer.take() {
+            h.abort();
+        }
+    }
+}
+
+/// Map a notify `EventKind` to our small enum. Unknown / "Any" / "Other"
+/// kinds collapse to `Modified` so we never silently drop a real change.
+fn classify(kind: &EventKind) -> ChangeKind {
+    match kind {
+        EventKind::Create(_) => ChangeKind::Created,
+        EventKind::Remove(_) => ChangeKind::Removed,
+        EventKind::Modify(_) | EventKind::Access(_) | EventKind::Any | EventKind::Other => {
+            ChangeKind::Modified
+        }
+    }
+}
+
+/// Per-path pending state used by the debouncer.
+struct Pending {
+    kind: ChangeKind,
+    last_seen: Instant,
+}
+
+/// The debouncer loop. Runs on a tokio task.
+///
+/// Strategy: bridge the sync `notify` channel onto a tokio channel via
+/// `spawn_blocking`, then loop with a small "wake every debounce/2"
+/// timer that flushes any path whose last event is older than the
+/// debounce window. This avoids per-path timer tasks (cheap) and gives
+/// O(1) flush per tick.
+async fn debouncer_task(
+    raw_rx: std_mpsc::Receiver<notify::Result<Event>>,
+    out_tx: mpsc::Sender<Change>,
+    debounce: Duration,
+) {
+    // Bridge sync→async. A small bounded buffer is fine: notify will
+    // back up briefly under bursts but we drain quickly.
+    let (bridge_tx, mut bridge_rx) = mpsc::channel::<notify::Result<Event>>(1024);
+    let bridge = tokio::task::spawn_blocking(move || {
+        while let Ok(msg) = raw_rx.recv() {
+            // blocking_send is fine: we're on a blocking thread.
+            if bridge_tx.blocking_send(msg).is_err() {
+                break;
+            }
+        }
+    });
+
+    let mut pending: HashMap<PathBuf, Pending> = HashMap::new();
+    // Wake at half the debounce window so worst-case extra latency is
+    // ~debounce + debounce/2. With the default 50ms that's ~75ms.
+    let mut tick = tokio::time::interval(debounce / 2);
+    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+    loop {
+        tokio::select! {
+            biased;
+
+            maybe_evt = bridge_rx.recv() => {
+                let Some(res) = maybe_evt else {
+                    // Bridge closed (notify watcher dropped). Flush
+                    // anything still pending, then exit.
+                    flush_all(&mut pending, &out_tx).await;
+                    break;
+                };
+                match res {
+                    Ok(evt) => {
+                        let kind = classify(&evt.kind);
+                        let now = Instant::now();
+                        for path in evt.paths {
+                            // For a given burst we keep the *latest* kind.
+                            // A Created followed by Modified collapses to
+                            // Modified, which is fine: the consumer will
+                            // re-read the file either way. A trailing
+                            // Removed wins, which is correct (file is gone).
+                            pending.insert(path, Pending { kind, last_seen: now });
+                        }
+                    }
+                    Err(e) => {
+                        warn!(error = %e, "notify watcher error");
+                    }
+                }
+            }
+
+            _ = tick.tick() => {
+                let now = Instant::now();
+                // Drain entries whose last event is older than `debounce`.
+                let ready: Vec<(PathBuf, ChangeKind)> = pending
+                    .iter()
+                    .filter(|(_, p)| now.duration_since(p.last_seen) >= debounce)
+                    .map(|(k, p)| (k.clone(), p.kind))
+                    .collect();
+                for (path, _) in &ready {
+                    pending.remove(path);
+                }
+                for (path, kind) in ready {
+                    if out_tx.send(Change { path, kind }).await.is_err() {
+                        // Receiver dropped; bail out of the loop.
+                        bridge.abort();
+                        return;
+                    }
+                }
+            }
+        }
+    }
+
+    // bridge task exits naturally when raw_rx closes.
+    let _ = bridge.await;
+}
+
+async fn flush_all(pending: &mut HashMap<PathBuf, Pending>, out_tx: &mpsc::Sender<Change>) {
+    for (path, p) in pending.drain() {
+        if out_tx.send(Change { path, kind: p.kind }).await.is_err() {
+            return;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_create_is_created() {
+        use notify::event::{CreateKind, EventKind};
+        assert_eq!(classify(&EventKind::Create(CreateKind::File)), ChangeKind::Created);
+    }
+
+    #[test]
+    fn classify_remove_is_removed() {
+        use notify::event::{EventKind, RemoveKind};
+        assert_eq!(classify(&EventKind::Remove(RemoveKind::File)), ChangeKind::Removed);
+    }
+
+    #[test]
+    fn classify_unknown_is_modified() {
+        use notify::event::EventKind;
+        assert_eq!(classify(&EventKind::Any), ChangeKind::Modified);
+        assert_eq!(classify(&EventKind::Other), ChangeKind::Modified);
+    }
+}

--- a/crates/zfb-watcher/tests/smoke.rs
+++ b/crates/zfb-watcher/tests/smoke.rs
@@ -1,0 +1,52 @@
+//! End-to-end smoke test for `zfb-watcher`.
+//!
+//! Spawns a real watcher rooted at a `tempfile::TempDir`, mutates a file
+//! under one of the watched relative paths, and asserts that a `Change`
+//! event arrives within a generous timeout.
+
+use std::fs;
+use std::time::Duration;
+
+use tempfile::tempdir;
+use tokio::time::timeout;
+
+use zfb_watcher::{ChangeKind, Watcher};
+
+#[tokio::test]
+async fn touching_file_emits_change() {
+    let root = tempdir().expect("tempdir");
+    let content_dir = root.path().join("content");
+    fs::create_dir_all(&content_dir).expect("create content dir");
+
+    // Watch `content/` (existing) and `data/` (deliberately missing — the
+    // watcher must not crash on this).
+    let (_watcher, mut rx) = Watcher::start(root.path(), ["content", "data"])
+        .expect("start watcher");
+
+    // Give notify a beat to register its OS-level watch before we start
+    // poking the filesystem. Otherwise on slower CI machines the very
+    // first event can race the kernel-side registration.
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let target = content_dir.join("hello.md");
+    fs::write(&target, b"# hi\n").expect("write file");
+
+    // 1s is generous: 50ms debounce + worst-case ~25ms tick lag + plenty
+    // of slack for noisy CI.
+    let change = timeout(Duration::from_secs(1), rx.recv())
+        .await
+        .expect("change arrived in time")
+        .expect("channel still open");
+
+    // The reported path should be exactly the file we wrote (notify
+    // reports absolute paths since we watched an absolute path).
+    assert_eq!(change.path, target, "unexpected change path");
+
+    // Kind should be Created or Modified — either is acceptable; some
+    // platforms collapse the create+write into a single Modify.
+    assert!(
+        matches!(change.kind, ChangeKind::Created | ChangeKind::Modified),
+        "unexpected kind: {:?}",
+        change.kind
+    );
+}


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/7
- parent issue (super-epic)
    - https://github.com/Takazudo/zudo-front-builder/issues/2

---

## Summary

Epic 6 — dev infrastructure half of the build pipeline. Adds the file watcher, dependency graph, and build orchestrator that respond to filesystem events and rebuild only what changed. Also tightens up Epic 3's error messages so failures point at the source file.

Targets the super-epic base `base/zfb-init`. Independent of Epic 4 and Epic 5; runs in parallel with both (already merged on the super-epic base).

## What landed

### `crates/zfb-watcher/` (Sub 1)
- Wraps the `notify` crate with a ~50 ms tokio-debouncer
- Watches `content/`, `pages/`, `components/`, `layouts/`, `styles/`, `data/`, `public/`, `zfb.config.ts`
- Missing watch paths are tolerated; emits `Change(path, kind)` over a tokio channel
- Drop / shutdown is graceful: pending events flush before exit

### `crates/zfb-graph/` (Sub 2)
- `DependencyGraph` with `dirty_pages(changed_path)`, `add_node`, `remove_node`
- Sentinel for coarse-rebuild paths (e.g., `zfb.config.ts` → all pages)
- Built around Epic 3's module-resolver output shape

### `crates/zfb-build/` (Sub 3)
- `BuildOrchestrator` ties `zfb-watcher` + `zfb-graph` + Epic 3/4/5 together
- `AssetPipeline` trait wraps the assemble-step so future SSR/edge builds can plug in without rewriting the orchestrator; `DevAssetPipeline` is the default impl
- Granularity policy: `.md` → single page, styles → CSS-only rerun, `"use client"` component → islands re-bundle, `zfb.config.ts` → full rebuild — documented in the crate README
- Atomic dist write via `atomic.rs` (sibling temp file + `fs::rename`); leftover temp file is cleaned up on rename failure

### Error-quality acceptance pass (Sub 4)
- 5 failure modes audited; modes 1 (broken JS import) and 3 (`paths()` wrong shape) got file-pointing improvements in `zfb-render`; mode 2 (invalid YAML frontmatter) was already passing and is now lock-in tested
- Modes 4 (unknown collection) and 5 (invalid `zfb.config.ts`) — surfaces don't exist yet in Epic 3; placeholder ignored tests left in to surface when they land

## Test status
- `cargo build --workspace` clean
- `cargo test --workspace` green (3 `#[ignore]`d placeholders for not-yet-implemented surfaces)
- `cargo clippy --workspace --all-targets` green

## Review
- `/gcoc-review` (gpt-4.1, free tier) — no critical bugs; one low-priority suggestion (clean up temp files on rename failure) was applied as commit 58838ac.

## Topic PRs
Topic branches were merged locally with `--no-ff`; topic merge commits are visible in the history.