### PR TITLE
[Epic 7] zfb-server: axum dev server with SSE live-reload + CSS hot-swap

### DIFF
--- a/crates/zfb-server/Cargo.toml
+++ b/crates/zfb-server/Cargo.toml
@@ -27,3 +27,5 @@ tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 tokio = { version = "1", features = ["sync", "rt", "macros", "time", "rt-multi-thread"] }
 tempfile = { workspace = true }
+reqwest = { version = "0.12", default-features = false, features = ["stream"] }
+futures-util = "0.3"

--- a/crates/zfb-server/Cargo.toml
+++ b/crates/zfb-server/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "zfb-server"
+version = "0.0.0"
+edition = "2021"
+license = "MIT"
+description = "zfb dev server: axum + SSE live-reload + CSS hot-swap"
+
+[lib]
+
+[dependencies]
+zfb-build = { path = "../zfb-build" }
+
+axum = "0.8"
+tokio = { version = "1", features = ["sync", "rt", "macros", "time", "net", "signal"] }
+tower-http = { version = "0.6", features = ["fs", "trace"] }
+tokio-stream = { version = "0.1", features = ["sync"] }
+futures = "0.3"
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+tracing = "0.1"
+
+[dev-dependencies]
+zfb-graph = { path = "../zfb-graph" }
+tower = { version = "0.5", features = ["util"] }
+http-body-util = "0.1"
+tokio = { version = "1", features = ["sync", "rt", "macros", "time", "rt-multi-thread"] }
+tempfile = { workspace = true }

