### PR TITLE
fix: resolve docs astro check errors (#38) + park parked Rust integration test (#37)

### DIFF
--- a/crates/zfb-render/Cargo.toml
+++ b/crates/zfb-render/Cargo.toml
@@ -13,11 +13,6 @@ description = "zfb render: SWC TSX→JS pipeline + JS runtime + page render orch
 # (trait + SWC pipeline + orchestrator) compiles and tests without it.
 default = []
 deno_core_host = ["dep:deno_core", "dep:tokio"]
-# Gates the end-to-end routing+rendering integration test. Off until the
-# orchestrator exposes render_route + RenderInput/Output and zfb-render
-# depends on zfb-router. See tests/integration_routing_rendering.rs for
-# the fixtures and harness already in place.
-integration_routing_rendering = []
 
 [dependencies]
 # Sibling crate: MDX → JSX-source emitter. The loader funnels `.mdx` and

--- a/crates/zfb-render/tests/integration_routing_rendering.rs
+++ b/crates/zfb-render/tests/integration_routing_rendering.rs
@@ -1,3 +1,23 @@
+// TODO(parked): This integration test is parked.
+//
+// It depends on the orchestrator API surface (`render_route`,
+// `RenderInput`, `RenderOutput`) and the `zfb-router` workspace crate,
+// none of which exist yet. Until those land, the test cannot compile,
+// and a `cargo clippy --workspace --all-features --all-targets` (or
+// `cargo check --all-features`) run otherwise breaks the workspace
+// build.
+//
+// To work around that, this file is unconditionally excluded from
+// compilation via `#![cfg(any())]` (the canonical "always-false" cfg)
+// and the matching `integration_routing_rendering = []` feature has
+// been removed from `crates/zfb-render/Cargo.toml`. The test source,
+// fixtures, layouts, components, and harness are intentionally kept on
+// disk so they remain version-controlled.
+//
+// When the orchestrator API and `zfb-router` crate land, restore the
+// original `#![cfg(feature = "integration_routing_rendering")]`
+// attribute below and re-add the feature line in `Cargo.toml`.
+
 //! End-to-end integration tests for the Epic 3 routing + rendering
 //! pipeline.
 //!
@@ -44,7 +64,7 @@
 // can be turned on with a single Cargo.toml change once the orchestrator
 // exposes the expected entry points and zfb-render adds zfb-router as
 // a dep. Tracked as the natural follow-up to Epic 3 (Subs 1–7).
-#![cfg(feature = "integration_routing_rendering")]
+#![cfg(any())]
 #![allow(dead_code)]
 
 use std::path::{Path, PathBuf};

--- a/docs/src/components/language-switcher.astro
+++ b/docs/src/components/language-switcher.astro
@@ -4,6 +4,13 @@ import { defaultLocale, type Locale } from "@/config/i18n";
 
 interface Props {
   lang?: Locale;
+  /**
+   * Optional list of supported locale codes. The component derives its links
+   * from `Astro.url.pathname` and the locale config in settings, so this prop
+   * is currently unused but accepted to keep the call site in `header.astro`
+   * type-safe (it forwards the project-wide `locales` array from `i18n.ts`).
+   */
+  locales?: readonly Locale[];
 }
 
 const { lang = defaultLocale } = Astro.props;

--- a/docs/src/config/settings.ts
+++ b/docs/src/config/settings.ts
@@ -6,6 +6,8 @@ export type {
   LocaleConfig,
   VersionConfig,
   FooterConfig,
+  FrontmatterPreviewConfig,
+  TagPlacement,
 } from "./settings-types";
 import type {
   HeaderNavItem,
@@ -14,6 +16,9 @@ import type {
   LocaleConfig,
   VersionConfig,
   FooterConfig,
+  FrontmatterPreviewConfig,
+  TagPlacement,
+  TagGovernanceMode,
 } from "./settings-types";
 
 export const settings = {
@@ -50,6 +55,27 @@ export const settings = {
   sidebarResizer: true as boolean,
   sidebarToggle: true as boolean,
   htmlPreview: undefined as HtmlPreviewConfig | undefined,
+  /**
+   * Optional URL of the project's GitHub repository. When set, the header
+   * renders a GitHub link icon. Leave undefined to omit the link.
+   */
+  githubUrl: undefined as string | undefined,
+  /**
+   * Frontmatter preview block, rendered above the doc body.
+   * `false` disables the feature entirely. An object enables it and may
+   * customise which keys are hidden via `ignoreKeys` / `extraIgnoreKeys`.
+   */
+  frontmatterPreview: false as false | FrontmatterPreviewConfig,
+  /**
+   * Where the per-page tag list is rendered. Undefined hides it.
+   * - `"after-title"` — directly below the page title.
+   * - `"before-pager"` — directly above the prev/next pager at the foot.
+   */
+  tagPlacement: undefined as TagPlacement | undefined,
+  /** Master on/off switch for consulting `tag-vocabulary.ts` at runtime. */
+  tagVocabulary: false as boolean,
+  /** Tag governance enforcement level. See `TagGovernanceMode` for values. */
+  tagGovernance: "off" as TagGovernanceMode,
   versions: [] as VersionConfig[],
   claudeResources: {
     claudeDir: ".claude",


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/39
    - closes https://github.com/Takazudo/zudo-front-builder/issues/37
    - closes https://github.com/Takazudo/zudo-front-builder/issues/38

---

## Summary

Picks up the two most recent open issues and fixes them in parallel via `/x-wt-teams -gcoc`.

### Topic 1 — `docs/`: resolve 20 `astro check` ts(2339) errors (closes #38)

`pnpm astro check` (run from `docs/`) reported 20 errors because the inferred `Settings` type was missing several runtime properties referenced in template `.astro` files. Fixed by adding entries to `docs/src/config/settings.ts` with conservative defaults that preserve current behavior:

- `githubUrl: undefined as string | undefined`
- `frontmatterPreview: false as false | FrontmatterPreviewConfig`
- `tagPlacement: undefined as TagPlacement | undefined`
- `tagVocabulary: false as boolean`
- `tagGovernance: "off" as TagGovernanceMode`

Also re-exports `FrontmatterPreviewConfig` and `TagPlacement` from `settings.ts`, and adds an optional `locales?: readonly Locale[]` prop to `language-switcher.astro` for header.astro's call site.

Result: `pnpm astro check` reports **0 errors, 0 warnings, 3 hints** (was 20 errors, 0 warnings, 3 hints). The 3 hints are pre-existing, unrelated.

### Topic 2 — `crates/zfb-render`: park `integration_routing_rendering` test (closes #37)

`cargo clippy --workspace --all-features --all-targets` failed because the empty `integration_routing_rendering = []` feature gate enabled compilation of a test whose dependencies (`render_route`, `RenderInput`, `RenderOutput`, `zfb-router`) have not yet landed. Applied **Option 1** from the issue:

- Removed `integration_routing_rendering = []` from `crates/zfb-render/Cargo.toml`.
- Switched `crates/zfb-render/tests/integration_routing_rendering.rs` to `#![cfg(any())]` (canonical "always-false" cfg) so it is unconditionally excluded from compilation regardless of feature flags.
- Added a TODO block at the top of the test file documenting the revival recipe (restore the original `#![cfg(feature = "...")]` and re-add the feature line) so the test source, fixtures, and harness stay version-controlled for when the orchestrator API lands.

Result: `cargo clippy --workspace --all-features --all-targets` succeeds. `cargo test --workspace` also passes.

## Out-of-scope finding raised separately

While verifying #37, the worktree agent noted that `cargo build --workspace --all-features --all-targets` still fails on a pre-existing V8 / `temporal_rs_*` linker error coming from `zfb-runtime-spike`'s `deno` feature — completely unrelated to this PR. Tracked at #41.

## Topic PRs

Both topics were implemented in parallel worktrees and merged locally into the base branch before pushing (per `/x-wt-teams` push-forbid pattern). No separate topic PRs were left open.

## Verification

- `cd docs && pnpm astro check` → 0 errors (was 20)
- `cargo clippy --workspace --all-features --all-targets` → ok
- `cargo test --workspace` → ok
- `/gcoc-review` on combined diff → no findings, all changes correct and safe
- CI on PR (Build docs site, health) → all green
