### PR TITLE
[zfb Init][Epic] zfb CLI follow-up — config wiring, output adoption, route enumeration

### DIFF
--- a/crates/zfb/Cargo.toml
+++ b/crates/zfb/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal
 tower-http = { version = "0.6", features = ["fs"] }
 zfb-build = { path = "../zfb-build" }
 zfb-graph = { path = "../zfb-graph" }
+zfb-router = { path = "../zfb-router" }
 zfb-server = { path = "../zfb-server" }
 zfb-watcher = { path = "../zfb-watcher" }
 

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -76,19 +76,10 @@ pub async fn run(args: &BuildArgs) -> Result<()> {
     // the CLI flag wins (clap injects the default "dist" if the user didn't
     // pass `--outdir`). When more config consumers land (e.g. `publicDir`
     // copy, `tailwind.enabled`), they'll read off the loaded `Config`.
-    let _config = match crate::config::load_from_dir(&project_root).await {
-        Ok(cfg) => cfg,
-        Err(e) => {
-            // Render the multi-line user-friendly error block before
-            // returning. `format_error` already includes a trailing newline,
-            // so trim the right side before handing it to `output::error`
-            // (which uses `eprintln!` and would otherwise add a second
-            // blank line). main() will still print a terse fallback line —
-            // a small redundancy that keeps the contract straightforward.
-            output::error(output::format_error(&e).trim_end());
-            return Err(e);
-        }
-    };
+    // Errors propagate to main() for centralized rendering.
+    let _config = crate::config::load_from_dir(&project_root)
+        .await
+        .context("failed to load project configuration")?;
 
     let outdir = resolve_outdir(&project_root, &args.outdir);
 

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -6,32 +6,42 @@
 //! `args.outdir` is the production output directory (default `dist`).
 //! Resolved relative to the current working directory if not absolute.
 //!
-//! ## v1 scope-down (Wave 2 / Sub 5)
+//! ## v1 scope (post Wave 2 / Sub 5 + Sub 3 + zfb-router wiring)
 //!
-//! At the time this command was wired up, the surrounding pieces of the
-//! production build pipeline are not yet in place:
+//! What this build now does:
 //!
-//! - `zfb-render` / `zfb-content` / `zfb-router` (Epic 3) is not connected
-//!   into the bin crate, so we have no real `PageRenderer` to plug into
-//!   the `zfb_build::BuildOrchestrator`.
-//! - The dependency-graph loader (the thing that populates
-//!   `zfb_graph::DependencyGraph` from project sources) has not landed,
-//!   so the orchestrator's `graph.pages()` would be empty and a one-shot
-//!   `tick` against a "full rebuild" plan resolves to zero work.
-//! - `crate::config::load_from_dir` is owned by Wave 2 / Sub 3 and merges
-//!   in after this branch.
+//! 1. Validates we're inside something that looks like a project root
+//!    (presence of a `pages/` directory).
+//! 2. Loads `zfb.config.{json,ts}` via `crate::config::load_from_dir`. JSON
+//!    parses; TS surfaces a clear "not yet supported" error. The CLI's
+//!    `--outdir` always wins over the loaded config (matches cmd-dev's
+//!    "CLI overrides config" contract — clap sets the default to "dist", so
+//!    by the time we see the value here it is always present).
+//! 3. Runs `zfb_router::Router::scan` on `pages/` to enumerate routes.
+//! 4. For every static route, writes a per-route stub HTML at the
+//!    conventional output path (`<outdir>/index.html` for `/`,
+//!    `<outdir>/<segments...>/index.html` otherwise) using
+//!    [`zfb_build::atomic_write_string`].
+//! 5. Skips dynamic / catchall routes with a `warn` line — those need a
+//!    runtime `paths()` evaluation that requires the real renderer (blocked
+//!    on ADR-001: `DenoCoreHost` is still a skeleton).
+//! 6. If the project has zero `pages/*.tsx` files we still emit a stub
+//!    `index.html` so `zfb preview` has something to serve.
+//! 7. Prints the canonical summary line `✓ N pages built in X.XXs` via
+//!    `crate::output::success` (which adds the green checkmark).
 //!
-//! Per the cmd-build brief, v1 is allowed to ship a stub that:
+//! What's still deferred:
 //!
-//! 1. validates we're inside something that looks like a project root
-//!    (presence of a `pages/` directory),
-//! 2. atomically writes a stub `<outdir>/index.html` so `zfb preview` has
-//!    something to serve, and
-//! 3. prints the canonical summary line `✓ N pages built in Xs`.
+//! - Real per-route SSR rendering. `zfb-render` / `zfb-content` need a
+//!   working `PageRenderer`, which depends on a working JS runtime
+//!   (ADR-001 / `DenoCoreHost` skeleton). Until then each static route's
+//!   body is a placeholder that names the route template.
+//! - Dynamic and catchall routes. Expanding `[slug].tsx` into concrete
+//!   paths needs `paths()` calls evaluated by the renderer; this is the
+//!   same blocker as above.
 //!
-//! The real renderer wires in once Epic 3 + the graph loader land. This
-//! file's `run` signature, the project-root validation, and the summary
-//! contract should remain stable across that swap.
+//! The command's `run` signature, the project-root validation, and the
+//! summary contract should remain stable across that swap.
 
 use std::env;
 use std::path::{Path, PathBuf};
@@ -39,19 +49,20 @@ use std::time::Instant;
 
 use anyhow::{anyhow, Context, Result};
 use zfb_build::atomic_write_string;
+use zfb_router::{Route, RouteKind, Router};
 
 use crate::cli::BuildArgs;
+use crate::output;
 
 pub async fn run(args: &BuildArgs) -> Result<()> {
     let started = Instant::now();
 
     let project_root = env::current_dir().context("failed to read current working directory")?;
 
-    // v1 project-root sanity check. The eventual config loader will give
-    // us a richer "is this a zfb project?" signal; until then, the
-    // presence of a `pages/` directory is the cheapest heuristic that
-    // matches the framework's vocabulary (see zfb-build's default watch
-    // roots, which include `pages`).
+    // v1 project-root sanity check. The config loader gives us a richer
+    // schema downstream, but the cheapest "is this a zfb project?" signal
+    // is still the presence of a `pages/` directory (matches the watcher's
+    // default roots and the router's scan target).
     let pages_dir = project_root.join("pages");
     if !pages_dir.is_dir() {
         return Err(anyhow!(
@@ -60,21 +71,86 @@ pub async fn run(args: &BuildArgs) -> Result<()> {
         ));
     }
 
+    // Load the project config. We do not currently consume any field other
+    // than to surface load errors — `outdir` is taken from `args` because
+    // the CLI flag wins (clap injects the default "dist" if the user didn't
+    // pass `--outdir`). When more config consumers land (e.g. `publicDir`
+    // copy, `tailwind.enabled`), they'll read off the loaded `Config`.
+    let _config = match crate::config::load_from_dir(&project_root).await {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            // Render the multi-line user-friendly error block before
+            // returning. `format_error` already includes a trailing newline,
+            // so trim the right side before handing it to `output::error`
+            // (which uses `eprintln!` and would otherwise add a second
+            // blank line). main() will still print a terse fallback line —
+            // a small redundancy that keeps the contract straightforward.
+            output::error(output::format_error(&e).trim_end());
+            return Err(e);
+        }
+    };
+
     let outdir = resolve_outdir(&project_root, &args.outdir);
 
-    // v1: emit a single stub index.html. When the real renderer wires in,
-    // this loop becomes "for each rendered page, atomic_write_string the
-    // HTML to <outdir>/<output_path>".
-    let index_path = outdir.join("index.html");
-    let stub_html = stub_index_html();
-    atomic_write_string(&index_path, &stub_html)
-        .with_context(|| format!("failed to write {}", index_path.display()))?;
+    // Enumerate routes. RouterError surfaces ambiguous routes with full
+    // source paths; we wrap with a one-line context so the user can tell
+    // where the failure happened in the build pipeline.
+    let router = Router::scan(&pages_dir)
+        .map_err(anyhow::Error::from)
+        .with_context(|| format!("scanning routes under {}", pages_dir.display()))?;
 
-    // v1 always emits one page (the stub index). Real builds will
-    // increment per RenderedPage.
-    let pages_built: usize = 1;
+    let routes = router.routes();
+    let mut pages_built: usize = 0;
+
+    if routes.is_empty() {
+        // Empty `pages/` is unusual but legal — the user might be
+        // bootstrapping. Still emit a stub index.html so `zfb preview`
+        // has something to serve.
+        output::warn(format!(
+            "no pages found under {}; emitting placeholder index.html only",
+            pages_dir.display()
+        ));
+        let index_path = outdir.join("index.html");
+        let stub = stub_route_html("/");
+        atomic_write_string(&index_path, &stub)
+            .with_context(|| format!("failed to write {}", index_path.display()))?;
+        pages_built = 1;
+    } else {
+        for route in routes {
+            match route.kind {
+                RouteKind::Static => {
+                    // route_output_path returns Some(_) for static routes
+                    // (see helper docs); destructure with a defensive
+                    // fallback so we never silently lose a static route.
+                    let Some(out_path) = route_output_path(&outdir, route) else {
+                        // Should not happen — keep the path narrow rather
+                        // than panicking.
+                        output::warn(format!(
+                            "static route {} produced no output path; skipping",
+                            route.template()
+                        ));
+                        continue;
+                    };
+                    let body = stub_route_html(&route.template());
+                    atomic_write_string(&out_path, &body)
+                        .with_context(|| format!("failed to write {}", out_path.display()))?;
+                    pages_built += 1;
+                }
+                RouteKind::Dynamic | RouteKind::Catchall => {
+                    output::warn(format!(
+                        "skipping {} — dynamic / catchall routes require runtime paths() \
+                         evaluation, pending real renderer (ADR-001)",
+                        route.template()
+                    ));
+                }
+            }
+        }
+    }
+
     let elapsed = started.elapsed().as_secs_f64();
-    println!("✓ {pages_built} pages built in {elapsed:.2}s");
+    // `output::success` adds the green ✓ prefix automatically; the canonical
+    // line text "✓ N pages built in X.XXs" is preserved.
+    output::success(format!("{pages_built} pages built in {elapsed:.2}s"));
 
     Ok(())
 }
@@ -91,16 +167,98 @@ fn resolve_outdir(project_root: &Path, outdir: &Path) -> PathBuf {
     }
 }
 
