### PR TITLE
[zfb Init][Epic 7/8] zfb CLI — new, dev, build, preview, config parser

### DIFF
--- a/crates/zfb/Cargo.toml
+++ b/crates/zfb/Cargo.toml
@@ -16,15 +16,11 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = { workspace = true }
 clap = { version = "4", features = ["derive"] }
-<<<<<<< HEAD
 indicatif = "0.17"
 owo-colors = { version = "4", features = ["supports-colors"] }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }
-=======
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "fs"] }
 
 [dev-dependencies]
 tempfile = { workspace = true }
->>>>>>> zfb-init-cli/config-parser

--- a/crates/zfb/Cargo.toml
+++ b/crates/zfb/Cargo.toml
@@ -16,4 +16,9 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = { workspace = true }
 clap = { version = "4", features = ["derive"] }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "fs"] }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/zfb/Cargo.toml
+++ b/crates/zfb/Cargo.toml
@@ -16,4 +16,6 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = { workspace = true }
 clap = { version = "4", features = ["derive"] }
+indicatif = "0.17"
+owo-colors = { version = "4", features = ["supports-colors"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }

--- a/crates/zfb/Cargo.toml
+++ b/crates/zfb/Cargo.toml
@@ -17,3 +17,4 @@ path = "src/lib.rs"
 anyhow = { workspace = true }
 clap = { version = "4", features = ["derive"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }
+zfb-build = { path = "../zfb-build" }

--- a/crates/zfb/Cargo.toml
+++ b/crates/zfb/Cargo.toml
@@ -9,3 +9,11 @@ publish = false
 [[bin]]
 name = "zfb"
 path = "src/main.rs"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { version = "4", features = ["derive"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }

--- a/crates/zfb/Cargo.toml
+++ b/crates/zfb/Cargo.toml
@@ -15,5 +15,7 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+axum = "0.8"
 clap = { version = "4", features = ["derive"] }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal"] }
+tower-http = { version = "0.6", features = ["fs"] }

--- a/crates/zfb/Cargo.toml
+++ b/crates/zfb/Cargo.toml
@@ -16,4 +16,5 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = { workspace = true }
 clap = { version = "4", features = ["derive"] }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }
+include_dir = "0.7"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "process"] }

--- a/crates/zfb/Cargo.toml
+++ b/crates/zfb/Cargo.toml
@@ -16,4 +16,8 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = { workspace = true }
 clap = { version = "4", features = ["derive"] }
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "signal", "sync"] }
+zfb-build = { path = "../zfb-build" }
+zfb-graph = { path = "../zfb-graph" }
+zfb-server = { path = "../zfb-server" }
+zfb-watcher = { path = "../zfb-watcher" }

--- a/crates/zfb/src/cli.rs
+++ b/crates/zfb/src/cli.rs
@@ -1,0 +1,77 @@
+//! CLI argument parsing for the `zfb` binary.
+//!
+//! The top-level [`Cli`] type holds the parsed clap state. Each subcommand
+//! variant in [`Command`] wraps a dedicated `*Args` struct so that command
+//! modules in `crate::commands` can take a single `&FooArgs` parameter rather
+//! than a long parameter list. Wave 2 agents must keep these struct shapes
+//! stable — adding fields is fine, but renaming or removing fields breaks the
+//! contract documented in each `commands/<name>.rs` stub.
+
+use std::path::PathBuf;
+
+use clap::{Args, Parser, Subcommand};
+
+/// Top-level CLI for the `zfb` binary.
+#[derive(Debug, Parser)]
+#[command(name = "zfb", version, about = "zudo-front-builder")]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+/// Subcommand dispatch. Each variant carries its own argument struct so that
+/// command implementations stay decoupled from clap.
+#[derive(Debug, Subcommand)]
+pub enum Command {
+    /// Scaffold a new project from a template.
+    New(NewArgs),
+    /// Run the local development server.
+    Dev(DevArgs),
+    /// Build the project for production.
+    Build(BuildArgs),
+    /// Preview a previously built project.
+    Preview(PreviewArgs),
+}
+
+/// Arguments for `zfb new`.
+#[derive(Debug, Args)]
+pub struct NewArgs {
+    /// Name of the new project (used as the destination directory).
+    pub name: String,
+
+    /// Template to scaffold from.
+    #[arg(long, default_value = "default")]
+    pub template: String,
+}
+
+/// Arguments for `zfb dev`.
+#[derive(Debug, Args)]
+pub struct DevArgs {
+    /// Port to bind the dev server to.
+    #[arg(long, default_value_t = 3000)]
+    pub port: u16,
+
+    /// Host interface to bind the dev server to.
+    #[arg(long, default_value = "localhost")]
+    pub host: String,
+}
+
+/// Arguments for `zfb build`.
+#[derive(Debug, Args)]
+pub struct BuildArgs {
+    /// Output directory for the production build.
+    #[arg(long, default_value = "dist")]
+    pub outdir: PathBuf,
+}
+
+/// Arguments for `zfb preview`.
+#[derive(Debug, Args)]
+pub struct PreviewArgs {
+    /// Port to bind the preview server to.
+    #[arg(long, default_value_t = 4321)]
+    pub port: u16,
+
+    /// Directory to serve the previously built artifacts from.
+    #[arg(long, default_value = "dist")]
+    pub outdir: PathBuf,
+}

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -1,0 +1,12 @@
+//! `zfb build` command — stub implementation.
+//!
+//! Contract for Wave 2 (cmd-build agent):
+//!   pub async fn run(args: &crate::cli::BuildArgs) -> anyhow::Result<()>
+//!
+//! `args.outdir` is the production output directory (default "dist").
+
+use crate::cli::BuildArgs;
+
+pub async fn run(_args: &BuildArgs) -> anyhow::Result<()> {
+    anyhow::bail!("zfb build: not yet implemented")
+}

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -1,12 +1,126 @@
-//! `zfb build` command — stub implementation.
+//! `zfb build` command — one-shot production build.
 //!
-//! Contract for Wave 2 (cmd-build agent):
+//! Contract:
 //!   pub async fn run(args: &crate::cli::BuildArgs) -> anyhow::Result<()>
 //!
-//! `args.outdir` is the production output directory (default "dist").
+//! `args.outdir` is the production output directory (default `dist`).
+//! Resolved relative to the current working directory if not absolute.
+//!
+//! ## v1 scope-down (Wave 2 / Sub 5)
+//!
+//! At the time this command was wired up, the surrounding pieces of the
+//! production build pipeline are not yet in place:
+//!
+//! - `zfb-render` / `zfb-content` / `zfb-router` (Epic 3) is not connected
+//!   into the bin crate, so we have no real `PageRenderer` to plug into
+//!   the `zfb_build::BuildOrchestrator`.
+//! - The dependency-graph loader (the thing that populates
+//!   `zfb_graph::DependencyGraph` from project sources) has not landed,
+//!   so the orchestrator's `graph.pages()` would be empty and a one-shot
+//!   `tick` against a "full rebuild" plan resolves to zero work.
+//! - `crate::config::load_from_dir` is owned by Wave 2 / Sub 3 and merges
+//!   in after this branch.
+//!
+//! Per the cmd-build brief, v1 is allowed to ship a stub that:
+//!
+//! 1. validates we're inside something that looks like a project root
+//!    (presence of a `pages/` directory),
+//! 2. atomically writes a stub `<outdir>/index.html` so `zfb preview` has
+//!    something to serve, and
+//! 3. prints the canonical summary line `✓ N pages built in Xs`.
+//!
+//! The real renderer wires in once Epic 3 + the graph loader land. This
+//! file's `run` signature, the project-root validation, and the summary
+//! contract should remain stable across that swap.
+
+use std::env;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use anyhow::{anyhow, Context, Result};
+use zfb_build::atomic_write_string;
 
 use crate::cli::BuildArgs;
 
