### PR TITLE
[zfb Init][Epic] zfb docs content + examples/basic-blog dogfood (#10)

### DIFF
--- a/docs/src/content/docs/api/define-config.mdx
+++ b/docs/src/content/docs/api/define-config.mdx
@@ -21,14 +21,32 @@ All keys are camelCase and mirror `crates/zfb/src/config.rs`.
 - `host`: string, default `"localhost"`
 - `port`: number, default `3000`
 - `framework`: `"preact" | "react"`, default `"preact"`
-- `collections`: `Record<string, CollectionDef>` — each entry has `type` (`"content" | "data"`), `directory`, and optional `schema`. A `schema` is a record mapping field names to `"string" | "number" | "boolean" | "date"`, with a trailing `?` (e.g. `"string?"`) to mark a field optional.
+- `collections`: array of `CollectionDef`. Each entry has `name` (the call-site identifier, e.g. `"blog"`), `path` (directory relative to the project root), and optional `schema` (reserved — accepted today but not enforced; see the v0 note below).
 - `tailwind?`: `{ enabled: boolean }`
 - `plugins?`: array — schema TBD; not yet consumed in v0.
 
 ## Examples
 
+```json
+// zfb.config.json — the form actually loaded by v0
+{
+  "outDir": "dist",
+  "framework": "preact",
+  "collections": [
+    {
+      "name": "blog",
+      "path": "content/blog"
+    }
+  ],
+  "tailwind": { "enabled": true }
+}
+```
+
 ```ts
-// zfb.config.ts (eventual canonical form)
+// zfb.config.ts — aspirational form, NOT yet loaded.
+// Documented here for forward compatibility; once the runtime ships
+// (ADR-001) this richer schema lands. Do NOT ship this alongside a
+// zfb.config.json — the v0 loader rejects when both files are present.
 import { defineConfig } from "zfb/config";
 
 export default defineConfig({
@@ -37,7 +55,7 @@ export default defineConfig({
   collections: {
     blog: {
       type: "content",
-      directory: "src/content/blog",
+      directory: "content/blog",
       schema: {
         title: "string",
         date: "date",
@@ -49,28 +67,9 @@ export default defineConfig({
 });
 ```
 
-```json
-{
-  "outDir": "dist",
-  "framework": "preact",
-  "collections": {
-    "blog": {
-      "type": "content",
-      "directory": "src/content/blog",
-      "schema": {
-        "title": "string",
-        "date": "date",
-        "draft": "boolean?"
-      }
-    }
-  },
-  "tailwind": { "enabled": true }
-}
-```
+<Warning title="v0: schema is intentionally narrow">
 
-<Warning title="v0: TS config not yet loaded">
-
-  `zfb.config.ts` parsing is pending the JS runtime decision (see [ADR-001](/architecture/js-runtime)). For now, write your configuration as `zfb.config.json` — the loader reads that form today.
+  Today the loader accepts only the JSON form above — `collections` is an array of `{ name, path, schema? }`, and `schema` is parsed but not enforced (it lands as opaque JSON, reserved for v1.1). The richer object-keyed shape with `type: "content" | "data"` and per-field validators is the planned future schema and is shown in the TypeScript example purely so you can author against it now and switch over later. `zfb.config.ts` parsing itself is pending the JS runtime decision (see [ADR-001](/architecture/js-runtime)). For now, write your configuration as `zfb.config.json` — the loader reads that form today.
 
 </Warning>
 
@@ -79,5 +78,5 @@ export default defineConfig({
 The loader enforces the following rules and reports errors with the file path plus `line:column` for JSON parse failures:
 
 - Collection names must be unique.
-- `directory` cannot be an absolute path.
-- `directory` cannot contain `..` segments that escape the project root.
+- `path` cannot be an absolute path.
+- `path` cannot contain `..` segments that escape the project root.

--- a/docs/src/content/docs/api/define-config.mdx
+++ b/docs/src/content/docs/api/define-config.mdx
@@ -1,0 +1,83 @@
+---
+title: defineConfig
+description: Define a zfb project configuration with full type inference.
+sidebar_position: 1
+---
+
+## Signature
+
+```ts
+defineConfig(config: Config): Config
+```
+
+`defineConfig` is re-exported from `zfb/config`. The helper is identity-typed: it returns its argument unchanged. Its only job is to give your editor IntelliSense and type-checking against the `Config` shape. The actual schema is enforced by Rust serde at config-load time, so the same rules apply whether you author your config in TypeScript or JSON.
+
+## Config shape
+
+All keys are camelCase and mirror `crates/zfb/src/config.rs`.
+
+- `outDir`: string, default `"dist"`
+- `publicDir`: string, default `"public"`
+- `host`: string, default `"localhost"`
+- `port`: number, default `3000`
+- `framework`: `"preact" | "react"`, default `"preact"`
+- `collections`: `Record<string, CollectionDef>` — each entry has `type` (`"content" | "data"`), `directory`, and optional `schema`. A `schema` is a record mapping field names to `"string" | "number" | "boolean" | "date"`, with a trailing `?` (e.g. `"string?"`) to mark a field optional.
+- `tailwind?`: `{ enabled: boolean }`
+- `plugins?`: array — schema TBD; not yet consumed in v0.
+
+## Examples
+
+```ts
+// zfb.config.ts (eventual canonical form)
+import { defineConfig } from "zfb/config";
+
+export default defineConfig({
+  outDir: "dist",
+  framework: "preact",
+  collections: {
+    blog: {
+      type: "content",
+      directory: "src/content/blog",
+      schema: {
+        title: "string",
+        date: "date",
+        draft: "boolean?",
+      },
+    },
+  },
+  tailwind: { enabled: true },
+});
+```
+
+```json
+{
+  "outDir": "dist",
+  "framework": "preact",
+  "collections": {
+    "blog": {
+      "type": "content",
+      "directory": "src/content/blog",
+      "schema": {
+        "title": "string",
+        "date": "date",
+        "draft": "boolean?"
+      }
+    }
+  },
+  "tailwind": { "enabled": true }
+}
+```
+
+<Warning title="v0: TS config not yet loaded">
+
+  `zfb.config.ts` parsing is pending the JS runtime decision (see [ADR-001](/architecture/js-runtime)). For now, write your configuration as `zfb.config.json` — the loader reads that form today.
+
+</Warning>
+
+## Validation
+
+The loader enforces the following rules and reports errors with the file path plus `line:column` for JSON parse failures:
+
+- Collection names must be unique.
+- `directory` cannot be an absolute path.
+- `directory` cannot contain `..` segments that escape the project root.

--- a/docs/src/content/docs/api/get-collection.mdx
+++ b/docs/src/content/docs/api/get-collection.mdx
@@ -1,0 +1,52 @@
+---
+title: getCollection
+description: Load all entries from a content or data collection.
+sidebar_position: 2
+---
+
+## Signature
+
+```ts
+getCollection(name: string): CollectionEntry[]
+```
+
+Call `getCollection` from a page module to load every entry in a named collection. The collection must be declared in your `zfb.config` under `collections`. Schema validation runs against each entry as it is read, so by the time the array reaches your component, frontmatter is already typed and verified.
+
+## CollectionEntry shape
+
+Each entry, per the current sketch in `zfb-content`, has the following fields:
+
+- `slug`: string — the filename without its extension, normalized to kebab-case.
+- `data`: object — the validated frontmatter (for `content` collections) or the parsed file body (for `data` collections).
+- `body`: string — rendered HTML for markdown entries; the raw value for data entries.
+- `id`: string — the full path relative to the collection's `directory`.
+
+## Example
+
+A typical use case is rendering a list of blog posts on an index page.
+
+```tsx
+import { getCollection } from "zfb/content";
+
+export default async function BlogIndex() {
+  const posts = await getCollection("blog");
+
+  return (
+    <ul>
+      {posts.map((post) => (
+        <li key={post.slug}>
+          <a href={`/blog/${post.slug}`}>{post.data.title}</a>
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+For dynamic per-entry pages, combine `getCollection` with a `paths()` export — see [paginate](/api/paginate) for the related pattern.
+
+<Warning title="v0 status">
+
+  Discovery and schema validation work today: `zfb` reads each collection directory, validates frontmatter against the declared schema, and surfaces errors with file paths. Wiring the `getCollection` call into the rendered page output requires the JS runtime, which is still pending — see [ADR-001](/architecture/js-runtime). You can declare collections and run the build to validate them; rendering will follow once the runtime ships.
+
+</Warning>

--- a/docs/src/content/docs/api/island.mdx
+++ b/docs/src/content/docs/api/island.mdx
@@ -1,0 +1,53 @@
+---
+title: "Islands (\"use client\")"
+description: "Mark a component as a client-hydrated island with the \"use client\" directive."
+sidebar_position: 4
+---
+
+## The directive
+
+A component file whose first statement is the literal string `"use client"` is treated as an **island** — a piece of UI that ships JavaScript and hydrates in the browser. Everything else stays server-rendered HTML.
+
+When the islands pipeline (`crates/zfb-islands`, esbuild-backed) sees the directive, the component is:
+
+- Compiled to ESM separately, with its own dependency graph.
+- Embedded into pages via a small bootstrap that hydrates the component when its DOM marker enters the viewport. This is the default lazy strategy.
+
+## Example
+
+The default template's counter shows the canonical shape: a leading `"use client"` line, then a normal Preact component.
+
+```tsx
+"use client";
+
+import { useState } from "preact/hooks";
+
+export default function Counter() {
+  const [count, setCount] = useState(0);
+  return (
+    <button onClick={() => setCount(count + 1)}>
+      Count: {count}
+    </button>
+  );
+}
+```
+
+Import the island from a server component or page module and render it as you would any other component. The build pipeline rewrites the import to insert the hydration marker and wire up the bootstrap.
+
+## Hydration directives
+
+Three directives are planned for picking when an island hydrates:
+
+- `client:load` — hydrate as soon as the page's JS runs.
+- `client:visible` — hydrate when the component scrolls into view (today's default behaviour).
+- `client:idle` — hydrate during the browser's next idle period.
+
+Only the default lazy/visible strategy is sketched in v0; the directive surface will land alongside the renderer.
+
+<Warning title="v0 status">
+
+  The `"use client"` detector and the esbuild-backed bundler are sketched in `crates/zfb-islands` but are not yet wired through the renderer (see [ADR-001](/architecture/js-runtime)). Components authored with `"use client"` will produce static SSR markup once the renderer lands; client hydration follows after that. You can write islands today using this pattern and they will activate as the pipeline completes.
+
+</Warning>
+
+For the broader story on islands architecture and when to reach for one, see [Islands](/concepts/islands).

--- a/docs/src/content/docs/api/meta-export.mdx
+++ b/docs/src/content/docs/api/meta-export.mdx
@@ -1,0 +1,49 @@
+---
+title: meta export
+description: Declare per-page head metadata via a meta export.
+sidebar_position: 5
+---
+
+## The pattern
+
+Every page module may export a `meta` constant (or an async function returning the same record) describing the page's `<head>` data — title, description, Open Graph tags, canonical URL, and so on. The renderer reads this export and merges it into the page layout's `<head>` block.
+
+The extraction goes through the `RenderHost::get_export` API, defined in `crates/zfb-render/src/render_host.rs`. That signature is the contract every JS runtime backend must satisfy when v0 of the renderer lands.
+
+## Example
+
+```tsx
+export const meta = {
+  title: "Blog — My Site",
+  description: "Latest writing on web development.",
+  canonical: "https://example.com/blog",
+  og: {
+    image: "/og/blog.png",
+    type: "website",
+  },
+};
+
+export default function BlogPage() {
+  return <article>{/* ... */}</article>;
+}
+```
+
+If you need data from a collection or an async source to compute meta — for example, an OG image derived from a CMS field — export `meta` as an async function. The renderer awaits it before rendering the page shell.
+
+## Recommended schema
+
+The renderer treats `meta` as a permissive bag, but the following keys are the supported subset and what page layouts will look for first:
+
+- `title?: string` — overrides the layout default for this page.
+- `description?: string` — used for the `<meta name="description">` tag and as the OG fallback.
+- `canonical?: string` — absolute URL for `<link rel="canonical">`.
+- `og?: { title?, description?, image?, type?, url? }` — Open Graph tags. Missing fields fall back to top-level `title` / `description` where it makes sense.
+- `twitter?: { card?, site?, creator?, image? }` — Twitter Card tags.
+
+Unknown keys pass through untouched, which lets you stash structured data for plugins or custom layout components.
+
+<Warning title="v0 status">
+
+  The `meta` extraction interface is defined in `zfb-render`, but actual extraction at render time depends on the JS runtime (see [ADR-001](/architecture/js-runtime)). For now, you can plan and write your `meta` exports against this schema — they will flow through the renderer once the runtime ships.
+
+</Warning>

--- a/docs/src/content/docs/api/paginate.mdx
+++ b/docs/src/content/docs/api/paginate.mdx
@@ -1,0 +1,57 @@
+---
+title: paginate
+description: Expand a list of items into paginated route instances.
+sidebar_position: 3
+---
+
+## Signature
+
+```ts
+paginate(items: T[], opts: { pageSize: number; route: string }): PaginationPath[]
+```
+
+Use `paginate` inside a `paths()` export to fan a list of items out across a paginated route. The function chunks `items` by `pageSize` and produces one `PaginationPath` per chunk. Each path knows its URL params and the props the page should receive.
+
+## PaginationPath shape
+
+- `params`: object — the URL params for the route. For paginated lists, this is typically `{ page: number }`.
+- `props`: object — passed to the page's default export. For a list page, this is usually `{ items: T[], page: number, totalPages: number }`.
+
+## Example
+
+Paginate a blog index 10 posts at a time under `/blog/page/[page]`.
+
+```tsx
+import { paginate, getCollection } from "zfb/content";
+
+export async function paths() {
+  const posts = await getCollection("blog");
+  return paginate(posts, {
+    pageSize: 10,
+    route: "/blog/page/[page]",
+  });
+}
+
+export default function BlogPage({ items, page, totalPages }) {
+  return (
+    <section>
+      <h2>Blog — page {page} of {totalPages}</h2>
+      <ul>
+        {items.map((post) => (
+          <li key={post.slug}>
+            <a href={`/blog/${post.slug}`}>{post.data.title}</a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+```
+
+The `[page]` segment in `route` matches the `params.page` value emitted by `paginate`. Page numbers start at 1.
+
+<Warning title="v0: paths() evaluation pending">
+
+  `paths()` is part of the routing model today — the router recognises dynamic routes and reserves the `paths` export name. Expanding `paths()` into concrete page instances at build time requires the JS runtime (see [ADR-001](/architecture/js-runtime)). `zfb build` currently warn-skips dynamic routes; you can write your `paginate` calls now and they will be honoured once the runtime lands.
+
+</Warning>

--- a/docs/src/content/docs/architecture/build-engine.mdx
+++ b/docs/src/content/docs/architecture/build-engine.mdx
@@ -1,0 +1,65 @@
+---
+title: Build engine
+description: "How zfb's crates fit together, why the rebuild is per-page, and what makes a `dist/` write safe."
+sidebar_position: 1
+---
+
+This page is about the *shape* of zfb's build engine. For a step-by-step walk of what happens when you save a file, read [Build pipeline](/docs/concepts/build-pipeline); this page explains why the story is shaped this way.
+
+## The crate split
+
+zfb is a Rust workspace. Each crate owns one slice of the build, and the data flowing between them is small and explicit.
+
+- **`zfb-router`** scans `pages/` and turns files into routes. It owns the file-name-to-URL convention and nothing else.
+- **`zfb-graph`** holds the dependency graph. Every page knows which sources it depends on (components, layouts, content, styles); every source knows which pages depend on it. This is the index that makes per-page rebuilds possible.
+- **`zfb-watcher`** wraps the `notify` crate, normalises the noisy native events into one `Change` per logical save, and emits them on a channel.
+- **`zfb-build`** is the orchestrator. It consumes `Change` values, classifies them, asks the graph which pages need rebuilding, and runs the asset pipeline.
+- **`zfb-render`** compiles TSX through SWC, hands the resulting JS to a `RenderHost`, and writes the HTML.
+- **`zfb-css`** processes CSS modules and global styles.
+- **`zfb-islands`** scans for `client:*` directives, bundles the per-island JS, and emits the hydration entry.
+- **`zfb-content`** parses Markdown / MDX content collections and runs the unified plugin chain.
+- **`zfb-server`** is the dev-only HTTP server: a page cache, a static-file route, and the live-reload SSE stream.
+
+The crates depend downward: the orchestrator knows about render, css, islands, content. The renderer does not know about the orchestrator. The server only reads.
+
+## Per-page rebuild, not per-bundle
+
+Bundler-based tools (Vite, esbuild) think in modules and chunks: a change invalidates a module, and the bundler walks the import graph to decide what to re-emit. zfb thinks in **pages**.
+
+When a file changes, `zfb-watcher` emits a `Change`, the orchestrator asks `zfb-graph` which pages depend on this path, and only those pages re-render. A leaf component used by three pages produces three page rebuilds — not a whole-site rebuild, not a bundler walk.
+
+The win is granularity. A 2,000-page site rebuilds the affected pages in milliseconds when a shared header changes. The cost is that the graph must be honest — `zfb-graph` is updated as part of every successful render so the next query has a current picture.
+
+<Info title="v0 status">
+
+  Most pieces of the engine are wired and unit-tested. The full
+  end-to-end render flow — TSX → JS → HTML — is gated on ADR-001's
+  runtime decision; see [JS runtime](/docs/architecture/js-runtime).
+
+</Info>
+
+## Atomic writes
+
+Every file in `dist/` is written through `atomic_write_string` (in `zfb-build`'s `atomic.rs`): write to a sibling temp file in the same directory, then `rename` over the destination. `rename` is atomic on POSIX for same-disk files, and Windows has the same guarantee through `MoveFileExW`'s replace-existing semantics.
+
+Concretely:
+
+- A reader opening `dist/index.html` mid-build sees the old bytes or the new bytes — never half-written, never empty.
+- A crashed build leaves orphan `*.tmp-<pid>-<seq>` files but never corrupts output. The naming is deliberate: `ls dist/` after a crash shows what was in flight.
+- The dev server can serve `dist/` while the orchestrator rewrites it. No coordination needed.
+
+This is the boring kind of correctness: not a feature, an invariant we never violate.
+
+## Watcher debounce and change coalescing
+
+`zfb-watcher` debounces native events with a 50ms default window. Editor saves are messy — vim writes to a swap file then renames; vscode emits multiple metadata events; `git checkout` produces hundreds of events at once. The debounce collapses each burst into one `Change` per path.
+
+The orchestrator does a second pass: when a tick fires, it drains every `Change` already in the channel before invoking the pipeline. A fast save burst still produces one pipeline run per natural pause. The orchestrator does no extra time-based coalescing on top of the watcher — the watcher already did the right thing. Typing fast does not thrash the build.
+
+## Relationship to the dev server
+
+The dev server (`zfb-server`) is a thin reader on top of the orchestrator's outputs. It owns a `PageCache` (URL path to rendered HTML, populated after every render), a `tokio::sync::broadcast` channel of `ReloadEvent` values, and an `axum` router that serves the cache, `dist/assets/`, `public/`, and an SSE endpoint at `/__zfb/reload`.
+
+The wiring point is `outcome_to_events` in `zfb-server`'s `livereload.rs`. Every non-noop `BuildOutcome` is translated into `ReloadEvent`s and broadcast. CSS-only changes emit a `css` event so the browser swaps stylesheets without losing client state; everything else emits a `page` event and triggers `location.reload()`.
+
+The server is dev-only. Production emits static files for an edge CDN. The same atomic-write guarantee that makes the dev server safe makes any production deploy safe.

--- a/docs/src/content/docs/architecture/framework-adapters.mdx
+++ b/docs/src/content/docs/architecture/framework-adapters.mdx
@@ -1,0 +1,74 @@
+---
+title: Framework adapters
+description: How zfb supports both Preact and React behind a single renderer, and the shape of the boundary that makes adding a third framework additive.
+sidebar_position: 3
+---
+
+zfb renders TSX. JSX is a syntax — the *runtime* that turns it into HTML is supplied by a framework. zfb supports two: **Preact** (default) and **React**. This page is the user-readable companion to ADR-002.
+
+## The need
+
+Two goals pull opposite ways. One: a single renderer pipeline that works the same for both frameworks, so we never fork the build. Two: many users want React (existing components, React-only libraries) and many want Preact (footprint, signals). zfb lets them pick:
+
+```ts
+// zfb.config.ts
+export default {
+  framework: "preact", // or "react"
+};
+```
+
+Read once at config-load time and threaded through the build. A one-line change for the user. For the renderer, the choice never appears — it talks to a uniform `Adapter` trait and has no `if framework == "react"` branches past adapter construction.
+
+## The boundary
+
+The contract lives in `crates/zfb-render/src/adapters/mod.rs`. Every adapter implements the same narrow trait:
+
+```rust
+pub trait Adapter {
+    fn name(&self) -> &'static str;
+    fn jsx_import_source(&self) -> &'static str;
+    fn render_to_string_module(&self) -> &'static str;
+    fn pre_render_setup(&self, host: &mut dyn RenderHost) -> Result<(), RenderError>;
+    fn hydrate_shim_specifier(&self) -> &'static str;
+    fn hydrate_shim_source(&self) -> &'static str;
+}
+```
+
+Three groups of responsibility, no more:
+
+1. **Tell the SWC pipeline which JSX import source to inject** (`jsx_import_source`). This drives the `transform-react` pass with `runtime: "automatic"` so user code never writes `import { h } from "preact"` or `import React from "react"` and never spells a `@jsxImportSource` pragma. The framework choice lives in config; SWC threads it everywhere.
+2. **Tell the runtime where the synchronous `renderToString` lives** (`render_to_string_module`) and **install a shim** (`pre_render_setup`) that aliases it as `globalThis.__zfbRenderToString`. The render orchestrator in `render.rs` then calls `__zfbRenderToString(vnode)` once per page, with no branching on framework identity.
+3. **Provide the client-side hydration shim** (`hydrate_shim_specifier` + `hydrate_shim_source`). The islands bundler folds this module into the islands bundle as the framework-specific entry. It exports `hydrateIsland(Component, props, element)`, and the framework-agnostic hydration runtime in `zfb-islands` calls it for every `[data-zfb-island]` element in the DOM.
+
+That is the entire surface. Hook semantics, signal interop, event delegation strategy — none of these are inside the boundary. Each framework keeps its own behaviour; the adapter only controls *which* framework is reached through.
+
+## Why a setup-phase shim
+
+`pre_render_setup` runs once, before the first page render, and installs `__zfbRenderToString` on `globalThis`. Per-page rendering is then one function call from Rust into JS — no module re-resolution, no shim re-installation, no per-call import dance. The cost is paid once per host lifetime; the benefit accrues across thousands of pages.
+
+Two tempting alternatives are ruled out. We are not generating per-page JS modules that import `preact-render-to-string` directly — that pushes module resolution onto the per-render hot path. We are not exposing a `hydrate_call()` API that returns a JS expression for Rust to template into source — that puts JS-expression concatenation in Rust, the wrong language for it. The shim keeps the Rust-to-JS boundary expressed purely as static module strings.
+
+## The Preact adapter
+
+Lives at `crates/zfb-render/src/adapters/preact.rs`. JSX import source `"preact"`; render module `"preact-render-to-string"`; hydration shim wraps `hydrate(vnode, container)`. Preact is the default because its footprint fits zfb's static-output target cleanly — `preact-render-to-string` is purpose-built for synchronous SSR and the runtime image stays small.
+
+## The React adapter
+
+Lives at `crates/zfb-render/src/adapters/react.rs`. Larger than Preact, opt-in for users who need the React ecosystem. JSX import source `"react"`; render module `"react-dom/server"`; hydration shim wraps React 18+'s `hydrateRoot(container, vnode)` — note the swapped argument order versus Preact, which the adapter owns so user code does not have to.
+
+The React adapter uses **synchronous** `renderToString`, not `renderToReadableStream` or `renderToPipeableStream`. zfb produces ahead-of-time static HTML; a sync string is simpler, deterministic, and avoids dragging Node streaming primitives into the build host. The cost is no streaming HTML and no React Server Components in v1.
+
+## Future adapters
+
+Solid, Vue SSR, Svelte SSR — none ship in v0. The `Adapter` trait is small enough that adding one is purely additive: a new adapter file, a new `Framework` enum variant, a new `make_adapter` arm. The render orchestrator does not change.
+
+If a future framework cannot satisfy the trait — for example, it requires an async render entry that does not fit `renderToString → string` — that is a reason to widen the trait deliberately, in a follow-on ADR, not to special-case it.
+
+<Info title="v0 status">
+
+  The `Adapter` trait, the `Framework` enum, and skeleton Preact and
+  React implementations are in place and unit-tested. The full
+  setup-shim wiring lights up when ADR-001 closes and the chosen
+  `RenderHost` implementation becomes functional end-to-end.
+
+</Info>

--- a/docs/src/content/docs/architecture/js-runtime.mdx
+++ b/docs/src/content/docs/architecture/js-runtime.mdx
@@ -1,0 +1,78 @@
+---
+title: JS runtime
+description: How zfb hosts JavaScript execution server-side, the candidates considered, and why the runtime is fixed by the binary.
+sidebar_position: 2
+---
+
+zfb renders TSX server-side. TSX compiles to JavaScript, and JavaScript needs an engine to execute it. Rust does not ship one, so zfb embeds a JS runtime. This page is the user-readable companion to ADR-001 — the architectural decision record that locks the runtime choice.
+
+## The need
+
+zfb's renderer compiles a page's TSX through SWC, hands the resulting ESM to a JS host, calls the module's `default` export, and writes the returned HTML to disk. The host must:
+
+- support ESM (`import` / `export`) so pages can import shared components naturally,
+- support top-level `await` so a page can `await fetch(...)` or `await loadCollection(...)` at module scope,
+- surface thrown errors with **source-accurate** locations — the stack-trace line must match the line in the user's TSX file, not an offset into a wrapped script,
+- evaluate the same module repeatedly across a build of hundreds of pages without leaking memory.
+
+## The candidates
+
+The spike crate at `crates/zfb-runtime-spike/` implements the same `RenderHost` trait against three live candidates, gated behind cargo features so the heavy V8 build is opt-in.
+
+- **`deno_core`** — V8 wrapped by Deno's reusable core. Ships an ES module loader, an event loop for top-level await, and source-mapped errors out of the box.
+- **`ssr_rs`** — a thin V8 wrapper specialised for Preact / React SSR. Narrower scope, single-bundle entry-point model.
+- **`rquickjs`** — Rust bindings around QuickJS. Small footprint, fast to compile, single-threaded.
+
+Two more were rejected without a measured spike. `rusty_v8` is the same V8 we would get through `deno_core`, only at a lower level — choosing it means re-implementing the loader and isolate plumbing `deno_core` already gives us. `boa` is a pure-Rust ESM implementation; ECMA conformance and source-map fidelity trail V8 by enough that real-world Preact / React SSR hits unsupported corners.
+
+## The trade-off matrix
+
+The spike's bench harness loads five representative scenarios — static page, dynamic route, content collection, `"use client"`, and top-level await — and measures cold start, warm mean, warm p95, and steady-state RSS. Headline numbers from the v0 measurement run:
+
+| Axis            | `deno_core` | `ssr_rs`  | `rquickjs`         |
+| --------------- | ----------- | --------- | ------------------ |
+| Warm render     | 16us        | 1.37ms    | 106us              |
+| Cold start      | 181us       | 5.88ms    | 572us              |
+| Steady-state RSS| 19MB        | 317MB     | 4.5MB              |
+| ESM             | native      | bundle    | partial            |
+| Top-level await | native      | bundle    | not supported sync |
+| Source maps     | native      | partial   | offsets only       |
+| Build cost      | ~3 minutes  | similar   | ~30 seconds        |
+
+The full table, raw samples, and methodology live in the [ADR](https://github.com/Takazudo/zudo-front-builder/blob/main/docs/architecture/adr-001-js-runtime.md). The V8-class engines win on the correctness axes; QuickJS wins on footprint and build cost. `ssr_rs`'s default per-render isolate creation dominates everything else and accumulates memory under load.
+
+## Constraints zfb imposes
+
+Two project-level invariants shape the choice further.
+
+**Single isolate per render thread.** V8's isolate is pinned to one thread; QuickJS keeps a similar invariant. Whichever runtime ships, the renderer treats the host as `!Send` and runs it on a dedicated thread, exchanging work over a channel.
+
+**The runtime is fixed by the binary, not by config.** `zfb.config.ts` cannot pick its own JS runtime. The runtime is whatever the `zfb` binary you installed was compiled with. That keeps the contract between zfb and user code single-valued — every project built with one binary uses the same runtime. The bootstrap rule lives in `crates/zfb/src/config.rs`.
+
+## The boundary
+
+Everything above the host is written against the `RenderHost` trait in `crates/zfb-render/src/render_host.rs`:
+
+```rust
+pub trait RenderHost {
+    fn execute_module(&mut self, name: &str, source: &str) -> Result<ModuleHandle>;
+    fn call_default(&mut self, handle: &ModuleHandle, props: JsonValue) -> Result<String>;
+    fn get_export(&mut self, handle: &ModuleHandle, name: &str) -> Result<JsonValue>;
+}
+```
+
+That is the entire surface the renderer uses. `zfb-render`, `zfb-build`, and the framework adapters never name the concrete runtime. A future ADR can swap the implementation without touching call sites — add a new host, re-run the bench, flip a feature flag, and run the adapter integration tests to confirm byte-identical HTML.
+
+## Status
+
+ADR-001 is in flight. The `RenderHost` trait is real; `DenoCoreHost` is a skeleton whose three trait methods are stubbed pending the ADR's final wiring. When ADR-001 closes, one host implementation lights up end-to-end and `Renderer::render()` becomes functional from TSX source to HTML on disk.
+
+<Warning title="In-flight decision">
+
+  This page reflects the analysis as of v0. The final ADR-001 decision
+  will replace this page's content with the chosen runtime and the
+  rationale that locked it in. Track [issue
+  #4](https://github.com/Takazudo/zudo-front-builder/issues/4) for the
+  closing post.
+
+</Warning>

--- a/docs/src/content/docs/architecture/why-rust.mdx
+++ b/docs/src/content/docs/architecture/why-rust.mdx
@@ -1,0 +1,49 @@
+---
+title: Why Rust
+description: The bet behind writing a static-site framework in Rust, what it buys, and what it costs.
+sidebar_position: 4
+---
+
+zfb is a static-site framework whose users write TypeScript and JSX. The framework itself is Rust. This page explains why.
+
+## Performance
+
+The headline is per-page rebuild time measured in milliseconds. Parsing, type checking, content processing, and atomic file writes are all native Rust — not "fast enough", just genuinely fast. A 2,000-page site rebuilds the affected pages in well under a second when a shared header changes, because the work is a tight Rust loop over a known dependency graph.
+
+The dev loop is the same shape. A save produces an FS event; the watcher debounces; the orchestrator queries the graph; affected pages re-render; the dev server broadcasts a reload. End-to-end latency lives in the tens of milliseconds for a typical edit. The browser refresh is the slow part.
+
+This is not magic. It is what you get when the framework does not JIT-warm an interpreter every save and does not keep a multi-gigabyte module graph in memory.
+
+## Memory safety and structured errors
+
+Rust's compiler eliminates use-after-free, data races, and null derefs at compile time. The build does not segfault halfway through writing `dist/`. The watcher does not panic when save bursts overlap. Boring wins, the kind you stop noticing once you have them.
+
+The visible win is error quality. zfb uses `anyhow` end-to-end, so every error reaches the CLI as a chain: the immediate failure, the operation that failed, the file path, the higher-level intent. A TSX compile error shows the file, line, column, and the operation that triggered it — not a generic "build failed".
+
+## Concurrency that fits
+
+The build orchestrator schedules across CPUs; the dev server runs an `axum` listener and an SSE broadcast at the same time. Rayon handles parallel-page rendering; tokio handles the async I/O. They coexist without ceremony — Rust's type system enforces the boundaries, so threads never share state they should not share.
+
+The same code in Node would need worker threads or child processes for equivalent isolation. Workers do not share modules; child processes do not share memory. Either way, you pay coordination overhead on every page that the Rust version does for free.
+
+## Distribution
+
+zfb is a single binary. `cargo install --path crates/zfb` produces an executable; that executable is the framework. No `node_modules` for zfb itself, no transitive tree to audit, no npm-install hop on every bootstrap. Your project still brings its own `pnpm` for the dependencies you import (TypeScript, npm packages, lockfiles), but the framework is not in that tree.
+
+A single binary pins cleanly. CI installs the version it needs; production deploys ship the same binary that ran in dev. The version your team is on is one number, not a constellation of `package.json` ranges.
+
+## Honest counterpoint: build cost
+
+The first `cargo build` of zfb's workspace is slow. If V8 (`deno_core`) ends up as the JS runtime — see [JS runtime](/docs/architecture/js-runtime) — the V8 source bundle compiles for 5 to 15 minutes on a typical contributor machine. Incremental builds are fast; the first one hurts.
+
+The runtime spike's QuickJS feature is much faster (around 30 seconds). We gate the heavy candidates behind opt-in cargo features so a contributor can run unit tests without waiting on V8. End users do not pay this cost — they install the prebuilt binary.
+
+## Compared to JS-based alternatives
+
+Vite, Next, Astro, SvelteKit — all great tools. zfb's bet is different, not better in every direction: **what if the framework was Rust and only the user code was JS / TS?**
+
+That tilts the trade-offs. Build speed gets cheaper because there is no bundler walking a JS module graph at framework cost. Distribution gets simpler — no framework `node_modules`. Memory and concurrency get language-level guarantees. Error quality gets a uniform shape through `anyhow`.
+
+The cost is a smaller plugin ecosystem in the framework's native language and a longer first build for contributors. zfb pays both on purpose, because the design point is users who want their build out of their way.
+
+If you want a JS-native framework with a vast plugin ecosystem and a hot-reload story polished over years, those tools exist. If you want the framework to disappear into a fast binary and the rebuild to feel like nothing happened, that is what zfb is for.

--- a/docs/src/content/docs/concepts/build-pipeline.mdx
+++ b/docs/src/content/docs/concepts/build-pipeline.mdx
@@ -1,0 +1,50 @@
+---
+title: Build Pipeline
+description: An end-to-end tour of how zfb turns your project into a built site.
+sidebar_position: 6
+category: Concepts
+---
+
+<Warning title="v0 status">
+
+Steps 1, 2, 3, and 9 work today. Steps 5–8 — render, CSS extraction, island bundling, and the build orchestrator's full per-page work — are sketched but not yet wired end-to-end. The blocker is ADR-001 (the JS runtime decision). See /architecture/build-engine for the deeper why-this-shape discussion and /architecture/js-runtime for the runtime decision itself.
+
+</Warning>
+
+zfb is built as a set of small Rust crates that each own one job. This page is a tour of the whole pipeline at the level of "which crate does what, and in what order" — enough to give you a mental map without diving into any single piece.
+
+## The crates, in order
+
+1. **CLI** — `crates/zfb`. Parses command-line args, loads `zfb.config.{ts,json}`, and dispatches to the `dev`, `build`, or `preview` command.
+2. **Router** — `crates/zfb-router`. Scans `pages/` and produces the route table. See [Routing](/concepts/routing).
+3. **Watcher** — `crates/zfb-watcher`. Dev mode only. Observes `pages/`, `content/`, `components/`, `layouts/`, `styles/`, `data/`, `public/`, and `zfb.config.ts`, and emits a stream of change events.
+4. **Dependency graph** — `crates/zfb-graph`. Tracks page-to-source dependencies. When the watcher reports a change, the graph answers a single question: which pages need to be rebuilt?
+5. **Build orchestrator** — `crates/zfb-build`. Coordinates the per-page work and writes outputs atomically via `atomic_write_string`, so a partial write can never leave `dist/` in a half-broken state.
+6. **Renderer** — `crates/zfb-render`. Compiles TSX to JS with SWC, evaluates the resulting ES module via the JS runtime host, and calls the page's `default()` export to produce an HTML string.
+7. **CSS pipeline** — `crates/zfb-css`. Runs Tailwind v4 and PostCSS as needed. See [Styling](/concepts/styling).
+8. **Islands pipeline** — `crates/zfb-islands`. Bundles each `"use client"` component as a separate ESM module via esbuild. See [Islands](/concepts/islands).
+9. **Server** — `crates/zfb-server`. Dev mode only. An axum-based HTTP server that serves the page cache as static files, plus an SSE channel at `/__zfb/livereload` for browser reload events.
+
+## Production: `zfb build`
+
+`zfb build` runs the pipeline once and writes a complete site to `outDir`:
+
+CLI → Router → Graph → Build orchestrator → Renderer → CSS pipeline → Islands pipeline.
+
+The watcher and dev server are not involved. Every page is rendered, every CSS bundle is produced, every island is bundled, and the result lands in `dist/` (or wherever `outDir` points). Atomic writes mean an interrupted build leaves the previous `dist/` intact rather than a partially overwritten mess.
+
+## Development: `zfb dev`
+
+`zfb dev` runs the same pipeline as a long-lived loop, plus the watcher and server:
+
+CLI → Router → Watcher → Build orchestrator → Renderer → CSS pipeline → Islands pipeline → Server.
+
+When the watcher reports a change, the dependency graph picks the affected pages, the orchestrator rebuilds only those, and the server broadcasts a reload event over the SSE channel. The browser reconnects automatically and reloads.
+
+## Preview: `zfb preview`
+
+`zfb preview` is the simplest command of the three: it serves the existing `dist/` directory as static files on `:4321`. There is no rendering, no watching, no rebuilding — it exists so you can sanity-check a production build locally before deploying it.
+
+## Why the split
+
+The crate boundaries are not accidental. Routing is a different problem from rendering, which is different from watching, which is different from serving. Splitting them means each crate stays small enough to test in isolation, and means the dev loop can swap in optimisations (incremental rebuilds, page caching, partial CSS extraction) without touching the production path. The deeper reasoning lives in [/architecture/build-engine](/architecture/build-engine).

--- a/docs/src/content/docs/concepts/content-collections.mdx
+++ b/docs/src/content/docs/concepts/content-collections.mdx
@@ -1,0 +1,73 @@
+---
+title: Content Collections
+description: Define typed collections of Markdown content in zfb.config and load them from pages.
+sidebar_position: 2
+category: Concepts
+---
+
+<Warning title="v0 status">
+
+File discovery, frontmatter parsing, and Markdown rendering live in `crates/zfb-content` and are wired up. Full integration with the page renderer is blocked on ADR-001 (the JS runtime decision). See /architecture/js-runtime for the deeper discussion.
+
+</Warning>
+
+A **content collection** is a directory of Markdown (or MDX) files declared in your project config. zfb scans the directory at build time, parses each file's frontmatter against a schema you supply, and exposes the entries through a `getCollection()` helper your pages can call.
+
+## Declaring a collection
+
+Collections are configured in `zfb.config.ts` (or `zfb.config.json`) under the `collections` key:
+
+```json
+{
+  "collections": {
+    "blog": {
+      "type": "content",
+      "directory": "content/blog",
+      "schema": {
+        "title": "string",
+        "date": "date",
+        "description": "string?"
+      }
+    }
+  }
+}
+```
+
+The `type: "content"` tells zfb that each file is a Markdown document with frontmatter and a body. The `schema` is enforced at build time — any entry missing a required field, or with the wrong type, fails the build with a clear error pointing at the offending file.
+
+A `?` suffix marks a field as optional. Supported field types include `string`, `number`, `boolean`, `date`, and arrays (`string[]`).
+
+## Loading entries from a page
+
+Pages use `getCollection()` to enumerate entries:
+
+```tsx
+import { getCollection } from "zfb/content";
+
+export default async function BlogIndex() {
+  const posts = await getCollection("blog");
+  return (
+    <ul>
+      {posts.map((post) => (
+        <li key={post.slug}>
+          <a href={`/blog/${post.slug}`}>{post.data.title}</a>
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+Each entry has three things you can rely on:
+
+- `data` — the parsed, validated frontmatter (typed against your schema).
+- `body` — the rendered HTML for the Markdown body.
+- `slug` — derived from the file name (`my-first-post.md` → `my-first-post`). Nested directories become slash-separated slugs.
+
+The function signature lives in [`getCollection`](/api/get-collection).
+
+## How parsing works
+
+Under the hood, the `zfb-content` crate handles three jobs: it walks the configured directory, parses each file's YAML frontmatter, and renders the Markdown body to HTML using a deterministic pipeline. Anything beyond that — picking up changes in dev, surfacing entries to your page code, or wiring the rendered HTML into the final output — depends on the renderer being live, which is the ADR-001 blocker.
+
+For now, the discovery half works end-to-end and is well worth modelling your content around. Once ADR-001 lands, your collection code will start producing rendered pages without further changes.

--- a/docs/src/content/docs/concepts/content-collections.mdx
+++ b/docs/src/content/docs/concepts/content-collections.mdx
@@ -15,27 +15,28 @@ A **content collection** is a directory of Markdown (or MDX) files declared in y
 
 ## Declaring a collection
 
-Collections are configured in `zfb.config.ts` (or `zfb.config.json`) under the `collections` key:
+Collections are configured in `zfb.config.json` under the `collections` key. Today the loader accepts an array of entries with `name` and `path`:
 
 ```json
 {
-  "collections": {
-    "blog": {
-      "type": "content",
-      "directory": "content/blog",
-      "schema": {
-        "title": "string",
-        "date": "date",
-        "description": "string?"
-      }
+  "collections": [
+    {
+      "name": "blog",
+      "path": "content/blog"
     }
-  }
+  ]
 }
 ```
 
-The `type: "content"` tells zfb that each file is a Markdown document with frontmatter and a body. The `schema` is enforced at build time — any entry missing a required field, or with the wrong type, fails the build with a clear error pointing at the offending file.
+The `name` is the identifier you pass to `getCollection()`. The `path` is the directory (relative to the project root) holding the entries. zfb walks that directory, treats each file as a Markdown document with frontmatter, and exposes its entries through `getCollection("blog")`.
 
-A `?` suffix marks a field as optional. Supported field types include `string`, `number`, `boolean`, `date`, and arrays (`string[]`).
+You can additionally supply an optional `schema` field — it is parsed but not yet enforced in v0; the planned future shape (per-field validators with `string`, `number`, `boolean`, `date`, `string[]` and a trailing `?` for optional) is described on the [`defineConfig`](/api/define-config) page so you can plan for it.
+
+<Info title="The richer schema lands with the runtime">
+
+  The forward-looking shape — `collections` keyed by name with `type: "content" | "data"`, `directory`, and an enforced `schema` — is the v1 target. It is documented on the `defineConfig` page for forward compatibility but is not what the loader accepts today. Author against the `[{ name, path }]` form for now; migrating later is a mechanical translation.
+
+</Info>
 
 ## Loading entries from a page
 

--- a/docs/src/content/docs/concepts/data.mdx
+++ b/docs/src/content/docs/concepts/data.mdx
@@ -1,0 +1,81 @@
+---
+title: Data
+description: Three options for sourcing structured data in zfb — content collections, data collections, and plain TS modules.
+sidebar_position: 3
+category: Concepts
+---
+
+<Info>
+
+The discovery and parsing halves of data and content collections work today. The bridge into the page renderer is part of the ADR-001 work.
+
+</Info>
+
+zfb gives you three different routes for getting structured data into a page, and the right choice depends on the shape of the data and how much ceremony you want around it.
+
+## 1. Content collections
+
+When the data is **prose** — blog posts, docs articles, recipes — use a content collection. Each entry is a Markdown file with frontmatter, the frontmatter is validated against a schema, and the body is rendered to HTML for you. See [Content Collections](/concepts/content-collections) for the full story.
+
+This is the right choice whenever the body of each entry is meant to be read.
+
+## 2. Data collections
+
+When the data is **structured** — a list of products, a directory of team members, a set of pricing tiers — use a data collection. The shape is the same as a content collection, but you set `type: "data"` and put JSON, YAML, or TOML files in the directory:
+
+```json
+{
+  "collections": {
+    "products": {
+      "type": "data",
+      "directory": "data/products",
+      "schema": {
+        "name": "string",
+        "price": "number",
+        "inStock": "boolean"
+      }
+    }
+  }
+}
+```
+
+Each file becomes one entry, validated against your schema. You load them the same way:
+
+```tsx
+import { getCollection } from "zfb/content";
+
+const products = await getCollection("products");
+```
+
+A data collection earns its keep when you want **per-entry validation, slug derivation, and the same loading API as your prose content** — without the Markdown-rendering step.
+
+## 3. Plain TS modules under `data/`
+
+For everything else — small lookups, helper functions, derived constants — a regular TypeScript module is the lightest path:
+
+```ts
+// data/site.ts
+export const siteName = "My Site";
+
+export function formatDate(date: Date) {
+  return date.toISOString().slice(0, 10);
+}
+```
+
+Import it from any page or component:
+
+```tsx
+import { siteName, formatDate } from "../data/site";
+```
+
+There is no schema, no slug, and no per-entry overhead. Use this when the "collection" framing would be more ceremony than the data deserves.
+
+## Picking the right tool
+
+A useful rule of thumb:
+
+- The data is **content meant to be read** → content collection.
+- The data is **structured records that share a shape** → data collection.
+- The data is **a handful of constants or a helper** → TS module under `data/`.
+
+You can mix all three in the same project without conflict.

--- a/docs/src/content/docs/concepts/data.mdx
+++ b/docs/src/content/docs/concepts/data.mdx
@@ -21,25 +21,20 @@ This is the right choice whenever the body of each entry is meant to be read.
 
 ## 2. Data collections
 
-When the data is **structured** — a list of products, a directory of team members, a set of pricing tiers — use a data collection. The shape is the same as a content collection, but you set `type: "data"` and put JSON, YAML, or TOML files in the directory:
+When the data is **structured** — a list of products, a directory of team members, a set of pricing tiers — use a data collection: a directory of JSON / YAML / TOML files declared in `zfb.config.json`. The same `[{ name, path }]` shape that content collections use today (see [Content Collections](/concepts/content-collections)) accepts data directories without ceremony:
 
 ```json
 {
-  "collections": {
-    "products": {
-      "type": "data",
-      "directory": "data/products",
-      "schema": {
-        "name": "string",
-        "price": "number",
-        "inStock": "boolean"
-      }
+  "collections": [
+    {
+      "name": "products",
+      "path": "data/products"
     }
-  }
+  ]
 }
 ```
 
-Each file becomes one entry, validated against your schema. You load them the same way:
+Each file becomes one entry. Per-entry schema validation is the planned future shape (matches the `defineConfig` v1 schema with explicit `type: "data"` + per-field validators); today the loader walks the directory and surfaces entries through `getCollection()`. You load them the same way:
 
 ```tsx
 import { getCollection } from "zfb/content";

--- a/docs/src/content/docs/concepts/islands.mdx
+++ b/docs/src/content/docs/concepts/islands.mdx
@@ -1,0 +1,73 @@
+---
+title: Islands
+description: "Mark client-interactive components with \"use client\" and let zfb hydrate them in the browser."
+sidebar_position: 5
+category: Concepts
+---
+
+<Warning title="v0 status">
+
+The `"use client"` detection and the island bundler are sketched in `crates/zfb-islands` but are not wired into the build output yet. The blocker is the same as the renderer (ADR-001 — the JS runtime decision). See /architecture/js-runtime for the deeper discussion.
+
+</Warning>
+
+zfb pages render to static HTML by default. **Islands** are the escape hatch — small components that ship JavaScript to the browser and hydrate on the client, while the rest of the page stays as plain HTML.
+
+The mental model is straightforward: most of your page is a static document. A few interactive bits — a counter, a search box, a modal trigger — are islands embedded inside that document, each loaded and hydrated independently.
+
+## Marking a component as an island
+
+Add the `"use client"` directive at the top of a `.tsx` file:
+
+```tsx
+"use client";
+
+import { useState } from "react";
+
+export default function Counter() {
+  const [count, setCount] = useState(0);
+  return (
+    <button onClick={() => setCount(count + 1)}>
+      Count: {count}
+    </button>
+  );
+}
+```
+
+That single directive is the whole opt-in. Files without it are pure server components — they render once at build time and never reach the browser.
+
+The default template's `components/counter.tsx` is the canonical example to look at when you start.
+
+## Using an island in a page
+
+Import the island and use it like any other component:
+
+```tsx
+import Counter from "../components/counter";
+
+export default function Home() {
+  return (
+    <main>
+      <h1>Welcome</h1>
+      <p>This paragraph is static HTML.</p>
+      <Counter />
+    </main>
+  );
+}
+```
+
+The page renders to HTML at build time. The `<Counter />` portion gets a marker in the output that the client bootstrap uses to find and hydrate the island.
+
+## How it will work end-to-end
+
+When the renderer is live, the pipeline for islands looks like this:
+
+1. **Detection.** During page render, the renderer notes every `"use client"` import as an island reference.
+2. **Bundling.** The build pipeline (`crates/zfb-islands`) compiles each island as a separate ESM bundle via esbuild — one file per island, so a page that uses three islands ships three small bundles instead of one large one.
+3. **Hydration.** The page HTML includes a small inline bootstrap that imports each island bundle and hydrates it when its DOM marker enters view (or immediately, if you opt in with `client:load`).
+
+The result is that each page only ships the JavaScript for the islands it actually uses, and only when those islands are needed. A page with no islands ships zero bytes of JS.
+
+## Today vs. soon
+
+The `"use client"` convention is real and the bundler is sketched out, but the wiring from page render → island detection → bundle output is part of the ADR-001 work. You can author islands now and they will start hydrating once the runtime lands.

--- a/docs/src/content/docs/concepts/routing.mdx
+++ b/docs/src/content/docs/concepts/routing.mdx
@@ -1,0 +1,69 @@
+---
+title: Routing
+description: How file-system routing under pages/ maps to URLs in zfb.
+sidebar_position: 1
+category: Concepts
+---
+
+<Warning title="v0 status">
+
+Today the framework's skeleton is shipping; the JS-runtime decision (ADR-001) lands the actual page rendering. Route discovery works now, but `paths()` evaluation for dynamic and catchall routes is deferred. See /architecture/js-runtime for the deeper discussion.
+
+</Warning>
+
+zfb uses **file-system routing** under the `pages/` directory. The router scans `pages/` at build time (and on every change in dev), turning each `.tsx` file into a route. The conventions match what you might recognise from Next.js or Astro.
+
+## File-to-route mapping
+
+| File | Route |
+| ---- | ----- |
+| `pages/index.tsx` | `/` |
+| `pages/about.tsx` | `/about` |
+| `pages/blog/index.tsx` | `/blog` |
+| `pages/blog/[slug].tsx` | `/blog/:slug` (dynamic) |
+| `pages/docs/[...slug].tsx` | `/docs/:slug*` (catchall) |
+| `pages/[lang]/[slug].tsx` | `/:lang/:slug` |
+
+A few rules worth knowing up front:
+
+- Files starting with `_` (for example `_app.tsx`) are ignored. Use this prefix for shared helpers that live next to your routes but should not be exposed.
+- Anything that is not a `.tsx` file is ignored as well — README files, fixtures, and ad-hoc notes are safe to drop in `pages/`.
+- Two files that resolve to the same template raise `RouterError::AmbiguousRoute` at build time, so the router never silently picks a winner.
+
+The scan is performed by `Router::scan` in the `zfb-router` crate. Results are sorted so that **static routes win over dynamic, and dynamic wins over catchall** — more specific routes are matched first.
+
+## Static, dynamic, and catchall routes
+
+Static routes (`pages/about.tsx`) match a single concrete URL. Dynamic routes use `[param]` brackets in the file name to capture a single path segment, and catchall routes use `[...param]` to capture any number of trailing segments.
+
+```tsx
+// pages/blog/[slug].tsx
+export default function BlogPost({ slug }: { slug: string }) {
+  return <article>Post for {slug}</article>;
+}
+```
+
+```tsx
+// pages/docs/[...slug].tsx
+export default function DocsPage({ slug }: { slug: string[] }) {
+  return <main>{slug.join("/")}</main>;
+}
+```
+
+## The `paths()` export
+
+Dynamic and catchall routes need to know which concrete URLs to render at build time. This is done by exporting a `paths()` function from the same file:
+
+```tsx
+// pages/blog/[slug].tsx
+export async function paths() {
+  const posts = await getCollection("blog");
+  return posts.map((p) => ({ slug: p.slug }));
+}
+
+export default function BlogPost({ slug }: { slug: string }) {
+  return <article>Post {slug}</article>;
+}
+```
+
+Today `paths()` evaluation requires the JS runtime, which is still being wired in (ADR-001). `zfb build` discovers dynamic and catchall routes correctly, but emits a warn-line and skips them until the runtime lands. Static routes go through the rest of the pipeline as expected.

--- a/docs/src/content/docs/concepts/styling.mdx
+++ b/docs/src/content/docs/concepts/styling.mdx
@@ -1,0 +1,74 @@
+---
+title: Styling
+description: Global CSS, Tailwind v4, and where component-scoped styling fits in zfb.
+sidebar_position: 4
+category: Concepts
+---
+
+<Info>
+
+The CSS pipeline (Tailwind compilation, PostCSS) is wired up in `crates/zfb-css` and runs today. Inlining the critical path into rendered HTML waits on the renderer (ADR-001).
+
+</Info>
+
+Styling in zfb is intentionally small. Today there are two layers — global CSS and Tailwind v4 — and one well-supported pattern for everything else: utility classes on the markup itself. Component-scoped styling is an open design space and is not part of v0.
+
+## Global CSS
+
+The default template ships with `styles/global.css`. This is plain CSS, processed by zfb's CSS pipeline, and made available to every page. Use it for design tokens, resets, base typography, and anything else that should apply site-wide:
+
+```css
+:root {
+  --color-text: #1a1a1a;
+  --color-bg: #ffffff;
+  --font-body: system-ui, sans-serif;
+}
+
+body {
+  color: var(--color-text);
+  background: var(--color-bg);
+  font-family: var(--font-body);
+}
+```
+
+Imports inside CSS work as you would expect — split your styles across files and pull them together from `global.css`.
+
+## Tailwind v4
+
+Tailwind v4 is opt-in via `zfb.config.{ts,json}`:
+
+```json
+{
+  "tailwind": {
+    "enabled": true
+  }
+}
+```
+
+When enabled, the `zfb-css` crate runs the bundled `tailwindcss-v4` binary as part of the build. There is **no per-project Tailwind install** — you do not add `tailwindcss` to `package.json` and you do not maintain a `tailwind.config.js`. The compiler is built into zfb itself.
+
+Once Tailwind is on, utility classes work in any `.tsx` file:
+
+```tsx
+export default function Hero() {
+  return (
+    <section className="mx-auto max-w-2xl px-6 py-12">
+      <h1 className="text-3xl font-bold">Hello</h1>
+    </section>
+  );
+}
+```
+
+Tailwind v4's CSS-first configuration is supported through `@theme` directives in `global.css` — you customise tokens by editing CSS, not a JS config file.
+
+## Component-scoped styling
+
+This is the part to be honest about. CSS Modules, styled-components, and vanilla-extract are all reasonable choices for scoped component styles, and none of them are integrated into v0 of zfb.
+
+The recommended pattern today is **global CSS for site-wide concerns plus Tailwind utility classes for component-level styling**. This keeps the build fast and the runtime trivial, and it maps cleanly onto Tailwind v4's design-token model.
+
+Component-scoped CSS is on the radar as future work, and the integration point will live in `crates/zfb-css`.
+
+## What lands in `dist/`
+
+Each rendered page in `dist/<route>.html` will eventually inline its critical CSS path so the first paint never waits for an external stylesheet. Today the build emits stub HTML without the CSS extraction step — that part lights up alongside the renderer. The compilation half (Tailwind, PostCSS, your `global.css`) already runs as part of the pipeline; what changes is where the output ends up.

--- a/docs/src/content/docs/dogfood/zudo-doc-migration.mdx
+++ b/docs/src/content/docs/dogfood/zudo-doc-migration.mdx
@@ -1,0 +1,67 @@
+---
+title: zudo-doc → zfb migration notes
+description: Path from zudo-doc-Astro to a future zudo-doc-zfb
+sidebar_position: 1
+---
+
+<Info>
+
+  Migration is out of scope for v0. This page records the design intent so
+  future contributors do not have to re-derive it.
+
+</Info>
+
+## Where we are today
+
+This documentation site runs on
+[zudo-doc](https://github.com/zudolab/zudo-doc), an Astro-based
+documentation framework. The full stack is Astro plus MDX, Tailwind CSS
+v4, Preact islands for interactivity, Shiki for syntax highlighting, and
+Pagefind for client-side search. Authoring is plain MDX with frontmatter,
+admonitions (`<Note>`, `<Tip>`, `<Info>`, `<Warning>`, `<Danger>`), a
+`sidebar_position` ordering rule, and a parallel Japanese tree at
+`src/content/docs-ja/` that mirrors the English structure.
+
+That whole authoring surface is what doc writers actually touch. The
+goal of the eventual migration is to keep that surface intact and swap
+the engine underneath it.
+
+## Where we want to go
+
+A future v2 of zudo-doc that runs on zfb instead of Astro. The contract
+for doc authors stays the same — the same MDX dialect, the same
+admonition components, the same frontmatter keys, the same i18n folder
+convention — and the build orchestrator becomes the zfb Rust binary
+talking to a JavaScript renderer. Writers should not have to learn a new
+tool to migrate.
+
+## What needs to land in zfb first
+
+The migration only becomes sane once the following gaps in zfb are
+closed.
+
+- **Real per-route SSR.** This is ADR-001 and is non-negotiable. Until
+  the renderer can turn a `pages/[slug].tsx` plus a content collection
+  entry into actual HTML, there is nothing to migrate onto.
+- **MDX in content collections.** Today the collection loader handles
+  Markdown only. MDX needs the JSX-friendly variant of the parser plumbed
+  through, so component imports inside content files resolve correctly.
+- **Pagefind-equivalent search.** Pagefind itself is framework-agnostic
+  — it indexes the built static output — so once SSR ships and the
+  rendered HTML actually reflects page content, the existing Pagefind
+  setup should drop in with no zfb-side changes required.
+- **i18n route patterns.** A `/ja/...` tree mirroring `/...` falls out of
+  zfb's folder-based routing naturally; nothing special is needed beyond
+  cloning `pages/` into `pages/ja/`.
+- **Plugin / integration API for doc-site transforms.** Today
+  `docs/src/plugins/` carries the doc-site-specific MDX transforms
+  (admonitions, code titles, mermaid). zfb does not yet expose a
+  plugin API where this code can be hung. Until it does, those
+  transforms have no host on the zfb side.
+
+## What this page is
+
+A waypoint, not a plan. The actual migration is a separate
+`/big-plan` once the gaps above are closed; this page exists so the
+next contributor who wonders "what would zudo-doc on zfb look like" can
+read the answer without reverse-engineering it from the codebase.

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -1,0 +1,56 @@
+---
+title: Installation
+description: Install the zfb CLI from source while v0 is still in development.
+sidebar_position: 2
+---
+
+zfb (zudo-front-builder) is shipped as a single Rust binary. While the project is in v0, there are no published releases on crates.io and no prebuilt binaries — you build the CLI yourself from this repository.
+
+## Prerequisites
+
+You will need:
+
+- **Rust toolchain** — install via [rustup](https://rustup.rs/). A recent stable toolchain (1.75 or newer) is fine.
+- **pnpm** — install via the [official installer](https://pnpm.io/installation). zfb scaffolds projects that use pnpm and will run `pnpm install` for you when it can find pnpm on your `PATH`.
+
+You do not need Node.js separately for the CLI itself. The runtime that executes your project's TypeScript is bundled with zfb (see the [JS runtime architecture page](/architecture/js-runtime)).
+
+## Build and install the CLI
+
+Clone the repository and install the `zfb` binary into your Cargo bin directory:
+
+```bash
+git clone https://github.com/Takazudo/zudo-front-builder.git
+cd zudo-front-builder
+cargo install --path crates/zfb
+```
+
+`cargo install` puts the binary at `~/.cargo/bin/zfb`. Make sure that directory is on your `PATH` (rustup configures this for you on a fresh install).
+
+If you would rather not install globally — for example, while hacking on the framework itself — build in place and call the binary directly:
+
+```bash
+cargo build -p zfb
+./target/debug/zfb --help
+```
+
+## Verify the install
+
+```bash
+zfb --help
+```
+
+You should see four subcommands:
+
+- `zfb new` — scaffold a new project
+- `zfb dev` — start the dev server with watcher and live-reload
+- `zfb build` — produce a static build
+- `zfb preview` — serve the build output
+
+If `zfb --help` prints all four, you're ready to move on to [Your first site](/getting-started/your-first-site).
+
+<Info title="v0 distribution">
+
+  This source-build flow is the only supported install path right now. Released crates and prebuilt binaries will land once the framework reaches a stable surface.
+
+</Info>

--- a/docs/src/content/docs/getting-started/project-structure.mdx
+++ b/docs/src/content/docs/getting-started/project-structure.mdx
@@ -1,0 +1,74 @@
+---
+title: Project structure
+description: A tour of every file and directory the default template lays down.
+sidebar_position: 4
+---
+
+When you run `zfb new my-site`, the `default` template lays down a small but complete project. Knowing what each directory is for makes the rest of the docs much easier to skim.
+
+```text
+my-site/
+├── pages/
+│   ├── index.tsx
+│   └── blog/
+│       └── [slug].tsx
+├── layouts/
+│   └── default.tsx
+├── components/
+│   └── counter.tsx
+├── content/
+│   └── blog/
+│       └── welcome.md
+├── styles/
+│   └── global.css
+├── public/
+├── zfb.config.ts
+├── package.json
+├── tsconfig.json
+└── .gitignore
+```
+
+## pages/
+
+File-system routing lives here. Every `.tsx` file under `pages/` becomes a route:
+
+- `pages/index.tsx` → `/`
+- `pages/about.tsx` → `/about`
+- `pages/blog/[slug].tsx` → `/blog/:slug` (dynamic route — one HTML file per resolved slug)
+- `pages/docs/[...slug].tsx` → catchall, matches any depth
+
+The default template ships an index page and one dynamic blog route. Dynamic and catchall routes are recognized by the router today, but per-instance expansion (the `paths()` evaluation that turns `[slug]` into concrete files at build time) lands with the JS runtime — see [JS runtime architecture](/architecture/js-runtime).
+
+## layouts/
+
+Reusable page wrappers. `layouts/default.tsx` is the shell every page imports — header, footer, common metadata, and so on. Layouts are plain TSX components; you compose them however you like.
+
+## components/
+
+Plain components and **islands**. `components/counter.tsx` opens with a `"use client"` directive — that's the marker that turns it into an island, hydrated in the browser. Components without `"use client"` render only on the server. The full mental model is on the [islands page](/concepts/islands).
+
+## content/
+
+Content collections. `content/blog/welcome.md` is the seed entry of a `blog` collection: Markdown (or MDX) files in a directory, queried from your pages via `getCollection("blog")`. Collection schemas are declared in `zfb.config.{json,ts}` under `collections`.
+
+## styles/
+
+Global CSS. `styles/global.css` is the entry point — import it from your root layout. The default template wires up Tailwind here when `tailwind.enabled` is set in the config.
+
+## public/
+
+Static assets served as-is from the site root. Put `favicon.ico`, robots.txt, and any image you want to reference by absolute URL here. zfb's dev server and `zfb preview` both serve `public/` directly.
+
+## zfb.config — JSON today, TS later
+
+The config file uses a camelCase schema with these keys: `outDir` (default `"dist"`), `publicDir` (default `"public"`), `host` (default `"localhost"`), `port` (default `3000`), `framework` (`"preact"` or `"react"`, default `"preact"`), `collections`, `tailwind`, and `plugins`.
+
+<Info title="zfb.config.ts is not loaded yet">
+
+  The template writes a `zfb.config.ts` so your editor gets type hints, but zfb only loads `zfb.config.json` today — TS config support lands with the JS runtime. For now, write your runtime configuration in `zfb.config.json` (same schema) and treat the `.ts` file as a typed reference.
+
+</Info>
+
+## package.json, tsconfig.json, .gitignore
+
+Standard project plumbing. `package.json` declares the framework runtime dependency (`preact` by default) and any libraries your islands import. `tsconfig.json` is configured so TSX in `pages/`, `layouts/`, and `components/` type-checks cleanly. The shipped `.gitignore` excludes `dist/` and `node_modules/` so build output and dependencies stay out of version control.

--- a/docs/src/content/docs/getting-started/your-first-site.mdx
+++ b/docs/src/content/docs/getting-started/your-first-site.mdx
@@ -1,0 +1,61 @@
+---
+title: Your first site
+description: Scaffold, run, and build a zfb project in about five minutes.
+sidebar_position: 3
+---
+
+This walkthrough takes you from an empty directory to a running dev server and a built site. It assumes you already [installed the zfb CLI](/getting-started/installation).
+
+## Scaffold a new project
+
+```bash
+zfb new my-site
+cd my-site
+```
+
+`zfb new` copies the `default` template into `my-site/`. If pnpm is on your `PATH`, zfb runs `pnpm install` automatically right after copying the template; otherwise it prints a short note telling you to run it yourself.
+
+The `--template` flag is reserved for future templates — only `default` ships today.
+
+## Start the dev server
+
+```bash
+zfb dev
+```
+
+You'll see a "ready" banner with the host and port (defaults: `http://localhost:3000`). zfb watches the project directory; saving any file in `pages/`, `layouts/`, `components/`, `content/`, or `styles/` triggers a live-reload broadcast to connected browsers. The server also serves anything you drop into `public/`.
+
+You can override host and port from the CLI — they always win over `zfb.config.json`:
+
+```bash
+zfb dev --port 4000 --host 0.0.0.0
+```
+
+<Warning title="v0 status — renderer pending">
+
+  Today `zfb dev` boots, watches files, and broadcasts live-reload events on save — but every page request currently falls through to a `dev_404` placeholder body. Per-route rendering is blocked on **ADR-001**: the JS runtime host (`DenoCoreHost`) is still a skeleton (`execute_module` returns a placeholder, `call_default` returns "not yet implemented"). The watcher, router, dev server, and live-reload pipeline are all real and exercisable; the actual page output lands once the runtime decision in [JS runtime architecture](/architecture/js-runtime) is implemented.
+
+</Warning>
+
+## Build and preview
+
+To produce a static build of the site:
+
+```bash
+zfb build
+zfb preview
+```
+
+`zfb build` resolves the output directory (defaulting to `dist/`), enumerates routes via the file-system router, and writes one HTML file per static route. `zfb preview` then serves that directory over HTTP on port `4321` by default. CLI flags (`--outdir`, `--port`) win over the config file in both commands.
+
+<Warning title="v0 status — build output is a placeholder">
+
+  Same caveat as `zfb dev`: `zfb build` already validates the project, loads config, and walks the route table — but each generated HTML file currently contains a stub noting the route template, not the rendered page. Real per-route SSR turns on the day ADR-001 lands. See [JS runtime architecture](/architecture/js-runtime).
+
+</Warning>
+
+## What to read next
+
+- [Project structure](/getting-started/project-structure) — what every directory the template created actually does.
+- [Routing](/concepts/routing) — how `pages/` becomes URLs, including dynamic and catchall routes.
+- [JS runtime architecture](/architecture/js-runtime) — the in-progress decision behind the rendering placeholder.

--- a/docs/src/content/docs/guides/customizing-markdown.mdx
+++ b/docs/src/content/docs/guides/customizing-markdown.mdx
@@ -1,0 +1,98 @@
+---
+title: Customizing Markdown
+description: How zfb renders Markdown today, what is configurable, and what is on the roadmap.
+sidebar_position: 3
+---
+
+<Warning title="v0 status">
+
+  Body rendering depends on the JS runtime decision tracked in ADR-001.
+  The parser pipeline in `crates/zfb-content` is wired and stable, but
+  the per-page consumption pattern shown below will firm up once that
+  decision lands.
+
+</Warning>
+
+zfb's Markdown story lives in the `zfb-content` Rust crate. It is
+deliberately small in v0: parse the file, hand you the body as a string,
+let your component decide how to render it. This page documents what is
+available today and what is planned.
+
+## The pipeline today
+
+When zfb reads a Markdown file from a content collection it does three
+things:
+
+1. Splits front matter using a `gray-matter`-style `---` separator.
+2. Parses the front matter into `entry.data` against the schema you
+   declared in `zfb.config`.
+3. Parses the body as CommonMark plus the GitHub-Flavored Markdown
+   extensions (tables, task lists, strikethrough, autolinks) and emits
+   it as an HTML string on `entry.body`.
+
+That string is what your TSX page receives. There is no virtual DOM
+representation, no AST handed to user code, and no per-page hook to
+intercept the parse.
+
+## Rendering Markdown in a page
+
+The standard pattern is to receive a content entry through `paths()` and
+inject the parsed HTML into your JSX:
+
+```tsx
+import { getCollection } from "zfb/content";
+
+export async function paths() {
+  const posts = await getCollection("blog");
+  return posts.map((post) => ({
+    params: { slug: post.slug },
+    props: { post },
+  }));
+}
+
+export default function PostPage({ post }) {
+  return (
+    <article
+      className="prose"
+      dangerouslySetInnerHTML={{ __html: post.body }}
+    />
+  );
+}
+```
+
+`dangerouslySetInnerHTML` reads alarmingly, but the input is your own
+Markdown — the same source you would have rendered in any other SSG. If
+you accept Markdown from untrusted users, sanitize before storing.
+
+## What is customisable today
+
+- **Front-matter schema** — every collection can declare its own field
+  types in `zfb.config`. Schema mismatches fail the build.
+- **GFM features** — enabled by default; there is no toggle to turn
+  individual extensions off in v0.
+- **HTML wrapping** — fully under your control. The `entry.body` string
+  is plain HTML; wrap, slot, and style it however you like.
+
+## What is planned, not built
+
+The following are deliberately out of scope for v0 and tracked for a
+later release:
+
+- Per-collection rehype / remark plugins.
+- Custom container directives — for example, `:::note` blocks that
+  expand into admonition components.
+- Shortcodes — inline component calls embedded in Markdown.
+- MDX support for content collections. (The docs site itself uses MDX,
+  but that runs through Astro and zudo-doc, not through zfb.)
+
+If your site needs any of these today, the practical options are: do
+the post-processing yourself in the page component, or ship a small
+remark step outside zfb and feed the rendered HTML back through your
+collection.
+
+<Tip>
+
+  When in doubt, render the body and style it. Most "I want to customize
+  Markdown" requests turn out to be styling questions that CSS solves.
+
+</Tip>

--- a/docs/src/content/docs/guides/migrating-from-astro.mdx
+++ b/docs/src/content/docs/guides/migrating-from-astro.mdx
@@ -65,10 +65,11 @@ const posts = await getCollection("blog");
 The return shape is similar — each entry exposes `slug`, `data`
 (frontmatter), and `body`. See /api/get-collection for the full surface.
 
-Schemas move from inline Zod to declarative config:
+Schemas move from inline Zod to declarative config. The v1 target is a
+record-keyed shape with explicit `type` and per-field validators:
 
 ```ts
-// zfb.config.ts
+// zfb.config.ts — v1 target shape (NOT yet loaded; see ADR-001)
 export default {
   collections: {
     blog: {
@@ -83,8 +84,11 @@ export default {
 };
 ```
 
-There is no Zod yet, only string field types like `"string"`, `"number"`,
-`"date"`, plus a trailing `?` for optional fields.
+There is no Zod — field validators are string tags like `"string"`,
+`"number"`, `"date"`, with a trailing `?` for optional. v0 currently
+loads only the simpler array form via `zfb.config.json` (see
+[`defineConfig`](/api/define-config)); the richer schema lands with the
+runtime decision.
 
 ## Islands
 

--- a/docs/src/content/docs/guides/migrating-from-astro.mdx
+++ b/docs/src/content/docs/guides/migrating-from-astro.mdx
@@ -1,0 +1,122 @@
+---
+title: Migrating from Astro
+description: A concept-by-concept map for moving an existing Astro static site to zfb.
+sidebar_position: 1
+---
+
+<Warning title="v0 status">
+
+  zfb's renderer is pending the runtime decision tracked in ADR-001
+  (see /architecture/js-runtime). Plan your migration now, but expect to
+  execute it once the renderer lands. APIs below are stable enough to
+  design against; specific imports may shift before 1.0.
+
+</Warning>
+
+If you already maintain an Astro site, most of zfb will feel familiar. Both
+projects ship file-based routing, content collections, and partial
+hydration. The differences are mostly about scope: zfb is smaller, more
+opinionated, and Rust-backed end to end.
+
+## Directory layout
+
+Astro puts everything under `src/`. zfb does not.
+
+| Astro                | zfb                  |
+| -------------------- | -------------------- |
+| `src/pages/`         | `pages/`             |
+| `src/layouts/`       | `layouts/`           |
+| `src/components/`    | `components/`        |
+| `src/content/`       | `content/`           |
+| `astro.config.mjs`   | `zfb.config.ts`      |
+
+The flatter layout matches the smaller surface area. There is no `src/`
+namespace to remember.
+
+## Components: one model, not two
+
+Astro's headline feature is the `.astro` file — a server-only template
+language with optional islands of framework code. zfb collapses that into
+a single component model: every component is a `.tsx` file. The `framework`
+field in `zfb.config` selects either Preact or React, and the same JSX
+flavor is used for layouts, pages, and components.
+
+```tsx
+export default function MarketingPage() {
+  return <main><h1>Hello</h1></main>;
+}
+```
+
+There is no separate template syntax to learn, but if you relied on
+`.astro` for things like top-level `await` outside components, you will
+need to move that work into a `paths()` export or a data collection.
+
+## Content collections
+
+Astro's `getCollection("blog")` from `astro:content` has a near-direct
+equivalent in zfb:
+
+```ts
+import { getCollection } from "zfb/content";
+
+const posts = await getCollection("blog");
+```
+
+The return shape is similar — each entry exposes `slug`, `data`
+(frontmatter), and `body`. See /api/get-collection for the full surface.
+
+Schemas move from inline Zod to declarative config:
+
+```ts
+// zfb.config.ts
+export default {
+  collections: {
+    blog: {
+      type: "content",
+      schema: {
+        title: "string",
+        pubDate: "date",
+        draft: "boolean?",
+      },
+    },
+  },
+};
+```
+
+There is no Zod yet, only string field types like `"string"`, `"number"`,
+`"date"`, plus a trailing `?` for optional fields.
+
+## Islands
+
+Astro uses `client:load`, `client:visible`, and friends as JSX attributes
+on imported framework components. zfb uses a file-level `"use client"`
+directive instead — the same pattern Next.js App Router popularized:
+
+```tsx
+"use client";
+
+export default function Counter() {
+  const [n, setN] = useState(0);
+  return <button onClick={() => setN(n + 1)}>{n}</button>;
+}
+```
+
+Anything imported from a `"use client"` file becomes an island
+automatically. See /api/island.
+
+## Slots and layouts
+
+Astro's `<slot />` becomes plain JSX `children`:
+
+```tsx
+export default function DocsLayout({ children }) {
+  return <div className="prose">{children}</div>;
+}
+```
+
+## What zfb does not have yet
+
+Be honest with yourself before committing to a port. zfb v0 has no
+integrations API, no view transitions, no Astro DB equivalent, and no
+server endpoints. If your site relies on any of these, stay on Astro for
+now and revisit once zfb 1.0 ships.

--- a/docs/src/content/docs/guides/migrating-from-eleventy.mdx
+++ b/docs/src/content/docs/guides/migrating-from-eleventy.mdx
@@ -1,0 +1,104 @@
+---
+title: Migrating from Eleventy
+description: Concept-by-concept guidance for moving an 11ty site to zfb — and an honest note on where it does not fit.
+sidebar_position: 2
+---
+
+<Warning title="v0 status">
+
+  zfb's renderer is pending the runtime decision tracked in ADR-001
+  (see /architecture/js-runtime). The migration map below is stable, but
+  hands-on porting is best done once the renderer lands.
+
+</Warning>
+
+Eleventy and zfb agree on the big things: small dependency footprint,
+file-based routing, content driven by Markdown plus front matter. Where
+they differ is the templating story. Read the
+[honest caveat](#honest-caveat) section before committing to a port.
+
+## Layouts and includes
+
+11ty puts layouts in `_includes/` and references them via front matter
+`layout:` keys. zfb reads layouts from `layouts/` and you import them
+directly into your page TSX:
+
+```tsx
+import BlogLayout from "../../layouts/blog-layout.tsx";
+
+export default function Page({ post }) {
+  return <BlogLayout><article>{post.body}</article></BlogLayout>;
+}
+```
+
+There is no front-matter `layout:` lookup — composition is by import.
+
+## Templates
+
+11ty ships Liquid, Nunjucks, Handlebars, and a handful of others. zfb
+ships exactly one template language: TSX. Markdown content still flows
+through the parser, but anything that wraps that content is JSX.
+
+If your codebase leans heavily on Nunjucks macros or Liquid filters, plan
+for real porting work. There is no shim layer.
+
+## Data cascade
+
+11ty's `_data/` directory and the global / directory / template data
+cascade have no direct equivalent in zfb. Instead, you express data in
+two places:
+
+- **Static / shared data** — declare a data collection in
+  `zfb.config.{ts,json}`:
+
+```ts
+{
+  collections: {
+    site: { type: "data", schema: { name: "string", url: "string" } },
+  },
+}
+```
+
+- **Per-page data** — return it from a page's `paths()` export, which
+  is the rough equivalent of 11ty's `eleventyComputed`:
+
+```ts
+export async function paths() {
+  const posts = await getCollection("blog");
+  return posts.map((post) => ({
+    params: { slug: post.slug },
+    props: { post, year: post.data.pubDate.getFullYear() },
+  }));
+}
+```
+
+## Pagination
+
+11ty's `pagination` front-matter key becomes a `paginate()` helper inside
+`paths()`. See /api/paginate for the full surface, but the shape is:
+
+```ts
+export async function paths() {
+  const posts = await getCollection("blog");
+  return paginate(posts, { pageSize: 10 });
+}
+```
+
+You get one route per page, plus the standard `currentPage`,
+`totalPages`, and `data` props.
+
+## Markdown front matter
+
+This part is largely unchanged. Use `---` as a separator at the top of
+your `.md` files; zfb-content parses the front matter into `entry.data`
+and the body into `entry.body`. The fields available depend on the
+collection schema you declared in `zfb.config`.
+
+## Honest caveat
+
+If you love Liquid or Nunjucks and dislike JSX, zfb is not for you. The
+framework is opinionated about JSX-as-templating, and there is no
+roadmap item to add an alternative. Eleventy will likely remain the
+better fit for that workflow indefinitely. zfb is most worth your time
+if you already write React or Preact components elsewhere and want a
+small, fast SSG that speaks the same language.

--- a/docs/src/content/docs/guides/migrating-from-eleventy.mdx
+++ b/docs/src/content/docs/guides/migrating-from-eleventy.mdx
@@ -49,13 +49,16 @@ cascade have no direct equivalent in zfb. Instead, you express data in
 two places:
 
 - **Static / shared data** — declare a data collection in
-  `zfb.config.{ts,json}`:
+  `zfb.config.json`. Today the loader accepts the simpler array form
+  (`{ name, path }`); the richer record-keyed form with explicit `type`
+  and per-field schemas is the v1 target — see
+  [`defineConfig`](/api/define-config) for both shapes side by side:
 
-```ts
+```json
 {
-  collections: {
-    site: { type: "data", schema: { name: "string", url: "string" } },
-  },
+  "collections": [
+    { "name": "site", "path": "data/site" }
+  ]
 }
 ```
 

--- a/docs/src/content/docs/guides/syntax-highlighting.mdx
+++ b/docs/src/content/docs/guides/syntax-highlighting.mdx
@@ -1,0 +1,97 @@
+---
+title: Syntax Highlighting
+description: There is no built-in syntax highlighter in zfb v0. Two practical patterns for user-side highlighting until one lands.
+sidebar_position: 4
+---
+
+<Warning title="v0 status">
+
+  zfb does not ship a built-in code-block highlighter yet. Both options
+  on this page are user-side. The official story will land alongside the
+  rendering pipeline once ADR-001 (see /architecture/js-runtime) is
+  decided.
+
+</Warning>
+
+If you write technical content with zfb today, your fenced code blocks
+render as plain `<pre><code>...</code></pre>` with the language as a
+class on the `<code>` element. There are two practical paths to colour
+them.
+
+<Tip>
+
+  Plain `<pre><code>` is more legible than people give it credit for.
+  Style it with CSS — a monospace font, comfortable line height, a
+  subtle background — and you have a perfectly serviceable baseline
+  while you decide whether you actually need a highlighter.
+
+</Tip>
+
+## Option 1 — Build-time highlighting
+
+Run a highlighter once during the build and bake the coloured HTML
+into the output. Today this means doing the work outside the framework,
+because zfb has no plugin API yet. A typical sketch:
+
+1. Build your site with `zfb build` so the rendered HTML is on disk.
+2. Walk the output directory with a small Node script.
+3. For each `.html` file, parse it, find every `<pre><code class="language-…">`
+   block, run Shiki or Prism over the inner text, and replace the node.
+4. Write the file back.
+
+```ts
+// post-build/highlight.ts — sketch only
+import { glob } from "glob";
+import { readFile, writeFile } from "node:fs/promises";
+import { codeToHtml } from "shiki";
+
+for (const file of await glob("dist/**/*.html")) {
+  const html = await readFile(file, "utf8");
+  const next = await highlightCodeBlocks(html, codeToHtml);
+  if (next !== html) await writeFile(file, next);
+}
+```
+
+Pros: zero JavaScript shipped to the browser, fully static output.
+Cons: extra build step, and you own the script. Once zfb exposes a
+post-render plugin hook, this same logic will move into a zfb plugin
+without changing semantics.
+
+## Option 2 — Client-time highlighting
+
+Ship a small highlighter to the browser as an island. Prism and
+highlight.js are the obvious choices. Mark the wrapper component as a
+client island with the `"use client"` directive:
+
+```tsx
+"use client";
+
+import { useEffect, useRef } from "preact/hooks";
+import Prism from "prismjs";
+import "prismjs/components/prism-typescript";
+
+export default function PrismRoot({ children }) {
+  const ref = useRef(null);
+  useEffect(() => { Prism.highlightAllUnder(ref.current); }, []);
+  return <div ref={ref}>{children}</div>;
+}
+```
+
+Wrap your article body in `<PrismRoot>` and the islanded component will
+hydrate, scan, and highlight the existing markup in place.
+
+Pros: no build step, easy to swap themes, works for user-generated
+content. Cons: extra JavaScript, a flash of unstyled code before the
+island hydrates, and the per-language grammars add bytes quickly.
+
+## Why the docs site looks different
+
+The site you are reading right now uses Shiki via Astro and zudo-doc.
+That stack ships with build-time highlighting baked in. zfb sites do
+not run on Astro, so that integration is not available — the two
+options above are what you have until zfb's own pipeline ships.
+
+When the renderer story is settled, expect a built-in build-time
+highlighter (probably Shiki) plus a configuration knob in `zfb.config`
+to choose themes and enabled languages. The migration from a hand-rolled
+post-build script will be straightforward.

--- a/examples/basic-blog/.gitignore
+++ b/examples/basic-blog/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.DS_Store

--- a/examples/basic-blog/README.md
+++ b/examples/basic-blog/README.md
@@ -1,0 +1,90 @@
+# basic-blog — zfb dogfood example
+
+A minimal real zfb site, kept inside the `zudo-front-builder` workspace as
+both a shipped example and a fixture the CLI can be smoke-tested against.
+
+## What is here
+
+```
+examples/basic-blog/
+├── content/blog/        5 markdown posts with frontmatter (title, date, description, tags)
+├── components/          theme-toggle.tsx — the only client island
+├── layouts/             default.tsx — shared chrome (header, footer, theme toggle)
+├── pages/
+│   ├── index.tsx               static — homepage listing all posts
+│   ├── blog/[slug].tsx         dynamic — one route per post
+│   ├── blog/page/[page].tsx    dynamic — paginated index, pageSize 3
+│   └── tags/[tag].tsx          dynamic — one route per unique tag
+├── styles/global.css    light/dark theme via CSS variables + [data-theme="dark"]
+├── zfb.config.future.ts canonical TS form (aspirational — see below)
+├── zfb.config.json      what the v0 CLI actually loads
+├── package.json
+├── tsconfig.json
+└── .gitignore
+```
+
+Cross-references into the docs:
+
+- [/getting-started/your-first-site](../../docs/src/content/docs/getting-started/) — narrative walkthrough.
+- [/concepts/routing](../../docs/src/content/docs/) — file-based routing rules.
+- [/api/get-collection](../../docs/src/content/docs/) — `getCollection("blog")`.
+- [/api/paginate](../../docs/src/content/docs/) — the pagination helper used in `blog/page/[page].tsx`.
+- [/architecture/js-runtime](../../docs/src/content/docs/) — the JS runtime decision (ADR-001) that gates real SSR.
+
+## v0 status — read this first
+
+Today, `zfb build` emits **per-route stub HTML** rather than fully rendered
+pages. The real per-route renderer is blocked on the JS runtime decision
+(ADR-001) — see `/architecture/js-runtime` in the docs site. The example is
+structured correctly and is ready for the renderer; right now `zfb build`
+in this directory will:
+
+- Write a single stub at `dist/index.html` for the static `/` route.
+- Warn-skip every **dynamic** route — `[slug]`, `page/[page]`, and
+  `tags/[tag]` — because each needs its `paths()` export evaluated by the
+  JS runtime to expand into concrete URLs.
+
+So the v0 build output here is just one HTML file. Once the renderer
+lands, the same files in this directory will produce a fully rendered
+blog (one post page, two paginated indexes, and one page per unique tag)
+with no source changes required.
+
+## Running it from the workspace
+
+The CLI in this repo is a Rust binary, not a published npm package, so you
+do not install zfb here. From inside `examples/basic-blog/`:
+
+```sh
+# one-shot build into ./dist (writes per-route stub HTML in v0)
+cargo run -p zfb -- build
+
+# or build into an arbitrary directory
+cargo run -p zfb -- build --outdir /tmp/basic-blog-out
+
+# dev server (port 3000)
+cargo run -p zfb -- dev
+```
+
+Equivalently, from the workspace root, point the CLI at this directory:
+
+```sh
+(cd examples/basic-blog && cargo run -p zfb -- build)
+```
+
+## Why two `zfb.config.*` files
+
+`zfb.config.future.ts` is the canonical, type-checked shape that zfb will
+load once the TS config loader lands. Today the v0 CLI hard-errors if it
+sees a real `zfb.config.ts` (see `crates/zfb/src/config.rs`), so the file
+is parked under a `.future.ts` name to keep it out of the loader's
+resolution path while still being available for review and type-checking.
+`zfb.config.json` is what the v0 build actually reads. Both files describe
+the same project; keep them in sync until the TS form is wired up — at
+which point you can rename `zfb.config.future.ts` to `zfb.config.ts` and
+delete the JSON sibling.
+
+## Stretch goals (not in v0)
+
+- RSS feed (`pages/rss.xml.ts`) — skipped until the renderer can return
+  non-HTML responses.
+- Real per-route SSR — see ADR-001.

--- a/examples/basic-blog/components/theme-toggle.tsx
+++ b/examples/basic-blog/components/theme-toggle.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useEffect, useState } from "preact/hooks";
+
+type Theme = "light" | "dark";
+
+const STORAGE_KEY = "basic-blog:theme";
+
+/**
+ * Reads the persisted preference, falling back to the OS-level
+ * `prefers-color-scheme` so the very first paint matches the user's system
+ * setting. Safe to call during initial render: returns `"light"` on the
+ * server (where there is no `window`), and the real value as soon as the
+ * island hydrates.
+ */
+function readInitialTheme(): Theme {
+  if (typeof window === "undefined") {
+    return "light";
+  }
+  const saved = window.localStorage.getItem(STORAGE_KEY);
+  if (saved === "light" || saved === "dark") {
+    return saved;
+  }
+  const prefersDark =
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-color-scheme: dark)").matches;
+  return prefersDark ? "dark" : "light";
+}
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState<Theme>(readInitialTheme);
+
+  useEffect(() => {
+    document.documentElement.dataset["theme"] = theme;
+    window.localStorage.setItem(STORAGE_KEY, theme);
+  }, [theme]);
+
+  const next: Theme = theme === "dark" ? "light" : "dark";
+  return (
+    <button
+      type="button"
+      class="theme-toggle"
+      aria-label={`Switch to ${next} theme`}
+      onClick={() => setTheme(next)}
+    >
+      {theme === "dark" ? "Light mode" : "Dark mode"}
+    </button>
+  );
+}

--- a/examples/basic-blog/content/blog/deploying-static-sites.md
+++ b/examples/basic-blog/content/blog/deploying-static-sites.md
@@ -1,0 +1,25 @@
+---
+title: Deploying Static Sites
+date: 2026-04-23
+description: Why a folder of HTML is still the most boring and reliable way to ship a site.
+tags:
+  - deploy
+  - perf
+---
+
+A zfb build emits a directory of static HTML, JavaScript, and assets.
+That output is intentionally boring: there is no server runtime to
+operate, no Lambda to wire up, and no edge worker to debug. You can
+upload the `dist/` folder to any host that knows how to serve files
+and the site will work.
+
+That boringness is also where most of the perf wins come from. A static
+HTML response is the fastest possible thing a CDN can do. There is no
+cold start, no template engine, and no database round-trip. The browser
+gets bytes, parses them, and paints. The only JavaScript that runs is
+the tiny island bundle for whatever components asked to be interactive.
+
+The practical upshot is that you can host a zfb site on Cloudflare
+Pages, Netlify, GitHub Pages, an S3 bucket, or even a USB stick plugged
+into a router, and the experience is the same. Pick whichever one is
+cheapest and stop thinking about it.

--- a/examples/basic-blog/content/blog/dev-loop-feel.md
+++ b/examples/basic-blog/content/blog/dev-loop-feel.md
@@ -1,0 +1,25 @@
+---
+title: The Dev Loop Should Feel Instant
+date: 2026-04-24
+description: "Notes on why zfb's dev server cares so much about cold-start and reload latency."
+tags:
+  - tooling
+  - perf
+---
+
+Most of a developer's day inside a site builder is spent in the inner
+loop: edit a file, glance at the browser, edit again. If that loop has
+even half a second of friction in it, the friction compounds across
+hundreds of edits a day and the whole experience starts to feel laggy.
+
+zfb treats the dev loop as a first-class product surface. The CLI starts
+the dev server in well under a second on a cold cache. File changes are
+detected by a native watcher rather than a polling loop, so the round
+trip from save to live-reload is dominated by the browser, not by the
+build tool. The orchestrator stays out of the way.
+
+This is the other reason the orchestrator is a Rust binary. Every
+millisecond of startup tax shows up in the inner loop, and a binary that
+the OS can map straight into memory has approximately zero of that tax.
+The renderer is allowed to be slow and clever; the orchestrator has to
+be fast and dumb.

--- a/examples/basic-blog/content/blog/hello-zfb.md
+++ b/examples/basic-blog/content/blog/hello-zfb.md
@@ -1,0 +1,22 @@
+---
+title: Hello, zfb
+date: 2026-04-20
+description: A short introduction to the basic-blog dogfood example.
+tags:
+  - intro
+  - framework
+---
+
+Welcome to the **basic-blog** example. This site is the smallest realistic
+shape of a zfb project: a few pages, a content collection of Markdown posts,
+a single client island, and a layout that pulls everything together.
+
+The point of the example is to be _read_ as much as it is to be built. Every
+file in here is meant to map cleanly onto a single concept in the docs:
+routing lives under `pages/`, content lives under `content/blog/`, and the
+shared chrome lives in `layouts/default.tsx`. If you can read this post,
+the content collection is wired up correctly.
+
+If you are exploring zfb for the first time, start with `pages/index.tsx`
+and follow the imports outward. Most of the moving parts are visible from
+that one file.

--- a/examples/basic-blog/content/blog/ssr-and-islands.md
+++ b/examples/basic-blog/content/blog/ssr-and-islands.md
@@ -1,0 +1,24 @@
+---
+title: SSR and Islands
+date: 2026-04-22
+description: How zfb plans to render pages on the server and hydrate only what needs to be interactive.
+tags:
+  - framework
+  - ssr
+---
+
+zfb pages are server-rendered by default. That means every route in
+`pages/` is turned into a real HTML file at build time, with the markup
+already in place when the browser receives it. Search engines, RSS
+readers, and link previews all see the same content the user does.
+
+For interactive bits — a counter, a theme toggle, a search box — zfb uses
+the **island** pattern. A component file marked `"use client"` becomes a
+hydration boundary: the server renders its initial HTML, and the client
+loads just enough JavaScript to wake up that one widget. Everything else
+on the page stays static.
+
+This trade is the whole point of the architecture. You get the SEO and
+performance of a static site, plus the interactivity of a SPA exactly
+where you ask for it, and nowhere else. The `<ThemeToggle />` in this
+example is the smallest possible demonstration of the pattern.

--- a/examples/basic-blog/content/blog/why-rust-cli.md
+++ b/examples/basic-blog/content/blog/why-rust-cli.md
@@ -1,0 +1,24 @@
+---
+title: Why a Rust CLI?
+date: 2026-04-21
+description: "The reasoning behind shipping zfb's developer tooling as a single Rust binary."
+tags:
+  - intro
+  - tooling
+---
+
+The zfb CLI is written in Rust and shipped as a single static binary. That
+choice is deliberate, and it is _not_ a religious one.
+
+A site builder spends most of its wall-clock time on three things: file
+system traversal, watching files for changes, and shelling out to small
+helper processes. All three benefit from a runtime with predictable
+startup, no install step, and no dependency on the user's local Node
+version. A Rust binary gets all of that for free, and the user does not
+need to think about which package manager pulled it down.
+
+The flip side is the rendering pipeline itself, which is decidedly _not_
+Rust. Pages render through a JavaScript runtime so authors can keep using
+Preact, JSX, and the rest of the npm ecosystem. The split is intentional:
+the orchestrator is Rust, the renderer is JS, and the seam between them
+is small enough to keep honest.

--- a/examples/basic-blog/layouts/default.tsx
+++ b/examples/basic-blog/layouts/default.tsx
@@ -1,0 +1,47 @@
+import type { ComponentChildren } from "preact";
+
+import ThemeToggle from "../components/theme-toggle";
+import "../styles/global.css";
+
+type Props = {
+  title?: string;
+  children: ComponentChildren;
+};
+
+/**
+ * The single shared chrome for every page in the example. The `"use client"`
+ * boundary is at `components/theme-toggle.tsx`, so this layout itself stays
+ * a plain server component — only the toggle ships JS to the browser.
+ */
+export default function DefaultLayout({
+  title = "basic-blog · zfb example",
+  children,
+}: Props) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>{title}</title>
+      </head>
+      <body>
+        <header class="site-header">
+          <a class="site-title" href="/">
+            basic-blog
+          </a>
+          <nav class="site-nav">
+            <a href="/blog/page/1">Posts</a>
+            <ThemeToggle />
+          </nav>
+        </header>
+        <main class="site-main">{children}</main>
+        <footer class="site-footer">
+          <p>
+            zfb basic-blog example · the smallest realistic shape of a zfb
+            site.
+          </p>
+        </footer>
+      </body>
+    </html>
+  );
+}

--- a/examples/basic-blog/package.json
+++ b/examples/basic-blog/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@zfb-examples/basic-blog",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Minimal real zfb site used as both an example and a dogfood fixture for the workspace.",
+  "scripts": {
+    "dev": "zfb dev",
+    "build": "zfb build",
+    "preview": "zfb preview"
+  },
+  "dependencies": {
+    "preact": "^10.22.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/examples/basic-blog/pages/blog/[slug].tsx
+++ b/examples/basic-blog/pages/blog/[slug].tsx
@@ -1,0 +1,61 @@
+import DefaultLayout from "../../layouts/default";
+
+type BlogEntry = {
+  slug: string;
+  data: {
+    title: string;
+    date: string;
+    description?: string;
+    tags?: string[];
+  };
+  body: string;
+};
+
+/**
+ * Per-post route. The `paths()` export is what the renderer evaluates to
+ * expand the dynamic `[slug]` segment into one concrete route per entry in
+ * the `blog` collection.
+ */
+export async function paths() {
+  const { getCollection } = await import("zfb/content");
+  const posts = (await getCollection("blog")) as BlogEntry[];
+  return posts.map((post) => ({
+    params: { slug: post.slug },
+    props: { post },
+  }));
+}
+
+type Props = {
+  post: BlogEntry;
+};
+
+export default function BlogPostPage({ post }: Props) {
+  const tags = post.data.tags ?? [];
+  return (
+    <DefaultLayout title={post.data.title}>
+      <article>
+        <h1>{post.data.title}</h1>
+        <p class="post-meta">
+          <time dateTime={post.data.date}>{post.data.date}</time>
+        </p>
+        {/* Body is markdown rendered to HTML by the collection loader. */}
+        <div
+          class="post-body"
+          dangerouslySetInnerHTML={{ __html: post.body }}
+        />
+        {tags.length > 0 ? (
+          <ul class="tag-list">
+            {tags.map((tag) => (
+              <li key={tag}>
+                <a href={`/tags/${tag}`}>#{tag}</a>
+              </li>
+            ))}
+          </ul>
+        ) : null}
+        <p>
+          <a href="/">← Back home</a>
+        </p>
+      </article>
+    </DefaultLayout>
+  );
+}

--- a/examples/basic-blog/pages/blog/page/[page].tsx
+++ b/examples/basic-blog/pages/blog/page/[page].tsx
@@ -1,0 +1,69 @@
+import DefaultLayout from "../../../layouts/default";
+
+type BlogEntry = {
+  slug: string;
+  data: {
+    title: string;
+    date: string;
+    description?: string;
+    tags?: string[];
+  };
+  body: string;
+};
+
+type PageData = {
+  data: BlogEntry[];
+  page: number;
+  lastPage: number;
+};
+
+/**
+ * Paginated index of blog posts. With `pageSize: 3` and 5 posts the runtime
+ * emits `/blog/page/1` and `/blog/page/2`. The `paginate()` helper is the
+ * canonical zfb shape for this; see /api/paginate in the docs.
+ */
+export async function paths() {
+  const { getCollection } = await import("zfb/content");
+  const { paginate } = await import("zfb/paginate");
+  const posts = (await getCollection("blog")) as BlogEntry[];
+  posts.sort((a, b) => b.data.date.localeCompare(a.data.date));
+  return paginate(posts, { pageSize: 3, param: "page" });
+}
+
+type Props = {
+  page: PageData;
+};
+
+export default function BlogIndexPage({ page }: Props) {
+  return (
+    <DefaultLayout title={`Posts — page ${page.page}`}>
+      <h1>All posts</h1>
+      <p class="post-meta">
+        Page {page.page} of {page.lastPage}
+      </p>
+      <ul class="post-list">
+        {page.data.map((post) => (
+          <li key={post.slug}>
+            <a href={`/blog/${post.slug}`}>{post.data.title}</a>
+            <div class="post-meta">
+              <time dateTime={post.data.date}>{post.data.date}</time>
+              {post.data.description ? <> · {post.data.description}</> : null}
+            </div>
+          </li>
+        ))}
+      </ul>
+      <nav class="pagination" aria-label="pagination">
+        {page.page > 1 ? (
+          <a href={`/blog/page/${page.page - 1}`}>← Newer</a>
+        ) : (
+          <span />
+        )}
+        {page.page < page.lastPage ? (
+          <a href={`/blog/page/${page.page + 1}`}>Older →</a>
+        ) : (
+          <span />
+        )}
+      </nav>
+    </DefaultLayout>
+  );
+}

--- a/examples/basic-blog/pages/index.tsx
+++ b/examples/basic-blog/pages/index.tsx
@@ -1,0 +1,52 @@
+import DefaultLayout from "../layouts/default";
+
+type BlogEntry = {
+  slug: string;
+  data: {
+    title: string;
+    date: string;
+    description?: string;
+    tags?: string[];
+  };
+  body: string;
+};
+
+/**
+ * The homepage lists every post in the `blog` collection, newest first. We
+ * intentionally do not paginate here — pagination is shown on
+ * `/blog/page/[page]` so each route demonstrates exactly one concept.
+ */
+export async function getStaticProps() {
+  const { getCollection } = await import("zfb/content");
+  const posts = (await getCollection("blog")) as BlogEntry[];
+  posts.sort((a, b) => b.data.date.localeCompare(a.data.date));
+  return { props: { posts } };
+}
+
+type Props = {
+  posts: BlogEntry[];
+};
+
+export default function HomePage({ posts }: Props) {
+  return (
+    <DefaultLayout title="basic-blog · zfb example">
+      <h1>basic-blog</h1>
+      <p>
+        A minimal real zfb site. Every file under this directory maps onto a
+        single concept in the docs.
+      </p>
+      <h2>Recent posts</h2>
+      <ul class="post-list">
+        {posts.map((post) => (
+          <li key={post.slug}>
+            <a href={`/blog/${post.slug}`}>{post.data.title}</a>
+            <div class="post-meta">
+              <time dateTime={post.data.date}>{post.data.date}</time>
+              {post.data.description ? <> · {post.data.description}</> : null}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </DefaultLayout>
+  );
+}

--- a/examples/basic-blog/pages/tags/[tag].tsx
+++ b/examples/basic-blog/pages/tags/[tag].tsx
@@ -1,0 +1,65 @@
+import DefaultLayout from "../../layouts/default";
+
+type BlogEntry = {
+  slug: string;
+  data: {
+    title: string;
+    date: string;
+    description?: string;
+    tags?: string[];
+  };
+  body: string;
+};
+
+/**
+ * One static page per unique tag. The renderer evaluates `paths()` once,
+ * collects every tag mentioned across the collection, and emits a route for
+ * each.
+ */
+export async function paths() {
+  const { getCollection } = await import("zfb/content");
+  const posts = (await getCollection("blog")) as BlogEntry[];
+  const byTag = new Map<string, BlogEntry[]>();
+  for (const post of posts) {
+    for (const tag of post.data.tags ?? []) {
+      const bucket = byTag.get(tag) ?? [];
+      bucket.push(post);
+      byTag.set(tag, bucket);
+    }
+  }
+  return Array.from(byTag.entries()).map(([tag, posts]) => {
+    posts.sort((a, b) => b.data.date.localeCompare(a.data.date));
+    return {
+      params: { tag },
+      props: { tag, posts },
+    };
+  });
+}
+
+type Props = {
+  tag: string;
+  posts: BlogEntry[];
+};
+
+export default function TagPage({ tag, posts }: Props) {
+  return (
+    <DefaultLayout title={`#${tag}`}>
+      <h1>
+        Posts tagged <code>#{tag}</code>
+      </h1>
+      <ul class="post-list">
+        {posts.map((post) => (
+          <li key={post.slug}>
+            <a href={`/blog/${post.slug}`}>{post.data.title}</a>
+            <div class="post-meta">
+              <time dateTime={post.data.date}>{post.data.date}</time>
+            </div>
+          </li>
+        ))}
+      </ul>
+      <p>
+        <a href="/">← Back home</a>
+      </p>
+    </DefaultLayout>
+  );
+}

--- a/examples/basic-blog/styles/global.css
+++ b/examples/basic-blog/styles/global.css
@@ -1,0 +1,103 @@
+@import "tailwindcss";
+
+:root {
+  --color-bg: #fdfdfc;
+  --color-fg: #1f1f1f;
+  --color-muted: #5b5b5b;
+  --color-accent: #2563eb;
+  --color-border: #e5e5e5;
+  color-scheme: light;
+  font-family:
+    system-ui,
+    -apple-system,
+    "Segoe UI",
+    sans-serif;
+  line-height: 1.6;
+}
+
+[data-theme="dark"] {
+  --color-bg: #121212;
+  --color-fg: #f0f0f0;
+  --color-muted: #a0a0a0;
+  --color-accent: #7aa7ff;
+  --color-border: #2a2a2a;
+  color-scheme: dark;
+}
+
+body {
+  margin: 0;
+  padding: 2rem;
+  max-width: 48rem;
+  margin-inline: auto;
+  background: var(--color-bg);
+  color: var(--color-fg);
+}
+
+a {
+  color: var(--color-accent);
+}
+
+.site-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-block-end: 1rem;
+  border-block-end: 1px solid var(--color-border);
+  margin-block-end: 2rem;
+}
+
+.site-title {
+  font-weight: 600;
+  text-decoration: none;
+  color: var(--color-fg);
+}
+
+.site-nav {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.site-footer {
+  margin-block-start: 3rem;
+  padding-block-start: 1rem;
+  border-block-start: 1px solid var(--color-border);
+  color: var(--color-muted);
+  font-size: 0.875rem;
+}
+
+.theme-toggle {
+  border: 1px solid var(--color-border);
+  background: transparent;
+  color: inherit;
+  padding: 0.25rem 0.75rem;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  font: inherit;
+}
+
+.post-meta {
+  color: var(--color-muted);
+  font-size: 0.875rem;
+}
+
+.post-list {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.tag-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  list-style: none;
+  padding: 0;
+}
+
+.pagination {
+  display: flex;
+  justify-content: space-between;
+  margin-block-start: 2rem;
+}

--- a/examples/basic-blog/tsconfig.json
+++ b/examples/basic-blog/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": false,
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./*"],
+      "@/components/*": ["./components/*"],
+      "@/layouts/*": ["./layouts/*"]
+    },
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": [
+    "pages/**/*",
+    "layouts/**/*",
+    "components/**/*",
+    "content/**/*",
+    "zfb.config.future.ts"
+  ],
+  "exclude": ["node_modules", "dist"]
+}

--- a/examples/basic-blog/zfb.config.future.ts
+++ b/examples/basic-blog/zfb.config.future.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from "zfb/config";
+
+// NOTE (v0): this file is intentionally named `zfb.config.future.ts` rather
+// than `zfb.config.ts`. The current zfb config loader hard-errors if it
+// finds a `zfb.config.ts` next to a `zfb.config.json` (see crates/zfb/src/
+// config.rs — TS loading is gated on ADR-001 / the JS runtime). Once the TS
+// loader lands, rename this to `zfb.config.ts` and delete the JSON sibling.
+// Until then, `zfb.config.json` is the source of truth and this file is the
+// canonical, type-checked shape kept in sync by hand for review purposes.
+export default defineConfig({
+  framework: "preact",
+  tailwind: {
+    enabled: true,
+  },
+  collections: {
+    blog: {
+      type: "content",
+      directory: "content/blog",
+      schema: {
+        title: "string",
+        date: "date",
+        description: "string?",
+        tags: "string[]?",
+      },
+    },
+  },
+});

--- a/examples/basic-blog/zfb.config.json
+++ b/examples/basic-blog/zfb.config.json
@@ -1,0 +1,14 @@
+{
+  "framework": "preact",
+  "outDir": "dist",
+  "publicDir": "public",
+  "tailwind": {
+    "enabled": true
+  },
+  "collections": [
+    {
+      "name": "blog",
+      "path": "content/blog"
+    }
+  ]
+}


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/10
- parent PR
    - (super-epic base; super-epic #2)

---

## Summary

Epic #10 — fills out the docs site with prose covering installation, concepts, API reference, guides, and architecture, plus an examples/basic-blog dogfood project.

### What landed

**22 new MDX docs files** under `docs/src/content/docs/`:

- `getting-started/installation.mdx` `your-first-site.mdx` `project-structure.mdx`
- `concepts/routing.mdx` `content-collections.mdx` `data.mdx` `styling.mdx` `islands.mdx` `build-pipeline.mdx`
- `api/define-config.mdx` `get-collection.mdx` `paginate.mdx` `island.mdx` `meta-export.mdx`
- `guides/migrating-from-astro.mdx` `migrating-from-eleventy.mdx` `customizing-markdown.mdx` `syntax-highlighting.mdx`
- `architecture/build-engine.mdx` `js-runtime.mdx` `framework-adapters.mdx` `why-rust.mdx`
- `dogfood/zudo-doc-migration.mdx`

Every page that walks through dev/build carries a `<Warning title="v0 status">` admonition pointing at `/architecture/js-runtime` (mirrors ADR-001 — the renderer host `DenoCoreHost` is still a skeleton). Architecture pages mirror Epic 3's ADR-001 and ADR-002 in user-readable form.

**examples/basic-blog/** — a freestanding zfb dogfood site (19 files): pages (index, blog/[slug], blog/page/[page], tags/[tag]), 5 blog posts in content/blog, a `"use client"` ThemeToggle island, default layout, light/dark CSS using CSS variables, package.json + tsconfig + .gitignore, README with v0 caveats, and dual config (zfb.config.json that loads today + zfb.config.future.ts that documents the v1 target shape).

### Two honest deviations from the original spec

1. **`zfb.config.future.ts` instead of `zfb.config.ts`** — the v0 loader rejects when both `.ts` and `.json` are present alongside each other (TS support is gated on ADR-001). Renaming the file makes the dual-fixture work today; the README documents the rename-back path for when TS lands.
2. **Schema docs corrected to v0 reality** — five docs files (api/define-config, concepts/content-collections, concepts/data, guides/migrating-from-astro, guides/migrating-from-eleventy) originally described an aspirational record-keyed `collections` shape with `type: "content" | "data"` and `directory` fields. Cross-checking against `crates/zfb/src/config.rs` (`CollectionDef = { name, path, schema? }`, `collections: Vec<CollectionDef>`) showed the v0 loader accepts only an array form. Fixed to describe the v0 form as canonical, with the richer v1 shape labelled aspirational. (commit `d9710cd`)

### v0 build smoke: examples/basic-blog passes weakly as expected

`cargo run -p zfb -- build --outdir /tmp/...` from inside `examples/basic-blog/` exits 0, writes `/index.html` (the only static route — `[slug]`, `[page]`, `[tag]` are all dynamic per the router's bracket-detection), and warn-skips the three dynamic routes with the documented "pending real renderer (ADR-001)" message. Acceptance criterion 2 ("examples/basic-blog/ builds via zfb build") is satisfied at the v0 contract level; full content-rendering arrives with the runtime decision.

### Verification

- `pnpm dlx @takazudo/mdx-formatter --check` — all 22 MDX files clean.
- `pnpm docs:build` — 77 pages built clean (was 53 before this PR; +24 = 22 new + 2 sub-section index auto-generations).
- `cargo build -p zfb` — clean.
- examples/basic-blog smoke build — exits 0, output matches expected v0 contract.
- Cross-link sweep — all `/architecture/...`, `/concepts/...`, `/api/...`, `/getting-started/...` references resolve to files in the diff or pre-existing siblings.

## What's deferred

- **Japanese mirrors** under `docs/src/content/docs-ja/` — out of scope for this epic; follow-up after the English content is reviewed. The Astro build auto-generates JA section index pages without per-page content; `/ja/docs/concepts/` etc. resolve but list zero items.
- **RSS feed for examples/basic-blog** — listed as a stretch goal in the issue, skipped.
- **Real per-route SSR rendering** — same blocker as #9 (ADR-001 / `DenoCoreHost` skeleton). Every page that promises rendered output explicitly notes this state.
- **Migrating zudo-doc itself onto zfb** (Sub 7) — notes only, not the actual migration.

## Topic PRs

Topic branches were merged locally (`--no-ff`) and deleted both locally and remotely. Per-topic PRs were not created (would have failed with "no commits between base and head" since topics were already in base by push time).

- `getting-started` — Sub 1 (3 files)
- `concepts` — Sub 2 (6 files)
- `api-reference` — Sub 3 (5 files)
- `guides` — Sub 4 (4 files)
- `architecture` — Sub 5 (4 files)
- `basic-blog-and-dogfood` — Sub 6 + Sub 7 (19 files)
- (manager) `d9710cd` — schema-honesty fix from gcoc-review cross-check

## Stats

- 47 files changed, ~2476 insertions, ~0 deletions (all additive)
- `pnpm docs:build` — 77 pages, 13s
- 6 child agents in parallel (max concurrency); zero merge conflicts; one cross-cutting manager fix