-/// Stub HTML emitted by the v1 build so `zfb preview` has something to
-/// serve. Intentionally minimal — once the real renderer lands this
-/// function disappears.
-fn stub_index_html() -> String {
-    "<!doctype html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n<title>zfb build</title>\n</head>\n<body>\n<h1>zfb build (v1 stub)</h1>\n<p>The production renderer is not yet wired in. This page is a placeholder so <code>zfb preview</code> has something to serve.</p>\n</body>\n</html>\n".to_string()
+/// Compute the on-disk output path for a route under `outdir`.
+///
+/// - The index route (`/`) maps to `<outdir>/index.html`.
+/// - A static route with template `/about` maps to `<outdir>/about/index.html`.
+/// - A multi-segment static route like `/blog/intro` maps to
+///   `<outdir>/blog/intro/index.html`.
+/// - Dynamic and catchall routes return `None` — they need runtime
+///   `paths()` expansion which v1 does not have.
+fn route_output_path(outdir: &Path, route: &Route) -> Option<PathBuf> {
+    if route.kind != RouteKind::Static {
+        return None;
+    }
+    if route.segments.is_empty() {
+        return Some(outdir.join("index.html"));
+    }
+    let mut path = outdir.to_path_buf();
+    for seg in &route.segments {
+        // Static-only by virtue of the kind check above; defensive match
+        // keeps the helper honest if `RouteKind::Static` ever grows new
+        // segment shapes.
+        match seg {
+            zfb_router::Segment::Static(s) => path.push(s),
+            _ => return None,
+        }
+    }
+    path.push("index.html");
+    Some(path)
+}
+
+/// Stub HTML emitted for each static route in the v1 build. Includes the
+/// route template in both `<title>` and `<body>` so the user can tell which
+/// file they're looking at while the real renderer is still pending.
+fn stub_route_html(template: &str) -> String {
+    // Minimal HTML escaping for the route template: only `<`, `>`, `&` need
+    // attention here, and segments are constrained by the router to ASCII
+    // identifiers + `:` / `*`. Doing it explicitly keeps the helper safe if
+    // that contract loosens.
+    let escaped = template
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;");
+    format!(
+        "<!doctype html>\n\
+         <html lang=\"en\">\n\
+         <head>\n\
+         <meta charset=\"utf-8\">\n\
+         <title>zfb build — {escaped}</title>\n\
+         </head>\n\
+         <body>\n\
+         <h1>zfb build (v1 stub)</h1>\n\
+         <p>Route: <code>{escaped}</code></p>\n\
+         <p>The production renderer is not yet wired in. This page is a placeholder so <code>zfb preview</code> has something to serve.</p>\n\
+         </body>\n\
+         </html>\n"
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use zfb_router::Segment;
+
+    fn static_route(segments: Vec<&str>) -> Route {
+        let segs: Vec<Segment> = segments
+            .into_iter()
+            .map(|s| Segment::Static(s.to_string()))
+            .collect();
+        Route {
+            source_path: PathBuf::from("pages/dummy.tsx"),
+            segments: segs,
+            kind: RouteKind::Static,
+            specificity: 0,
+        }
+    }
+
+    fn dynamic_route() -> Route {
+        Route {
+            source_path: PathBuf::from("pages/[slug].tsx"),
+            segments: vec![Segment::Dynamic("slug".to_string())],
+            kind: RouteKind::Dynamic,
+            specificity: 0,
+        }
+    }
+
+    fn catchall_route() -> Route {
+        Route {
+            source_path: PathBuf::from("pages/[...rest].tsx"),
+            segments: vec![Segment::Catchall("rest".to_string())],
+            kind: RouteKind::Catchall,
+            specificity: 0,
+        }
+    }
 
     #[test]
     fn resolve_outdir_keeps_absolute_paths() {
@@ -117,10 +275,62 @@ mod tests {
     }
 
     #[test]
-    fn stub_html_is_well_formed_html() {
-        let html = stub_index_html();
+    fn stub_route_html_contains_template_and_is_well_formed() {
+        let html = stub_route_html("/about");
         assert!(html.starts_with("<!doctype html>"));
-        assert!(html.contains("zfb build"));
+        assert!(html.contains("/about"));
+        assert!(html.contains("<title>zfb build — /about</title>"));
         assert!(html.trim_end().ends_with("</html>"));
+    }
+
+    #[test]
+    fn stub_route_html_escapes_template() {
+        // Defensive: even though the router constrains segment shapes, the
+        // helper itself must not let `<`/`>`/`&` flow into HTML unescaped.
+        let html = stub_route_html("/<x>&");
+        assert!(html.contains("&lt;x&gt;&amp;"));
+        assert!(!html.contains("/<x>"));
+    }
+
+    #[test]
+    fn route_output_path_index() {
+        let outdir = Path::new("/out");
+        let route = static_route(vec![]);
+        assert_eq!(
+            route_output_path(outdir, &route),
+            Some(PathBuf::from("/out/index.html"))
+        );
+    }
+
+    #[test]
+    fn route_output_path_single_segment_static() {
+        let outdir = Path::new("/out");
+        let route = static_route(vec!["about"]);
+        assert_eq!(
+            route_output_path(outdir, &route),
+            Some(PathBuf::from("/out/about/index.html"))
+        );
+    }
+
+    #[test]
+    fn route_output_path_multi_segment_static() {
+        let outdir = Path::new("/out");
+        let route = static_route(vec!["blog", "intro"]);
+        assert_eq!(
+            route_output_path(outdir, &route),
+            Some(PathBuf::from("/out/blog/intro/index.html"))
+        );
+    }
+
+    #[test]
+    fn route_output_path_dynamic_returns_none() {
+        let outdir = Path::new("/out");
+        assert_eq!(route_output_path(outdir, &dynamic_route()), None);
+    }
+
+    #[test]
+    fn route_output_path_catchall_returns_none() {
+        let outdir = Path::new("/out");
+        assert_eq!(route_output_path(outdir, &catchall_route()), None);
     }
 }

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -86,17 +86,11 @@ pub async fn run(args: &DevArgs) -> Result<()> {
     // 1. Resolve the project root and load configuration.
     let project_root = std::env::current_dir().context("failed to read current working dir")?;
 
-    let cfg = match config::load_from_dir(&project_root).await {
-        Ok(cfg) => cfg,
-        Err(err) => {
-            // Surface the failure with the structured error renderer so
-            // the user sees a readable multi-line block, then propagate
-            // so the process exits non-zero.
-            output::error("failed to load project configuration");
-            eprint!("{}", output::format_error(&err));
-            return Err(err);
-        }
-    };
+    // Errors propagate to main(), which renders them through
+    // output::format_error — see main.rs for the centralization rationale.
+    let cfg = config::load_from_dir(&project_root)
+        .await
+        .context("failed to load project configuration")?;
 
     // 2. Resolve filesystem roots from config (relative paths join onto
     //    the project root; absolute paths used as-is).

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -12,29 +12,46 @@
 //!    [`zfb_server::outcome_to_events`] and broadcasts them.
 //!
 //! Then it binds the address from `args.host:args.port`, prints the
-//! ready banner, and runs the axum server until Ctrl+C.
+//! ready banner via [`crate::output::ready`], and runs the axum server
+//! until Ctrl+C.
 //!
-//! ## v1 scope-down: noop page renderer
+//! ## Configuration
 //!
-//! Wiring the real `zfb-render` page renderer (which depends on
-//! `deno_core_host` and the SSR bundle) is deliberately deferred — Sub 4
-//! owns only `crates/zfb/src/commands/dev.rs` and the v1 acceptance is
-//! "the dev server boots and serves SOMETHING (even the dev_404 body)
-//! with live-reload working". So we hand the orchestrator a
+//! Project configuration is loaded via [`crate::config::load_from_dir`]
+//! at startup. Today this resolves to a `zfb.config.json` if present, or
+//! sensible defaults otherwise; encountering a `zfb.config.ts` produces a
+//! clear "not yet supported" error (the TS pipeline is blocked on
+//! ADR-001's runtime decision).
+//!
+//! **Precedence rule:** CLI args (`--host`, `--port`) override the
+//! corresponding config values **unconditionally**. `clap` defaults
+//! `args.host` and `args.port` to concrete values, so we cannot cheaply
+//! distinguish "user passed `--port`" from "user accepted the default";
+//! treating CLI as authoritative keeps the rule predictable and avoids
+//! `ArgMatches` plumbing. `out_dir` and `public_dir` come from config
+//! (resolved against the project root via [`resolve_under_root`]) since
+//! there is no CLI override for them on `zfb dev`.
+//!
+//! ## v1 scope-down: noop page renderer (still deferred)
+//!
+//! Wiring the real `zfb-render` page renderer remains deferred — it
+//! depends on `deno_core_host`, which is still a skeleton pending
+//! ADR-001's JS-runtime decision. So we hand the orchestrator a
 //! [`zfb_build::PageRenderer`] that returns an empty render set: the
 //! orchestrator still drives the watcher + dep-graph + reload broadcast
 //! correctly, the [`zfb_server::PageCache`] simply stays empty, and
 //! every request falls through to [`zfb_server::DEV_404_BODY`]. Real
 //! renderer integration (and the cache-population side of the
-//! `on_outcome` callback) is a follow-up after Wave 2 lands.
+//! `on_outcome` callback) will land once `DenoCoreHost` is real.
 //!
-//! Configuration loading (`crate::config::load_from_dir`) is also
-//! deferred per the manager's plan — it's Sub 3's territory and gets
-//! wired in after merge. For now we work directly off
-//! [`std::env::current_dir`] and a fixed list of watch roots.
+//! ## Output
+//!
+//! Status lines (ready banner, orchestrator failures) go through
+//! [`crate::output`] so colour/no-colour and stdout/stderr conventions
+//! are handled centrally.
 
 use std::net::{SocketAddr, ToSocketAddrs};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use anyhow::{Context, Result};
@@ -47,6 +64,8 @@ use zfb_graph::{DependencyGraph, PageId};
 use zfb_server::{outcome_to_events, serve, PageCache, ReloadEvent, ServeOpts};
 
 use crate::cli::DevArgs;
+use crate::config;
+use crate::output;
 
 /// Default source directories the watcher follows. Missing entries are
 /// silently skipped by `zfb_watcher::Watcher::start`, so it's fine to
@@ -64,12 +83,25 @@ const DEFAULT_WATCH_ROOTS: &[&str] = &[
 
 /// Entry point for `zfb dev`.
 pub async fn run(args: &DevArgs) -> Result<()> {
-    // 1. Resolve the project root. TODO(Sub 3 follow-up): replace with
-    //    `crate::config::load_from_dir(&cwd).await` once config wiring
-    //    lands; for v1 we operate on the current dir directly.
+    // 1. Resolve the project root and load configuration.
     let project_root = std::env::current_dir().context("failed to read current working dir")?;
-    let dist_root = project_root.join("dist");
-    let public_root = project_root.join("public");
+
+    let cfg = match config::load_from_dir(&project_root).await {
+        Ok(cfg) => cfg,
+        Err(err) => {
+            // Surface the failure with the structured error renderer so
+            // the user sees a readable multi-line block, then propagate
+            // so the process exits non-zero.
+            output::error("failed to load project configuration");
+            eprint!("{}", output::format_error(&err));
+            return Err(err);
+        }
+    };
+
+    // 2. Resolve filesystem roots from config (relative paths join onto
+    //    the project root; absolute paths used as-is).
+    let dist_root = resolve_under_root(&project_root, &cfg.out_dir);
+    let public_root = resolve_under_root(&project_root, &cfg.public_dir);
 
     // ServeDir on a missing directory just 404s, but creating dist/
     // up-front avoids a noisy warning the first time the dev server
@@ -80,25 +112,26 @@ pub async fn run(args: &DevArgs) -> Result<()> {
             .with_context(|| format!("failed to create dist dir {}", dist_root.display()))?;
     }
 
-    // 2. Resolve the bind address. `args.host` may be "localhost",
-    //    "127.0.0.1", "0.0.0.0", etc., so we go through ToSocketAddrs.
+    // 3. Resolve the bind address. CLI args win unconditionally over
+    //    config values — see the precedence note in the module doc.
     let addr = resolve_addr(&args.host, args.port)?;
 
-    // 3. Live-reload broadcast channel. 64 slots is plenty for a dev
+    // 4. Live-reload broadcast channel. 64 slots is plenty for a dev
     //    server: one event per build tick and a handful of subscribers.
     let (tx, _rx) = broadcast::channel::<ReloadEvent>(64);
 
-    // 4. Page cache shared between the orchestrator's render outputs
+    // 5. Page cache shared between the orchestrator's render outputs
     //    and the server's GET handlers.
     let pages = PageCache::new();
 
-    // 5. Build orchestrator setup. Empty dep graph for v1 — the
-    //    resolver/loader that populates it is out of scope for Sub 4.
+    // 6. Build orchestrator setup. Empty dep graph for v1 — the
+    //    resolver/loader that populates it is out of scope for this
+    //    sub-task.
     let graph = Arc::new(Mutex::new(DependencyGraph::new()));
     let pipeline = DevAssetPipeline::new();
     let watch_roots: Vec<PathBuf> = DEFAULT_WATCH_ROOTS.iter().map(PathBuf::from).collect();
-    let config = OrchestratorConfig::new(&project_root, watch_roots);
-    let orchestrator = BuildOrchestrator::new(config, graph, pipeline);
+    let orch_config = OrchestratorConfig::new(&project_root, watch_roots);
+    let orchestrator = BuildOrchestrator::new(orch_config, graph, pipeline);
 
     // Noop page renderer — see crate-level scope-down note above.
     let render_pages: PageRenderer = Arc::new(|_pages: &[PageId]| Ok(Vec::new()));
@@ -109,7 +142,7 @@ pub async fn run(args: &DevArgs) -> Result<()> {
         run_islands: None,
     };
 
-    // 6. Wire on_outcome: translate each non-noop tick to ReloadEvents
+    // 7. Wire on_outcome: translate each non-noop tick to ReloadEvents
     //    and broadcast them. Page cache population is intentionally
     //    skipped here because the noop renderer never emits any
     //    RenderedPage outputs (BuildOutcome only carries page IDs, not
@@ -124,20 +157,19 @@ pub async fn run(args: &DevArgs) -> Result<()> {
         }
     };
 
-    // 7. Spawn the orchestrator's watcher loop.
+    // 8. Spawn the orchestrator's watcher loop.
     let orch_handle = tokio::spawn(async move {
         if let Err(err) = orchestrator.run(ctx, on_outcome).await {
             // The orchestrator's loop logs its own per-tick errors and
             // keeps going; reaching here means the watcher itself died.
-            // Surface that to stderr so the user sees something rather
-            // than a silent dead dev server.
-            eprintln!("zfb dev: build orchestrator stopped: {err:#}");
+            // Surface that via the structured error helper so the user
+            // sees something rather than a silent dead dev server.
+            output::error(&format!("build orchestrator stopped: {err:#}"));
         }
     });
 
-    // 8. Build the serve options and announce readiness just before
-    //    handing control to axum. Plain println for now — Sub 7 may
-    //    upgrade this to colored output.
+    // 9. Build the serve options and announce readiness just before
+    //    handing control to axum.
     let opts = ServeOpts {
         project_root,
         dist_root,
@@ -147,12 +179,12 @@ pub async fn run(args: &DevArgs) -> Result<()> {
         broadcast: tx,
     };
 
-    println!("→ ready on http://{}:{}", args.host, args.port);
+    output::ready(&format!("http://{}:{}", args.host, args.port));
 
-    // 9. Run the server, racing against Ctrl+C. axum::serve has no
-    //    graceful-shutdown wiring in the zfb-server crate today, so on
-    //    Ctrl+C we abort the orchestrator task and let the runtime
-    //    drop the server when this future returns. Process exits 0.
+    // 10. Run the server, racing against Ctrl+C. axum::serve has no
+    //     graceful-shutdown wiring in the zfb-server crate today, so on
+    //     Ctrl+C we abort the orchestrator task and let the runtime
+    //     drop the server when this future returns. Process exits 0.
     tokio::select! {
         res = serve(opts) => {
             // serve() returned on its own — propagate any error.
@@ -176,4 +208,68 @@ fn resolve_addr(host: &str, port: u16) -> Result<SocketAddr> {
         .with_context(|| format!("could not resolve bind address {pair}"))?;
     iter.next()
         .ok_or_else(|| anyhow::anyhow!("no socket addresses resolved for {pair}"))
+}
+
+/// Resolve a config-supplied path against the project root.
+///
+/// - If `p` is absolute, it is returned unchanged so users can point at
+///   directories outside the project (e.g. a shared `dist/` on a CI box).
+/// - Otherwise it is joined onto `project_root`.
+///
+/// This deliberately does **not** canonicalise — the directory may not
+/// exist yet (`dist/` is created lazily right after this call), and we
+/// want to preserve the user's spelling for log output.
+fn resolve_under_root(project_root: &Path, p: &Path) -> PathBuf {
+    if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        project_root.join(p)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_under_root_joins_relative_paths() {
+        let root = Path::new("/tmp/proj");
+        let p = Path::new("dist");
+        assert_eq!(resolve_under_root(root, p), PathBuf::from("/tmp/proj/dist"));
+    }
+
+    #[test]
+    fn resolve_under_root_joins_nested_relative_paths() {
+        let root = Path::new("/tmp/proj");
+        let p = Path::new("build/out");
+        assert_eq!(
+            resolve_under_root(root, p),
+            PathBuf::from("/tmp/proj/build/out")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_under_root_keeps_absolute_paths_as_is() {
+        let root = Path::new("/tmp/proj");
+        let p = Path::new("/var/www/dist");
+        assert_eq!(resolve_under_root(root, p), PathBuf::from("/var/www/dist"));
+    }
+
+    #[test]
+    fn resolve_under_root_handles_dot_relative() {
+        // `./public` should still anchor under the project root rather
+        // than be silently rewritten — `Path::join` preserves the `.`,
+        // which is fine because filesystem APIs treat it as a no-op.
+        let root = Path::new("/tmp/proj");
+        let p = Path::new("./public");
+        let resolved = resolve_under_root(root, p);
+        // The resolved path must start with the project root. We don't
+        // require an exact textual match because `join` may or may not
+        // collapse the `.` depending on platform conventions.
+        assert!(
+            resolved.starts_with(root),
+            "expected {resolved:?} to start with {root:?}"
+        );
+    }
 }

--- a/crates/zfb/src/commands/new.rs
+++ b/crates/zfb/src/commands/new.rs
@@ -6,6 +6,11 @@
 //! After the files are in place we attempt to run `pnpm install`; if pnpm is
 //! missing we print a friendly notice and continue successfully so the user can
 //! run install themselves later.
+//!
+//! Status messages go through [`crate::output`] so they look consistent with
+//! the rest of the zfb CLI. `zfb new` deliberately does NOT load
+//! `zfb.config.{json,ts}` — at the moment this command runs the project does
+//! not yet exist on disk, so there is no config to apply.
 
 use std::io::ErrorKind;
 use std::path::Path;
@@ -15,6 +20,7 @@ use std::fs;
 use tokio::process::Command;
 
 use crate::cli::NewArgs;
+use crate::output;
 
 /// Compile-time embedding of `crates/zfb/templates/`.
 ///
@@ -63,19 +69,23 @@ pub async fn run(args: &NewArgs) -> anyhow::Result<()> {
     match try_pnpm_install(dest).await {
         PnpmOutcome::Ran => {}
         PnpmOutcome::Missing => {
-            println!(
-                "pnpm not found on PATH \u{2014} skipping install. Run pnpm install manually before zfb dev."
+            output::warn(
+                "pnpm not found on PATH \u{2014} skipping install. Run pnpm install manually before zfb dev.",
             );
         }
         PnpmOutcome::Failed(msg) => {
-            println!("pnpm install failed: {msg}. Run pnpm install manually before zfb dev.");
+            output::warn(&format!(
+                "pnpm install failed: {msg}. Run pnpm install manually before zfb dev."
+            ));
         }
     }
 
-    println!(
-        "\u{2713} Created {} (template: {}). Next: cd {} && zfb dev",
+    // `output::success` already prefixes a green checkmark; do not include
+    // one in the message body or the user sees `✓ ✓ Created ...`.
+    output::success(&format!(
+        "Created {} (template: {}). Next: cd {} && zfb dev",
         args.name, args.template, args.name
-    );
+    ));
 
     Ok(())
 }

--- a/crates/zfb/src/commands/preview.rs
+++ b/crates/zfb/src/commands/preview.rs
@@ -8,34 +8,89 @@
 //! Directory-style URLs (`/`, `/foo/bar/`) resolve to the matching
 //! `index.html` via [`ServeDir`]'s default `append_index_html_on_directories`
 //! behavior.
+//!
+//! ## Config wiring
+//!
+//! Loads `zfb.config.json` (or surfaces a clear "ts not yet supported" error
+//! for `zfb.config.ts`) via [`crate::config::load_from_dir`] from the current
+//! working directory. The config's `outDir` is treated as the *default* — a
+//! CLI `--outdir` value always wins, since the user explicitly typed it. The
+//! same precedence applies to `--port`. Output uses [`crate::output`]
+//! helpers for consistent styling with the other zfb commands.
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::path::{Path, PathBuf};
 
 use anyhow::Context;
 use axum::Router;
 use tower_http::services::ServeDir;
 
 use crate::cli::PreviewArgs;
+use crate::config;
+use crate::output;
+
+/// Default value used by clap for `--outdir`. Kept in sync with
+/// [`crate::cli::PreviewArgs`] so we can detect when the user did not pass an
+/// explicit override and we should fall back to the config's `outDir`.
+const CLAP_DEFAULT_OUTDIR: &str = "dist";
+
+/// Default value used by clap for `--port`. Same rationale as
+/// [`CLAP_DEFAULT_OUTDIR`] — when the user did not pass `--port`, we let the
+/// config's `port` win.
+const CLAP_DEFAULT_PORT: u16 = 4321;
 
 pub async fn run(args: &PreviewArgs) -> anyhow::Result<()> {
+    // Resolve the project root from the current working directory and load
+    // the project config (if any). A missing config file is fine — it
+    // returns `Config::default()`. Any *real* error (e.g. invalid JSON,
+    // unsupported zfb.config.ts) is surfaced via the output helpers and
+    // propagated so `main()` can exit non-zero.
+    let project_root = std::env::current_dir().context("failed to read current working dir")?;
+    let cfg = match config::load_from_dir(&project_root).await {
+        Ok(cfg) => cfg,
+        Err(err) => {
+            output::error(&output::format_error(&err));
+            return Err(err);
+        }
+    };
+
+    // CLI `--outdir` wins over config `outDir`. We can only tell whether the
+    // CLI value is "explicit" by comparing against clap's default literal, so
+    // both the literal and the type stay in sync with `PreviewArgs::outdir`.
+    let outdir = if args.outdir == PathBuf::from(CLAP_DEFAULT_OUTDIR) {
+        cfg.out_dir.clone()
+    } else {
+        args.outdir.clone()
+    };
+    // Resolve a relative outdir against the project root so the
+    // existence check (and ServeDir) operate on an unambiguous path.
+    let outdir = resolve_under_root(&project_root, &outdir);
+
+    // CLI `--port` wins over config `port`. Same fallback rule as outdir.
+    let port = if args.port == CLAP_DEFAULT_PORT {
+        cfg.port
+    } else {
+        args.port
+    };
+
     // Verify the output directory exists *before* binding the port so that
     // missing-build errors don't leave a half-started server behind.
-    if !args.outdir.exists() {
+    if !outdir.exists() {
         anyhow::bail!(
             "{} does not exist — run zfb build first",
-            args.outdir.display()
+            outdir.display()
         );
     }
 
-    let serve_dir = ServeDir::new(&args.outdir);
+    let serve_dir = ServeDir::new(&outdir);
     let app = Router::new().fallback_service(serve_dir);
 
-    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), args.port);
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
     let listener = tokio::net::TcpListener::bind(addr)
         .await
         .with_context(|| format!("failed to bind preview server to {addr}"))?;
 
-    println!("→ preview ready on http://localhost:{}", args.port);
+    output::ready(&format!("http://localhost:{}", port));
 
     axum::serve(listener, app)
         .with_graceful_shutdown(async {
@@ -47,4 +102,62 @@ pub async fn run(args: &PreviewArgs) -> anyhow::Result<()> {
         .context("preview server failed")?;
 
     Ok(())
+}
+
+/// Resolve `path` against `root` if it is relative; absolute paths are
+/// returned unchanged. Pure path arithmetic — no I/O, no `canonicalize`, so
+/// it works equally for paths that don't yet exist.
+fn resolve_under_root(root: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        root.join(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_under_root_joins_relative_paths() {
+        let root = Path::new("/tmp/project");
+        assert_eq!(
+            resolve_under_root(root, Path::new("dist")),
+            PathBuf::from("/tmp/project/dist")
+        );
+        assert_eq!(
+            resolve_under_root(root, Path::new("build/out")),
+            PathBuf::from("/tmp/project/build/out")
+        );
+    }
+
+    #[test]
+    fn resolve_under_root_passes_absolute_paths_through() {
+        let root = Path::new("/tmp/project");
+        let abs = if cfg!(windows) {
+            PathBuf::from("C:/elsewhere/dist")
+        } else {
+            PathBuf::from("/elsewhere/dist")
+        };
+        assert_eq!(resolve_under_root(root, &abs), abs);
+    }
+
+    #[test]
+    fn clap_defaults_match_cli_struct() {
+        // Defensive: if `PreviewArgs` ever changes its clap defaults, the
+        // CLI-vs-config precedence logic in `run()` would silently break.
+        // This keeps the literals here honest.
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct Wrap {
+            #[command(flatten)]
+            args: PreviewArgs,
+        }
+
+        let parsed = Wrap::try_parse_from(["zfb-preview-test"]).expect("defaults parse");
+        assert_eq!(parsed.args.outdir, PathBuf::from(CLAP_DEFAULT_OUTDIR));
+        assert_eq!(parsed.args.port, CLAP_DEFAULT_PORT);
+    }
 }

--- a/crates/zfb/src/commands/preview.rs
+++ b/crates/zfb/src/commands/preview.rs
@@ -40,13 +40,11 @@ pub async fn run(args: &PreviewArgs) -> anyhow::Result<()> {
     // unsupported zfb.config.ts) is surfaced via the output helpers and
     // propagated so `main()` can exit non-zero.
     let project_root = std::env::current_dir().context("failed to read current working dir")?;
-    let _cfg = match config::load_from_dir(&project_root).await {
-        Ok(cfg) => cfg,
-        Err(err) => {
-            output::error(&output::format_error(&err));
-            return Err(err);
-        }
-    };
+    // Errors propagate to main() for centralized rendering — see
+    // commands/dev.rs and main.rs for the shared rationale.
+    let _cfg = config::load_from_dir(&project_root)
+        .await
+        .context("failed to load project configuration")?;
 
     // Resolve `args.outdir` against the project root so the existence check
     // (and `ServeDir`) operate on an unambiguous path. CLI wins over config

--- a/crates/zfb/src/commands/preview.rs
+++ b/crates/zfb/src/commands/preview.rs
@@ -13,10 +13,14 @@
 //!
 //! Loads `zfb.config.json` (or surfaces a clear "ts not yet supported" error
 //! for `zfb.config.ts`) via [`crate::config::load_from_dir`] from the current
-//! working directory. The config's `outDir` is treated as the *default* — a
-//! CLI `--outdir` value always wins, since the user explicitly typed it. The
-//! same precedence applies to `--port`. Output uses [`crate::output`]
-//! helpers for consistent styling with the other zfb commands.
+//! working directory. Loading the config validates the project; the
+//! command-line `--outdir` and `--port` arguments win **unconditionally** —
+//! `clap` defaults them to concrete values, so we cannot cheaply distinguish
+//! "user passed the flag" from "user accepted the default", and treating CLI
+//! as authoritative keeps the rule predictable across all four commands (see
+//! the matching note in `commands/dev.rs` and `commands/build.rs`). Output
+//! uses [`crate::output`] helpers for consistent styling with the other zfb
+//! commands.
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::{Path, PathBuf};
@@ -29,16 +33,6 @@ use crate::cli::PreviewArgs;
 use crate::config;
 use crate::output;
 
-/// Default value used by clap for `--outdir`. Kept in sync with
-/// [`crate::cli::PreviewArgs`] so we can detect when the user did not pass an
-/// explicit override and we should fall back to the config's `outDir`.
-const CLAP_DEFAULT_OUTDIR: &str = "dist";
-
-/// Default value used by clap for `--port`. Same rationale as
-/// [`CLAP_DEFAULT_OUTDIR`] — when the user did not pass `--port`, we let the
-/// config's `port` win.
-const CLAP_DEFAULT_PORT: u16 = 4321;
-
 pub async fn run(args: &PreviewArgs) -> anyhow::Result<()> {
     // Resolve the project root from the current working directory and load
     // the project config (if any). A missing config file is fine — it
@@ -46,7 +40,7 @@ pub async fn run(args: &PreviewArgs) -> anyhow::Result<()> {
     // unsupported zfb.config.ts) is surfaced via the output helpers and
     // propagated so `main()` can exit non-zero.
     let project_root = std::env::current_dir().context("failed to read current working dir")?;
-    let cfg = match config::load_from_dir(&project_root).await {
+    let _cfg = match config::load_from_dir(&project_root).await {
         Ok(cfg) => cfg,
         Err(err) => {
             output::error(&output::format_error(&err));
@@ -54,24 +48,11 @@ pub async fn run(args: &PreviewArgs) -> anyhow::Result<()> {
         }
     };
 
-    // CLI `--outdir` wins over config `outDir`. We can only tell whether the
-    // CLI value is "explicit" by comparing against clap's default literal, so
-    // both the literal and the type stay in sync with `PreviewArgs::outdir`.
-    let outdir = if args.outdir == PathBuf::from(CLAP_DEFAULT_OUTDIR) {
-        cfg.out_dir.clone()
-    } else {
-        args.outdir.clone()
-    };
-    // Resolve a relative outdir against the project root so the
-    // existence check (and ServeDir) operate on an unambiguous path.
-    let outdir = resolve_under_root(&project_root, &outdir);
-
-    // CLI `--port` wins over config `port`. Same fallback rule as outdir.
-    let port = if args.port == CLAP_DEFAULT_PORT {
-        cfg.port
-    } else {
-        args.port
-    };
+    // Resolve `args.outdir` against the project root so the existence check
+    // (and `ServeDir`) operate on an unambiguous path. CLI wins over config
+    // unconditionally — see the precedence note in the module doc comment.
+    let outdir = resolve_under_root(&project_root, &args.outdir);
+    let port = args.port;
 
     // Verify the output directory exists *before* binding the port so that
     // missing-build errors don't leave a half-started server behind.
@@ -143,21 +124,4 @@ mod tests {
         assert_eq!(resolve_under_root(root, &abs), abs);
     }
 
-    #[test]
-    fn clap_defaults_match_cli_struct() {
-        // Defensive: if `PreviewArgs` ever changes its clap defaults, the
-        // CLI-vs-config precedence logic in `run()` would silently break.
-        // This keeps the literals here honest.
-        use clap::Parser;
-
-        #[derive(Parser)]
-        struct Wrap {
-            #[command(flatten)]
-            args: PreviewArgs,
-        }
-
-        let parsed = Wrap::try_parse_from(["zfb-preview-test"]).expect("defaults parse");
-        assert_eq!(parsed.args.outdir, PathBuf::from(CLAP_DEFAULT_OUTDIR));
-        assert_eq!(parsed.args.port, CLAP_DEFAULT_PORT);
-    }
 }

--- a/crates/zfb/src/main.rs
+++ b/crates/zfb/src/main.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 
 use zfb::cli::{Cli, Command};
 use zfb::commands;
+use zfb::output;
 
 #[tokio::main]
 async fn main() {
@@ -13,7 +14,11 @@ async fn main() {
         Command::Preview(args) => commands::preview::run(args).await,
     };
     if let Err(e) = result {
-        eprintln!("error: {e:#}");
+        // Single, centralized error rendering so individual commands can
+        // just `return Err(e)` without pre-printing — avoids the
+        // double-print that would otherwise happen when a command both
+        // formats the error itself and returns it for main to log again.
+        output::error(output::format_error(&e).trim_end());
         std::process::exit(1);
     }
 }


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/9
- parent PR
    - (super-epic base; super-epic #2)

---

## Summary

Follow-up on the Epic #9 verification comment — lands the deferred items that don't depend on ADR-001:

- **Config wiring** — `crate::config::load_from_dir` now drives `zfb dev`, `zfb build`, and `zfb preview`. JSON path is fully supported; `zfb.config.ts` returns the existing clear "not yet supported" error from the loader. Across all three commands the precedence rule is the same: CLI args win unconditionally over config (clap defaults to concrete values, so we cannot cheaply tell "user passed the flag" from "user accepted the default" — treating CLI as authoritative is the predictable rule).
- **Output adoption** — `crate::output::*` (`info` / `success` / `warn` / `error` / `ready` / `format_error`) is now used in `cmd-dev`, `cmd-build`, `cmd-preview`, and `cmd-new`. Raw `println!` / `eprintln!` removed from those four files.
- **`zfb build` route enumeration** — `zfb_router::Router::scan(&pages_dir)` enumerates routes; static routes get a per-route stub HTML written via `zfb_build::atomic_write_string`; dynamic / catchall routes are warn-skipped (they need a runtime `paths()` evaluation, which depends on the renderer). Empty-pages projects still emit a stub `index.html` so `zfb preview` has something to serve. The canonical `✓ N pages built in X.XXs` summary now reflects the real route count via `output::success`.
- **Centralized error rendering** — `main.rs` is now the single error renderer (`output::error(format_error(&e))`); commands that previously formatted errors before returning have been collapsed to plain `?` + `anyhow::Context`. This was a `gcoc-review` finding; the prior pattern double-printed every config-load failure.

### What's still deferred (intentional, blocked on ADR-001)

- Real per-route SSR rendering in `cmd-dev` and `cmd-build`. `zfb_render::render_host::DenoCoreHost` is still a skeleton (`execute_module` returns a placeholder, `call_default` returns `RenderError::Runtime("not yet implemented (ADR-001 pending)")`). The actual JS-runtime work currently lives in the separate `zfb-runtime-spike` crate as ADR-001 inputs.
- Page-cache population in `cmd-dev`'s `on_outcome` callback — same blocker.
- Dynamic and catchall route expansion in `cmd-build` — same blocker (needs `paths()` execution).
- `zfb.config.ts` loading — same `Sub 3` deferral as the prior session.

The CLI surface, the `BuildContext` / `PageRenderer` boundary, and the `Renderer<H: RenderHost>` boundary are all untouched, so when ADR-001 lands the swap is local to the renderer body and the on_outcome cache-fill block.

## Topic PRs

Topic branches were merged locally into `base/zfb-init-cli` (regular `--no-ff` merges) and deleted both locally and remotely. Per-topic PRs were not created (would have failed with "no commits between base and head" since the topics were already in base by the time the push happened).

- `cmd-dev-polish` — config + output adoption in `commands/dev.rs`
- `cmd-build-routes` — config + output + `zfb_router::Router::scan` route enumeration in `commands/build.rs`
- `cmd-preview-new-polish` — config wiring (preview) + output adoption (preview + new)
- (manager) `commands/preview.rs` precedence fix to align with cmd-dev / cmd-build
- (manager) `main.rs` centralized error renderer (gcoc-review fix)

## Stats

- 6 files changed, ~479 insertions, ~97 deletions
- 34 unit tests pass on the merged base
- `cargo build -p zfb` clean, no warnings
- `gcoc-review` ran on the full diff; 1 HIGH finding (double-print) and 2 MEDIUM (consistency, route mapping) — HIGH addressed; MEDIUM and LOW were already-correct or out-of-scope