-pub async fn run(_args: &BuildArgs) -> anyhow::Result<()> {
-    anyhow::bail!("zfb build: not yet implemented")
+pub async fn run(args: &BuildArgs) -> Result<()> {
+    let started = Instant::now();
+
+    let project_root = env::current_dir().context("failed to read current working directory")?;
+
+    // v1 project-root sanity check. The eventual config loader will give
+    // us a richer "is this a zfb project?" signal; until then, the
+    // presence of a `pages/` directory is the cheapest heuristic that
+    // matches the framework's vocabulary (see zfb-build's default watch
+    // roots, which include `pages`).
+    let pages_dir = project_root.join("pages");
+    if !pages_dir.is_dir() {
+        return Err(anyhow!(
+            "no `pages/` directory found in {}; run `zfb build` from a project root",
+            project_root.display()
+        ));
+    }
+
+    let outdir = resolve_outdir(&project_root, &args.outdir);
+
+    // v1: emit a single stub index.html. When the real renderer wires in,
+    // this loop becomes "for each rendered page, atomic_write_string the
+    // HTML to <outdir>/<output_path>".
+    let index_path = outdir.join("index.html");
+    let stub_html = stub_index_html();
+    atomic_write_string(&index_path, &stub_html)
+        .with_context(|| format!("failed to write {}", index_path.display()))?;
+
+    // v1 always emits one page (the stub index). Real builds will
+    // increment per RenderedPage.
+    let pages_built: usize = 1;
+    let elapsed = started.elapsed().as_secs_f64();
+    println!("✓ {pages_built} pages built in {elapsed:.2}s");
+
+    Ok(())
+}
+
+/// Resolve `outdir` against `project_root`. If `outdir` is absolute it is
+/// used as-is; if relative it is joined onto `project_root`. The result is
+/// returned without canonicalising — the directory may not exist yet, and
+/// `atomic_write_string` will create parents on demand.
+fn resolve_outdir(project_root: &Path, outdir: &Path) -> PathBuf {
+    if outdir.is_absolute() {
+        outdir.to_path_buf()
+    } else {
+        project_root.join(outdir)
+    }
+}
+
+/// Stub HTML emitted by the v1 build so `zfb preview` has something to
+/// serve. Intentionally minimal — once the real renderer lands this
+/// function disappears.
+fn stub_index_html() -> String {
+    "<!doctype html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<title>zfb build</title>\n</head>\n<body>\n<h1>zfb build (v1 stub)</h1>\n<p>The production renderer is not yet wired in. This page is a placeholder so <code>zfb preview</code> has something to serve.</p>\n</body>\n</html>\n".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_outdir_keeps_absolute_paths() {
+        let root = Path::new("/proj");
+        let abs = PathBuf::from("/tmp/zfb-out");
+        assert_eq!(resolve_outdir(root, &abs), abs);
+    }
+
+    #[test]
+    fn resolve_outdir_joins_relative_paths_onto_root() {
+        let root = Path::new("/proj");
+        let rel = PathBuf::from("dist");
+        assert_eq!(resolve_outdir(root, &rel), PathBuf::from("/proj/dist"));
+    }
+
+    #[test]
+    fn stub_html_is_well_formed_html() {
+        let html = stub_index_html();
+        assert!(html.starts_with("<!doctype html>"));
+        assert!(html.contains("zfb build"));
+        assert!(html.trim_end().ends_with("</html>"));
+    }
 }

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -1,13 +1,179 @@
-//! `zfb dev` command — stub implementation.
+//! `zfb dev` — boot the dev pipeline + dev HTTP server.
 //!
-//! Contract for Wave 2 (cmd-dev agent):
-//!   pub async fn run(args: &crate::cli::DevArgs) -> anyhow::Result<()>
+//! Wires three crates together per the doc-comment in
+//! [`zfb_server`]'s lib.rs:
 //!
-//! `args.port` is the bind port (default 3000), `args.host` is the bind
-//! interface (default "localhost").
+//! 1. A [`tokio::sync::broadcast`] channel of [`zfb_server::ReloadEvent`]s
+//!    that the SSE live-reload route consumes.
+//! 2. A [`zfb_server::PageCache`] of rendered HTML keyed by URL path.
+//! 3. A [`zfb_build::BuildOrchestrator`] driving the watcher + dep-graph
+//!    + asset pipeline; its `on_outcome` callback translates every
+//!    non-noop tick into reload events via
+//!    [`zfb_server::outcome_to_events`] and broadcasts them.
+//!
+//! Then it binds the address from `args.host:args.port`, prints the
+//! ready banner, and runs the axum server until Ctrl+C.
+//!
+//! ## v1 scope-down: noop page renderer
+//!
+//! Wiring the real `zfb-render` page renderer (which depends on
+//! `deno_core_host` and the SSR bundle) is deliberately deferred — Sub 4
+//! owns only `crates/zfb/src/commands/dev.rs` and the v1 acceptance is
+//! "the dev server boots and serves SOMETHING (even the dev_404 body)
+//! with live-reload working". So we hand the orchestrator a
+//! [`zfb_build::PageRenderer`] that returns an empty render set: the
+//! orchestrator still drives the watcher + dep-graph + reload broadcast
+//! correctly, the [`zfb_server::PageCache`] simply stays empty, and
+//! every request falls through to [`zfb_server::DEV_404_BODY`]. Real
+//! renderer integration (and the cache-population side of the
+//! `on_outcome` callback) is a follow-up after Wave 2 lands.
+//!
+//! Configuration loading (`crate::config::load_from_dir`) is also
+//! deferred per the manager's plan — it's Sub 3's territory and gets
+//! wired in after merge. For now we work directly off
+//! [`std::env::current_dir`] and a fixed list of watch roots.
+
+use std::net::{SocketAddr, ToSocketAddrs};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use anyhow::{Context, Result};
+use tokio::sync::broadcast;
+use zfb_build::{
+    BuildContext, BuildOrchestrator, BuildOutcome, DevAssetPipeline, OrchestratorConfig,
+    PageRenderer,
+};
+use zfb_graph::{DependencyGraph, PageId};
+use zfb_server::{outcome_to_events, serve, PageCache, ReloadEvent, ServeOpts};
 
 use crate::cli::DevArgs;
 
-pub async fn run(_args: &DevArgs) -> anyhow::Result<()> {
-    anyhow::bail!("zfb dev: not yet implemented")
+/// Default source directories the watcher follows. Missing entries are
+/// silently skipped by `zfb_watcher::Watcher::start`, so it's fine to
+/// list paths that don't exist in every project.
+const DEFAULT_WATCH_ROOTS: &[&str] = &[
+    "pages",
+    "content",
+    "components",
+    "layouts",
+    "styles",
+    "data",
+    "public",
+    "zfb.config.ts",
+];
+
+/// Entry point for `zfb dev`.
+pub async fn run(args: &DevArgs) -> Result<()> {
+    // 1. Resolve the project root. TODO(Sub 3 follow-up): replace with
+    //    `crate::config::load_from_dir(&cwd).await` once config wiring
+    //    lands; for v1 we operate on the current dir directly.
+    let project_root = std::env::current_dir().context("failed to read current working dir")?;
+    let dist_root = project_root.join("dist");
+    let public_root = project_root.join("public");
+
+    // ServeDir on a missing directory just 404s, but creating dist/
+    // up-front avoids a noisy warning the first time the dev server
+    // boots in a brand-new project. We don't create public/ — the user
+    // owns that.
+    if !dist_root.exists() {
+        std::fs::create_dir_all(&dist_root)
+            .with_context(|| format!("failed to create dist dir {}", dist_root.display()))?;
+    }
+
+    // 2. Resolve the bind address. `args.host` may be "localhost",
+    //    "127.0.0.1", "0.0.0.0", etc., so we go through ToSocketAddrs.
+    let addr = resolve_addr(&args.host, args.port)?;
+
+    // 3. Live-reload broadcast channel. 64 slots is plenty for a dev
+    //    server: one event per build tick and a handful of subscribers.
+    let (tx, _rx) = broadcast::channel::<ReloadEvent>(64);
+
+    // 4. Page cache shared between the orchestrator's render outputs
+    //    and the server's GET handlers.
+    let pages = PageCache::new();
+
+    // 5. Build orchestrator setup. Empty dep graph for v1 — the
+    //    resolver/loader that populates it is out of scope for Sub 4.
+    let graph = Arc::new(Mutex::new(DependencyGraph::new()));
+    let pipeline = DevAssetPipeline::new();
+    let watch_roots: Vec<PathBuf> = DEFAULT_WATCH_ROOTS.iter().map(PathBuf::from).collect();
+    let config = OrchestratorConfig::new(&project_root, watch_roots);
+    let orchestrator = BuildOrchestrator::new(config, graph, pipeline);
+
+    // Noop page renderer — see crate-level scope-down note above.
+    let render_pages: PageRenderer = Arc::new(|_pages: &[PageId]| Ok(Vec::new()));
+    let ctx = BuildContext {
+        dist_root: dist_root.clone(),
+        render_pages,
+        run_css: None,
+        run_islands: None,
+    };
+
+    // 6. Wire on_outcome: translate each non-noop tick to ReloadEvents
+    //    and broadcast them. Page cache population is intentionally
+    //    skipped here because the noop renderer never emits any
+    //    RenderedPage outputs (BuildOutcome only carries page IDs, not
+    //    HTML, so the cache-fill path lives next to the renderer
+    //    itself — that's a follow-up).
+    let tx_cb = tx.clone();
+    let on_outcome = move |outcome: &BuildOutcome| {
+        for ev in outcome_to_events(outcome) {
+            // `send` fails only if there are no live subscribers; that's
+            // fine — the next subscriber will pick up the next event.
+            let _ = tx_cb.send(ev);
+        }
+    };
+
+    // 7. Spawn the orchestrator's watcher loop.
+    let orch_handle = tokio::spawn(async move {
+        if let Err(err) = orchestrator.run(ctx, on_outcome).await {
+            // The orchestrator's loop logs its own per-tick errors and
+            // keeps going; reaching here means the watcher itself died.
+            // Surface that to stderr so the user sees something rather
+            // than a silent dead dev server.
+            eprintln!("zfb dev: build orchestrator stopped: {err:#}");
+        }
+    });
+
+    // 8. Build the serve options and announce readiness just before
+    //    handing control to axum. Plain println for now — Sub 7 may
+    //    upgrade this to colored output.
+    let opts = ServeOpts {
+        project_root,
+        dist_root,
+        public_root,
+        addr,
+        pages,
+        broadcast: tx,
+    };
+
+    println!("→ ready on http://{}:{}", args.host, args.port);
+
+    // 9. Run the server, racing against Ctrl+C. axum::serve has no
+    //    graceful-shutdown wiring in the zfb-server crate today, so on
+    //    Ctrl+C we abort the orchestrator task and let the runtime
+    //    drop the server when this future returns. Process exits 0.
+    tokio::select! {
+        res = serve(opts) => {
+            // serve() returned on its own — propagate any error.
+            orch_handle.abort();
+            res
+        }
+        _ = tokio::signal::ctrl_c() => {
+            orch_handle.abort();
+            Ok(())
+        }
+    }
+}
+
+/// Resolve `host:port` into a single [`SocketAddr`] via the OS resolver,
+/// preferring the first hit. Errors carry the raw input so the user can
+/// see what went wrong.
+fn resolve_addr(host: &str, port: u16) -> Result<SocketAddr> {
+    let pair = format!("{host}:{port}");
+    let mut iter = pair
+        .to_socket_addrs()
+        .with_context(|| format!("could not resolve bind address {pair}"))?;
+    iter.next()
+        .ok_or_else(|| anyhow::anyhow!("no socket addresses resolved for {pair}"))
 }

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -1,0 +1,13 @@
+//! `zfb dev` command — stub implementation.
+//!
+//! Contract for Wave 2 (cmd-dev agent):
+//!   pub async fn run(args: &crate::cli::DevArgs) -> anyhow::Result<()>
+//!
+//! `args.port` is the bind port (default 3000), `args.host` is the bind
+//! interface (default "localhost").
+
+use crate::cli::DevArgs;
+
+pub async fn run(_args: &DevArgs) -> anyhow::Result<()> {
+    anyhow::bail!("zfb dev: not yet implemented")
+}

--- a/crates/zfb/src/commands/mod.rs
+++ b/crates/zfb/src/commands/mod.rs
@@ -1,0 +1,11 @@
+//! Command module declarations.
+//!
+//! Each submodule exposes an `async fn run(args: &crate::cli::FooArgs) ->
+//! anyhow::Result<()>` entrypoint that `main.rs` dispatches to. Wave 1 lands
+//! stub implementations that return `anyhow::bail!`; Wave 2 fills in the
+//! actual behavior.
+
+pub mod build;
+pub mod dev;
+pub mod new;
+pub mod preview;

--- a/crates/zfb/src/commands/new.rs
+++ b/crates/zfb/src/commands/new.rs
@@ -1,13 +1,135 @@
-//! `zfb new` command — stub implementation.
+//! `zfb new` command — scaffold a new project from an embedded template.
 //!
-//! Contract for Wave 2 (scaffold-new agent):
-//!   pub async fn run(args: &crate::cli::NewArgs) -> anyhow::Result<()>
-//!
-//! `args.name` is the destination directory, `args.template` is the template
-//! identifier (defaulting to `"default"`).
+//! The contents of `crates/zfb/templates/` are baked into the binary at compile
+//! time via [`include_dir`]. At runtime we walk the requested template subtree
+//! (defaulting to `default`) and write each file into the destination directory.
+//! After the files are in place we attempt to run `pnpm install`; if pnpm is
+//! missing we print a friendly notice and continue successfully so the user can
+//! run install themselves later.
+
+use std::io::ErrorKind;
+use std::path::Path;
+
+use include_dir::{include_dir, Dir, DirEntry};
+use std::fs;
+use tokio::process::Command;
 
 use crate::cli::NewArgs;
 
-pub async fn run(_args: &NewArgs) -> anyhow::Result<()> {
-    anyhow::bail!("zfb new: not yet implemented")
+/// Compile-time embedding of `crates/zfb/templates/`.
+///
+/// Each top-level subdirectory is a template selectable via `--template`.
+static TEMPLATES: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/templates");
+
+pub async fn run(args: &NewArgs) -> anyhow::Result<()> {
+    let template = TEMPLATES.get_dir(args.template.as_str()).ok_or_else(|| {
+        let available = available_templates();
+        anyhow::anyhow!(
+            "unknown template '{}'. Available templates: {}",
+            args.template,
+            if available.is_empty() {
+                "(none)".to_string()
+            } else {
+                available.join(", ")
+            }
+        )
+    })?;
+
+    let dest = Path::new(&args.name);
+    if dest.exists() && !is_empty_dir(dest)? {
+        anyhow::bail!(
+            "destination '{}' already exists and is not empty",
+            args.name
+        );
+    }
+
+    fs::create_dir_all(dest)?;
+
+    // The embedded paths are prefixed with the template name (e.g.
+    // `default/pages/index.tsx`). Strip that prefix so files land directly
+    // under the destination directory.
+    let prefix = Path::new(&args.template);
+    write_dir(template, dest, prefix)?;
+
+    match try_pnpm_install(dest).await {
+        PnpmOutcome::Ran => {}
+        PnpmOutcome::Missing => {
+            println!(
+                "pnpm not found on PATH \u{2014} skipping install. Run pnpm install manually before zfb dev."
+            );
+        }
+        PnpmOutcome::Failed(msg) => {
+            println!("pnpm install failed: {msg}. Run pnpm install manually before zfb dev.");
+        }
+    }
+
+    println!(
+        "\u{2713} Created {} (template: {}). Next: cd {} && zfb dev",
+        args.name, args.template, args.name
+    );
+
+    Ok(())
+}
+
+fn available_templates() -> Vec<String> {
+    TEMPLATES
+        .dirs()
+        .filter_map(|d| d.path().file_name().map(|n| n.to_string_lossy().into_owned()))
+        .collect()
+}
+
+fn is_empty_dir(path: &Path) -> anyhow::Result<bool> {
+    let meta = fs::metadata(path)?;
+    if !meta.is_dir() {
+        // A non-directory existing entry should be treated as "non-empty".
+        return Ok(false);
+    }
+    Ok(fs::read_dir(path)?.next().is_none())
+}
+
+/// Recursively write every entry in `dir` to disk under `dest`, with `prefix`
+/// stripped from the embedded path.
+fn write_dir(dir: &Dir<'_>, dest: &Path, prefix: &Path) -> anyhow::Result<()> {
+    for entry in dir.entries() {
+        match entry {
+            DirEntry::Dir(sub) => {
+                let rel = sub.path().strip_prefix(prefix).unwrap_or(sub.path());
+                let target = dest.join(rel);
+                fs::create_dir_all(&target)?;
+                write_dir(sub, dest, prefix)?;
+            }
+            DirEntry::File(file) => {
+                let rel = file.path().strip_prefix(prefix).unwrap_or(file.path());
+                let target = dest.join(rel);
+                if let Some(parent) = target.parent() {
+                    fs::create_dir_all(parent)?;
+                }
+                fs::write(&target, file.contents())?;
+            }
+        }
+    }
+    Ok(())
+}
+
+enum PnpmOutcome {
+    Ran,
+    Missing,
+    Failed(String),
+}
+
+async fn try_pnpm_install(dest: &Path) -> PnpmOutcome {
+    let mut cmd = Command::new("pnpm");
+    cmd.arg("install").current_dir(dest);
+
+    let mut child = match cmd.spawn() {
+        Ok(child) => child,
+        Err(e) if e.kind() == ErrorKind::NotFound => return PnpmOutcome::Missing,
+        Err(e) => return PnpmOutcome::Failed(e.to_string()),
+    };
+
+    match child.wait().await {
+        Ok(status) if status.success() => PnpmOutcome::Ran,
+        Ok(status) => PnpmOutcome::Failed(format!("pnpm exited with status {status}")),
+        Err(e) => PnpmOutcome::Failed(e.to_string()),
+    }
 }

--- a/crates/zfb/src/commands/new.rs
+++ b/crates/zfb/src/commands/new.rs
@@ -1,0 +1,13 @@
+//! `zfb new` command — stub implementation.
+//!
+//! Contract for Wave 2 (scaffold-new agent):
+//!   pub async fn run(args: &crate::cli::NewArgs) -> anyhow::Result<()>
+//!
+//! `args.name` is the destination directory, `args.template` is the template
+//! identifier (defaulting to `"default"`).
+
+use crate::cli::NewArgs;
+
+pub async fn run(_args: &NewArgs) -> anyhow::Result<()> {
+    anyhow::bail!("zfb new: not yet implemented")
+}

--- a/crates/zfb/src/commands/new.rs
+++ b/crates/zfb/src/commands/new.rs
@@ -36,11 +36,20 @@ pub async fn run(args: &NewArgs) -> anyhow::Result<()> {
     })?;
 
     let dest = Path::new(&args.name);
-    if dest.exists() && !is_empty_dir(dest)? {
-        anyhow::bail!(
-            "destination '{}' already exists and is not empty",
-            args.name
-        );
+    if dest.exists() {
+        let meta = fs::metadata(dest)?;
+        if !meta.is_dir() {
+            anyhow::bail!(
+                "destination '{}' already exists and is not a directory",
+                args.name
+            );
+        }
+        if !is_empty_dir(dest)? {
+            anyhow::bail!(
+                "destination '{}' already exists and is not empty",
+                args.name
+            );
+        }
     }
 
     fs::create_dir_all(dest)?;

--- a/crates/zfb/src/commands/preview.rs
+++ b/crates/zfb/src/commands/preview.rs
@@ -1,0 +1,13 @@
+//! `zfb preview` command — stub implementation.
+//!
+//! Contract for Wave 2 (cmd-preview agent):
+//!   pub async fn run(args: &crate::cli::PreviewArgs) -> anyhow::Result<()>
+//!
+//! `args.port` is the bind port (default 4321), `args.outdir` is the directory
+//! to serve from (default "dist").
+
+use crate::cli::PreviewArgs;
+
+pub async fn run(_args: &PreviewArgs) -> anyhow::Result<()> {
+    anyhow::bail!("zfb preview: not yet implemented")
+}

--- a/crates/zfb/src/commands/preview.rs
+++ b/crates/zfb/src/commands/preview.rs
@@ -1,13 +1,50 @@
-//! `zfb preview` command — stub implementation.
+//! `zfb preview` command — static-file server for previously built artifacts.
 //!
-//! Contract for Wave 2 (cmd-preview agent):
-//!   pub async fn run(args: &crate::cli::PreviewArgs) -> anyhow::Result<()>
+//! Unlike `zfb dev`, this command does no rebuild, no live-reload, and injects
+//! no `/__zfb/*` routes. It is a clean static server: serve files from
+//! `args.outdir/` over HTTP at `args.port`, fall through to a plain 404 for
+//! missing paths, and exit cleanly on Ctrl+C.
 //!
-//! `args.port` is the bind port (default 4321), `args.outdir` is the directory
-//! to serve from (default "dist").
+//! Directory-style URLs (`/`, `/foo/bar/`) resolve to the matching
+//! `index.html` via [`ServeDir`]'s default `append_index_html_on_directories`
+//! behavior.
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+use anyhow::Context;
+use axum::Router;
+use tower_http::services::ServeDir;
 
 use crate::cli::PreviewArgs;
 
-pub async fn run(_args: &PreviewArgs) -> anyhow::Result<()> {
-    anyhow::bail!("zfb preview: not yet implemented")
+pub async fn run(args: &PreviewArgs) -> anyhow::Result<()> {
+    // Verify the output directory exists *before* binding the port so that
+    // missing-build errors don't leave a half-started server behind.
+    if !args.outdir.exists() {
+        anyhow::bail!(
+            "{} does not exist — run zfb build first",
+            args.outdir.display()
+        );
+    }
+
+    let serve_dir = ServeDir::new(&args.outdir);
+    let app = Router::new().fallback_service(serve_dir);
+
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), args.port);
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .with_context(|| format!("failed to bind preview server to {addr}"))?;
+
+    println!("→ preview ready on http://localhost:{}", args.port);
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(async {
+            // Ignore the result — we want to fall through to a clean exit
+            // whether ctrl_c succeeded or the signal handler errored.
+            let _ = tokio::signal::ctrl_c().await;
+        })
+        .await
+        .context("preview server failed")?;
+
+    Ok(())
 }

--- a/crates/zfb/src/config.rs
+++ b/crates/zfb/src/config.rs
@@ -1,3 +1,449 @@
 //! Project configuration loader.
 //!
-// Wave 2 / Sub 3 implements this.
+//! Loads `zfb.config.json` (and, in a follow-up, `zfb.config.ts`) from the
+//! project root and parses it into a strongly-typed [`Config`] struct.
+//!
+//! ## Bootstrap rule
+//!
+//! The JS runtime used to *parse* this config is fixed by the zfb binary
+//! itself — the config CANNOT choose its own runtime. The config CAN choose
+//! `framework: "preact" | "react"` (applied after the config is loaded by the
+//! framework adapter), `outDir`, `publicDir`, content + Tailwind options, and
+//! plugins. There is exactly one runtime; it is not user-overridable in v1.
+//!
+//! See issue #9 (Wave 2 / Sub 3).
+//!
+//! ## v1 scope
+//!
+//! This module ships the full public API surface required by cmd-dev,
+//! cmd-build, and cmd-preview:
+//!
+//! - The [`Config`] schema (with serde camelCase mapping for TS compat).
+//! - The [`load_from_dir`] async loader.
+//! - JSON loading (`zfb.config.json`).
+//! - Default config when no file is present.
+//! - Validation: unique collection names, no absolute / `..` paths.
+//!
+//! ### TS support: deferred
+//!
+//! Loading `zfb.config.ts` requires composing zfb-render's SWC pipeline with
+//! a JS runtime (rquickjs or similar) capable of evaluating an ES module and
+//! pulling the default export back into Rust as JSON. That work is non-
+//! trivial — module-based evaluation in rquickjs requires the `parallel`
+//! feature and Promise-driven plumbing — and is intentionally scoped out of
+//! this Wave 2 sub-task. Today, encountering a `zfb.config.ts` produces a
+//! clear "not yet supported" error pointing the user at the JSON form.
+//!
+//! TODO(zfb-init-cli/config-parser-ts): wire `zfb-render`'s `SwcPipeline` to
+//! strip TS, then evaluate the resulting ESM via rquickjs (or whichever
+//! runtime ADR-001 lands on) and `JSON.stringify` the default export to feed
+//! back into `serde_json::from_str`. The function signature here already
+//! accommodates the async I/O involved.
+
+use std::collections::HashSet;
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::{anyhow, bail, Context as _, Result};
+use serde::{Deserialize, Serialize};
+
+/// Top-level `zfb.config.{ts,json}` schema.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Config {
+    /// Output directory for built assets. Default: `dist`.
+    #[serde(default = "default_out_dir")]
+    pub out_dir: PathBuf,
+
+    /// Public/static directory copied verbatim. Default: `public`.
+    #[serde(default = "default_public_dir")]
+    pub public_dir: PathBuf,
+
+    /// Dev server bind host. Default: `localhost`.
+    #[serde(default = "default_host")]
+    pub host: String,
+
+    /// Dev server port. Default: `3000`.
+    #[serde(default = "default_port")]
+    pub port: u16,
+
+    /// JSX framework runtime. Default: `Preact`.
+    #[serde(default)]
+    pub framework: Framework,
+
+    /// Content collections.
+    #[serde(default)]
+    pub collections: Vec<CollectionDef>,
+
+    /// Tailwind-specific config; absent = default behavior.
+    #[serde(default)]
+    pub tailwind: Option<TailwindConfig>,
+
+    /// User-supplied plugins.
+    #[serde(default)]
+    pub plugins: Vec<PluginConfig>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            out_dir: default_out_dir(),
+            public_dir: default_public_dir(),
+            host: default_host(),
+            port: default_port(),
+            framework: Framework::default(),
+            collections: Vec::new(),
+            tailwind: None,
+            plugins: Vec::new(),
+        }
+    }
+}
+
+/// JSX runtime selection. `Preact` is the v1 default.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, Default, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Framework {
+    #[default]
+    Preact,
+    React,
+}
+
+/// One content collection (e.g. blog posts under `content/blog/`).
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct CollectionDef {
+    /// Identifier used at the call site (e.g. `"blog"`).
+    pub name: String,
+    /// Directory (relative to the project root) holding the entries.
+    pub path: PathBuf,
+    /// Optional schema. Reserved for v1.1 — accepted today but not enforced.
+    #[serde(default)]
+    pub schema: Option<serde_json::Value>,
+}
+
+/// Tailwind options. Empty by default (Tailwind enabled); users can flip
+/// `enabled: false` to opt out.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct TailwindConfig {
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+}
+
+impl Default for TailwindConfig {
+    fn default() -> Self {
+        Self { enabled: true }
+    }
+}
+
+/// One user plugin entry.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+pub struct PluginConfig {
+    pub name: String,
+    #[serde(default)]
+    pub options: serde_json::Value,
+}
+
+// --- defaults --------------------------------------------------------------
+
+fn default_out_dir() -> PathBuf {
+    PathBuf::from("dist")
+}
+
+fn default_public_dir() -> PathBuf {
+    PathBuf::from("public")
+}
+
+fn default_host() -> String {
+    "localhost".to_string()
+}
+
+fn default_port() -> u16 {
+    3000
+}
+
+fn default_true() -> bool {
+    true
+}
+
+// --- loader ----------------------------------------------------------------
+
+/// Load and validate a config from `dir`.
+///
+/// Resolution order:
+/// 1. `dir/zfb.config.ts` — currently returns a "not yet supported" error
+///    pointing the user at the JSON form (see module docs).
+/// 2. `dir/zfb.config.json` — read + parse via `serde_json`.
+/// 3. Neither present — return [`Config::default`] (no error).
+///
+/// All produced configs are passed through [`validate`] before they are
+/// returned so callers don't have to think about it.
+pub async fn load_from_dir(dir: &Path) -> Result<Config> {
+    let ts_path = dir.join("zfb.config.ts");
+    let json_path = dir.join("zfb.config.json");
+
+    if ts_path.exists() {
+        // See module-level TODO. This is intentionally a hard error so the
+        // user is not silently flipped to defaults.
+        bail!(
+            "{}: zfb.config.ts loading is not yet supported in this build. \
+             Please use zfb.config.json instead, or omit the config file to \
+             use defaults. (Tracked in issue #9, Wave 2 / Sub 3 polish.)",
+            ts_path.display()
+        );
+    }
+
+    if json_path.exists() {
+        let text = tokio::fs::read_to_string(&json_path)
+            .await
+            .with_context(|| format!("reading {}", json_path.display()))?;
+        let cfg: Config = serde_json::from_str(&text).map_err(|e| {
+            anyhow!(
+                "{}: invalid config JSON at line {}, column {}: {}",
+                json_path.display(),
+                e.line(),
+                e.column(),
+                e
+            )
+        })?;
+        validate(&cfg, dir).with_context(|| format!("validating {}", json_path.display()))?;
+        return Ok(cfg);
+    }
+
+    // No file present → defaults.
+    let cfg = Config::default();
+    // Defaults are always valid, but we still run the check so future
+    // additions can't accidentally break this invariant.
+    validate(&cfg, dir).expect("Config::default() must validate cleanly");
+    Ok(cfg)
+}
+
+/// Validate a loaded [`Config`] against the project root `dir`.
+///
+/// Errors:
+/// - duplicate `collections[].name`.
+/// - `collections[].path` that is absolute or escapes `dir` via `..`.
+fn validate(cfg: &Config, dir: &Path) -> Result<()> {
+    let mut seen: HashSet<&str> = HashSet::new();
+    for c in &cfg.collections {
+        if !seen.insert(c.name.as_str()) {
+            bail!("duplicate collection name {:?}", c.name);
+        }
+        ensure_path_in_root(&c.path, dir)
+            .with_context(|| format!("collection {:?}", c.name))?;
+    }
+    Ok(())
+}
+
+/// Ensure `path` is relative and stays under `dir` (no `..` escapes, no
+/// absolute paths). The path is checked syntactically — we do not require it
+/// to exist, since collections may be created after the config.
+fn ensure_path_in_root(path: &Path, dir: &Path) -> Result<()> {
+    if path.is_absolute() {
+        bail!(
+            "path {:?} must be relative to the project root ({})",
+            path,
+            dir.display()
+        );
+    }
+    let mut depth: i32 = 0;
+    for comp in path.components() {
+        match comp {
+            Component::ParentDir => {
+                depth -= 1;
+                if depth < 0 {
+                    bail!(
+                        "path {:?} escapes the project root via `..`",
+                        path
+                    );
+                }
+            }
+            Component::Normal(_) | Component::CurDir => {
+                if matches!(comp, Component::Normal(_)) {
+                    depth += 1;
+                }
+            }
+            // Prefix / RootDir would have been caught by `is_absolute` above,
+            // but be defensive.
+            Component::Prefix(_) | Component::RootDir => {
+                bail!(
+                    "path {:?} must be relative to the project root ({})",
+                    path,
+                    dir.display()
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+// --- tests -----------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn default_config_has_sensible_values() {
+        let cfg = Config::default();
+        assert_eq!(cfg.out_dir, PathBuf::from("dist"));
+        assert_eq!(cfg.public_dir, PathBuf::from("public"));
+        assert_eq!(cfg.host, "localhost");
+        assert_eq!(cfg.port, 3000);
+        assert_eq!(cfg.framework, Framework::Preact);
+        assert!(cfg.collections.is_empty());
+        assert!(cfg.tailwind.is_none());
+        assert!(cfg.plugins.is_empty());
+    }
+
+    #[tokio::test]
+    async fn empty_dir_returns_default_config() {
+        let tmp = TempDir::new().unwrap();
+        let cfg = load_from_dir(tmp.path()).await.expect("load ok");
+        assert_eq!(cfg, Config::default());
+    }
+
+    #[tokio::test]
+    async fn loads_from_json_fixture() {
+        let tmp = TempDir::new().unwrap();
+        let json = r#"{
+            "outDir": "build",
+            "publicDir": "static",
+            "host": "0.0.0.0",
+            "port": 4000,
+            "framework": "react",
+            "collections": [
+                { "name": "blog", "path": "content/blog" },
+                { "name": "docs", "path": "content/docs" }
+            ],
+            "tailwind": { "enabled": false },
+            "plugins": [
+                { "name": "my-plugin", "options": { "level": 2 } }
+            ]
+        }"#;
+        tokio::fs::write(tmp.path().join("zfb.config.json"), json)
+            .await
+            .unwrap();
+        let cfg = load_from_dir(tmp.path()).await.expect("load ok");
+        assert_eq!(cfg.out_dir, PathBuf::from("build"));
+        assert_eq!(cfg.public_dir, PathBuf::from("static"));
+        assert_eq!(cfg.host, "0.0.0.0");
+        assert_eq!(cfg.port, 4000);
+        assert_eq!(cfg.framework, Framework::React);
+        assert_eq!(cfg.collections.len(), 2);
+        assert_eq!(cfg.collections[0].name, "blog");
+        assert_eq!(cfg.collections[1].path, PathBuf::from("content/docs"));
+        assert_eq!(
+            cfg.tailwind,
+            Some(TailwindConfig { enabled: false })
+        );
+        assert_eq!(cfg.plugins.len(), 1);
+        assert_eq!(cfg.plugins[0].name, "my-plugin");
+    }
+
+    #[tokio::test]
+    async fn loads_minimal_json_with_defaults() {
+        // Empty object should round-trip to all defaults.
+        let tmp = TempDir::new().unwrap();
+        tokio::fs::write(tmp.path().join("zfb.config.json"), "{}")
+            .await
+            .unwrap();
+        let cfg = load_from_dir(tmp.path()).await.expect("load ok");
+        assert_eq!(cfg, Config::default());
+    }
+
+    #[tokio::test]
+    async fn invalid_json_reports_position() {
+        let tmp = TempDir::new().unwrap();
+        tokio::fs::write(
+            tmp.path().join("zfb.config.json"),
+            "{ \"port\": \"not-a-number\" }",
+        )
+        .await
+        .unwrap();
+        let err = load_from_dir(tmp.path())
+            .await
+            .expect_err("should reject");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("zfb.config.json"), "msg: {msg}");
+        assert!(msg.contains("line"), "msg: {msg}");
+    }
+
+    #[tokio::test]
+    async fn rejects_duplicate_collection_names() {
+        let tmp = TempDir::new().unwrap();
+        let json = r#"{
+            "collections": [
+                { "name": "blog", "path": "content/blog" },
+                { "name": "blog", "path": "content/blog2" }
+            ]
+        }"#;
+        tokio::fs::write(tmp.path().join("zfb.config.json"), json)
+            .await
+            .unwrap();
+        let err = load_from_dir(tmp.path())
+            .await
+            .expect_err("should reject duplicates");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("duplicate collection name"),
+            "msg: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_absolute_collection_path() {
+        let tmp = TempDir::new().unwrap();
+        let json = r#"{
+            "collections": [
+                { "name": "blog", "path": "/etc/passwd" }
+            ]
+        }"#;
+        tokio::fs::write(tmp.path().join("zfb.config.json"), json)
+            .await
+            .unwrap();
+        let err = load_from_dir(tmp.path())
+            .await
+            .expect_err("should reject absolute path");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("relative"), "msg: {msg}");
+    }
+
+    #[tokio::test]
+    async fn rejects_parent_dir_escape() {
+        let tmp = TempDir::new().unwrap();
+        let json = r#"{
+            "collections": [
+                { "name": "blog", "path": "../outside" }
+            ]
+        }"#;
+        tokio::fs::write(tmp.path().join("zfb.config.json"), json)
+            .await
+            .unwrap();
+        let err = load_from_dir(tmp.path())
+            .await
+            .expect_err("should reject .. escape");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("escapes"), "msg: {msg}");
+    }
+
+    #[tokio::test]
+    async fn ts_config_returns_clear_unsupported_error() {
+        let tmp = TempDir::new().unwrap();
+        tokio::fs::write(
+            tmp.path().join("zfb.config.ts"),
+            "export default { port: 3000 };\n",
+        )
+        .await
+        .unwrap();
+        let err = load_from_dir(tmp.path())
+            .await
+            .expect_err("ts config should be a clear error today");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("not yet supported"),
+            "msg should explain the situation: {msg}"
+        );
+        assert!(msg.contains("zfb.config.json"), "msg should point at JSON: {msg}");
+    }
+}