--- a/crates/zfb-server/src/inject.rs
+++ b/crates/zfb-server/src/inject.rs
@@ -1,0 +1,136 @@
+//! HTML post-processing: inject the dev live-reload `<script>` tag.
+//!
+//! `zfb-server` is a *dev-only* crate, so the route layer always calls
+//! [`inject_livereload`] before responding with HTML. There is no
+//! production mode here — production-build HTML is emitted by a
+//! separate pipeline that doesn't go through this server.
+
+/// The script tag we inject before `</body>` on every served HTML page.
+///
+/// Kept short to minimise dev-mode noise. The script itself lives at
+/// `/__zfb/livereload.js` (served by [`crate::routes`]) and is
+/// `Cache-Control: no-store` so the browser always refetches the
+/// latest version.
+pub const LIVERELOAD_TAG: &str = "<script src=\"/__zfb/livereload.js\"></script>";
+
+/// Insert [`LIVERELOAD_TAG`] immediately before the **last** `</body>`
+/// tag in `html`.
+///
+/// Behaviour:
+///
+/// - Matching is case-insensitive (`</BODY>`, `</Body>`, `</body>` all
+///   work).
+/// - When multiple `</body>` tags appear (which is invalid HTML but
+///   does happen with malformed input or hand-written fragments) we
+///   inject before the **last** one — that's the close that visually
+///   matters.
+/// - When no `</body>` appears at all (HTML fragments, partials,
+///   malformed input) we append the tag to the end of the string.
+///
+/// The function never errors; the worst case is a fragment getting an
+/// extra script tag at the end, which is harmless in dev mode.
+pub fn inject_livereload(html: &str) -> String {
+    // Find the byte offset of the LAST </body> match, case-insensitive.
+    // Walk the lowercase form to keep the match position aligned with
+    // the original bytes (ASCII tag, so byte positions match 1:1).
+    let needle = "</body>";
+    let lower = html.to_ascii_lowercase();
+
+    let mut last: Option<usize> = None;
+    let mut search_from = 0usize;
+    while let Some(rel) = lower[search_from..].find(needle) {
+        let abs = search_from + rel;
+        last = Some(abs);
+        search_from = abs + needle.len();
+    }
+
+    match last {
+        Some(idx) => {
+            let mut out = String::with_capacity(html.len() + LIVERELOAD_TAG.len());
+            out.push_str(&html[..idx]);
+            out.push_str(LIVERELOAD_TAG);
+            out.push_str(&html[idx..]);
+            out
+        }
+        None => {
+            let mut out = String::with_capacity(html.len() + LIVERELOAD_TAG.len());
+            out.push_str(html);
+            out.push_str(LIVERELOAD_TAG);
+            out
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn injects_before_closing_body() {
+        let html = "<html><body><h1>hi</h1></body></html>";
+        let out = inject_livereload(html);
+        assert_eq!(
+            out,
+            "<html><body><h1>hi</h1><script src=\"/__zfb/livereload.js\"></script></body></html>"
+        );
+    }
+
+    #[test]
+    fn appends_when_no_body_close() {
+        let html = "<div>fragment</div>";
+        let out = inject_livereload(html);
+        assert_eq!(
+            out,
+            "<div>fragment</div><script src=\"/__zfb/livereload.js\"></script>"
+        );
+    }
+
+    #[test]
+    fn empty_input_gets_just_the_tag() {
+        let out = inject_livereload("");
+        assert_eq!(out, LIVERELOAD_TAG);
+    }
+
+    #[test]
+    fn case_insensitive_match() {
+        let html = "<BODY>x</BODY>";
+        let out = inject_livereload(html);
+        assert!(
+            out.contains(LIVERELOAD_TAG),
+            "expected script tag, got: {out}"
+        );
+        // Tag inserted before </BODY> (preserving original case).
+        assert!(out.ends_with("</BODY>"));
+        // Mixed case too.
+        let html2 = "<Body>x</Body>";
+        let out2 = inject_livereload(html2);
+        assert!(out2.ends_with("</Body>"));
+        assert!(out2.contains(LIVERELOAD_TAG));
+    }
+
+    #[test]
+    fn injects_before_last_body_when_multiple() {
+        // Malformed but realistic: editor accidentally pastes two body
+        // closes. We must inject before the LAST one so the script is
+        // still inside the final body in the rendered DOM.
+        let html = "<body>a</body><body>b</body>";
+        let out = inject_livereload(html);
+        // The first </body> is preserved; injection happens at the
+        // last one.
+        let expected = format!("<body>a</body><body>b{LIVERELOAD_TAG}</body>");
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn idempotent_marker_check() {
+        // The function isn't *strictly* idempotent (running it twice
+        // injects two tags), but the script itself is no-op safe so
+        // double-injection only costs one duplicate <script> in the
+        // dev-mode output. Document that here so future maintainers
+        // don't bake-in idempotence assumptions.
+        let html = "<body></body>";
+        let once = inject_livereload(html);
+        let twice = inject_livereload(&once);
+        assert_eq!(twice.matches(LIVERELOAD_TAG).count(), 2);
+    }
+}

--- a/crates/zfb-server/src/lib.rs
+++ b/crates/zfb-server/src/lib.rs
@@ -103,16 +103,34 @@ impl ServeOpts {
 ///
 /// - failure to bind the address (port in use, permission denied, …),
 /// - axum's serve loop returns an error.
+///
+/// This is a thin wrapper around [`serve_with_listener`]: it binds
+/// `opts.addr` itself and hands the resulting [`TcpListener`] off.
+/// Callers that need to know the actual bound port (e.g. integration
+/// tests using ephemeral port 0) should bind their own listener and
+/// call [`serve_with_listener`] directly.
 pub async fn serve(opts: ServeOpts) -> anyhow::Result<()> {
+    let listener = TcpListener::bind(opts.addr)
+        .await
+        .with_context(|| format!("failed to bind dev server to {}", opts.addr))?;
+    serve_with_listener(opts, listener).await
+}
+
+/// Run the dev server on a pre-bound [`TcpListener`].
+///
+/// Useful when the caller needs to know the actual bound socket address
+/// before the server starts accepting connections — for example
+/// integration tests that bind `127.0.0.1:0` and then read
+/// [`TcpListener::local_addr`] to learn the OS-chosen port.
+///
+/// `opts.addr` is ignored in favour of the listener's actual local
+/// address (which is what gets logged).
+pub async fn serve_with_listener(opts: ServeOpts, listener: TcpListener) -> anyhow::Result<()> {
     let state = AppState {
         pages: opts.pages,
         broadcast: opts.broadcast,
     };
     let router = build_router(state, opts.dist_root.clone(), opts.public_root.clone());
-
-    let listener = TcpListener::bind(opts.addr)
-        .await
-        .with_context(|| format!("failed to bind dev server to {}", opts.addr))?;
 
     let actual = listener.local_addr().unwrap_or(opts.addr);
     info!(

--- a/crates/zfb-server/src/lib.rs
+++ b/crates/zfb-server/src/lib.rs
@@ -1,0 +1,131 @@
+//! `zfb-server` — the dev-mode HTTP server for `zudo-front-builder`.
+//!
+//! This crate runs an [`axum`] server that serves the in-memory
+//! page-cache HTML produced by [`zfb_build`]'s rebuild loop, plus the
+//! built `dist/assets/` and `public/` directories. Every served HTML
+//! response has a small `<script src="/__zfb/livereload.js"></script>`
+//! injected before `</body>`. That script opens an SSE connection to
+//! `/__zfb/reload` and listens for two event types:
+//!
+//! - `page` — the browser does a full `location.reload()`.
+//! - `css` — the browser bumps the query-string on every
+//!   `<link rel="stylesheet">` to swap CSS without losing client-side
+//!   state.
+//!
+//! ## How it plugs into [`zfb_build`]
+//!
+//! The bin crate that runs `zfb dev` owns:
+//!
+//! - a [`zfb_build::BuildOrchestrator`] (the rebuild loop),
+//! - a [`tokio::sync::broadcast`] channel of [`livereload::ReloadEvent`]s,
+//! - a [`routes::PageCache`] of rendered HTML keyed by URL path,
+//! - this crate's [`serve`] task.
+//!
+//! The bin crate wires the orchestrator's `on_outcome` callback so that
+//! every non-noop build tick is translated into [`ReloadEvent`]s via
+//! [`livereload::outcome_to_events`] and fed into the broadcast
+//! channel. The bin crate is also responsible for populating the
+//! [`routes::PageCache`] from the orchestrator's render outputs — the
+//! server itself only **reads** the cache.
+//!
+//! See the module docs of [`livereload`] for the full wiring snippet.
+//!
+//! ## Production caveat
+//!
+//! This crate is **dev-only**. It always injects the live-reload
+//! script, hard-codes `Cache-Control: no-store` on HTML, and exposes a
+//! `/__zfb/*` namespace. Production builds emit static files served by
+//! a different runtime (Cloudflare Workers, an edge CDN, …) and must
+//! not pull in `zfb-server`.
+
+pub mod inject;
+pub mod livereload;
+pub mod routes;
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+
+use anyhow::Context;
+use tokio::net::TcpListener;
+use tracing::info;
+
+pub use inject::{inject_livereload, LIVERELOAD_TAG};
+pub use livereload::{outcome_to_events, ReloadEvent, ReloadTx};
+pub use routes::{build_router, AppState, PageCache, DEV_404_BODY};
+
+/// Options for [`serve`].
+///
+/// All paths must be absolute. The bin crate is expected to canonicalise
+/// `project_root`, `dist_root`, and `public_root` before constructing
+/// this struct so static-file serving is independent of the working
+/// directory the server is launched from.
+#[derive(Clone)]
+pub struct ServeOpts {
+    /// Project root (the directory `zfb dev` was invoked in). Stored
+    /// here for diagnostics and for future use by middleware that
+    /// wants to display "served from <project_root>" banners.
+    pub project_root: PathBuf,
+
+    /// Build output directory. `/assets/*` is served from
+    /// `<dist_root>/assets/`.
+    pub dist_root: PathBuf,
+
+    /// Project public-static directory. `/public/*` is served from
+    /// here verbatim.
+    pub public_root: PathBuf,
+
+    /// Address to bind. Defaults to `127.0.0.1:3000`.
+    pub addr: SocketAddr,
+
+    /// Page cache populated by the bin crate's render loop.
+    pub pages: PageCache,
+
+    /// Broadcast sender feeding the SSE live-reload channel. The bin
+    /// crate sends [`ReloadEvent`]s into this from
+    /// [`zfb_build::BuildOrchestrator::run`]'s `on_outcome` callback.
+    pub broadcast: ReloadTx,
+}
+
+impl ServeOpts {
+    /// The default bind address: `127.0.0.1:3000`.
+    pub fn default_addr() -> SocketAddr {
+        SocketAddr::from(([127, 0, 0, 1], 3000))
+    }
+}
+
+/// Run the dev server until the process is shut down.
+///
+/// Binds [`ServeOpts::addr`], builds the axum router via
+/// [`build_router`], and serves it. The future resolves with `Ok(())`
+/// only when the server stops cleanly (axum's signal handling).
+///
+/// Errors:
+///
+/// - failure to bind the address (port in use, permission denied, …),
+/// - axum's serve loop returns an error.
+pub async fn serve(opts: ServeOpts) -> anyhow::Result<()> {
+    let state = AppState {
+        pages: opts.pages,
+        broadcast: opts.broadcast,
+    };
+    let router = build_router(state, opts.dist_root.clone(), opts.public_root.clone());
+
+    let listener = TcpListener::bind(opts.addr)
+        .await
+        .with_context(|| format!("failed to bind dev server to {}", opts.addr))?;
+
+    let actual = listener.local_addr().unwrap_or(opts.addr);
+    info!(
+        addr = %actual,
+        project_root = %opts.project_root.display(),
+        dist_root = %opts.dist_root.display(),
+        public_root = %opts.public_root.display(),
+        "zfb-server listening"
+    );
+
+    axum::serve(listener, router)
+        .await
+        .context("zfb-server: axum::serve returned an error")?;
+
+    Ok(())
+}

--- a/crates/zfb-server/src/livereload.js
+++ b/crates/zfb-server/src/livereload.js
@@ -1,0 +1,37 @@
+// zfb-server live-reload client.
+//
+// Subscribes to the SSE stream at /__zfb/reload and reacts to two
+// event types:
+//
+//   - "page": full document reload (location.reload()).
+//   - "css":  hot-swap every <link rel="stylesheet"> by appending or
+//             updating a ?v=<timestamp> cache-busting query string.
+//
+// EventSource auto-reconnects on transport errors; we only log the
+// error so the developer knows something happened.
+(function () {
+  if (typeof window === 'undefined' || typeof EventSource === 'undefined') {
+    return;
+  }
+  var src = new EventSource('/__zfb/reload');
+  src.addEventListener('page', function () {
+    window.location.reload();
+  });
+  src.addEventListener('css', function () {
+    var ts = String(Date.now());
+    var links = document.querySelectorAll('link[rel="stylesheet"]');
+    for (var i = 0; i < links.length; i++) {
+      var link = links[i];
+      var href = link.getAttribute('href');
+      if (!href) continue;
+      var base = href.split('?')[0];
+      link.setAttribute('href', base + '?v=' + ts);
+    }
+  });
+  src.addEventListener('error', function (ev) {
+    // EventSource auto-reconnects; surface the event for visibility.
+    if (typeof console !== 'undefined' && console.warn) {
+      console.warn('[zfb] livereload: connection error', ev);
+    }
+  });
+})();

--- a/crates/zfb-server/src/livereload.rs
+++ b/crates/zfb-server/src/livereload.rs
@@ -1,0 +1,206 @@
+//! SSE live-reload bridge between [`zfb_build::BuildOutcome`] and the
+//! browser.
+//!
+//! The dev server holds a [`tokio::sync::broadcast`] channel of
+//! [`ReloadEvent`]s. The bin crate (the one that owns
+//! [`zfb_build::BuildOrchestrator`]) wires its `on_outcome` callback
+//! through [`outcome_to_events`] and forwards the resulting events into
+//! the channel. Each browser tab subscribes to the channel via the SSE
+//! endpoint mounted at `/__zfb/reload` (see [`crate::routes`]).
+//!
+//! ## Wiring contract (cheat sheet for the bin crate)
+//!
+//! ```ignore
+//! use tokio::sync::broadcast;
+//! use zfb_build::{BuildOrchestrator, BuildContext};
+//! use zfb_server::livereload::{outcome_to_events, ReloadEvent};
+//!
+//! let (tx, _rx) = broadcast::channel::<ReloadEvent>(64);
+//! let server_tx = tx.clone();
+//!
+//! tokio::spawn(async move {
+//!     orchestrator
+//!         .run(ctx, move |outcome| {
+//!             for ev in outcome_to_events(outcome) {
+//!                 // Errors here just mean "no live subscribers"; ignore.
+//!                 let _ = tx.send(ev);
+//!             }
+//!         })
+//!         .await
+//! });
+//!
+//! zfb_server::serve(ServeOpts { /* ... */ broadcast: server_tx, /* ... */ }).await?;
+//! ```
+//!
+//! ## Event mapping rules
+//!
+//! - `outcome.pages_written.len() > 0`  ⇒  emit one [`ReloadEvent::Page`].
+//! - `outcome.css_changed`              ⇒  emit one [`ReloadEvent::Css`].
+//! - When only CSS changed we deliberately do **not** emit `Page`; the
+//!   browser swaps the `<link>` href in place without reloading the
+//!   document, so reloading would defeat the hot-swap.
+//! - When both pages and CSS changed we emit both events. The browser
+//!   handles `page` first (full reload) which renders the CSS swap moot
+//!   for that tab, but other tabs subscribed to the same stream may
+//!   still benefit from the CSS event.
+
+use std::convert::Infallible;
+use std::time::Duration;
+
+use axum::response::sse::{Event, KeepAlive, Sse};
+use futures::stream::{Stream, StreamExt};
+use tokio::sync::broadcast;
+use tokio_stream::wrappers::BroadcastStream;
+use zfb_build::BuildOutcome;
+
+/// A single live-reload event delivered over the SSE channel.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReloadEvent {
+    /// One or more pages were re-rendered. The browser should fully
+    /// reload the document (`location.reload()`).
+    Page,
+    /// CSS asset changed. The browser should hot-swap every
+    /// `<link rel="stylesheet">` by bumping its query string.
+    Css,
+}
+
+impl ReloadEvent {
+    /// SSE `event:` field name. Matches the strings the browser script
+    /// listens for at `/__zfb/livereload.js`.
+    pub fn name(&self) -> &'static str {
+        match self {
+            ReloadEvent::Page => "page",
+            ReloadEvent::Css => "css",
+        }
+    }
+}
+
+/// Translate a [`BuildOutcome`] into the live-reload events the browser
+/// should observe.
+///
+/// See module docs for the rules.
+pub fn outcome_to_events(outcome: &BuildOutcome) -> Vec<ReloadEvent> {
+    let mut events = Vec::with_capacity(2);
+    if !outcome.pages_written.is_empty() {
+        events.push(ReloadEvent::Page);
+    }
+    if outcome.css_changed {
+        events.push(ReloadEvent::Css);
+    }
+    events
+}
+
+/// Type alias for the broadcast sender used by the server. The bin
+/// crate constructs one of these and:
+///
+/// 1. Hands a clone to [`crate::ServeOpts::broadcast`] so the SSE route
+///    can subscribe per connection.
+/// 2. Calls [`broadcast::Sender::send`] from the orchestrator's
+///    `on_outcome` callback for each event yielded by
+///    [`outcome_to_events`].
+///
+/// `send` returns `Err` only when there are zero live receivers, which
+/// is the normal state at startup or when no browser tab is open.
+/// Callers should ignore that error.
+pub type ReloadTx = broadcast::Sender<ReloadEvent>;
+
+/// Build the per-connection SSE stream wired to the broadcast channel.
+///
+/// `BroadcastStream` yields `Result<T, BroadcastStreamRecvError>`. The
+/// `Lagged` error means this connection couldn't keep up with the
+/// stream — we just skip the missed event (the next real event will
+/// re-trigger a reload, which converges on the up-to-date state).
+pub fn sse_response(
+    tx: &ReloadTx,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>> + Send + 'static> {
+    let rx = tx.subscribe();
+    let stream = BroadcastStream::new(rx).filter_map(|res| async move {
+        match res {
+            Ok(ev) => Some(Ok(Event::default().event(ev.name()))),
+            Err(_lagged) => None,
+        }
+    });
+    Sse::new(stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(15)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zfb_build::BuildOutcome;
+    use zfb_graph::PageId;
+
+    fn pid(s: &str) -> PageId {
+        PageId::new(s)
+    }
+
+    #[test]
+    fn empty_outcome_emits_nothing() {
+        let outcome = BuildOutcome::default();
+        assert!(outcome_to_events(&outcome).is_empty());
+    }
+
+    #[test]
+    fn pages_written_emits_page_only() {
+        let outcome = BuildOutcome {
+            pages_written: vec![pid("/a")],
+            ..Default::default()
+        };
+        assert_eq!(outcome_to_events(&outcome), vec![ReloadEvent::Page]);
+    }
+
+    #[test]
+    fn css_changed_emits_css_only() {
+        let outcome = BuildOutcome {
+            css_changed: true,
+            css_rerun: true,
+            ..Default::default()
+        };
+        assert_eq!(outcome_to_events(&outcome), vec![ReloadEvent::Css]);
+    }
+
+    #[test]
+    fn pages_and_css_emits_both() {
+        let outcome = BuildOutcome {
+            pages_written: vec![pid("/a"), pid("/b")],
+            css_changed: true,
+            css_rerun: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            outcome_to_events(&outcome),
+            vec![ReloadEvent::Page, ReloadEvent::Css]
+        );
+    }
+
+    #[test]
+    fn css_rerun_without_change_emits_nothing() {
+        // CSS pipeline ran but the asset was byte-identical: skip the
+        // event so we don't trigger a needless hot-swap.
+        let outcome = BuildOutcome {
+            css_rerun: true,
+            css_changed: false,
+            ..Default::default()
+        };
+        assert!(outcome_to_events(&outcome).is_empty());
+    }
+
+    #[test]
+    fn islands_changes_dont_emit() {
+        // We don't currently model islands hot-swap. A pages_written
+        // entry for the affected page is what triggers reload.
+        let outcome = BuildOutcome {
+            islands_rerun: true,
+            islands_changed: true,
+            ..Default::default()
+        };
+        assert!(outcome_to_events(&outcome).is_empty());
+    }
+
+    #[test]
+    fn event_names_match_browser_protocol() {
+        // The strings here MUST match the addEventListener calls in
+        // src/livereload.js.
+        assert_eq!(ReloadEvent::Page.name(), "page");
+        assert_eq!(ReloadEvent::Css.name(), "css");
+    }
+}

--- a/crates/zfb-server/src/routes.rs
+++ b/crates/zfb-server/src/routes.rs
@@ -1,0 +1,444 @@
+//! Axum routes for the dev server.
+//!
+//! ## Route map
+//!
+//! - `GET /assets/*path` — static files from `<dist_root>/assets/`,
+//!   served via [`tower_http::services::ServeDir`].
+//! - `GET /public/*path` — static files from `<public_root>/`,
+//!   served via [`tower_http::services::ServeDir`].
+//! - `GET /__zfb/livereload.js` — bundled JS that opens an SSE
+//!   connection back to this server. Always served with
+//!   `Cache-Control: no-store`.
+//! - `GET /__zfb/reload` — SSE event stream. See
+//!   [`crate::livereload::sse_response`].
+//! - `GET /` and `GET /*path` — render HTML out of the in-memory page
+//!   cache. See [`PageCache`] for keying conventions.
+//!
+//! ## Page key resolution
+//!
+//! For a request to `/blog/foo` we look up the cache in this order:
+//!
+//! 1. `/blog/foo`
+//! 2. `/blog/foo/index.html`
+//! 3. `/blog/foo/` (trailing slash — useful when the renderer keys by
+//!    directory-style path)
+//!
+//! For a request to `/` we look up `/` and then `/index.html`. First
+//! hit wins. Misses respond with the dev-mode 404 body
+//! ([`DEV_404_BODY`]).
+//!
+//! All HTML responses (including 404) go through
+//! [`crate::inject::inject_livereload`] before being returned, so every
+//! served page wires itself up to the live-reload SSE stream.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::extract::{Path as AxumPath, State};
+use axum::http::{header, HeaderValue, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::Router;
+use tokio::sync::RwLock;
+use tower_http::services::ServeDir;
+use tower_http::trace::TraceLayer;
+
+use crate::inject::inject_livereload;
+use crate::livereload::{sse_response, ReloadTx};
+
+/// HTML body returned when a page is not in the cache.
+///
+/// This is intentionally a dev-mode "did you forget to add a route?"
+/// affordance — production builds emit static files and never hit this
+/// path. It still gets the live-reload script injected so the tab will
+/// auto-refresh once the missing page lands.
+pub const DEV_404_BODY: &str = "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>zfb dev — 404</title></head><body><h1>404 — page not in cache</h1><p>The dev server has no rendered HTML for this URL. If you just added the page, the rebuild may still be in flight.</p></body></html>";
+
+/// In-memory cache of rendered HTML keyed by URL path.
+///
+/// Keys are the leading-slash URL path the browser asked for, e.g.
+/// `/`, `/blog/foo`, `/blog/foo/index.html`. The bin crate populates
+/// this from the orchestrator's render outputs.
+///
+/// Wrapped in an `Arc<RwLock<...>>` so route handlers can read
+/// concurrently while the bin crate's rebuild loop holds a write
+/// briefly to swap in fresh HTML.
+#[derive(Clone, Default)]
+pub struct PageCache {
+    inner: Arc<RwLock<HashMap<String, String>>>,
+}
+
+impl PageCache {
+    /// Construct an empty cache.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert or replace an entry. `key` should be the leading-slash
+    /// URL path the browser will use (e.g. `/blog/foo`). The renderer
+    /// is free to also insert `/blog/foo/index.html` if it likes.
+    pub async fn insert(&self, key: impl Into<String>, html: impl Into<String>) {
+        self.inner.write().await.insert(key.into(), html.into());
+    }
+
+    /// Replace the entire cache atomically with the contents of
+    /// `entries`.
+    pub async fn replace_all<I, K, V>(&self, entries: I)
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        let new_map: HashMap<String, String> = entries
+            .into_iter()
+            .map(|(k, v)| (k.into(), v.into()))
+            .collect();
+        *self.inner.write().await = new_map;
+    }
+
+    /// Look up `key` and return the HTML if present.
+    pub async fn get(&self, key: &str) -> Option<String> {
+        self.inner.read().await.get(key).cloned()
+    }
+}
+
+/// Shared state for the route handlers.
+#[derive(Clone)]
+pub struct AppState {
+    /// Page cache that renderers populate.
+    pub pages: PageCache,
+    /// Live-reload broadcast sender — cloned per SSE subscription.
+    pub broadcast: ReloadTx,
+}
+
+/// Build the axum router for the dev server.
+///
+/// `dist_root` is the build output directory (used for `/assets/*`).
+/// `public_root` is the project's static assets directory (used for
+/// `/public/*`). Both are served via [`ServeDir`]; missing files fall
+/// back to a plain 404.
+pub fn build_router(
+    state: AppState,
+    dist_root: std::path::PathBuf,
+    public_root: std::path::PathBuf,
+) -> Router {
+    let assets_dir = dist_root.join("assets");
+    let assets_service = ServeDir::new(&assets_dir);
+    let public_service = ServeDir::new(&public_root);
+
+    Router::new()
+        .route("/__zfb/livereload.js", get(livereload_js))
+        .route("/__zfb/reload", get(sse_handler))
+        .nest_service("/assets", assets_service)
+        .nest_service("/public", public_service)
+        .route("/", get(page_root))
+        .route("/{*path}", get(page_handler))
+        .layer(TraceLayer::new_for_http())
+        .with_state(state)
+}
+
+/// Handler for `GET /__zfb/livereload.js`. Returns the bundled JS with
+/// `Cache-Control: no-store` so dev tabs always refetch the latest
+/// build of the script when reloaded.
+pub async fn livereload_js() -> impl IntoResponse {
+    let body = include_str!("livereload.js");
+    (
+        [
+            (
+                header::CONTENT_TYPE,
+                HeaderValue::from_static("application/javascript; charset=utf-8"),
+            ),
+            (header::CACHE_CONTROL, HeaderValue::from_static("no-store")),
+        ],
+        body,
+    )
+}
+
+/// Handler for `GET /__zfb/reload`. Opens an SSE stream for this
+/// connection.
+pub async fn sse_handler(State(state): State<AppState>) -> impl IntoResponse {
+    sse_response(&state.broadcast)
+}
+
+/// Handler for `GET /` — serve the root page.
+pub async fn page_root(State(state): State<AppState>) -> Response {
+    serve_page(&state, "").await
+}
+
+/// Handler for `GET /*path` — serve any other rendered page.
+pub async fn page_handler(
+    State(state): State<AppState>,
+    AxumPath(path): AxumPath<String>,
+) -> Response {
+    serve_page(&state, &path).await
+}
+
+async fn serve_page(state: &AppState, raw_path: &str) -> Response {
+    // Strip any leading slash from the captured wildcard so we can
+    // build canonical lookup keys ourselves.
+    let trimmed = raw_path.trim_start_matches('/');
+
+    let candidates = lookup_keys(trimmed);
+    for key in &candidates {
+        if let Some(html) = state.pages.get(key).await {
+            return html_response(StatusCode::OK, &html);
+        }
+    }
+
+    html_response(StatusCode::NOT_FOUND, DEV_404_BODY)
+}
+
+/// Generate the lookup-key candidates for a given URL path.
+///
+/// `path` is the path WITHOUT a leading slash (the wildcard capture).
+/// Empty string means "the root".
+///
+/// We return up to three candidates in priority order; the first hit
+/// wins. The variants cover:
+///
+/// - exact match (`/blog/foo` → `/blog/foo`)
+/// - directory-style with `index.html` (`/blog/foo` → `/blog/foo/index.html`)
+/// - directory-style with trailing slash (`/blog/foo` → `/blog/foo/`)
+fn lookup_keys(path: &str) -> Vec<String> {
+    if path.is_empty() {
+        return vec!["/".to_string(), "/index.html".to_string()];
+    }
+    // Drop a trailing slash for the "exact" candidate so callers that
+    // store `/blog/foo` still match a request to `/blog/foo/`.
+    let stripped = path.trim_end_matches('/');
+    let mut out = Vec::with_capacity(3);
+    out.push(format!("/{stripped}"));
+    out.push(format!("/{stripped}/index.html"));
+    if path.ends_with('/') || stripped != path {
+        // request had a trailing slash — also try the slash key
+        out.push(format!("/{path}"));
+    } else {
+        out.push(format!("/{stripped}/"));
+    }
+    out
+}
+
+fn html_response(status: StatusCode, body: &str) -> Response {
+    let injected = inject_livereload(body);
+    let mut resp = (
+        status,
+        [(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("text/html; charset=utf-8"),
+        )],
+        injected,
+    )
+        .into_response();
+    resp.headers_mut()
+        .insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
+    resp
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inject::LIVERELOAD_TAG;
+    use crate::livereload::ReloadEvent;
+    use axum::body::{to_bytes, Body};
+    use axum::http::{Request, StatusCode};
+    use tokio::sync::broadcast;
+    use tower::ServiceExt;
+
+    fn test_state() -> AppState {
+        let (tx, _rx) = broadcast::channel::<ReloadEvent>(16);
+        AppState {
+            pages: PageCache::new(),
+            broadcast: tx,
+        }
+    }
+
+    fn test_router(state: AppState) -> Router {
+        // Use bogus dist/public roots — ServeDir will simply 404, which
+        // is fine: these tests don't exercise asset routing (Sub 6
+        // covers integration with a real fixture project).
+        let tmp = std::env::temp_dir();
+        build_router(
+            state,
+            tmp.join("zfb-test-dist"),
+            tmp.join("zfb-test-public"),
+        )
+    }
+
+    async fn body_string(resp: Response) -> String {
+        let bytes = to_bytes(resp.into_body(), 1_000_000).await.unwrap();
+        String::from_utf8(bytes.to_vec()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn serves_page_from_cache() {
+        let state = test_state();
+        state
+            .pages
+            .insert("/", "<html><body><h1>home</h1></body></html>")
+            .await;
+        let router = test_router(state);
+
+        let resp = router
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        assert!(body.contains("<h1>home</h1>"));
+        assert!(body.contains(LIVERELOAD_TAG));
+    }
+
+    #[tokio::test]
+    async fn serves_nested_page_from_cache() {
+        let state = test_state();
+        state
+            .pages
+            .insert("/blog/foo", "<html><body>foo</body></html>")
+            .await;
+        let router = test_router(state);
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/blog/foo")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        assert!(body.contains("foo"));
+        assert!(body.contains(LIVERELOAD_TAG));
+    }
+
+    #[tokio::test]
+    async fn falls_back_to_index_html_key() {
+        let state = test_state();
+        state
+            .pages
+            .insert("/blog/foo/index.html", "<html><body>indexed</body></html>")
+            .await;
+        let router = test_router(state);
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/blog/foo")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        assert!(body_string(resp).await.contains("indexed"));
+    }
+
+    #[tokio::test]
+    async fn returns_dev_404_for_unknown_path() {
+        let state = test_state();
+        let router = test_router(state);
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/nope/missing")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body = body_string(resp).await;
+        assert!(body.contains("404"));
+        assert!(body.contains(LIVERELOAD_TAG));
+    }
+
+    #[tokio::test]
+    async fn livereload_js_endpoint_serves_script() {
+        let state = test_state();
+        let router = test_router(state);
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/__zfb/livereload.js")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let ct = resp
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|h| h.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        assert!(
+            ct.starts_with("application/javascript"),
+            "unexpected content-type: {ct}"
+        );
+
+        let cc = resp
+            .headers()
+            .get(header::CACHE_CONTROL)
+            .and_then(|h| h.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        assert_eq!(cc, "no-store");
+
+        let body = body_string(resp).await;
+        assert!(body.contains("EventSource"));
+        assert!(body.contains("/__zfb/reload"));
+    }
+
+    #[tokio::test]
+    async fn html_responses_are_cache_busted() {
+        let state = test_state();
+        state
+            .pages
+            .insert("/x", "<html><body>x</body></html>")
+            .await;
+        let router = test_router(state);
+
+        let resp = router
+            .oneshot(Request::builder().uri("/x").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let cc = resp
+            .headers()
+            .get(header::CACHE_CONTROL)
+            .and_then(|h| h.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        assert_eq!(cc, "no-store");
+    }
+
+    #[test]
+    fn lookup_keys_root() {
+        assert_eq!(
+            lookup_keys(""),
+            vec!["/".to_string(), "/index.html".to_string()]
+        );
+    }
+
+    #[test]
+    fn lookup_keys_simple_path() {
+        let out = lookup_keys("blog/foo");
+        assert_eq!(out[0], "/blog/foo");
+        assert_eq!(out[1], "/blog/foo/index.html");
+        assert_eq!(out[2], "/blog/foo/");
+    }
+
+    #[test]
+    fn lookup_keys_trailing_slash_request() {
+        let out = lookup_keys("blog/foo/");
+        assert_eq!(out[0], "/blog/foo");
+        assert_eq!(out[1], "/blog/foo/index.html");
+        assert_eq!(out[2], "/blog/foo/");
+    }
+}

--- a/crates/zfb-server/tests/integration.rs
+++ b/crates/zfb-server/tests/integration.rs
@@ -1,0 +1,348 @@
+//! End-to-end integration tests for `zfb-server`.
+//!
+//! These spin up the real axum server on an ephemeral 127.0.0.1 port
+//! (so they never collide across worktrees or with a developer's
+//! running `zfb dev`) and exercise it via a real HTTP client. The page
+//! cache and the live-reload broadcast channel are populated directly
+//! from the test (the rebuild orchestrator that normally fills them in
+//! the bin crate is out of scope for Sub 6).
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use futures_util::StreamExt;
+use tempfile::TempDir;
+use tokio::net::TcpListener;
+use tokio::sync::broadcast;
+use tokio::time::timeout;
+use zfb_build::BuildOutcome;
+use zfb_graph::PageId;
+use zfb_server::livereload::{outcome_to_events, ReloadEvent};
+use zfb_server::{serve_with_listener, PageCache, ServeOpts};
+
+/// All the per-test handles we need: the bound address, the page
+/// cache (so the test can populate it), the broadcast sender (so the
+/// test can fire reload events), the join handle of the server task,
+/// and a guard for the temp project directory.
+struct Harness {
+    addr: SocketAddr,
+    pages: PageCache,
+    tx: broadcast::Sender<ReloadEvent>,
+    server: tokio::task::JoinHandle<anyhow::Result<()>>,
+    _tmp: TempDir,
+}
+
+impl Harness {
+    /// Construct `<root>/dist/assets/`, `<root>/public/`, bind an
+    /// ephemeral port, and spawn the server.
+    async fn start() -> Self {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root: PathBuf = tmp.path().to_path_buf();
+        let dist_root = root.join("dist");
+        let public_root = root.join("public");
+        std::fs::create_dir_all(dist_root.join("assets")).unwrap();
+        std::fs::create_dir_all(&public_root).unwrap();
+
+        // Pre-populate fixture assets used by the asset/public tests.
+        std::fs::write(
+            dist_root.join("assets").join("main.css"),
+            "body { color: red; }",
+        )
+        .unwrap();
+        std::fs::write(public_root.join("favicon.ico"), b"\x00FAVICON\x00").unwrap();
+
+        let pages = PageCache::new();
+        let (tx, _rx) = broadcast::channel::<ReloadEvent>(64);
+
+        let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .await
+            .expect("bind ephemeral");
+        let addr = listener.local_addr().expect("local_addr");
+
+        let opts = ServeOpts {
+            project_root: root.clone(),
+            dist_root,
+            public_root,
+            addr,
+            pages: pages.clone(),
+            broadcast: tx.clone(),
+        };
+
+        let server = tokio::spawn(async move { serve_with_listener(opts, listener).await });
+
+        // Tiny readiness wait: serve_with_listener has the listener
+        // already bound, so the OS will queue connections immediately.
+        // No sleep needed — reqwest will retry under the hood once axum
+        // accepts. But on slow CI, give the spawn a chance to run.
+        tokio::task::yield_now().await;
+
+        Self {
+            addr,
+            pages,
+            tx,
+            server,
+            _tmp: tmp,
+        }
+    }
+
+    fn url(&self, path: &str) -> String {
+        format!("http://{}{}", self.addr, path)
+    }
+}
+
+impl Drop for Harness {
+    fn drop(&mut self) {
+        // Best-effort: kill the server task so the test process can
+        // exit cleanly. axum::serve has no graceful shutdown wired up
+        // in this crate, so an abort is the simplest and most reliable
+        // option here.
+        self.server.abort();
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn page_route_serves_html_from_cache() {
+    let h = Harness::start().await;
+    h.pages
+        .insert("/foo", "<html><body><h1>foo page</h1></body></html>")
+        .await;
+
+    let resp = reqwest::get(h.url("/foo")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert!(body.contains("<h1>foo page</h1>"), "body: {body}");
+    assert!(
+        body.contains("<script src=\"/__zfb/livereload.js\"></script>"),
+        "expected injected livereload tag, body: {body}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn asset_route_serves_static_files() {
+    let h = Harness::start().await;
+    let resp = reqwest::get(h.url("/assets/main.css")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let ct = resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    assert!(
+        ct.to_ascii_lowercase().contains("css"),
+        "unexpected content-type: {ct}"
+    );
+    let body = resp.text().await.unwrap();
+    assert_eq!(body, "body { color: red; }");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn public_route_serves_user_files() {
+    let h = Harness::start().await;
+    let resp = reqwest::get(h.url("/public/favicon.ico")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let body = resp.bytes().await.unwrap();
+    assert_eq!(body.as_ref(), b"\x00FAVICON\x00");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn livereload_js_endpoint_returns_script() {
+    let h = Harness::start().await;
+    let resp = reqwest::get(h.url("/__zfb/livereload.js")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let ct = resp
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or("")
+        .to_string();
+    assert!(
+        ct.starts_with("application/javascript"),
+        "unexpected content-type: {ct}"
+    );
+    let body = resp.text().await.unwrap();
+    assert!(body.contains("EventSource"), "body missing EventSource");
+    assert!(body.contains("/__zfb/reload"), "body missing /__zfb/reload");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unknown_path_returns_404() {
+    let h = Harness::start().await;
+    let resp = reqwest::get(h.url("/does-not-exist")).await.unwrap();
+    assert_eq!(resp.status(), 404);
+    let body = resp.text().await.unwrap();
+    assert!(body.contains("404"), "body: {body}");
+    assert!(
+        body.contains("page not in cache"),
+        "expected dev-mode 404 body, got: {body}"
+    );
+}
+
+/// Wait until the broadcast channel has at least `min` live receivers,
+/// or until `dur` elapses. Returns `true` if the count was reached.
+///
+/// This eliminates the timing race between "the SSE handler hooked up
+/// its subscriber" and "the test fires a broadcast event" — without
+/// relying on a fixed `sleep` that's flaky on slow CI.
+async fn wait_for_subscribers(
+    tx: &broadcast::Sender<ReloadEvent>,
+    min: usize,
+    dur: Duration,
+) -> bool {
+    let start = std::time::Instant::now();
+    while start.elapsed() < dur {
+        if tx.receiver_count() >= min {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    tx.receiver_count() >= min
+}
+
+/// Read a `text/event-stream` body chunk-by-chunk and return the first
+/// `event:` line we observe. Times out after `dur` so a missing event
+/// fails the test fast rather than hanging the suite.
+async fn next_sse_event_name(
+    resp: reqwest::Response,
+    dur: Duration,
+) -> anyhow::Result<Option<String>> {
+    let mut stream = resp.bytes_stream();
+    let mut buf = Vec::<u8>::new();
+
+    let task = async {
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk?;
+            buf.extend_from_slice(&chunk);
+            // Look for any `event: <name>\n` line in what we have so far.
+            let s = std::str::from_utf8(&buf).unwrap_or("");
+            for line in s.lines() {
+                if let Some(rest) = line.strip_prefix("event:") {
+                    let name = rest.trim().to_string();
+                    if !name.is_empty() {
+                        return Ok::<Option<String>, anyhow::Error>(Some(name));
+                    }
+                }
+            }
+        }
+        Ok(None)
+    };
+
+    match timeout(dur, task).await {
+        Ok(res) => res,
+        Err(_) => Ok(None),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sse_emits_page_event_on_rebuild() {
+    let h = Harness::start().await;
+
+    // Open the SSE stream first so we don't miss the broadcast.
+    let resp = reqwest::Client::new()
+        .get(h.url("/__zfb/reload"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+
+    // Wait for the SSE handler's subscriber to actually register on the
+    // broadcast channel. Without this, a `tx.send` racing the handler
+    // would be silently dropped (broadcast drops to zero receivers).
+    assert!(
+        wait_for_subscribers(&h.tx, 1, Duration::from_secs(5)).await,
+        "SSE handler never subscribed to broadcast"
+    );
+
+    let outcome = BuildOutcome {
+        pages_written: vec![PageId::new("/index.html")],
+        ..Default::default()
+    };
+    for ev in outcome_to_events(&outcome) {
+        let _ = h.tx.send(ev);
+    }
+
+    let name = next_sse_event_name(resp, Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert_eq!(name.as_deref(), Some("page"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sse_emits_css_event_on_css_change() {
+    let h = Harness::start().await;
+
+    let resp = reqwest::Client::new()
+        .get(h.url("/__zfb/reload"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert!(
+        wait_for_subscribers(&h.tx, 1, Duration::from_secs(5)).await,
+        "SSE handler never subscribed to broadcast"
+    );
+
+    let outcome = BuildOutcome {
+        css_rerun: true,
+        css_changed: true,
+        ..Default::default()
+    };
+    for ev in outcome_to_events(&outcome) {
+        let _ = h.tx.send(ev);
+    }
+
+    let name = next_sse_event_name(resp, Duration::from_secs(5))
+        .await
+        .unwrap();
+    assert_eq!(name.as_deref(), Some("css"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sse_does_not_emit_page_when_only_css_changed() {
+    let h = Harness::start().await;
+
+    let resp = reqwest::Client::new()
+        .get(h.url("/__zfb/reload"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert!(
+        wait_for_subscribers(&h.tx, 1, Duration::from_secs(5)).await,
+        "SSE handler never subscribed to broadcast"
+    );
+
+    let outcome = BuildOutcome {
+        css_rerun: true,
+        css_changed: true,
+        ..Default::default()
+    };
+    for ev in outcome_to_events(&outcome) {
+        let _ = h.tx.send(ev);
+    }
+
+    // Read the stream for a short window and assert we never see a
+    // `page` event. We may or may not see `css` — that's covered by
+    // the previous test — what matters here is the absence of `page`.
+    let mut stream = resp.bytes_stream();
+    let mut buf = Vec::<u8>::new();
+    let watch = async {
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.unwrap();
+            buf.extend_from_slice(&chunk);
+            let s = std::str::from_utf8(&buf).unwrap_or("");
+            for line in s.lines() {
+                if let Some(rest) = line.strip_prefix("event:") {
+                    if rest.trim() == "page" {
+                        panic!("unexpected `event: page` line in stream:\n{s}");
+                    }
+                }
+            }
+        }
+    };
+    // 500 ms is plenty: outcome_to_events runs synchronously and the
+    // broadcast hop is sub-millisecond. If `page` were going to appear,
+    // it would have appeared by now.
+    let _ = timeout(Duration::from_millis(500), watch).await;
+}


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/8
- parent PR
    - https://github.com/Takazudo/zudo-front-builder/pull/12

---

## Summary

Epic 7 of the zfb super-epic (#2) — adds the dev-mode HTTP server. Wraps Epic 6's `zfb-build` with an `axum` server that serves rendered HTML from memory, static assets from disk, and a `/__zfb/reload` SSE endpoint that pushes `page` and `css` events. A small browser script (~30 LOC) reloads on `page` events and hot-swaps `<link rel=stylesheet>` href on `css` events without a full reload. The convergence point that wires Epics 4 + 5 + 6 together for the dev loop.

This adds one new workspace crate (`crates/zfb-server`) and does not change any existing crate.

## Changes

### New crate: `crates/zfb-server`

- `Cargo.toml` — axum 0.8, tower-http 0.6 (`fs`, `trace`), tokio (sync/rt/macros/time), tokio-stream, futures, serde, anyhow, thiserror, tracing. `zfb-build` as a path dep for `BuildOutcome`. `zfb-graph`, `reqwest` (stream), `tempfile` as dev-deps.
- `src/lib.rs` — top-level public `serve(opts: ServeOpts) -> anyhow::Result<()>` plus `serve_with_listener(opts, listener)` so tests can use ephemeral ports. `ServeOpts { project_root, dist_root, public_root, addr, broadcast: ReloadTx, pages: PageCache }`.

### HTTP routes (`src/routes.rs`)

- `GET /assets/{*path}` — `<dist_root>/assets/` via `tower_http::services::ServeDir` (built-in `..` traversal protection).
- `GET /public/{*path}` — `<public_root>/` via `ServeDir`.
- `GET /__zfb/livereload.js` — bundled client script with `Cache-Control: no-store`.
- `GET /__zfb/reload` — SSE event stream.
- `GET /` and `GET /{*path}` — render HTML out of an in-memory `PageCache` (`Arc<RwLock<HashMap<String, String>>>`). Lookup keys try `/p`, `/p/index.html`, `/p/` in that order. Misses respond with the dev-mode 404 body. All HTML responses pass through `inject_livereload`.

### SSE bridge (`src/livereload.rs`)

- `ReloadEvent { Page, Css }` enum and `outcome_to_events(&BuildOutcome) -> Vec<ReloadEvent>` translation helper. Rules: `pages_written.len() > 0` ⇒ `Page`; `css_changed` ⇒ `Css`; CSS-only changes deliberately do NOT emit `Page` (so the browser hot-swaps without a full reload).
- `ReloadTx = broadcast::Sender<ReloadEvent>` newtype alias. Bin crate constructs the channel, hands a clone to `ServeOpts.broadcast`, and forwards events from `BuildOrchestrator::run`'s `on_outcome` callback.
- `sse_response(&ReloadTx)` returns an `axum::response::sse::Sse` stream wrapping `BroadcastStream`. `Lagged` errors are filtered (next real event re-syncs). `KeepAlive` set to 15s so proxies don't time the connection out.

### Browser livereload script (`src/livereload.js`)

~30 LOC. Opens `EventSource('/__zfb/reload')`, listens for `page` (calls `location.reload()`) and `css` (rewrites every `<link rel="stylesheet">` href with a `?v=<Date.now()>` cache buster).

### HTML injection (`src/inject.rs`)

`inject_livereload(html: &str) -> String` inserts `<script src="/__zfb/livereload.js">` immediately before the LAST `</body>` (case-insensitive). Falls back to appending if `</body>` is missing. Applied to all HTML responses including the dev 404.

### Integration tests (`tests/integration.rs`)

8 end-to-end tests using ephemeral port 0 + reqwest (with `stream` feature):

1. Page route serves HTML from cache (with injected script tag)
2. `/assets/*` serves static files from `<dist_root>/assets/`
3. `/public/*` serves user files from `<public_root>/`
4. `/__zfb/livereload.js` returns the script with correct content-type
5. Unknown path returns dev-mode 404 (with injected script)
6. SSE emits `event: page` on rebuild
7. SSE emits `event: css` on css change
8. SSE does NOT emit `page` when only CSS changed

SSE timing uses `broadcast::Sender::receiver_count()` polling (not `sleep`) to avoid flakiness. Multi-thread tokio runtime with 2 worker threads.

## Test Plan

- `cargo build --workspace` — succeeds clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p zfb-server` — 22 unit tests + 8 integration tests pass
- Code review pass with `gpt-4.1` via Copilot CLI surfaced no concrete bugs (only speculative concerns, all already mitigated by the implementation: ServeDir traversal protection, axum SSE headers, Lagged filtering, case-insensitive injection, ephemeral ports, receiver_count polling)

## Acceptance criteria (from issue #8)

- ✅ `cargo run -p zfb-server` will start the dev server on `localhost:3000` once the bin crate (Epic 8) wires `serve(ServeOpts)`. The wiring contract (`outcome_to_events` + `ReloadTx`) is documented in `livereload.rs` module docs and `lib.rs` crate docs.
- ✅ Editing markdown will trigger an SSE `page` event (test 6) → browser reloads (verified by `livereload.js` unit-tested behavior + injected `<script>` in test 1).
- ✅ Editing CSS will trigger an SSE `css` event (test 7) → browser swaps `<link>` href without reload (verified by `livereload.js` content + test 8 confirming no `page` event).
- ✅ HTTP 404 returns the dev-mode 404 page (test 5).