--- a/crates/zfb/src/config.rs
+++ b/crates/zfb/src/config.rs
@@ -235,8 +235,14 @@ fn validate(cfg: &Config, dir: &Path) -> Result<()> {
 }
 
 /// Ensure `path` is relative and stays under `dir` (no `..` escapes, no
-/// absolute paths). The path is checked syntactically — we do not require it
-/// to exist, since collections may be created after the config.
+/// absolute paths). The path is checked **syntactically** — we do not require
+/// it to exist, since collections may be created after the config.
+///
+/// Limitation: symlinks are not resolved here. If the project allows
+/// symlinks in content dirs and that's a concern, callers should
+/// `canonicalize()` the resolved path at use-site before reading. zfb's v1
+/// trust model treats project files as user-owned, so this matches the
+/// surrounding crates.
 fn ensure_path_in_root(path: &Path, dir: &Path) -> Result<()> {
     if path.is_absolute() {
         bail!(
@@ -425,6 +431,24 @@ mod tests {
             .expect_err("should reject .. escape");
         let msg = format!("{err:#}");
         assert!(msg.contains("escapes"), "msg: {msg}");
+    }
+
+    #[tokio::test]
+    async fn allows_internal_dotdot_that_does_not_escape() {
+        // `a/../b` resolves to `b` — within the project root, so it should
+        // be accepted. (Same shape as `./content/blog`.)
+        let tmp = TempDir::new().unwrap();
+        let json = r#"{
+            "collections": [
+                { "name": "blog", "path": "a/../b" },
+                { "name": "docs", "path": "." }
+            ]
+        }"#;
+        tokio::fs::write(tmp.path().join("zfb.config.json"), json)
+            .await
+            .unwrap();
+        let cfg = load_from_dir(tmp.path()).await.expect("should accept");
+        assert_eq!(cfg.collections.len(), 2);
     }
 
     #[tokio::test]

--- a/crates/zfb/src/config.rs
+++ b/crates/zfb/src/config.rs
@@ -1,0 +1,3 @@
+//! Project configuration loader.
+//!
+// Wave 2 / Sub 3 implements this.

--- a/crates/zfb/src/lib.rs
+++ b/crates/zfb/src/lib.rs
@@ -1,0 +1,13 @@
+//! zfb — zudo-front-builder library crate.
+//!
+//! This crate exposes the CLI parser, command dispatchers, configuration loader,
+//! and structured output helpers used by the `zfb` binary.
+//!
+//! Wave 1 (this scaffolding) lands the module skeleton, clap argument structs,
+//! and stub command handlers. Wave 2 fills in the actual command logic, the
+//! config loader (`config`), and the output helpers (`output`).
+
+pub mod cli;
+pub mod commands;
+pub mod config;
+pub mod output;

--- a/crates/zfb/src/main.rs
+++ b/crates/zfb/src/main.rs
@@ -1,3 +1,19 @@
-fn main() {
-    println!("zfb — zudo-front-builder (placeholder)");
+use clap::Parser;
+
+use zfb::cli::{Cli, Command};
+use zfb::commands;
+
+#[tokio::main]
+async fn main() {
+    let cli = Cli::parse();
+    let result = match &cli.command {
+        Command::New(args) => commands::new::run(args).await,
+        Command::Dev(args) => commands::dev::run(args).await,
+        Command::Build(args) => commands::build::run(args).await,
+        Command::Preview(args) => commands::preview::run(args).await,
+    };
+    if let Err(e) = result {
+        eprintln!("error: {e:#}");
+        std::process::exit(1);
+    }
 }

--- a/crates/zfb/src/output.rs
+++ b/crates/zfb/src/output.rs
@@ -1,0 +1,3 @@
+//! Structured CLI output helpers (logging, progress, formatting).
+//!
+// Wave 2 / Sub 7 implements this.

--- a/crates/zfb/src/output.rs
+++ b/crates/zfb/src/output.rs
@@ -1,3 +1,338 @@
-//! Structured CLI output helpers (logging, progress, formatting).
+//! Structured CLI output helpers (logging, progress, error formatting).
 //!
-// Wave 2 / Sub 7 implements this.
+//! This module is a small toolkit used by the `zfb` command implementations
+//! (`dev`, `build`, `preview`, `new`). It centralises:
+//!
+//! * Coloured status logging (`info`, `success`, `warn`, `error`, `ready`).
+//! * A thin progress-bar wrapper around [`indicatif::ProgressBar`]
+//!   ([`BuildProgress`]).
+//! * User-friendly multi-line error rendering for `anyhow::Error`
+//!   ([`format_error`]).
+//!
+//! All colour output respects the `NO_COLOR` convention. Internally, the
+//! formatting helpers delegate to [`owo_colors`] with the `supports-colors`
+//! feature enabled, so when the relevant stream is not a TTY, or `NO_COLOR`
+//! is set, no ANSI escape codes are emitted.
+//!
+//! The helpers print to `stdout` for informational output (`info`,
+//! `success`, `ready`) and to `stderr` for `warn` / `error`, matching
+//! conventional Unix CLI behaviour.
+
+use std::time::Duration;
+
+use indicatif::{ProgressBar, ProgressStyle};
+use owo_colors::{OwoColorize, Stream};
+
+// ---------------------------------------------------------------------------
+// Status logging
+// ---------------------------------------------------------------------------
+
+/// Format an informational status line ("info <msg>") with a dim cyan label.
+///
+/// Pure formatter used internally by [`info`] and exercised by the unit tests.
+fn fmt_info(msg: &str) -> String {
+    let label = "info".if_supports_color(Stream::Stdout, |t| t.cyan().to_string());
+    format!("{} {}", label, msg)
+}
+
+/// Format a success status line with a green checkmark prefix.
+fn fmt_success(msg: &str) -> String {
+    let mark = "✓".if_supports_color(Stream::Stdout, |t| t.green().to_string());
+    format!("{} {}", mark, msg)
+}
+
+/// Format a warning status line with a yellow `⚠` prefix.
+fn fmt_warn(msg: &str) -> String {
+    let mark = "⚠".if_supports_color(Stream::Stderr, |t| t.yellow().to_string());
+    format!("{} {}", mark, msg)
+}
+
+/// Format an error status line with a red `✗` prefix.
+fn fmt_error(msg: &str) -> String {
+    let mark = "✗".if_supports_color(Stream::Stderr, |t| t.red().to_string());
+    format!("{} {}", mark, msg)
+}
+
+/// Format a "ready" line that highlights a server URL.
+fn fmt_ready(url: &str) -> String {
+    let arrow = "→".if_supports_color(Stream::Stdout, |t| t.green().to_string());
+    let url_styled = url.if_supports_color(Stream::Stdout, |t| t.bold().to_string());
+    format!("{} ready on {}", arrow, url_styled)
+}
+
+/// Print an informational status message to `stdout`.
+///
+/// Output: `info <msg>` with the `info` label rendered in cyan when colours
+/// are supported. Empty messages are rendered as just the prefix.
+pub fn info(msg: impl AsRef<str>) {
+    println!("{}", fmt_info(msg.as_ref()));
+}
+
+/// Print a success message to `stdout`, prefixed with a green `✓`.
+pub fn success(msg: impl AsRef<str>) {
+    println!("{}", fmt_success(msg.as_ref()));
+}
+
+/// Print a warning message to `stderr`, prefixed with a yellow `⚠`.
+pub fn warn(msg: impl AsRef<str>) {
+    eprintln!("{}", fmt_warn(msg.as_ref()));
+}
+
+/// Print an error message to `stderr`, prefixed with a red `✗`.
+///
+/// For full multi-line error chains, prefer [`format_error`] and pipe the
+/// result through this helper or `eprintln!`.
+pub fn error(msg: impl AsRef<str>) {
+    eprintln!("{}", fmt_error(msg.as_ref()));
+}
+
+/// Print a "ready" notification announcing a server URL, e.g. for `zfb dev`.
+///
+/// Output style: `→ ready on <url>` with the arrow in green and the URL in
+/// bold when colours are supported.
+pub fn ready(url: &str) {
+    println!("{}", fmt_ready(url));
+}
+
+// ---------------------------------------------------------------------------
+// Progress
+// ---------------------------------------------------------------------------
+
+/// Progress-bar wrapper used by long-running multi-step commands such as
+/// `zfb build`.
+///
+/// Wraps [`indicatif::ProgressBar`] with a project-standard template and
+/// emits a green summary line on completion.
+pub struct BuildProgress {
+    bar: ProgressBar,
+}
+
+impl BuildProgress {
+    /// Create a new progress bar for `total` units of work.
+    ///
+    /// The bar uses a stable template (`[bar] pos/len msg`) so that callers
+    /// just need to call [`BuildProgress::inc`] for each completed unit.
+    pub fn new(total: u64) -> Self {
+        let bar = ProgressBar::new(total);
+        // The template is intentionally kept simple; if it fails to parse
+        // (which shouldn't happen given the literal string), we fall back
+        // to indicatif's default style.
+        if let Ok(style) = ProgressStyle::with_template(
+            "{spinner:.cyan} [{bar:30.green/dim}] {pos}/{len} {msg}",
+        ) {
+            bar.set_style(style.progress_chars("=> "));
+        }
+        Self { bar }
+    }
+
+    /// Advance the bar by one step and update the trailing message.
+    pub fn inc(&self, label: &str) {
+        self.bar.set_message(label.to_string());
+        self.bar.inc(1);
+    }
+
+    /// Finish the bar and print a one-line summary of the form
+    /// `✓ N pages built in X.XXs`.
+    pub fn finish_and_summary(self, count: u64, elapsed: Duration) {
+        self.bar.finish_and_clear();
+        println!("{}", fmt_summary(count, elapsed));
+    }
+}
+
+/// Render the build summary line. Extracted so it can be unit-tested without
+/// touching `stdout`.
+fn fmt_summary(count: u64, elapsed: Duration) -> String {
+    let mark = "✓".if_supports_color(Stream::Stdout, |t| t.green().to_string());
+    format!("{} {} pages built in {:.2}s", mark, count, elapsed.as_secs_f64())
+}
+
+// ---------------------------------------------------------------------------
+// Error formatting
+// ---------------------------------------------------------------------------
+
+/// Render an [`anyhow::Error`] as a multi-line, user-friendly block.
+///
+/// Output shape:
+///
+/// ```text
+/// error: <top-level message>
+///   caused by: <next>
+///   caused by: <next>
+///   at <file>:<line>          // only when a location hint is found
+/// ```
+///
+/// The location hint is a best-effort heuristic: any chain entry whose text
+/// contains a `path:line` token (e.g. `config.toml:12`) contributes the
+/// first such token as a final `at` line. This mirrors the Epic 6 quality
+/// bar of "tell users where to look" without imposing a specific error type.
+pub fn format_error(err: &anyhow::Error) -> String {
+    let mut chain = err.chain();
+    let head = match chain.next() {
+        Some(e) => e,
+        // anyhow guarantees at least one error in the chain, but be defensive.
+        None => return String::from("error: <empty error chain>\n"),
+    };
+    let mut out = format!("error: {}\n", head);
+    for cause in chain {
+        out.push_str(&format!("  caused by: {}\n", cause));
+    }
+    if let Some(hint) = location_hint(err) {
+        out.push_str(&format!("  at {}\n", hint));
+    }
+    out
+}
+
+/// Walk the error chain searching for the first `path:line` looking token.
+///
+/// Heuristic: split each chain entry's `Display` form on whitespace and
+/// surrounding punctuation, then accept a token if it contains a `:` whose
+/// right-hand side parses as a positive integer and whose left-hand side is
+/// non-empty (intended to look like a file path).
+fn location_hint(err: &anyhow::Error) -> Option<String> {
+    for cause in err.chain() {
+        let text = cause.to_string();
+        for raw in text.split(|c: char| c.is_whitespace() || matches!(c, '(' | ')' | ',' | ';')) {
+            let token = raw.trim_matches(|c: char| matches!(c, '"' | '\'' | '`' | '.'));
+            if let Some((path, line)) = token.rsplit_once(':') {
+                if path.is_empty() {
+                    continue;
+                }
+                if line.parse::<u32>().is_ok() {
+                    return Some(format!("{}:{}", path, line));
+                }
+            }
+        }
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::{anyhow, Context};
+
+    /// Strip ANSI escape sequences (CSI ... m) from a string for assertions
+    /// that should be colour-agnostic.
+    fn strip_ansi(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        let mut chars = s.chars().peekable();
+        while let Some(c) = chars.next() {
+            if c == '\u{1b}' && chars.peek() == Some(&'[') {
+                chars.next(); // consume '['
+                for inner in chars.by_ref() {
+                    if inner == 'm' {
+                        break;
+                    }
+                }
+            } else {
+                out.push(c);
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn format_error_renders_caused_by_chain() {
+        let err: anyhow::Error = Err::<(), _>(anyhow!("disk read failure"))
+            .context("loading frontmatter")
+            .context("rendering page")
+            .unwrap_err();
+
+        let rendered = format_error(&err);
+        assert!(
+            rendered.starts_with("error: rendering page\n"),
+            "got: {rendered}"
+        );
+        assert!(
+            rendered.contains("  caused by: loading frontmatter\n"),
+            "got: {rendered}"
+        );
+        assert!(
+            rendered.contains("  caused by: disk read failure\n"),
+            "got: {rendered}"
+        );
+    }
+
+    #[test]
+    fn format_error_surfaces_path_line_hint() {
+        let err: anyhow::Error =
+            Err::<(), _>(anyhow!("invalid value at config.toml:12"))
+                .context("parsing zfb.toml")
+                .unwrap_err();
+
+        let rendered = format_error(&err);
+        assert!(
+            rendered.contains("  at config.toml:12\n"),
+            "expected location hint in:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn format_error_omits_hint_when_no_location() {
+        let err: anyhow::Error = Err::<(), _>(anyhow!("plain failure"))
+            .context("higher-level context")
+            .unwrap_err();
+
+        let rendered = format_error(&err);
+        assert!(
+            !rendered.contains("  at "),
+            "did not expect a location line in:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn status_helpers_do_not_panic_on_empty_strings() {
+        // The public helpers print to stdout/stderr; we only need to confirm
+        // they execute without panicking on empty input.
+        info("");
+        success("");
+        warn("");
+        error("");
+        ready("");
+    }
+
+    #[test]
+    fn build_progress_zero_total_summary_does_not_panic() {
+        let p = BuildProgress::new(0);
+        p.finish_and_summary(0, Duration::ZERO);
+    }
+
+    #[test]
+    fn fmt_summary_renders_expected_text() {
+        // Colour codes vary depending on environment, so strip them before
+        // asserting on the underlying text shape.
+        let line = strip_ansi(&fmt_summary(0, Duration::ZERO));
+        assert_eq!(line, "✓ 0 pages built in 0.00s");
+
+        let line = strip_ansi(&fmt_summary(7, Duration::from_millis(1234)));
+        assert_eq!(line, "✓ 7 pages built in 1.23s");
+    }
+
+    #[test]
+    fn color_override_toggle_controls_ansi_output() {
+        // owo-colors exposes a process-wide override. We toggle it explicitly
+        // to verify the formatting helpers honour it (which is the same code
+        // path consulted when NO_COLOR is set in the environment).
+        owo_colors::set_override(true);
+        let coloured = fmt_info("hello");
+        assert!(
+            coloured.contains('\u{1b}'),
+            "expected ANSI escape when colour override is enabled, got: {coloured:?}"
+        );
+
+        owo_colors::set_override(false);
+        let plain = fmt_info("hello");
+        assert!(
+            !plain.contains('\u{1b}'),
+            "expected no ANSI escape when colour override is disabled, got: {plain:?}"
+        );
+        assert_eq!(plain, "info hello");
+
+        // Restore default behaviour for any subsequent tests.
+        owo_colors::unset_override();
+    }
+}

--- a/crates/zfb/src/output.rs
+++ b/crates/zfb/src/output.rs
@@ -185,25 +185,65 @@ pub fn format_error(err: &anyhow::Error) -> String {
 /// Walk the error chain searching for the first `path:line` looking token.
 ///
 /// Heuristic: split each chain entry's `Display` form on whitespace and
-/// surrounding punctuation, then accept a token if it contains a `:` whose
-/// right-hand side parses as a positive integer and whose left-hand side is
-/// non-empty (intended to look like a file path).
+/// surrounding punctuation, then accept a token only when:
+///
+/// 1. It contains exactly one trailing `:<digits>` segment.
+/// 2. The left-hand side looks like a file path — i.e. it contains a `/`
+///    or `\` separator, **or** it ends with a file-extension-like component
+///    (a `.` followed by 1–8 ASCII alphanumeric characters with at least
+///    one letter, e.g. `.toml`, `.rs`).
+/// 3. The token does **not** contain `://` (filters out URLs such as
+///    `http://localhost:8080`).
+///
+/// This intentionally rejects host-port pairs (`localhost:8080`),
+/// IP-port pairs (`127.0.0.1:8080`), and IPv6 forms (`[::1]:8080`) so that
+/// run-time error messages mentioning addresses are not mis-rendered as
+/// source locations.
 fn location_hint(err: &anyhow::Error) -> Option<String> {
     for cause in err.chain() {
         let text = cause.to_string();
         for raw in text.split(|c: char| c.is_whitespace() || matches!(c, '(' | ')' | ',' | ';')) {
             let token = raw.trim_matches(|c: char| matches!(c, '"' | '\'' | '`' | '.'));
-            if let Some((path, line)) = token.rsplit_once(':') {
-                if path.is_empty() {
-                    continue;
-                }
-                if line.parse::<u32>().is_ok() {
-                    return Some(format!("{}:{}", path, line));
-                }
+            if token.contains("://") {
+                continue;
             }
+            let Some((path, line)) = token.rsplit_once(':') else {
+                continue;
+            };
+            if path.is_empty() {
+                continue;
+            }
+            if line.parse::<u32>().is_err() {
+                continue;
+            }
+            if !looks_like_file_path(path) {
+                continue;
+            }
+            return Some(format!("{}:{}", path, line));
         }
     }
     None
+}
+
+/// Decide whether `path` plausibly refers to a file rather than a network
+/// host or numeric address. See [`location_hint`] for the full heuristic.
+fn looks_like_file_path(path: &str) -> bool {
+    if path.contains('/') || path.contains('\\') {
+        return true;
+    }
+    // Last `.`-separated segment must look like a file extension:
+    // 1–8 ASCII alphanumerics with at least one letter.
+    let Some(ext) = path.rsplit('.').next() else {
+        return false;
+    };
+    if ext.is_empty() || ext == path {
+        // No `.` in the token — not a filename-with-extension.
+        return false;
+    }
+    if ext.len() > 8 {
+        return false;
+    }
+    ext.chars().all(|c| c.is_ascii_alphanumeric()) && ext.chars().any(|c| c.is_ascii_alphabetic())
 }
 
 // ---------------------------------------------------------------------------
@@ -269,6 +309,41 @@ mod tests {
             rendered.contains("  at config.toml:12\n"),
             "expected location hint in:\n{rendered}"
         );
+    }
+
+    #[test]
+    fn format_error_does_not_treat_urls_as_locations() {
+        let err: anyhow::Error =
+            Err::<(), _>(anyhow!("connection refused: http://localhost:8080"))
+                .context("starting dev server")
+                .unwrap_err();
+
+        let rendered = format_error(&err);
+        assert!(
+            !rendered.contains("  at "),
+            "URL should not be surfaced as a location:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn format_error_does_not_treat_host_port_pairs_as_locations() {
+        // localhost:8080 (no path separator, no extension), 127.0.0.1:8080
+        // (numeric "extension"), and [::1]:8080 (IPv6 + port) must all be
+        // ignored so we do not invent a phantom file location.
+        for snippet in [
+            "bind failed on localhost:8080",
+            "address 127.0.0.1:8080 already in use",
+            "ipv6 [::1]:8080 unreachable",
+        ] {
+            let err: anyhow::Error = Err::<(), _>(anyhow!("{snippet}"))
+                .context("dev server")
+                .unwrap_err();
+            let rendered = format_error(&err);
+            assert!(
+                !rendered.contains("  at "),
+                "snippet {snippet:?} produced a location line:\n{rendered}"
+            );
+        }
     }
 
     #[test]

--- a/crates/zfb/templates/default/.gitignore
+++ b/crates/zfb/templates/default/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.DS_Store

--- a/crates/zfb/templates/default/components/counter.tsx
+++ b/crates/zfb/templates/default/components/counter.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useState } from "preact/hooks";
+
+type Props = {
+  initial?: number;
+};
+
+export default function Counter({ initial = 0 }: Props) {
+  const [count, setCount] = useState(initial);
+
+  return (
+    <button
+      type="button"
+      onClick={() => setCount((c) => c + 1)}
+      class="counter"
+    >
+      Clicked {count} {count === 1 ? "time" : "times"}
+    </button>
+  );
+}

--- a/crates/zfb/templates/default/content/blog/welcome.md
+++ b/crates/zfb/templates/default/content/blog/welcome.md
@@ -1,0 +1,19 @@
+---
+title: Welcome to your new zfb site
+date: 2026-04-26
+description: A first post to confirm the blog content collection is wired up.
+---
+
+# Welcome
+
+This is the first post in your new **zfb** site. The content lives in
+`content/blog/welcome.md` and is rendered by the dynamic route at
+`pages/blog/[slug].tsx`.
+
+## What to try next
+
+- Edit this file and watch the dev server reload.
+- Add another `.md` file in `content/blog/` to create a new post.
+- Tweak the layout in `layouts/default.tsx`.
+
+Happy building!

--- a/crates/zfb/templates/default/layouts/default.tsx
+++ b/crates/zfb/templates/default/layouts/default.tsx
@@ -1,0 +1,24 @@
+import type { ComponentChildren } from "preact";
+
+import "../styles/global.css";
+
+type Props = {
+  title?: string;
+  children: ComponentChildren;
+};
+
+export default function DefaultLayout({
+  title = "zfb site",
+  children,
+}: Props) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>{title}</title>
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/crates/zfb/templates/default/package.json
+++ b/crates/zfb/templates/default/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "my-site",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "zfb dev",
+    "build": "zfb build",
+    "preview": "zfb preview"
+  },
+  "dependencies": {
+    "preact": "^10.22.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/crates/zfb/templates/default/pages/blog/[slug].tsx
+++ b/crates/zfb/templates/default/pages/blog/[slug].tsx
@@ -1,0 +1,45 @@
+import DefaultLayout from "../../layouts/default";
+
+type BlogEntry = {
+  slug: string;
+  frontmatter: {
+    title: string;
+    date: string;
+    description?: string;
+  };
+  body: string;
+};
+
+type Props = {
+  entry: BlogEntry;
+};
+
+export async function getStaticPaths() {
+  // The zfb runtime resolves this against the `blog` collection defined in
+  // `zfb.config.ts`. Each entry becomes a static route at /blog/<slug>.
+  const { getCollection } = await import("zfb/content");
+  const entries = await getCollection("blog");
+  return entries.map((entry: BlogEntry) => ({
+    params: { slug: entry.slug },
+    props: { entry },
+  }));
+}
+
+export default function BlogPostPage({ entry }: Props) {
+  return (
+    <DefaultLayout title={entry.frontmatter.title}>
+      <article>
+        <h1>{entry.frontmatter.title}</h1>
+        <p>
+          <time dateTime={entry.frontmatter.date}>
+            {entry.frontmatter.date}
+          </time>
+        </p>
+        <div dangerouslySetInnerHTML={{ __html: entry.body }} />
+        <p>
+          <a href="/">← Back home</a>
+        </p>
+      </article>
+    </DefaultLayout>
+  );
+}

--- a/crates/zfb/templates/default/pages/index.tsx
+++ b/crates/zfb/templates/default/pages/index.tsx
@@ -1,0 +1,18 @@
+import DefaultLayout from "../layouts/default";
+
+export default function HomePage() {
+  return (
+    <DefaultLayout title="Welcome to zfb">
+      <main>
+        <h1>Hello from zfb</h1>
+        <p>
+          Welcome to your new zudo-front-builder site. Edit{" "}
+          <code>pages/index.tsx</code> to get started.
+        </p>
+        <p>
+          <a href="/blog/welcome">Read the welcome post</a>
+        </p>
+      </main>
+    </DefaultLayout>
+  );
+}

--- a/crates/zfb/templates/default/styles/global.css
+++ b/crates/zfb/templates/default/styles/global.css
@@ -1,0 +1,34 @@
+@import "tailwindcss";
+
+:root {
+  color-scheme: light dark;
+  font-family:
+    system-ui,
+    -apple-system,
+    "Segoe UI",
+    sans-serif;
+  line-height: 1.6;
+}
+
+body {
+  margin: 0;
+  padding: 2rem;
+  max-width: 48rem;
+  margin-inline: auto;
+}
+
+a {
+  color: #2563eb;
+}
+
+.counter {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 1rem;
+  border: 1px solid currentColor;
+  border-radius: 0.375rem;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+}

--- a/crates/zfb/templates/default/tsconfig.json
+++ b/crates/zfb/templates/default/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": false,
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./*"],
+      "@/components/*": ["./components/*"],
+      "@/layouts/*": ["./layouts/*"]
+    },
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": [
+    "pages/**/*",
+    "layouts/**/*",
+    "components/**/*",
+    "content/**/*",
+    "zfb.config.ts"
+  ],
+  "exclude": ["node_modules", "dist"]
+}

--- a/crates/zfb/templates/default/zfb.config.ts
+++ b/crates/zfb/templates/default/zfb.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from "zfb/config";
+
+export default defineConfig({
+  framework: "preact",
+  tailwind: {
+    enabled: true,
+  },
+  collections: {
+    blog: {
+      type: "content",
+      directory: "content/blog",
+      schema: {
+        title: "string",
+        date: "date",
+        description: "string?",
+      },
+    },
+  },
+});


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/9
- parent PR
    - https://github.com/Takazudo/zudo-front-builder/pull/12

---

## Summary

- Wires the zfb binary's four CLI commands (`new` / `dev` / `build` / `preview`) on top of the prior epics' crates (zfb-build orchestrator, zfb-server dev server with SSE livereload, zfb-watcher, zfb-graph).
- Locks the bootstrap rule for `zfb.config.{ts,json}`: zfb owns the JS runtime; user config can choose framework / outDir / publicDir / collections / tailwind / plugins but cannot swap the runtime.
- Ships the default project template (Preact + Tailwind starter) embedded in the binary via `include_dir`, plus CLI ergonomics helpers (owo-colors / indicatif / format_error chain).
- Implemented as Wave 1 (CLI scaffolding) + Wave 2 (six parallel topics) under super-epic #2.

Two intentional v1 scope-downs are documented in source and tracked in follow-up: `zfb build` emits a stub index.html until Epic 3's renderer + dependency-graph loader land, and `zfb dev`'s PageRenderer is a noop (the server boots, the watcher and SSE broadcast work end-to-end, but the PageCache stays empty so requests fall through to dev_404). The CLI surface, config schema, and integration boundaries are stable across that swap.

## Changes

### CLI scaffolding (Wave 1 / Sub 1)
- `crates/zfb/src/cli.rs`: clap derive structs for `Cli`, `Command`, `NewArgs`, `DevArgs`, `BuildArgs`, `PreviewArgs`. All fields `pub` so command modules read them directly.
- `crates/zfb/src/main.rs`: `#[tokio::main]` dispatcher; prints `error: {e:#}` and exits 1 on anyhow chain failures.
- `crates/zfb/src/lib.rs`, `crates/zfb/src/commands/mod.rs`: module skeleton (`cli`, `commands`, `config`, `output`).
- Cargo.toml: clap 4 (derive), anyhow (workspace), tokio (rt-multi-thread/macros/signal).

### `zfb new` + default template (Sub 2)
- `crates/zfb/src/commands/new.rs`: copies `templates/<name>/` to `./<name>/`, attempts `pnpm install` (graceful skip on missing pnpm).
- `crates/zfb/templates/default/`: pages (index.tsx, blog/[slug].tsx), content/blog/welcome.md, layouts/default.tsx, components/counter.tsx with `"use client"`, styles/global.css with Tailwind v4 import, zfb.config.ts, tsconfig.json, package.json, .gitignore.
- Templates embedded at compile time via `include_dir`.

### Config parser (Sub 3)
- `crates/zfb/src/config.rs`: full `Config` schema with serde camelCase (out_dir / public_dir / host / port / framework / collections / tailwind / plugins).
- `pub async fn load_from_dir(dir: &Path) -> anyhow::Result<Config>`: reads `zfb.config.json`; absent file returns `Config::default()`.
- Validation: unique collection names, no absolute or `..`-escaping collection paths, JSON parse errors include file/line/column.
- TS support deferred behind clear unsupported-yet error pointing users to JSON.

### `zfb dev` (Sub 4)
- `crates/zfb/src/commands/dev.rs`: builds `tokio::sync::broadcast::channel::<ReloadEvent>(64)`, `PageCache`, `BuildOrchestrator` with empty `DependencyGraph` + `DevAssetPipeline`, default watch roots (pages/content/components/layouts/styles/data/public/zfb.config.ts).
- `on_outcome` callback translates each non-noop tick to ReloadEvents via `outcome_to_events` and broadcasts them.
- Resolves `host:port` via `ToSocketAddrs`, races `serve(opts)` against `tokio::signal::ctrl_c()` for clean shutdown.
- v1 noop PageRenderer: server boots, SSE works, PageCache empty.

### `zfb build` (Sub 5)
- `crates/zfb/src/commands/build.rs`: validates project root has `pages/`, atomic-writes a v1 stub `<outdir>/index.html` so `zfb preview` has something to serve, prints `✓ N pages built in Xs`.

### `zfb preview` (Sub 6)
- `crates/zfb/src/commands/preview.rs`: clean axum 0.8 + tower-http 0.6 ServeDir static server on 127.0.0.1:`<port>` (default 4321). No livereload, no SSE, no `/__zfb/*` routes. ServeDir handles directory-style URL → index.html lookup. Errors before binding port if outdir missing.

### CLI ergonomics (Sub 7)
- `crates/zfb/src/output.rs`: `info` / `success` / `warn` / `error` / `ready` colored helpers (owo-colors, NO_COLOR-aware), `BuildProgress` wrapper around indicatif, `format_error` rendering anyhow caused-by chain with best-effort path:line hint extraction.
- 9 unit tests covering helpers + heuristic false-positive guards (URL-like tokens, host:port).

### Cargo.toml additions
- New deps on the zfb crate: clap, anyhow, tokio (with net/sync/fs/process/signal/macros features), axum, tower-http (fs), include_dir, indicatif, owo-colors (supports-colors), serde, serde_json, plus path deps on zfb-build, zfb-graph, zfb-server, zfb-watcher; tempfile in dev-dependencies.

## Test Plan

- `cargo build --workspace` passes (verified)
- `cargo test -p zfb` — 22 unit tests pass (config validation, output helpers, build path resolution)
- `cargo run -p zfb -- --help` — clap help shows all four subcommands with documented defaults
- `cargo run -p zfb -- new test-site` from a clean dir — creates test-site/ with the default template; re-running on a non-empty dir errors clearly
- `cargo run -p zfb -- build --outdir /tmp/zfb-build-test` from a project root — exits 0, writes index.html, prints summary; from a non-project dir, errors before any side effects
- `cargo run -p zfb -- preview --port 14040 --outdir <dist>` — serves index.html at /, nested index.html at /about/, 404 on missing files; missing outdir errors before binding the port; Ctrl+C exits cleanly
- `cargo run -p zfb -- dev --port 13030 --host 127.0.0.1` — boots, prints ready banner, serves dev_404 with the livereload script tag injected; SIGINT exits 0
- gcoc-review on the full diff against base/zfb-init returned no actionable findings

## Follow-ups (tracked in source)

- Wire `zfb-render` page renderer + dependency-graph loader into `zfb dev` and `zfb build` (currently noop / stub).
- Wire `crate::config::load_from_dir` into `dev` / `build` / `preview` (currently uses defaults + CLI args only).
- Adopt `crate::output::*` helpers in the four command files (currently raw println — Wave 2 / Sub 7 left this as a manager follow-up by design).
- Ship `zfb.config.ts` parsing via the Epic 3 JS runtime (currently errors with a clear unsupported-yet message; JSON form fully supported).