### PR TITLE
zfb-hygiene: deno_core retirement, version pins, graph persistence (#55)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ crates/zfb/binaries/esbuild/esbuild
 
 # Ephemeral / temp files (e.g. agent prompts, review diffs)
 __inbox/
+
+# Per-project zfb cache (graph snapshot, etc.) — created in user
+# project roots when `zfb dev` runs. Never committed.
+.zfb/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,46 @@ The Cloudflare Pages deploy workflow (wired up in a later sub-task) expects the 
 - **`CLOUDFLARE_ACCOUNT_ID`** (required) — the Cloudflare account ID that owns the Pages project.
 - **`IFTTT_PROD_NOTIFY`** (optional) — IFTTT webhook key used to push a notification when a production deploy lands. Omit to skip notifications.
 
+## External tool version pins
+
+zfb shells out to a small set of third-party tools (esbuild for the islands bundler, wrangler/miniflare/workerd for Cloudflare Pages preview, Tailwind v4 for the CSS engine). Every one of those tools is **exact-pinned** so that the same source tree produces byte-identical output regardless of when or where it is built — this matters for asset-hash stability and for keeping the SSR pipeline from drifting under our feet when upstream cuts a patch release.
+
+The pin lives in two places that **must move together**:
+
+1. The npm-side declaration in [`package.json`](./package.json) (no `^`/`~` for these entries).
+2. The Rust-side constant that the subprocess wrapper checks against at startup.
+
+| Tool        | Rust constant                                                                                       | Where                                          | npm-side pin                          |
+| ----------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------------- | ------------------------------------- |
+| esbuild     | `EXPECTED_ESBUILD_VERSION`, `EXPECTED_ESBUILD_SHA256`                                               | `crates/zfb-islands/src/esbuild.rs`            | (binary; populated by release engineering into `crates/zfb/binaries/esbuild/esbuild`) |
+| wrangler    | `EXPECTED_WRANGLER_VERSION`                                                                         | `crates/zfb/src/commands/preview.rs`           | `wrangler` in `package.json`          |
+| miniflare   | `EXPECTED_MINIFLARE_VERSION` (informational; not gated at runtime — wrangler owns the subprocess)   | `crates/zfb/src/commands/preview.rs`           | `miniflare` in `package.json`         |
+| workerd     | `EXPECTED_WORKERD_VERSION` (informational; pinned transitively via miniflare → `pnpm-lock.yaml`)    | `crates/zfb/src/commands/preview.rs`           | (transitive; resolved in `pnpm-lock.yaml`) |
+
+### Bumping wrangler / miniflare / workerd
+
+1. Pick the new versions you want (typically a coordinated wrangler + miniflare + workerd set; see the [wrangler changelog](https://github.com/cloudflare/workers-sdk/releases?q=wrangler) for matched sets).
+2. Edit the `wrangler` and `miniflare` entries in `package.json` to the new exact versions.
+3. Edit `EXPECTED_WRANGLER_VERSION`, `EXPECTED_MINIFLARE_VERSION`, and `EXPECTED_WORKERD_VERSION` in `crates/zfb/src/commands/preview.rs` to match.
+4. Run `pnpm install` to refresh `pnpm-lock.yaml`. Confirm the resolved `workerd` version in the lockfile matches the constant you just set.
+5. Run `cargo test -p zfb` to make sure the version-gate tests still pass.
+6. Commit `package.json`, `pnpm-lock.yaml`, and the constants change in one commit so the pin moves atomically.
+
+If you ever need to bypass the wrangler version gate (e.g. while a bump is mid-flight on a feature branch), set `ZFB_SKIP_WRANGLER_VERSION_CHECK=1` for the duration of the `zfb preview` invocation. Do not check this in.
+
+### Bumping esbuild
+
+esbuild is shipped as a Go-built standalone CLI binary that release engineering downloads into `crates/zfb/binaries/esbuild/esbuild` at release-tarball assembly time — the binary is **not** committed to this repo. To bump:
+
+1. Pick the new esbuild version (the latest stable 0.x at release-cut time; see <https://github.com/evanw/esbuild/releases>).
+2. Edit `EXPECTED_ESBUILD_VERSION` in `crates/zfb-islands/src/esbuild.rs`.
+3. Compute the SHA-256 of the platform-specific binary you intend to ship (e.g. `sha256sum esbuild` on Linux, `shasum -a 256 esbuild` on macOS) and edit `EXPECTED_ESBUILD_SHA256` to that lowercase hex digest. Leave the constant as the empty string (`""`) only if you are explicitly handing the SHA-pin step off to the next release-engineering pass — the version gate still runs in that case, but the checksum gate is skipped (with a clear log line).
+4. Update the `## esbuild Version` table in `crates/zfb-islands/README.md`.
+5. Run `cargo test -p zfb-islands` — the unit tests use the mock-subprocess code path and do not require the real binary.
+6. Drop the new binary into `crates/zfb/binaries/esbuild/esbuild` locally to test the end-to-end gate, but do not commit it (`.gitignore` already excludes the path).
+
+The verification gate is implemented in `ensure_binary_verified` in `crates/zfb-islands/src/esbuild.rs` and runs once per binary path per process: it spawns `esbuild --version`, asserts the reported version equals `EXPECTED_ESBUILD_VERSION`, and (when populated) hashes the binary and asserts the SHA-256 equals `EXPECTED_ESBUILD_SHA256`. A mismatch on either gate aborts with a clear, actionable error pointing back at this section.
+
 ## License
 
 By contributing, you agree that your contributions will be licensed under the [MIT License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -30,6 +30,44 @@ pnpm docs:preview        # preview the built site
 pnpm docs:check          # astro check (type/content validation)
 ```
 
+## Limits
+
+`zfb build` reads every configured content collection, builds an
+in-memory `ContentSnapshot` (one entry per `.md` / `.mdx` / `.tsx`
+under each collection root), and embeds it into the worker bundle that
+miniflare loads at build time. The full snapshot lives in V8 RAM for
+the duration of the render pass — there is no streaming or sharding
+today.
+
+For the project sizes the engine targets (the docs site, blogs,
+typical `zudo-doc`-scale content sets — hundreds of MDX files with
+short bodies) this fits comfortably in default Node + workerd memory.
+Very large content sets (tens of thousands of entries, or entries
+with multi-megabyte bodies) will push V8 RSS up linearly with snapshot
+size; if you are headed in that direction, you should monitor the
+snapshot size and plan for the streaming / per-collection sharding
+work tracked as future engine roadmap.
+
+To inspect the snapshot footprint of a build, set `ZFB_DEBUG_SNAPSHOT`
+to `1` (or `true`):
+
+```sh
+ZFB_DEBUG_SNAPSHOT=1 pnpm exec zfb build
+```
+
+zfb will print one line to stderr while building:
+
+```
+content snapshot: 187 entries / 412 KB
+```
+
+`entries` is the total number of content entries across all
+collections. `KB` is the byte size of the deterministic JSON
+serialization of the snapshot — a useful proxy for the V8 heap cost,
+since that is the shape miniflare receives. Any other value (`0`,
+unset, `yes`, etc.) leaves the build silent so a stray export does
+not change CI output.
+
 ## License
 
 MIT — see [LICENSE](./LICENSE).

--- a/crates/zfb-build/Cargo.toml
+++ b/crates/zfb-build/Cargo.toml
@@ -16,9 +16,10 @@ zfb-graph = { path = "../zfb-graph" }
 zfb-content = { path = "../zfb-content" }
 # Read-only consumption of the framework adapter contract (ADR-002).
 # The bundler only touches `Framework`, `make_adapter`, and the adapter's
-# `hydrate_shim_*` accessors. Default features are kept (no
-# `deno_core_host`) so this stays compile-cheap and does not drag V8 into
-# `zfb-build`'s dependency surface.
+# `hydrate_shim_*` accessors. Per ADR-005 the JS runtime is no longer
+# embedded (deno_core was retired), so `zfb-render` is compile-cheap and
+# carries no V8 / native-runtime cost into `zfb-build`'s dependency
+# surface.
 zfb-render = { path = "../zfb-render" }
 
 anyhow = { workspace = true }

--- a/crates/zfb-build/README.md
+++ b/crates/zfb-build/README.md
@@ -15,9 +15,10 @@ The dev-loop orchestrator for the zudo-front-builder framework.
 The orchestrator deliberately does **not** depend on those last three
 crates. They're injected as callback functions on a `BuildContext` so:
 
-- the orchestrator's surface stays free of feature-gated dependencies
-  (notably `zfb-render`'s `deno_core_host` feature, which pulls in V8),
-  and
+- the orchestrator's surface stays free of heavyweight transitive
+  dependencies (the SWC pipeline in `zfb-render`, and the
+  miniflare / esbuild npm subprocess wrappers in `zfb-css` /
+  `zfb-islands`), and
 - tests can plug in fakes that count invocations without spawning
   Tailwind / esbuild subprocesses.
 
@@ -99,7 +100,7 @@ builds will need different behaviour:
 | ---------- | --------------------------------------------------------- |
 | Production | Minify, fail-fast, hashed asset URLs in HTML.             |
 | SSR        | Skip writing HTML to disk; emit into a runtime bundle.    |
-| Edge       | Skip dist/ entirely; emit deno-shaped artefacts in RAM.   |
+| Edge       | Skip dist/ entirely; emit workerd-shaped artefacts in RAM. |
 
 Locking the orchestrator to a concrete struct now would force a
 refactor when production-build lands. Locking to a trait costs one

--- a/crates/zfb-build/src/lib.rs
+++ b/crates/zfb-build/src/lib.rs
@@ -15,8 +15,10 @@
 //! goes through pluggable callback functions ([`PageRenderer`],
 //! [`CssRunner`], [`IslandsRunner`]) so:
 //!
-//! - the orchestrator's surface stays free of feature-gated dependencies
-//!   (notably `zfb-render`'s `deno_core_host` feature), and
+//! - the orchestrator's surface stays free of heavyweight transitive
+//!   dependencies (SWC's TSX→JS pipeline in `zfb-render`, and the
+//!   miniflare/esbuild npm subprocess wrappers in `zfb-css` /
+//!   `zfb-islands`), and
 //! - tests can plug in fakes that count invocations rather than spinning
 //!   up Tailwind/esbuild subprocesses.
 //!

--- a/crates/zfb-build/src/orchestrator.rs
+++ b/crates/zfb-build/src/orchestrator.rs
@@ -357,7 +357,7 @@ mod tests {
                 assert!(s.contains(&pid("/proj/pages/a.tsx")));
                 assert!(!s.contains(&pid("/proj/pages/b.tsx")));
             }
-            _ => panic!(),
+            other => unreachable!("expected PageSelection::Specific, got {other:?}"),
         }
         assert!(!plan.rerun_css);
         assert!(!plan.rerun_islands);
@@ -373,7 +373,7 @@ mod tests {
                 assert!(s.contains(&pid("/proj/pages/b.tsx")));
                 assert!(!s.contains(&pid("/proj/pages/c.tsx")));
             }
-            _ => panic!(),
+            other => unreachable!("expected PageSelection::Specific, got {other:?}"),
         }
         // components/ is in default islands roots -> islands rerun.
         assert!(plan.rerun_islands);
@@ -407,7 +407,7 @@ mod tests {
             PageSelection::Specific(s) => {
                 assert_eq!(s, BTreeSet::from([pid("/proj/pages/c.tsx")]));
             }
-            _ => panic!(),
+            other => unreachable!("expected PageSelection::Specific, got {other:?}"),
         }
     }
 

--- a/crates/zfb-build/src/pipeline/mod.rs
+++ b/crates/zfb-build/src/pipeline/mod.rs
@@ -24,8 +24,8 @@
 //!   asset filenames + HTML rewrite so deployed assets can be cached
 //!   forever. No SSE — `dist/` is a static tree the user uploads to a
 //!   CDN.
-//! - **SSR / edge**: skip writing HTML to disk; emit it into a deno-
-//!   shaped runtime bundle.
+//! - **SSR / edge**: skip writing HTML to disk; emit it into a
+//!   workerd-shaped runtime bundle (see ADR-005).
 //!
 //! Locking the orchestrator to a concrete struct now would force a
 //! refactor when production-build lands. Locking to a trait costs a
@@ -36,9 +36,10 @@
 //! The orchestrator deliberately doesn't depend on `zfb-render`,
 //! `zfb-css`, or `zfb-islands` directly:
 //!
-//! - `zfb-render` requires the `deno_core_host` feature (gigabytes of V8
-//!   build artefacts) for a working host. The orchestrator must compile
-//!   without that feature flag flipped on.
+//! - `zfb-render` carries the SWC TSX→JS pipeline and (per ADR-005) the
+//!   miniflare-subprocess render host. Keeping that out of the
+//!   orchestrator's surface lets `zfb-build` compile cheaply for tests
+//!   and for callers that only need orchestration types.
 //! - The CSS / islands crates ship trait-based plug points
 //!   (`CssEngine`, `ClientBundler`) plus subprocess wrappers around
 //!   third-party CLIs (Tailwind, esbuild). Pulling them in transitively

--- a/crates/zfb-build/src/plan.rs
+++ b/crates/zfb-build/src/plan.rs
@@ -185,7 +185,7 @@ mod tests {
                 assert!(s.contains(&pid("/p/a.tsx")));
                 assert!(s.contains(&pid("/p/b.tsx")));
             }
-            _ => panic!(),
+            other => unreachable!("expected PageSelection::Specific, got {other:?}"),
         }
     }
 }

--- a/crates/zfb-build/src/renderer.rs
+++ b/crates/zfb-build/src/renderer.rs
@@ -1180,7 +1180,7 @@ mod tests {
                 assert_eq!(status, 500);
                 assert!(body.contains("Error: boom"));
             }
-            other => panic!("expected RenderFailed, got {other:?}"),
+            other => unreachable!("expected RenderFailed, got {other:?}"),
         }
     }
 
@@ -1285,7 +1285,7 @@ mod tests {
                     "expected pages/error.tsx:5:* got {loc}; body={body}"
                 );
             }
-            other => panic!("expected RenderFailed, got {other:?}"),
+            other => unreachable!("expected RenderFailed, got {other:?}"),
         }
     }
 

--- a/crates/zfb-content/src/collection.rs
+++ b/crates/zfb-content/src/collection.rs
@@ -783,7 +783,7 @@ mod tests {
                 assert_eq!(errors.len(), 1);
                 assert!(matches!(errors[0], CollectionError::Frontmatter { .. }));
             }
-            other => panic!("expected Multiple, got {other:?}"),
+            other => unreachable!("expected Multiple, got {other:?}"),
         }
     }
 
@@ -802,7 +802,7 @@ mod tests {
                 assert_eq!(errors.len(), 1);
                 assert!(matches!(errors[0], CollectionError::Frontmatter { .. }));
             }
-            other => panic!("expected Multiple, got {other:?}"),
+            other => unreachable!("expected Multiple, got {other:?}"),
         }
     }
 
@@ -817,7 +817,7 @@ mod tests {
                 assert_eq!(errors.len(), 1);
                 assert!(matches!(errors[0], CollectionError::Schema { .. }));
             }
-            other => panic!("expected Multiple, got {other:?}"),
+            other => unreachable!("expected Multiple, got {other:?}"),
         }
     }
 
@@ -839,7 +839,7 @@ mod tests {
                 assert_eq!(errors.len(), 1);
                 assert!(matches!(errors[0], CollectionError::Schema { .. }));
             }
-            other => panic!("expected Multiple, got {other:?}"),
+            other => unreachable!("expected Multiple, got {other:?}"),
         }
     }
 
@@ -867,7 +867,7 @@ mod tests {
                 assert!(kinds.contains(&"schema"));
                 assert!(!summary.is_empty());
             }
-            other => panic!("expected Multiple, got {other:?}"),
+            other => unreachable!("expected Multiple, got {other:?}"),
         }
     }
 

--- a/crates/zfb-content/src/content_bridge.rs
+++ b/crates/zfb-content/src/content_bridge.rs
@@ -3,10 +3,10 @@
 //! This module defines the serializable shape that flows from the Rust
 //! build into the JS runtime so TSX page modules can call
 //! `getCollection("docs")` and `getEntry("docs", "slug")` synchronously
-//! during SSR. The actual deno_core wiring (embedding the snapshot into
-//! `globalThis.__zfb.content`) is gated by ADR-001 and lands in a
-//! follow-up epic — this sub delivers ONLY the Rust contract and the
-//! TypeScript surface.
+//! during SSR. The actual JS-side wiring (embedding the snapshot into
+//! `globalThis.__zfb.content` via the miniflare runtime per ADR-005)
+//! lands in a follow-up epic — this sub delivers ONLY the Rust contract
+//! and the TypeScript surface.
 //!
 //! See `docs/architecture/adr-004-content-bridge.md` for the JS-side
 //! contract spec.

--- a/crates/zfb-content/src/content_bridge.rs
+++ b/crates/zfb-content/src/content_bridge.rs
@@ -179,7 +179,60 @@ pub fn build_snapshot(collections: &[CollectionConfig]) -> Result<ContentSnapsho
         out.insert(cfg.name.clone(), snapshots);
     }
 
-    Ok(ContentSnapshot { collections: out })
+    let snapshot = ContentSnapshot { collections: out };
+    log_snapshot_size_if_requested(&snapshot);
+    Ok(snapshot)
+}
+
+/// If `ZFB_DEBUG_SNAPSHOT` is set to a truthy value (`1` or `true`,
+/// case-insensitive), print a one-line summary of the serialized
+/// snapshot size to stderr. Anything else (unset, empty, `0`, `false`,
+/// or unrecognized) is a no-op.
+///
+/// Used to monitor V8 RAM pressure: zfb embeds the full content
+/// snapshot in the miniflare worker at build time, so the byte size
+/// reported here is roughly what gets held in V8 during render. See
+/// the "Limits" section of the project README.
+///
+/// Failure is silent on purpose — debug telemetry must never panic the
+/// build. If `serde_json::to_string` ever returns `Err` (it cannot for
+/// our shape, which contains no NaN/non-string keys), we just skip the
+/// log line.
+fn log_snapshot_size_if_requested(snap: &ContentSnapshot) {
+    if !debug_snapshot_enabled() {
+        return;
+    }
+    let entries: usize = snap.collections.values().map(|v| v.len()).sum();
+    let bytes = match serde_json::to_string(snap) {
+        Ok(s) => s.len(),
+        Err(_) => return,
+    };
+    // Round up so a 1-byte snapshot still reports as 1 KB rather than 0.
+    let kb = bytes.div_ceil(1024);
+    eprintln!("content snapshot: {entries} entries / {kb} KB");
+}
+
+/// Read `ZFB_DEBUG_SNAPSHOT` and decide whether to emit the debug line.
+/// Truthy values: `1`, `true` (case-insensitive). Everything else —
+/// including unset, empty string, and unrecognized values like `yes` —
+/// is treated as off so a stray export does not change build output.
+///
+/// Public so the CLI can avoid building a snapshot purely for telemetry
+/// when the flag is off.
+pub fn debug_snapshot_enabled() -> bool {
+    std::env::var("ZFB_DEBUG_SNAPSHOT")
+        .ok()
+        .as_deref()
+        .map(parse_debug_truthy)
+        .unwrap_or(false)
+}
+
+/// Pure parser for the `ZFB_DEBUG_SNAPSHOT` value. Split out from
+/// [`debug_snapshot_enabled`] so the truthiness rule is testable
+/// without mutating process-global env state.
+fn parse_debug_truthy(raw: &str) -> bool {
+    let t = raw.trim();
+    t.eq_ignore_ascii_case("1") || t.eq_ignore_ascii_case("true")
 }
 
 // -----------------------------------------------------------------------------
@@ -430,6 +483,19 @@ mod tests {
         let err = build_snapshot(&[cfg]).expect_err("malformed YAML must fail");
         match err {
             BridgeError::Walk { collection, .. } => assert_eq!(collection, "blog"),
+        }
+    }
+
+    #[test]
+    fn debug_truthy_parser_accepts_only_documented_truthy_values() {
+        // Documented truthy: `1`, `true` (case-insensitive, trim whitespace).
+        for raw in ["1", " 1 ", "true", "TRUE", "True", "  true\n"] {
+            assert!(parse_debug_truthy(raw), "{raw:?} should be truthy");
+        }
+        // Everything else is off — guards against accidental enabling
+        // when a script sets `ZFB_DEBUG_SNAPSHOT=yes` or similar.
+        for raw in ["", "0", "false", "no", "yes", "on", "off", "TRUE!"] {
+            assert!(!parse_debug_truthy(raw), "{raw:?} should be falsy");
         }
     }
 

--- a/crates/zfb-content/src/frontmatter.rs
+++ b/crates/zfb-content/src/frontmatter.rs
@@ -383,7 +383,7 @@ mod tests {
         let err = extract(&path, "---\ntitle: x\n---\n").expect_err("should fail");
         match err {
             FrontmatterError::UnsupportedExtension(ext) => assert_eq!(ext, "markdown"),
-            other => panic!("expected UnsupportedExtension, got {other:?}"),
+            other => unreachable!("expected UnsupportedExtension, got {other:?}"),
         }
     }
 

--- a/crates/zfb-content/src/lib.rs
+++ b/crates/zfb-content/src/lib.rs
@@ -11,7 +11,10 @@ pub mod serializer;
 pub mod syntect_highlight;
 pub mod tsx_frontmatter;
 
-pub use content_bridge::{build_snapshot, BridgeError, CollectionConfig, ContentSnapshot, EntrySnapshot};
+pub use content_bridge::{
+    build_snapshot, debug_snapshot_enabled, BridgeError, CollectionConfig, ContentSnapshot,
+    EntrySnapshot,
+};
 
 pub use frontmatter::{
     extract as extract_frontmatter, FrontmatterError, UnifiedFrontmatter,

--- a/crates/zfb-content/src/pipeline.rs
+++ b/crates/zfb-content/src/pipeline.rs
@@ -451,7 +451,7 @@ mod tests {
     fn root_children(node: &HastNode) -> &[HastNode] {
         match node {
             HastNode::Root { children } => children,
-            _ => panic!("expected Root, got {node:?}"),
+            _ => unreachable!("expected Root, got {node:?}"),
         }
     }
 
@@ -473,7 +473,7 @@ mod tests {
                 assert_eq!(tag, expected_tag, "tag mismatch in {node:?}");
                 (attrs.as_slice(), children.as_slice(), *void)
             }
-            _ => panic!("expected Element<{expected_tag}>, got {node:?}"),
+            _ => unreachable!("expected Element<{expected_tag}>, got {node:?}"),
         }
     }
 
@@ -783,7 +783,7 @@ mod tests {
                     "expected class=touched on {c:?}"
                 );
             } else {
-                panic!("expected element, got {c:?}");
+                unreachable!("expected element, got {c:?}");
             }
         }
     }

--- a/crates/zfb-content/src/plugins/admonitions.rs
+++ b/crates/zfb-content/src/plugins/admonitions.rs
@@ -133,7 +133,7 @@ mod tests {
     fn flow(node: &MdastNode) -> &MdxJsxFlowElement {
         match node {
             MdastNode::MdxJsxFlowElement(j) => j,
-            other => panic!("expected MdxJsxFlowElement, got {other:?}"),
+            other => unreachable!("expected MdxJsxFlowElement, got {other:?}"),
         }
     }
 
@@ -145,7 +145,7 @@ mod tests {
             text_para(":::"),
         ]);
         let MdastNode::Root(Root { children, .. }) = root else {
-            panic!()
+            unreachable!("expected MdastNode::Root")
         };
         assert_eq!(children.len(), 1);
         let j = flow(&children[0]);
@@ -170,7 +170,7 @@ mod tests {
                 text_para(":::"),
             ]);
             let MdastNode::Root(Root { children, .. }) = root else {
-                panic!()
+                unreachable!("expected MdastNode::Root")
             };
             assert_eq!(children.len(), 1);
             let j = flow(&children[0]);
@@ -186,17 +186,17 @@ mod tests {
             text_para(":::"),
         ]);
         let MdastNode::Root(Root { children, .. }) = root else {
-            panic!()
+            unreachable!("expected MdastNode::Root")
         };
         let j = flow(&children[0]);
         assert_eq!(j.attributes.len(), 1);
         let AttributeContent::Property(prop) = &j.attributes[0] else {
-            panic!()
+            unreachable!("expected AttributeContent::Property")
         };
         assert_eq!(prop.name, "title");
         match &prop.value {
             Some(AttributeValue::Literal(v)) => assert_eq!(v, "Click me"),
-            other => panic!("expected literal, got {other:?}"),
+            other => unreachable!("expected literal, got {other:?}"),
         }
     }
 
@@ -208,7 +208,7 @@ mod tests {
             text_para(":::"),
         ]);
         let MdastNode::Root(Root { children, .. }) = root else {
-            panic!()
+            unreachable!("expected MdastNode::Root")
         };
         // No transformation: 3 paragraphs preserved.
         assert_eq!(children.len(), 3);
@@ -218,7 +218,7 @@ mod tests {
     fn missing_close_left_alone() {
         let root = run_root(vec![text_para(":::note"), text_para("body")]);
         let MdastNode::Root(Root { children, .. }) = root else {
-            panic!()
+            unreachable!("expected MdastNode::Root")
         };
         assert_eq!(children.len(), 2);
         assert!(matches!(children[0], MdastNode::Paragraph(_)));

--- a/crates/zfb-content/src/plugins/code_title.rs
+++ b/crates/zfb-content/src/plugins/code_title.rs
@@ -182,7 +182,7 @@ mod tests {
         let mut tree = root(vec![pre_with_meta(Some("title=\"main.rs\""))]);
         CodeTitlePlugin::new().visit(&mut tree);
         let HastNode::Root { children } = tree else {
-            panic!()
+            unreachable!("expected HastNode::Root")
         };
         let HastNode::Element {
             tag,
@@ -191,7 +191,7 @@ mod tests {
             ..
         } = &children[0]
         else {
-            panic!()
+            unreachable!("unreachable in test")
         };
         assert_eq!(tag, "figure");
         assert!(attrs.contains(&("class".to_string(), "code-figure".to_string())));
@@ -201,12 +201,12 @@ mod tests {
             ..
         } = &children[0]
         else {
-            panic!()
+            unreachable!("unreachable in test")
         };
         assert_eq!(cap_tag, "figcaption");
         assert_eq!(cap_children, &[HastNode::Text("main.rs".into())]);
         let HastNode::Element { tag: pre_tag, .. } = &children[1] else {
-            panic!()
+            unreachable!("expected HastNode::Element")
         };
         assert_eq!(pre_tag, "pre");
     }
@@ -232,10 +232,10 @@ mod tests {
         let mut tree = root(vec![pre_with_meta(Some("foo=1 title=\"a.rs\" bar=2"))]);
         CodeTitlePlugin::new().visit(&mut tree);
         let HastNode::Root { children } = tree else {
-            panic!()
+            unreachable!("expected HastNode::Root")
         };
         let HastNode::Element { tag, .. } = &children[0] else {
-            panic!()
+            unreachable!("expected HastNode::Element")
         };
         assert_eq!(tag, "figure");
     }

--- a/crates/zfb-content/src/plugins/directives.rs
+++ b/crates/zfb-content/src/plugins/directives.rs
@@ -786,14 +786,14 @@ mod tests {
     fn flow(node: &MdastNode) -> &MdxJsxFlowElement {
         match node {
             MdastNode::MdxJsxFlowElement(j) => j,
-            other => panic!("expected MdxJsxFlowElement, got {other:?}"),
+            other => unreachable!("expected MdxJsxFlowElement, got {other:?}"),
         }
     }
 
     fn text(node: &MdastNode) -> &MdxJsxTextElement {
         match node {
             MdastNode::MdxJsxTextElement(j) => j,
-            other => panic!("expected MdxJsxTextElement, got {other:?}"),
+            other => unreachable!("expected MdxJsxTextElement, got {other:?}"),
         }
     }
 
@@ -917,7 +917,7 @@ mod tests {
         if let MdastNode::Text(t) = &j.children[0] {
             assert_eq!(t.value, "Label");
         } else {
-            panic!("expected Text child, got {:?}", j.children[0]);
+            unreachable!("expected Text child, got {:?}", j.children[0]);
         }
     }
 
@@ -938,14 +938,14 @@ mod tests {
             })],
         );
         let MdastNode::Paragraph(Paragraph { children, .. }) = &out[0] else {
-            panic!("expected paragraph, got {:?}", out[0]);
+            unreachable!("expected paragraph, got {:?}", out[0]);
         };
         // children: [Text("Press "), MdxJsxTextElement(<Kbd>), Text(" to save")]
         assert_eq!(children.len(), 3);
         if let MdastNode::Text(t) = &children[0] {
             assert_eq!(t.value, "Press ");
         } else {
-            panic!("expected leading Text");
+            unreachable!("expected leading Text");
         }
         let j = text(&children[1]);
         assert_eq!(j.name.as_deref(), Some("Kbd"));
@@ -953,7 +953,7 @@ mod tests {
         if let MdastNode::Text(t) = &children[2] {
             assert_eq!(t.value, " to save");
         } else {
-            panic!("expected trailing Text");
+            unreachable!("expected trailing Text");
         }
     }
 
@@ -972,7 +972,7 @@ mod tests {
             })],
         );
         let MdastNode::Paragraph(Paragraph { children, .. }) = &out[0] else {
-            panic!()
+            unreachable!("expected MdastNode::Paragraph")
         };
         let j = text(&children[1]);
         assert_eq!(j.name.as_deref(), Some("Link"));
@@ -1023,7 +1023,7 @@ mod tests {
             })],
         );
         let MdastNode::Paragraph(Paragraph { children, .. }) = &out[0] else {
-            panic!()
+            unreachable!("expected MdastNode::Paragraph")
         };
         // No JSX node — text preserved verbatim. Either as a single
         // unchanged Text node, or split but still semantically the
@@ -1113,7 +1113,7 @@ mod tests {
         });
         let out = run_with_registry(&mut r, vec![bq]);
         let MdastNode::Blockquote(bq) = &out[0] else {
-            panic!("expected blockquote")
+            unreachable!("expected blockquote")
         };
         assert_eq!(bq.children.len(), 1, "admonition collapsed inside bq");
         let j = flow(&bq.children[0]);

--- a/crates/zfb-content/src/plugins/heading_links.rs
+++ b/crates/zfb-content/src/plugins/heading_links.rs
@@ -195,15 +195,15 @@ mod tests {
         let mut tree = root(vec![h(2, "Hello World")]);
         HeadingLinksPlugin::new().visit(&mut tree);
         let HastNode::Root { children } = tree else {
-            panic!()
+            unreachable!("expected HastNode::Root")
         };
         assert_eq!(first_attr(&children[0], "id"), Some("hello-world"));
 
         let HastNode::Element { children: hc, .. } = &children[0] else {
-            panic!()
+            unreachable!("expected HastNode::Element")
         };
         let HastNode::Element { tag, attrs, .. } = &hc[0] else {
-            panic!()
+            unreachable!("expected HastNode::Element")
         };
         assert_eq!(tag, "a");
         assert!(attrs.contains(&("href".to_string(), "#hello-world".to_string())));
@@ -223,7 +223,7 @@ mod tests {
         let mut tree = root(vec![h(2, "A"), h(2, "A"), h(2, "A")]);
         HeadingLinksPlugin::new().visit(&mut tree);
         let HastNode::Root { children } = tree else {
-            panic!()
+            unreachable!("expected HastNode::Root")
         };
         assert_eq!(first_attr(&children[0], "id"), Some("a"));
         assert_eq!(first_attr(&children[1], "id"), Some("a-1"));

--- a/crates/zfb-content/src/plugins/image_enlarge.rs
+++ b/crates/zfb-content/src/plugins/image_enlarge.rs
@@ -109,10 +109,10 @@ mod tests {
         };
         ImageEnlargePlugin::new().visit(&mut tree);
         let HastNode::Root { children } = tree else {
-            panic!()
+            unreachable!("expected HastNode::Root after visit")
         };
         let HastNode::Raw(raw) = &children[0] else {
-            panic!("expected Raw, got {:?}", children[0])
+            unreachable!("expected Raw, got {:?}", children[0])
         };
         assert!(raw.starts_with("<ImageEnlarge"));
         assert!(raw.contains("src=\"pic.png\""));
@@ -142,10 +142,10 @@ mod tests {
         };
         ImageEnlargePlugin::new().visit(&mut tree);
         let HastNode::Root { children } = tree else {
-            panic!()
+            unreachable!("expected HastNode::Root after visit")
         };
         let HastNode::Raw(raw) = &children[0] else {
-            panic!()
+            unreachable!("expected Raw, got {:?}", children[0])
         };
         assert!(raw.contains("alt=\"a&amp;b&quot;c\""));
     }

--- a/crates/zfb-content/src/plugins/mermaid.rs
+++ b/crates/zfb-content/src/plugins/mermaid.rs
@@ -123,13 +123,13 @@ mod tests {
         let mut tree = root(vec![pre_with_lang(Some("language-mermaid"))]);
         MermaidPlugin::new().visit(&mut tree);
         let HastNode::Root { children } = tree else {
-            panic!()
+            unreachable!("expected HastNode::Root")
         };
         let HastNode::Element { children: pc, .. } = &children[0] else {
-            panic!()
+            unreachable!("expected HastNode::Element")
         };
         let HastNode::Element { children: cc, .. } = &pc[0] else {
-            panic!()
+            unreachable!("expected HastNode::Element")
         };
         assert_eq!(cc, &[HastNode::Text("graph TD;".into())]);
     }
@@ -140,10 +140,10 @@ mod tests {
         MermaidPlugin::new().visit(&mut tree);
         MermaidPlugin::new().visit(&mut tree);
         let HastNode::Root { children } = &tree else {
-            panic!()
+            unreachable!("expected HastNode::Root")
         };
         let HastNode::Element { attrs, .. } = &children[0] else {
-            panic!()
+            unreachable!("expected HastNode::Element")
         };
         let count = attrs.iter().filter(|(k, _)| k == "data-mermaid").count();
         assert_eq!(count, 1);

--- a/crates/zfb-content/src/plugins/resolve_links.rs
+++ b/crates/zfb-content/src/plugins/resolve_links.rs
@@ -140,12 +140,14 @@ mod tests {
     }
 
     fn link_url(node: &MdastNode) -> String {
-        let MdastNode::Root(r) = node else { panic!() };
+        let MdastNode::Root(r) = node else {
+            unreachable!("expected MdastNode::Root")
+        };
         let MdastNode::Paragraph(p) = &r.children[0] else {
-            panic!()
+            unreachable!("expected MdastNode::Paragraph")
         };
         let MdastNode::Link(l) = &p.children[0] else {
-            panic!()
+            unreachable!("expected MdastNode::Link")
         };
         l.url.clone()
     }

--- a/crates/zfb-content/src/plugins/strip_md_ext.rs
+++ b/crates/zfb-content/src/plugins/strip_md_ext.rs
@@ -89,10 +89,10 @@ mod tests {
 
     fn href(node: &HastNode) -> String {
         let HastNode::Root { children } = node else {
-            panic!()
+            unreachable!("expected HastNode::Root")
         };
         let HastNode::Element { attrs, .. } = &children[0] else {
-            panic!()
+            unreachable!("expected HastNode::Element")
         };
         attrs.iter().find(|(k, _)| k == "href").unwrap().1.clone()
     }

--- a/crates/zfb-content/src/plugins/syntect_plugin.rs
+++ b/crates/zfb-content/src/plugins/syntect_plugin.rs
@@ -138,10 +138,10 @@ mod tests {
         };
         plugin.visit(&mut tree);
         let HastNode::Root { children } = tree else {
-            panic!()
+            unreachable!("expected HastNode::Root")
         };
         let HastNode::Raw(html) = &children[0] else {
-            panic!("expected Raw, got {:?}", children[0])
+            unreachable!("expected Raw, got {:?}", children[0])
         };
         assert!(html.contains("<pre class=\"syntect-"), "got: {html}");
         assert!(html.contains("</code></pre>"));
@@ -180,10 +180,10 @@ mod tests {
         };
         plugin.visit(&mut tree);
         let HastNode::Root { children } = tree else {
-            panic!()
+            unreachable!("expected HastNode::Root")
         };
         let HastNode::Raw(html) = &children[0] else {
-            panic!()
+            unreachable!("expected HastNode::Raw")
         };
         assert_eq!(html, "<pre><code>hello</code></pre>");
     }

--- a/crates/zfb-content/src/syntect_highlight.rs
+++ b/crates/zfb-content/src/syntect_highlight.rs
@@ -266,7 +266,7 @@ mod tests {
         let err = h.set_default_theme("nonexistent").unwrap_err();
         match err {
             HighlightError::UnknownTheme(name) => assert_eq!(name, "nonexistent"),
-            other => panic!("expected UnknownTheme, got {other:?}"),
+            other => unreachable!("expected UnknownTheme, got {other:?}"),
         }
     }
 

--- a/crates/zfb-content/src/tsx_frontmatter.rs
+++ b/crates/zfb-content/src/tsx_frontmatter.rs
@@ -996,7 +996,7 @@ mod tests {
                 col,
                 ..
             } => (file, export, line, col),
-            other => panic!("expected ComputedValue, got {other:?}"),
+            other => unreachable!("expected ComputedValue, got {other:?}"),
         };
         assert_eq!(file, "blog/post.tsx");
         assert_eq!(export, "frontmatter");
@@ -1033,7 +1033,7 @@ mod tests {
                     "reason should mention substitutions, got {reason:?}",
                 );
             }
-            other => panic!("expected ComputedValue, got {other:?}"),
+            other => unreachable!("expected ComputedValue, got {other:?}"),
         }
     }
 
@@ -1051,7 +1051,7 @@ mod tests {
                     "reason should mention spread, got {reason:?}",
                 );
             }
-            other => panic!("expected ComputedValue, got {other:?}"),
+            other => unreachable!("expected ComputedValue, got {other:?}"),
         }
     }
 
@@ -1083,7 +1083,7 @@ mod tests {
         let err = extract(src, "no-fm.tsx").expect_err("must fail");
         match err {
             TsxFrontmatterError::MissingFrontmatter { file } => assert_eq!(file, "no-fm.tsx"),
-            other => panic!("expected MissingFrontmatter, got {other:?}"),
+            other => unreachable!("expected MissingFrontmatter, got {other:?}"),
         }
     }
 
@@ -1099,7 +1099,7 @@ mod tests {
                 assert_eq!(name, "frontmatter");
                 assert!(line >= 2, "second export should be on line >= 2");
             }
-            other => panic!("expected DuplicateExport, got {other:?}"),
+            other => unreachable!("expected DuplicateExport, got {other:?}"),
         }
     }
 
@@ -1126,7 +1126,7 @@ mod tests {
             TsxFrontmatterError::WrongShape { export, .. } => {
                 assert_eq!(export, "frontmatter");
             }
-            other => panic!("expected WrongShape, got {other:?}"),
+            other => unreachable!("expected WrongShape, got {other:?}"),
         }
     }
 
@@ -1141,7 +1141,7 @@ mod tests {
             TsxFrontmatterError::WrongShape { export, .. } => {
                 assert_eq!(export, "extension");
             }
-            other => panic!("expected WrongShape, got {other:?}"),
+            other => unreachable!("expected WrongShape, got {other:?}"),
         }
     }
 

--- a/crates/zfb-content/tests/error_messages.rs
+++ b/crates/zfb-content/tests/error_messages.rs
@@ -49,13 +49,13 @@ fn malformed_frontmatter_error_points_at_file_and_yaml_location() {
         .expect_err("malformed frontmatter should fail");
 
     let CollectionError::Multiple { errors, .. } = &err else {
-        panic!("expected Multiple aggregate, got {err:?}");
+        unreachable!("expected Multiple aggregate, got {err:?}");
     };
     assert_eq!(errors.len(), 1, "expected a single aggregated error");
 
     let inner = &errors[0];
     let CollectionError::Frontmatter { path, message } = inner else {
-        panic!("expected Frontmatter variant, got {inner:?}");
+        unreachable!("expected Frontmatter variant, got {inner:?}");
     };
 
     assert_eq!(path, &bad, "error must carry the offending file path");

--- a/crates/zfb-content/tests/integration_collections.rs
+++ b/crates/zfb-content/tests/integration_collections.rs
@@ -87,7 +87,7 @@ fn invalid_frontmatter_returns_multiple_error() {
             );
             assert!(!summary.is_empty(), "summary must be non-empty");
         }
-        other => panic!("expected Multiple error, got {other:?}"),
+        other => unreachable!("expected Multiple error, got {other:?}"),
     }
 }
 
@@ -112,7 +112,7 @@ fn missing_required_field_returns_multiple_error() {
                 errors[0],
             );
         }
-        other => panic!("expected Multiple, got {other:?}"),
+        other => unreachable!("expected Multiple, got {other:?}"),
     }
 }
 

--- a/crates/zfb-content/tests/integration_pipeline.rs
+++ b/crates/zfb-content/tests/integration_pipeline.rs
@@ -164,6 +164,9 @@ fn assert_snapshot_eq(actual: &str, snapshot_path: &Path) {
                 actual.lines().count(),
             )
         });
+    // Snapshot mismatch is a legitimate test-failure mechanism. `panic!`
+    // is the assertion primitive here because the bespoke diff output is
+    // more readable than `assert_eq!` of two large strings.
     panic!(
         "snapshot mismatch at {snapshot_path:?}\n{line}\n--- expected ---\n{expected}\n--- actual ---\n{actual}",
     );

--- a/crates/zfb-graph/Cargo.toml
+++ b/crates/zfb-graph/Cargo.toml
@@ -9,3 +9,10 @@ description = "zfb dependency graph: tracks which pages depend on which sources 
 
 [dependencies]
 thiserror = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+bincode = "1"
+sha2 = "0.10"
+walkdir = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/zfb-graph/src/error.rs
+++ b/crates/zfb-graph/src/error.rs
@@ -1,16 +1,29 @@
 //! Crate-wide error type.
 //!
-//! The graph itself is a pure in-memory data structure that does not perform
-//! IO, so today's error surface is small. The type is reserved as a stable
-//! public name so future fallible operations (graph persistence, cycle checks
-//! against an external resolver, etc.) can fit without a breaking API change.
+//! The graph itself is a pure in-memory data structure, but the
+//! persistence layer (see [`crate::persist`]) performs IO and
+//! (de)serialisation, so the error surface covers those failure modes.
 
 /// Errors produced by `zfb-graph`.
 #[derive(Debug, thiserror::Error)]
 pub enum GraphError {
-    /// Reserved variant. Currently no operation produces this; reserved so the
-    /// enum is non-empty and downstream `match` arms can be exhaustive once
-    /// fallible APIs are added (e.g., persistence, cross-resolver validation).
+    /// Reserved variant. Currently no in-memory operation produces this;
+    /// reserved so the enum is non-empty and downstream `match` arms can
+    /// be exhaustive once additional fallible APIs are added.
     #[error("internal graph error: {0}")]
     Internal(String),
+
+    /// Filesystem IO failed while persisting or loading the graph.
+    #[error("graph persistence IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// Binary (de)serialisation failed.
+    #[error("graph persistence codec error: {0}")]
+    Codec(#[from] bincode::Error),
+
+    /// On-disk file did not start with the expected magic / version
+    /// header. Treated as "not a graph file we can read" and surfaced
+    /// so callers can decide whether to discard and rebuild.
+    #[error("graph persistence: invalid file header (not a zfb-graph snapshot, or version mismatch)")]
+    BadHeader,
 }

--- a/crates/zfb-graph/src/lib.rs
+++ b/crates/zfb-graph/src/lib.rs
@@ -38,9 +38,11 @@
 //! [`DependencyGraph::mark_global`].
 
 pub mod error;
+pub mod persist;
 
 pub use error::GraphError;
 
+use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
@@ -49,7 +51,7 @@ use std::path::{Path, PathBuf};
 ///
 /// We use a newtype rather than a bare `PathBuf` so future migrations (e.g.
 /// switching to a content-hash key) do not ripple through callers.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub struct PageId(PathBuf);
 
 impl PageId {
@@ -90,7 +92,7 @@ impl From<&Path> for PageId {
 ///
 /// Kept deliberately small: the resolver exposes raw paths today, so
 /// classification is the consumer's job. Add variants conservatively.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 pub enum DepKind {
     /// A `.tsx` / `.ts` / `.jsx` / `.js` module imported from the page graph.
     Module,
@@ -172,7 +174,7 @@ impl DirtySet {
 /// `component_name`), CSS modules by source path. Producers of this record
 /// are not required to canonicalise paths, but they must hand in the same
 /// representation they query against.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AssetDeps {
     /// Stable component identifiers (see `zfb_islands::scanner`'s notion of
     /// component-name identity) of every `"use client"` island the page
@@ -218,6 +220,7 @@ impl AssetDeps {
 ///   `assets_css_reverse[module_path] -> {pages}` — reverse indexes that
 ///   power [`DependencyGraph::pages_using_island`] and
 ///   [`DependencyGraph::pages_using_css_module`] in O(1).
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct DependencyGraph {
     forward: HashMap<PageId, Vec<(PathBuf, DepKind)>>,
     reverse: HashMap<PathBuf, HashSet<PageId>>,

--- a/crates/zfb-graph/src/lib.rs
+++ b/crates/zfb-graph/src/lib.rs
@@ -641,7 +641,7 @@ mod tests {
                 assert_eq!(set.len(), 1);
                 assert!(set.contains(&pid("/pages/index.tsx")));
             }
-            DirtySet::All => panic!("expected specific set, got All"),
+            DirtySet::All => unreachable!("expected specific set, got All"),
         }
     }
 

--- a/crates/zfb-graph/src/persist.rs
+++ b/crates/zfb-graph/src/persist.rs
@@ -42,7 +42,7 @@ use std::collections::BTreeMap;
 use std::fs::{self, File};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::time::UNIX_EPOCH;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -103,8 +103,10 @@ impl ManifestDigest {
     ///
     /// `config_files` is the list of config-like files whose full
     /// byte content matters (e.g. `zfb.config.json`,
-    /// `zfb.config.ts`). Missing files are silently skipped — they
-    /// contribute no bytes. Paths may be absolute or relative to
+    /// `zfb.config.ts`). Missing files are folded in as
+    /// "cfg-missing:<rel_path>" so a presence/absence transition
+    /// flips the digest even if a sibling file with identical
+    /// content is present. Paths may be absolute or relative to
     /// `project_root`.
     pub fn compute(
         project_root: &Path,
@@ -122,15 +124,28 @@ impl ManifestDigest {
         cfg_paths.sort();
         cfg_paths.dedup();
         for p in &cfg_paths {
-            if let Ok(bytes) = fs::read(p) {
-                hasher.update(b"cfg:");
-                let rel = relativise(project_root, p);
-                hasher.update(rel.as_bytes());
-                hasher.update(b":");
-                hasher.update(&(bytes.len() as u64).to_le_bytes());
-                hasher.update(b":");
-                hasher.update(&bytes);
-                hasher.update(b"\n");
+            let rel = relativise(project_root, p);
+            match fs::read(p) {
+                Ok(bytes) => {
+                    hasher.update(b"cfg:");
+                    hasher.update(rel.as_bytes());
+                    hasher.update(b":");
+                    hasher.update(&(bytes.len() as u64).to_le_bytes());
+                    hasher.update(b":");
+                    hasher.update(&bytes);
+                    hasher.update(b"\n");
+                }
+                // File absent (or unreadable): still fingerprint the
+                // path so a presence/absence transition flips the
+                // digest. Without this, deleting `zfb.config.json`
+                // while keeping `zfb.config.ts` could produce the
+                // same digest as the inverse if the surviving file's
+                // content happens to match.
+                Err(_) => {
+                    hasher.update(b"cfg-missing:");
+                    hasher.update(rel.as_bytes());
+                    hasher.update(b"\n");
+                }
             }
         }
 
@@ -237,15 +252,29 @@ pub fn save_to_disk(
     buf.extend_from_slice(digest.as_bytes());
     buf.extend_from_slice(&body);
 
-    // Atomic-ish write: write to `path.tmp`, then rename. On the
-    // same filesystem rename is atomic on POSIX/Windows.
-    let tmp = path.with_extension("bin.tmp");
+    // Atomic-ish write: write to a per-process unique temp, then
+    // rename. On the same filesystem rename is atomic on
+    // POSIX/Windows. The PID + nanos suffix prevents two concurrent
+    // `zfb dev` processes from clobbering each other's temp file
+    // (e.g. user runs two dev sessions in the same project, or a
+    // future `zfb build` invocation runs alongside).
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(0);
+    let tmp = path.with_extension(format!("bin.tmp.{}.{}", std::process::id(), nanos));
     {
         let mut f = File::create(&tmp)?;
         f.write_all(&buf)?;
         f.sync_all()?;
     }
-    fs::rename(&tmp, path)?;
+    if let Err(err) = fs::rename(&tmp, path) {
+        // Best-effort cleanup of the temp on rename failure so we
+        // don't leak a stray `.tmp.{pid}.{nanos}` if the destination
+        // FS rejected the rename.
+        let _ = fs::remove_file(&tmp);
+        return Err(err.into());
+    }
     Ok(())
 }
 
@@ -425,6 +454,42 @@ mod tests {
         let d1 = ManifestDigest::compute(root, &watch, &cfgs).unwrap();
         let d2 = ManifestDigest::compute(root, &watch, &cfgs).unwrap();
         assert_eq!(d1, d2);
+    }
+
+    #[test]
+    fn missing_cfg_file_is_fingerprinted_not_silently_skipped() {
+        // Regression: deleting one config file while keeping a sibling
+        // with identical content must produce a different digest from
+        // the inverse arrangement. Without the "cfg-missing:<rel>"
+        // fold-in, both arrangements hash the same content twice and
+        // collide.
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let json = root.join("zfb.config.json");
+        let ts = root.join("zfb.config.ts");
+        let watch: Vec<PathBuf> = vec![];
+        let cfgs = vec![
+            PathBuf::from("zfb.config.json"),
+            PathBuf::from("zfb.config.ts"),
+        ];
+
+        // Both files present, identical content.
+        std::fs::write(&json, b"same content").unwrap();
+        std::fs::write(&ts, b"same content").unwrap();
+        let both = ManifestDigest::compute(root, &watch, &cfgs).unwrap();
+
+        // Only JSON present.
+        std::fs::remove_file(&ts).unwrap();
+        let only_json = ManifestDigest::compute(root, &watch, &cfgs).unwrap();
+
+        // Only TS present (re-create TS, remove JSON).
+        std::fs::write(&ts, b"same content").unwrap();
+        std::fs::remove_file(&json).unwrap();
+        let only_ts = ManifestDigest::compute(root, &watch, &cfgs).unwrap();
+
+        assert_ne!(both, only_json, "both vs only-json must differ");
+        assert_ne!(both, only_ts, "both vs only-ts must differ");
+        assert_ne!(only_json, only_ts, "only-json vs only-ts must differ");
     }
 
     #[test]

--- a/crates/zfb-graph/src/persist.rs
+++ b/crates/zfb-graph/src/persist.rs
@@ -1,0 +1,504 @@
+//! Persist [`DependencyGraph`] snapshots to disk so cold starts can
+//! reuse a previously-computed graph instead of rebuilding from
+//! scratch.
+//!
+//! ## Wire format
+//!
+//! `MAGIC (4) || VERSION (2 LE) || DIGEST (32) || bincode(DependencyGraph)`
+//!
+//! Magic + version let us reject foreign files and stale formats
+//! without misreading bytes as a graph. The digest is checked against
+//! the caller's freshly-computed [`ManifestDigest`] before any
+//! deserialisation work happens; if they disagree, the file is
+//! discarded. Bincode (1.x) is used because it's already tiny, fast,
+//! and serde-native — no extra ceremony needed for the graph types
+//! that already derive `Serialize`/`Deserialize`.
+//!
+//! ## Manifest digest — what invalidates the graph
+//!
+//! [`ManifestDigest::compute`] hashes the inputs that determine graph
+//! identity:
+//!
+//! 1. The full byte content of every "config-like" file the caller
+//!    passes in (e.g. `zfb.config.json`, `zfb.config.ts`). Those files
+//!    are tiny and definitive; a single byte change must invalidate.
+//! 2. A canonical listing of every file under each watched root, fed
+//!    in as `(relative_path, mtime_secs, len_bytes)`. We deliberately
+//!    use mtime+len rather than full content hashes — file metadata
+//!    is cheap to read and matches the heuristic Make/Ninja-style
+//!    incremental tools have used reliably for decades. The trade-off
+//!    is documented: an unchanged file whose mtime jitters (e.g. a
+//!    `touch` with no edits) will trigger a fresh build on the next
+//!    `zfb dev` start. That is the safe direction — false-invalidate,
+//!    never false-reuse — so we accept it.
+//!
+//! Entries are sorted by path before hashing so the digest is
+//! deterministic across runs and platforms (HashMap ordering is not).
+//!
+//! Future work: when the resolver lands a content-hash side-channel,
+//! callers can plug it in here without changing the wire format.
+
+use std::collections::BTreeMap;
+use std::fs::{self, File};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use walkdir::WalkDir;
+
+use crate::error::GraphError;
+use crate::DependencyGraph;
+
+/// 4-byte magic identifying a zfb-graph snapshot file.
+const MAGIC: &[u8; 4] = b"ZFBG";
+
+/// On-disk format version. Bump on any backwards-incompatible
+/// change to the wire format or to fields that bincode round-trips.
+const VERSION: u16 = 1;
+
+/// Stable hash over the inputs that determine graph identity.
+///
+/// Two graphs built from the same set of inputs produce the same
+/// digest; any tracked change flips it. Use [`Self::compute`] to
+/// build one from a project layout, or [`Self::from_bytes`] when
+/// reading a digest off disk.
+///
+/// The digest is opaque — the only operations callers should rely on
+/// are equality and the [`Self::as_hex`] debugging helper.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ManifestDigest([u8; 32]);
+
+impl ManifestDigest {
+    /// Wrap a precomputed 32-byte digest. Mostly useful in tests.
+    pub fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(bytes)
+    }
+
+    /// Borrow the raw 32 bytes.
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    /// Hex-encoded digest, lowercase. For debug logs only.
+    pub fn as_hex(&self) -> String {
+        let mut s = String::with_capacity(64);
+        for b in &self.0 {
+            s.push_str(&format!("{:02x}", b));
+        }
+        s
+    }
+
+    /// Compute a digest over a project layout.
+    ///
+    /// `project_root` is the prefix used to resolve relative
+    /// `watch_roots` and to emit project-relative paths inside the
+    /// hash (so the digest does not depend on the absolute install
+    /// directory).
+    ///
+    /// `watch_roots` is the list of directory or file roots whose
+    /// listing affects graph identity. Missing roots are silently
+    /// skipped — they contribute the empty listing.
+    ///
+    /// `config_files` is the list of config-like files whose full
+    /// byte content matters (e.g. `zfb.config.json`,
+    /// `zfb.config.ts`). Missing files are silently skipped — they
+    /// contribute no bytes. Paths may be absolute or relative to
+    /// `project_root`.
+    pub fn compute(
+        project_root: &Path,
+        watch_roots: &[PathBuf],
+        config_files: &[PathBuf],
+    ) -> Result<Self, GraphError> {
+        let mut hasher = Sha256::new();
+
+        // (1) Config files — full content hash. Sort by absolute path
+        // so the order in `config_files` does not affect the digest.
+        let mut cfg_paths: Vec<PathBuf> = config_files
+            .iter()
+            .map(|p| resolve(project_root, p))
+            .collect();
+        cfg_paths.sort();
+        cfg_paths.dedup();
+        for p in &cfg_paths {
+            if let Ok(bytes) = fs::read(p) {
+                hasher.update(b"cfg:");
+                let rel = relativise(project_root, p);
+                hasher.update(rel.as_bytes());
+                hasher.update(b":");
+                hasher.update(&(bytes.len() as u64).to_le_bytes());
+                hasher.update(b":");
+                hasher.update(&bytes);
+                hasher.update(b"\n");
+            }
+        }
+
+        // (2) Watched roots — listing of (rel_path, mtime, len).
+        // Collect into a BTreeMap so the iteration order is
+        // deterministic regardless of filesystem walk order.
+        let mut entries: BTreeMap<String, FileMeta> = BTreeMap::new();
+        for root in watch_roots {
+            let abs_root = resolve(project_root, root);
+            if !abs_root.exists() {
+                continue;
+            }
+            if abs_root.is_file() {
+                if let Ok(meta) = abs_root.metadata() {
+                    let rel = relativise(project_root, &abs_root);
+                    entries.insert(rel, FileMeta::from_metadata(&meta));
+                }
+                continue;
+            }
+            for entry in WalkDir::new(&abs_root)
+                .follow_links(false)
+                .into_iter()
+                .filter_map(|e| e.ok())
+            {
+                if !entry.file_type().is_file() {
+                    continue;
+                }
+                let Ok(meta) = entry.metadata() else { continue };
+                let rel = relativise(project_root, entry.path());
+                entries.insert(rel, FileMeta::from_metadata(&meta));
+            }
+        }
+        for (rel, meta) in &entries {
+            hasher.update(b"f:");
+            hasher.update(rel.as_bytes());
+            hasher.update(b":");
+            hasher.update(&meta.mtime.to_le_bytes());
+            hasher.update(b":");
+            hasher.update(&meta.len.to_le_bytes());
+            hasher.update(b"\n");
+        }
+
+        let out = hasher.finalize();
+        let mut buf = [0u8; 32];
+        buf.copy_from_slice(&out);
+        Ok(Self(buf))
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FileMeta {
+    mtime: i64,
+    len: u64,
+}
+
+impl FileMeta {
+    fn from_metadata(m: &fs::Metadata) -> Self {
+        let mtime = m
+            .modified()
+            .ok()
+            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        Self {
+            mtime,
+            len: m.len(),
+        }
+    }
+}
+
+fn resolve(project_root: &Path, p: &Path) -> PathBuf {
+    if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        project_root.join(p)
+    }
+}
+
+fn relativise(project_root: &Path, p: &Path) -> String {
+    p.strip_prefix(project_root)
+        .unwrap_or(p)
+        .to_string_lossy()
+        .into_owned()
+}
+
+/// Serialise `graph` and `digest` to `path`. Creates parent
+/// directories as needed and writes via a temp-file rename so a
+/// crash partway through does not leave a half-written graph file.
+pub fn save_to_disk(
+    graph: &DependencyGraph,
+    digest: &ManifestDigest,
+    path: &Path,
+) -> Result<(), GraphError> {
+    if let Some(parent) = path.parent() {
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+    }
+
+    let body = bincode::serialize(graph)?;
+    let mut buf: Vec<u8> = Vec::with_capacity(4 + 2 + 32 + body.len());
+    buf.extend_from_slice(MAGIC);
+    buf.extend_from_slice(&VERSION.to_le_bytes());
+    buf.extend_from_slice(digest.as_bytes());
+    buf.extend_from_slice(&body);
+
+    // Atomic-ish write: write to `path.tmp`, then rename. On the
+    // same filesystem rename is atomic on POSIX/Windows.
+    let tmp = path.with_extension("bin.tmp");
+    {
+        let mut f = File::create(&tmp)?;
+        f.write_all(&buf)?;
+        f.sync_all()?;
+    }
+    fs::rename(&tmp, path)?;
+    Ok(())
+}
+
+/// Try to read a graph from `path` and return it iff the on-disk
+/// digest matches `expected`.
+///
+/// Returns `Ok(None)` for the common "no usable cache" cases —
+/// missing file, mismatched digest, or a header from a different
+/// version of zfb. Returns `Err` only for genuine IO / decode
+/// failures the caller may want to surface (e.g. permission
+/// denied), so callers can simply pattern-match `Ok(Some(g))` for
+/// the fast path and fall back to a fresh graph otherwise.
+pub fn load_from_disk(
+    path: &Path,
+    expected: &ManifestDigest,
+) -> Result<Option<DependencyGraph>, GraphError> {
+    let mut f = match File::open(path) {
+        Ok(f) => f,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e.into()),
+    };
+
+    let mut header = [0u8; 4 + 2 + 32];
+    if let Err(e) = f.read_exact(&mut header) {
+        if e.kind() == std::io::ErrorKind::UnexpectedEof {
+            // Truncated / empty file — discard.
+            return Ok(None);
+        }
+        return Err(e.into());
+    }
+
+    if &header[0..4] != MAGIC {
+        return Ok(None);
+    }
+    let version = u16::from_le_bytes([header[4], header[5]]);
+    if version != VERSION {
+        return Ok(None);
+    }
+    let mut on_disk_digest = [0u8; 32];
+    on_disk_digest.copy_from_slice(&header[6..6 + 32]);
+    if on_disk_digest != *expected.as_bytes() {
+        return Ok(None);
+    }
+
+    let mut body = Vec::new();
+    f.read_to_end(&mut body)?;
+    let graph: DependencyGraph = bincode::deserialize(&body)?;
+    Ok(Some(graph))
+}
+
+// -----------------------------------------------------------------------------
+// tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{DepKind, PageDeps, PageId};
+    use std::path::PathBuf;
+
+    fn p(s: &str) -> PathBuf {
+        PathBuf::from(s)
+    }
+    fn pid(s: &str) -> PageId {
+        PageId::new(p(s))
+    }
+
+    fn small_graph() -> DependencyGraph {
+        let mut g = DependencyGraph::new();
+        g.upsert(PageDeps::new(
+            pid("/pages/a.tsx"),
+            vec![(p("/layouts/main.tsx"), DepKind::Module)],
+        ));
+        g.upsert(PageDeps::new(
+            pid("/pages/b.tsx"),
+            vec![
+                (p("/layouts/main.tsx"), DepKind::Module),
+                (p("/styles/site.css"), DepKind::Style),
+            ],
+        ));
+        g.mark_global("/zfb.config.ts");
+        g
+    }
+
+    #[test]
+    fn roundtrip_write_then_read_matches() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".zfb").join("graph.bin");
+        let digest = ManifestDigest::from_bytes([7u8; 32]);
+
+        let g = small_graph();
+        save_to_disk(&g, &digest, &path).expect("save");
+
+        let loaded = load_from_disk(&path, &digest)
+            .expect("load")
+            .expect("present + digest match");
+        assert_eq!(loaded, g);
+    }
+
+    #[test]
+    fn digest_mismatch_invalidates() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("graph.bin");
+        let written_digest = ManifestDigest::from_bytes([1u8; 32]);
+        let other_digest = ManifestDigest::from_bytes([2u8; 32]);
+
+        save_to_disk(&small_graph(), &written_digest, &path).unwrap();
+
+        // Right digest → present.
+        assert!(load_from_disk(&path, &written_digest).unwrap().is_some());
+        // Wrong digest → discarded; caller will rebuild.
+        assert!(load_from_disk(&path, &other_digest).unwrap().is_none());
+    }
+
+    #[test]
+    fn missing_file_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("does-not-exist.bin");
+        let digest = ManifestDigest::from_bytes([0u8; 32]);
+        assert!(load_from_disk(&path, &digest).unwrap().is_none());
+    }
+
+    #[test]
+    fn bad_magic_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("garbage.bin");
+        std::fs::write(&path, b"not a zfb-graph file at all, just bytes").unwrap();
+        let digest = ManifestDigest::from_bytes([0u8; 32]);
+        assert!(load_from_disk(&path, &digest).unwrap().is_none());
+    }
+
+    #[test]
+    fn manifest_digest_changes_when_file_content_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("pages")).unwrap();
+        let cfg = root.join("zfb.config.json");
+        std::fs::write(&cfg, b"{\"x\":1}").unwrap();
+
+        let watch = vec![PathBuf::from("pages")];
+        let cfgs = vec![PathBuf::from("zfb.config.json")];
+
+        let d1 = ManifestDigest::compute(root, &watch, &cfgs).unwrap();
+
+        // Change config content → digest must flip.
+        std::fs::write(&cfg, b"{\"x\":2}").unwrap();
+        let d2 = ManifestDigest::compute(root, &watch, &cfgs).unwrap();
+        assert_ne!(d1, d2);
+    }
+
+    #[test]
+    fn manifest_digest_changes_when_watched_file_added() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("pages")).unwrap();
+
+        let watch = vec![PathBuf::from("pages")];
+        let cfgs: Vec<PathBuf> = vec![];
+
+        let d1 = ManifestDigest::compute(root, &watch, &cfgs).unwrap();
+        std::fs::write(root.join("pages").join("new.tsx"), b"export {}").unwrap();
+        let d2 = ManifestDigest::compute(root, &watch, &cfgs).unwrap();
+        assert_ne!(d1, d2);
+    }
+
+    #[test]
+    fn manifest_digest_is_stable_across_calls() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        std::fs::create_dir_all(root.join("pages")).unwrap();
+        std::fs::write(root.join("pages").join("a.tsx"), b"a").unwrap();
+        std::fs::write(root.join("pages").join("b.tsx"), b"bb").unwrap();
+
+        let watch = vec![PathBuf::from("pages")];
+        let cfgs: Vec<PathBuf> = vec![];
+
+        let d1 = ManifestDigest::compute(root, &watch, &cfgs).unwrap();
+        let d2 = ManifestDigest::compute(root, &watch, &cfgs).unwrap();
+        assert_eq!(d1, d2);
+    }
+
+    #[test]
+    fn missing_watch_root_is_skipped_not_an_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let watch = vec![PathBuf::from("nope-not-here")];
+        let cfgs: Vec<PathBuf> = vec![];
+        // Should not error and should be reproducible.
+        let d = ManifestDigest::compute(root, &watch, &cfgs).unwrap();
+        assert_eq!(d, ManifestDigest::compute(root, &watch, &cfgs).unwrap());
+    }
+
+    /// Acceptance evidence (sub-task 5 of issue #55): a non-trivial
+    /// previously-persisted graph reloads from disk in well under
+    /// 50ms when nothing has changed. Modelled on a basic-blog-sized
+    /// site (~50 pages, modest dep counts each) — comfortably
+    /// larger than the example we ship while still fast to set up.
+    #[test]
+    fn cold_load_of_realistic_graph_is_under_50ms() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("graph.bin");
+        let digest = ManifestDigest::from_bytes([42u8; 32]);
+
+        let mut g = DependencyGraph::new();
+        for i in 0..50 {
+            let page = pid(&format!("/pages/p{i}.tsx"));
+            let mut deps = Vec::with_capacity(8);
+            // A handful of shared layout/component/css deps per
+            // page — exercises both forward and reverse indexes.
+            deps.push((p("/layouts/main.tsx"), DepKind::Module));
+            deps.push((p("/components/header.tsx"), DepKind::Module));
+            deps.push((p("/components/footer.tsx"), DepKind::Module));
+            deps.push((p("/styles/site.css"), DepKind::Style));
+            for j in 0..4 {
+                deps.push((
+                    PathBuf::from(format!("/components/widget-{i}-{j}.tsx")),
+                    DepKind::Module,
+                ));
+            }
+            g.upsert(PageDeps::new(page, deps));
+        }
+        save_to_disk(&g, &digest, &path).unwrap();
+
+        let started = std::time::Instant::now();
+        let loaded = load_from_disk(&path, &digest)
+            .expect("load")
+            .expect("present");
+        let elapsed = started.elapsed();
+        assert_eq!(loaded, g);
+        // Generous ceiling for noisy CI; the typical local run is
+        // sub-millisecond.
+        assert!(
+            elapsed < std::time::Duration::from_millis(50),
+            "graph reload took {elapsed:?}, expected < 50ms",
+        );
+    }
+
+    #[test]
+    fn manifest_digest_handles_single_file_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let cfg = root.join("zfb.config.ts");
+        std::fs::write(&cfg, b"export default {}").unwrap();
+
+        // Pass the config file path as a *watch root* (not as a
+        // config_file): the digest builder should treat single-file
+        // roots correctly without crashing or skipping.
+        let watch = vec![PathBuf::from("zfb.config.ts")];
+        let cfgs: Vec<PathBuf> = vec![];
+
+        let d1 = ManifestDigest::compute(root, &watch, &cfgs).unwrap();
+        std::fs::write(&cfg, b"export default { changed: true }").unwrap();
+        let d2 = ManifestDigest::compute(root, &watch, &cfgs).unwrap();
+        assert_ne!(d1, d2);
+    }
+}

--- a/crates/zfb-islands/Cargo.toml
+++ b/crates/zfb-islands/Cargo.toml
@@ -15,7 +15,8 @@ description = "zfb islands runtime: \"use client\" AST scanner, esbuild subproce
 # binary (`EXPECTED_ESBUILD_SHA256`, possibly empty during development) is
 # also verified when populated.
 #
-# To bump:
+# To bump, follow the "External tool version pins" procedure in
+# CONTRIBUTING.md at the workspace root. Quick-reference:
 #   1. Edit EXPECTED_ESBUILD_VERSION in src/esbuild.rs.
 #   2. Edit EXPECTED_ESBUILD_SHA256 in src/esbuild.rs (or set it to "" to
 #      keep the slot open until release engineering fills the new hash in).

--- a/crates/zfb-islands/src/esbuild.rs
+++ b/crates/zfb-islands/src/esbuild.rs
@@ -30,8 +30,9 @@ use crate::bundler::{
 /// The pinned esbuild CLI version this crate runs against.
 ///
 /// At subprocess startup we run `esbuild --version` and abort with a
-/// clear error if the reported version does not match. To bump, see the
-/// instructions in `Cargo.toml`.
+/// clear error if the reported version does not match. To bump, see
+/// the "External tool version pins" section in `CONTRIBUTING.md` at
+/// the workspace root.
 pub const EXPECTED_ESBUILD_VERSION: &str = "0.24.0";
 
 /// SHA-256 of the pinned esbuild binary, lowercase hex.
@@ -40,7 +41,8 @@ pub const EXPECTED_ESBUILD_VERSION: &str = "0.24.0";
 /// populated the slot — in that case the checksum verification is
 /// skipped (with a clear log line) and only the `--version` check is
 /// enforced. Once populated, the checksum verification runs on first
-/// subprocess invocation and any mismatch aborts with a clear error.
+/// subprocess invocation and any mismatch aborts with a clear error
+/// pointing at the bump procedure in `CONTRIBUTING.md`.
 pub const EXPECTED_ESBUILD_SHA256: &str = "";
 
 /// One-time cache of `(binary_path → outcome)` for the version + checksum
@@ -106,8 +108,10 @@ fn ensure_binary_verified(binary_path: &Path, skip: bool) -> Result<()> {
     if reported != EXPECTED_ESBUILD_VERSION {
         return Err(anyhow!(
             "esbuild version mismatch: expected `{}` (pinned in zfb-islands), got `{}` from {}. \
-             Update EXPECTED_ESBUILD_VERSION in zfb-islands/src/esbuild.rs and refresh the \
-             binary under crates/zfb/binaries/esbuild/esbuild.",
+             To resolve, follow the \"External tool version pins\" procedure in CONTRIBUTING.md \
+             at the workspace root: bump EXPECTED_ESBUILD_VERSION (and EXPECTED_ESBUILD_SHA256) \
+             in crates/zfb-islands/src/esbuild.rs in lock-step with the binary under \
+             crates/zfb/binaries/esbuild/esbuild.",
             EXPECTED_ESBUILD_VERSION,
             reported,
             binary_path.display()
@@ -125,7 +129,12 @@ fn ensure_binary_verified(binary_path: &Path, skip: bool) -> Result<()> {
         if !actual.eq_ignore_ascii_case(EXPECTED_ESBUILD_SHA256) {
             return Err(anyhow!(
                 "esbuild binary checksum mismatch for {}: \
-                 expected sha256 `{}`, got `{}`",
+                 expected sha256 `{}`, got `{}`. \
+                 To resolve, follow the \"External tool version pins\" procedure in \
+                 CONTRIBUTING.md at the workspace root: either replace the binary with \
+                 one matching EXPECTED_ESBUILD_SHA256, or — when bumping intentionally — \
+                 update both the version and SHA256 constants in \
+                 crates/zfb-islands/src/esbuild.rs in lock-step with the new binary.",
                 binary_path.display(),
                 EXPECTED_ESBUILD_SHA256,
                 actual

--- a/crates/zfb-islands/src/scanner.rs
+++ b/crates/zfb-islands/src/scanner.rs
@@ -978,7 +978,7 @@ mod tests {
             ScanError::Parse { path, .. } => {
                 assert_eq!(path, root().join("pages/broken.tsx"));
             }
-            other => panic!("expected Parse error, got {other:?}"),
+            other => unreachable!("expected Parse error, got {other:?}"),
         }
     }
 

--- a/crates/zfb-render/Cargo.toml
+++ b/crates/zfb-render/Cargo.toml
@@ -38,3 +38,9 @@ thiserror = { workspace = true }
 [dev-dependencies]
 serde_json = { workspace = true }
 tempfile = { workspace = true }
+# Used by tests/integration_routing_rendering.rs to scan the routing
+# fixtures into a `Route` table. Lives in dev-deps because zfb-render
+# itself does not need to depend on zfb-router at runtime — the build
+# orchestrator (`zfb-build`) is what wires the two together in
+# production.
+zfb-router = { path = "../zfb-router" }

--- a/crates/zfb-render/src/adapters/preact.rs
+++ b/crates/zfb-render/src/adapters/preact.rs
@@ -166,7 +166,7 @@ mod tests {
         let err = PreactAdapter.pre_render_setup(&mut host).unwrap_err();
         let msg = match err {
             RenderError::Adapter(m) => m,
-            other => panic!("expected RenderError::Adapter, got {other:?}"),
+            other => unreachable!("expected RenderError::Adapter, got {other:?}"),
         };
         assert!(msg.contains("preact"));
         assert!(msg.contains("oops"));

--- a/crates/zfb-render/src/adapters/react.rs
+++ b/crates/zfb-render/src/adapters/react.rs
@@ -192,7 +192,7 @@ mod tests {
         let err = ReactAdapter.pre_render_setup(&mut host).unwrap_err();
         let msg = match err {
             RenderError::Adapter(m) => m,
-            other => panic!("expected RenderError::Adapter, got {other:?}"),
+            other => unreachable!("expected RenderError::Adapter, got {other:?}"),
         };
         assert!(msg.contains("react"));
         assert!(msg.contains("oops"));

--- a/crates/zfb-render/src/meta.rs
+++ b/crates/zfb-render/src/meta.rs
@@ -419,7 +419,7 @@ mod tests {
         let err = parse_meta(Some(&v)).unwrap_err();
         match err {
             MetaError::InvalidShape(_) => {}
-            other => panic!("expected InvalidShape, got {other:?}"),
+            other => unreachable!("expected InvalidShape, got {other:?}"),
         }
     }
 
@@ -429,7 +429,7 @@ mod tests {
         let err = parse_meta(Some(&v)).unwrap_err();
         match err {
             MetaError::InvalidShape(msg) => assert!(msg.contains("string")),
-            other => panic!("expected InvalidShape, got {other:?}"),
+            other => unreachable!("expected InvalidShape, got {other:?}"),
         }
     }
 
@@ -529,7 +529,7 @@ mod tests {
         let err = resolve_meta(meta, &page, root, &[]).unwrap_err();
         match err {
             MetaError::LayoutOutsideProjectRoot(_) => {}
-            other => panic!("expected LayoutOutsideProjectRoot, got {other:?}"),
+            other => unreachable!("expected LayoutOutsideProjectRoot, got {other:?}"),
         }
     }
 
@@ -545,7 +545,7 @@ mod tests {
         let err = resolve_meta(meta, &page, root, &[]).unwrap_err();
         match err {
             MetaError::LayoutOutsideProjectRoot(_) => {}
-            other => panic!("expected LayoutOutsideProjectRoot, got {other:?}"),
+            other => unreachable!("expected LayoutOutsideProjectRoot, got {other:?}"),
         }
     }
 
@@ -561,7 +561,7 @@ mod tests {
         let err = resolve_meta(meta, &page, root, &[]).unwrap_err();
         match err {
             MetaError::LayoutNotFound(p) => assert!(p.contains("layouts/nope.tsx")),
-            other => panic!("expected LayoutNotFound, got {other:?}"),
+            other => unreachable!("expected LayoutNotFound, got {other:?}"),
         }
     }
 

--- a/crates/zfb-render/src/paths.rs
+++ b/crates/zfb-render/src/paths.rs
@@ -56,13 +56,38 @@ pub struct ResolvedPath {
 pub enum PathsError {
     /// A required dynamic/catch-all param was missing from a `paths()`
     /// entry's `params` object.
-    #[error("missing param `{name}` in paths() entry for route `{route}`")]
-    MissingParam { name: String, route: String },
+    ///
+    /// `provided` is the list of keys the entry's `params` object actually
+    /// carried (sorted), so a typo like `wrongName` instead of `slug` shows
+    /// up directly in the error: "params must include `slug`, got
+    /// [`wrongName`]".
+    #[error(
+        "missing param `{name}` in paths() entry for route `{route}`: \
+         params must include `{name}`, got [{provided_pretty}]",
+        provided_pretty = pretty_keys(provided),
+    )]
+    MissingParam {
+        name: String,
+        route: String,
+        provided: Vec<String>,
+    },
 
     /// A `paths()` entry's `params` object contained a key that is not
     /// declared in the route template.
-    #[error("extra param `{name}` not declared in route `{route}`")]
-    ExtraParam { name: String, route: String },
+    ///
+    /// `expected` is the list of param names declared in the route template
+    /// (sorted). Surfacing it next to the offending name produces a clear
+    /// "expected one of […], got `wrongName`" diagnostic.
+    #[error(
+        "extra param `{name}` not declared in route `{route}`: \
+         expected one of [{expected_pretty}], got `{name}`",
+        expected_pretty = pretty_keys(expected),
+    )]
+    ExtraParam {
+        name: String,
+        route: String,
+        expected: Vec<String>,
+    },
 
     /// A param value had the wrong JSON shape (e.g. number where a string
     /// was expected, empty string, etc.).
@@ -226,6 +251,7 @@ pub fn resolve_paths(
                 .ok_or_else(|| PathsError::MissingParam {
                     name: (*name).to_string(),
                     route: route_template.to_string(),
+                    provided: sorted_keys(params_obj.keys()),
                 })?;
             let resolved = if *is_catchall {
                 catchall_string(raw, name, route_template)?
@@ -241,6 +267,7 @@ pub fn resolve_paths(
                 return Err(PathsError::ExtraParam {
                     name: k.clone(),
                     route: route_template.to_string(),
+                    expected: required.iter().map(|(n, _)| (*n).to_string()).collect(),
                 });
             }
         }
@@ -388,6 +415,28 @@ fn build_url(route_segments: &[Segment], params: &HashMap<String, String>) -> St
     url.push('/');
     url.push_str(&parts.join("/"));
     url
+}
+
+/// Collect an iterator of `&String` keys into a sorted owned `Vec<String>`,
+/// for stable error output.
+fn sorted_keys<'a, I>(iter: I) -> Vec<String>
+where
+    I: IntoIterator<Item = &'a String>,
+{
+    let mut v: Vec<String> = iter.into_iter().cloned().collect();
+    v.sort();
+    v
+}
+
+/// Render a list of param names as `` `a`, `b`, `c` `` for embedding in error
+/// messages. An empty list renders as the empty string so the surrounding
+/// `[...]` shows up as `[]`.
+fn pretty_keys(keys: &[String]) -> String {
+    let mut parts = Vec::with_capacity(keys.len());
+    for k in keys {
+        parts.push(format!("`{k}`"));
+    }
+    parts.join(", ")
 }
 
 fn value_kind(val: &Value) -> &'static str {
@@ -568,14 +617,50 @@ mod tests {
         let mut cache = PathsCache::new();
         let segs = route_blog_slug();
         let export = json!([
-            { "params": { "wrong": "x" } }
+            { "params": { "wrongName": "x" } }
         ]);
 
         let err = resolve_paths(&mut cache, "blog/[slug].tsx", &segs, &export).unwrap_err();
+        let msg = err.to_string();
+        // The message must point at the source file path.
+        assert!(
+            msg.contains("blog/[slug].tsx"),
+            "expected route file path in error, got: {msg}",
+        );
+        // The message must say what was expected and what was provided.
+        assert!(
+            msg.contains("`slug`") && msg.contains("`wrongName`"),
+            "expected `expected/got` param diagnostic in error, got: {msg}",
+        );
         match err {
-            PathsError::MissingParam { name, route } => {
+            PathsError::MissingParam {
+                name,
+                route,
+                provided,
+            } => {
                 assert_eq!(name, "slug");
                 assert_eq!(route, "blog/[slug].tsx");
+                assert_eq!(provided, vec!["wrongName".to_string()]);
+            }
+            other => panic!("expected MissingParam, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_param_with_empty_params_lists_no_provided_keys() {
+        let mut cache = PathsCache::new();
+        let segs = route_blog_slug();
+        let export = json!([
+            { "params": {} }
+        ]);
+
+        let err = resolve_paths(&mut cache, "blog/[slug].tsx", &segs, &export).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("blog/[slug].tsx"), "got: {msg}");
+        assert!(msg.contains("got []"), "got: {msg}");
+        match err {
+            PathsError::MissingParam { provided, .. } => {
+                assert!(provided.is_empty(), "expected empty provided, got {provided:?}");
             }
             other => panic!("expected MissingParam, got {other:?}"),
         }
@@ -590,10 +675,21 @@ mod tests {
         ]);
 
         let err = resolve_paths(&mut cache, "blog/[slug].tsx", &segs, &export).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("blog/[slug].tsx"), "got: {msg}");
+        assert!(
+            msg.contains("`slug`") && msg.contains("`unexpected`"),
+            "expected `expected one of … got …` diagnostic, got: {msg}",
+        );
         match err {
-            PathsError::ExtraParam { name, route } => {
+            PathsError::ExtraParam {
+                name,
+                route,
+                expected,
+            } => {
                 assert_eq!(name, "unexpected");
                 assert_eq!(route, "blog/[slug].tsx");
+                assert_eq!(expected, vec!["slug".to_string()]);
             }
             other => panic!("expected ExtraParam, got {other:?}"),
         }

--- a/crates/zfb-render/src/paths.rs
+++ b/crates/zfb-render/src/paths.rs
@@ -577,7 +577,7 @@ mod tests {
                 assert_eq!(name, "slug");
                 assert_eq!(route, "blog/[slug].tsx");
             }
-            other => panic!("expected MissingParam, got {other:?}"),
+            other => unreachable!("expected MissingParam, got {other:?}"),
         }
     }
 
@@ -595,7 +595,7 @@ mod tests {
                 assert_eq!(name, "unexpected");
                 assert_eq!(route, "blog/[slug].tsx");
             }
-            other => panic!("expected ExtraParam, got {other:?}"),
+            other => unreachable!("expected ExtraParam, got {other:?}"),
         }
     }
 
@@ -758,7 +758,7 @@ mod tests {
             PathsError::AmbiguousResolution { route, .. } => {
                 assert_eq!(route, "blog/[slug].tsx");
             }
-            other => panic!("expected AmbiguousResolution, got {other:?}"),
+            other => unreachable!("expected AmbiguousResolution, got {other:?}"),
         }
     }
 

--- a/crates/zfb-render/src/paths_extract.rs
+++ b/crates/zfb-render/src/paths_extract.rs
@@ -517,7 +517,7 @@ mod tests {
                     ]),
                 );
             }
-            other => panic!("expected Literal, got {other:?}"),
+            other => unreachable!("expected Literal, got {other:?}"),
         }
     }
 
@@ -532,7 +532,7 @@ mod tests {
             PathsExtraction::Literal(v) => {
                 assert_eq!(v, json!([{ "params": { "slug": "a" } }]));
             }
-            other => panic!("expected Literal, got {other:?}"),
+            other => unreachable!("expected Literal, got {other:?}"),
         }
     }
 
@@ -545,7 +545,7 @@ mod tests {
             PathsExtraction::Literal(v) => {
                 assert_eq!(v, json!([{ "params": { "slug": "x" } }]));
             }
-            other => panic!("expected Literal, got {other:?}"),
+            other => unreachable!("expected Literal, got {other:?}"),
         }
     }
 
@@ -560,7 +560,7 @@ mod tests {
             PathsExtraction::Literal(v) => {
                 assert_eq!(v, json!([{ "params": { "slug": "y" } }]));
             }
-            other => panic!("expected Literal, got {other:?}"),
+            other => unreachable!("expected Literal, got {other:?}"),
         }
     }
 
@@ -575,7 +575,7 @@ mod tests {
             PathsExtraction::Literal(v) => {
                 assert_eq!(v, json!([{ "params": { "slug": "z" } }]));
             }
-            other => panic!("expected Literal, got {other:?}"),
+            other => unreachable!("expected Literal, got {other:?}"),
         }
     }
 
@@ -588,7 +588,7 @@ mod tests {
             PathsExtraction::Literal(v) => {
                 assert_eq!(v, json!([{ "params": { "slug": "x" } }]));
             }
-            other => panic!("expected Literal, got {other:?}"),
+            other => unreachable!("expected Literal, got {other:?}"),
         }
     }
 
@@ -599,7 +599,7 @@ mod tests {
         "#;
         match extract_ok(src) {
             PathsExtraction::Literal(v) => assert_eq!(v, json!([])),
-            other => panic!("expected Literal, got {other:?}"),
+            other => unreachable!("expected Literal, got {other:?}"),
         }
     }
 
@@ -630,7 +630,7 @@ mod tests {
                     "non-literal reason should not be empty",
                 );
             }
-            other => panic!("expected NonLiteral, got {other:?}"),
+            other => unreachable!("expected NonLiteral, got {other:?}"),
         }
     }
 
@@ -644,7 +644,7 @@ mod tests {
             PathsExtraction::NonLiteral { reason } => {
                 assert!(reason.contains("function call"), "{reason}");
             }
-            other => panic!("expected NonLiteral, got {other:?}"),
+            other => unreachable!("expected NonLiteral, got {other:?}"),
         }
     }
 
@@ -658,7 +658,7 @@ mod tests {
             PathsExtraction::NonLiteral { reason } => {
                 assert!(reason.contains("identifier"), "{reason}");
             }
-            other => panic!("expected NonLiteral, got {other:?}"),
+            other => unreachable!("expected NonLiteral, got {other:?}"),
         }
     }
 
@@ -675,7 +675,7 @@ mod tests {
             PathsExtraction::NonLiteral { reason } => {
                 assert!(reason.contains("must be a function"), "{reason}");
             }
-            other => panic!("expected NonLiteral, got {other:?}"),
+            other => unreachable!("expected NonLiteral, got {other:?}"),
         }
     }
 
@@ -703,7 +703,7 @@ mod tests {
             PathsExtraction::NonLiteral { reason } => {
                 assert!(reason.contains("no return"), "{reason}");
             }
-            other => panic!("expected NonLiteral, got {other:?}"),
+            other => unreachable!("expected NonLiteral, got {other:?}"),
         }
     }
 
@@ -716,7 +716,7 @@ mod tests {
             PathsExtraction::NonLiteral { reason } => {
                 assert!(reason.contains("returns nothing"), "{reason}");
             }
-            other => panic!("expected NonLiteral, got {other:?}"),
+            other => unreachable!("expected NonLiteral, got {other:?}"),
         }
     }
 
@@ -740,7 +740,7 @@ mod tests {
             PathsExtraction::NonLiteral { reason } => {
                 assert!(reason.contains("substitution"), "{reason}");
             }
-            other => panic!("expected NonLiteral, got {other:?}"),
+            other => unreachable!("expected NonLiteral, got {other:?}"),
         }
     }
 
@@ -760,7 +760,7 @@ mod tests {
                     json!([{ "params": { "slug": ["a", "b", "c"] } }]),
                 );
             }
-            other => panic!("expected Literal, got {other:?}"),
+            other => unreachable!("expected Literal, got {other:?}"),
         }
     }
 
@@ -778,7 +778,7 @@ mod tests {
             PathsExtraction::Literal(v) => {
                 assert_eq!(v, json!([{ "params": { "slug": "ok" } }]));
             }
-            other => panic!("expected Literal, got {other:?}"),
+            other => unreachable!("expected Literal, got {other:?}"),
         }
     }
 }

--- a/crates/zfb-render/tests/error_messages.rs
+++ b/crates/zfb-render/tests/error_messages.rs
@@ -83,7 +83,7 @@ fn broken_relative_import_points_at_importer_file_and_lists_candidates() {
                 "expected the resolver to record probed candidates, got tried={tried:?}",
             );
         }
-        other => panic!("expected RenderError::Resolve, got {other:?}"),
+        other => unreachable!("expected RenderError::Resolve, got {other:?}"),
     }
 }
 
@@ -128,7 +128,7 @@ fn paths_export_wrong_top_level_shape_names_route_file() {
             );
             assert_eq!(field.as_deref(), Some("paths()"));
         }
-        other => panic!("expected InvalidPathsExport, got {other:?}"),
+        other => unreachable!("expected InvalidPathsExport, got {other:?}"),
     }
 }
 

--- a/crates/zfb-render/tests/error_messages.rs
+++ b/crates/zfb-render/tests/error_messages.rs
@@ -161,6 +161,92 @@ fn paths_entry_missing_params_names_field_and_route_file() {
     );
 }
 
+/// Canonical Sub-6 case: a `paths()` returning `[{ params: { wrongName: "x" } }]`
+/// for `[slug].tsx` must surface BOTH the source file path AND a clear
+/// "expected `slug`, got `wrongName`" param-name diagnostic.
+#[test]
+fn paths_missing_param_surfaces_expected_and_got_with_route_file() {
+    let mut cache = PathsCache::new();
+    let segs = vec![Segment::Dynamic("slug".to_string())];
+    let export = serde_json::json!([{ "params": { "wrongName": "x" } }]);
+
+    let err = resolve_paths(&mut cache, "pages/[slug].tsx", &segs, &export)
+        .expect_err("missing required param should fail");
+    let msg = err.to_string();
+
+    // (a) Source file path is present.
+    assert!(
+        msg.contains("pages/[slug].tsx"),
+        "expected route file path in error, got: {msg}",
+    );
+    // (b) Expected param name is present.
+    assert!(
+        msg.contains("`slug`"),
+        "expected required param name in error, got: {msg}",
+    );
+    // (c) The actually-provided key (the typo) is present so the user can
+    //     spot the mismatch immediately.
+    assert!(
+        msg.contains("`wrongName`"),
+        "expected provided-keys list to mention `wrongName`, got: {msg}",
+    );
+    // (d) The structured form carries both fields so consumers (CLI
+    //     diagnostics) can format the same diagnostic without re-parsing.
+    match err {
+        PathsError::MissingParam {
+            name,
+            route,
+            provided,
+        } => {
+            assert_eq!(name, "slug");
+            assert_eq!(route, "pages/[slug].tsx");
+            assert_eq!(provided, vec!["wrongName".to_string()]);
+        }
+        other => panic!("expected MissingParam, got {other:?}"),
+    }
+}
+
+/// `ExtraParam` should likewise carry the route file path AND a clear
+/// "expected one of […], got `…`" diagnostic listing the route's declared
+/// param names.
+#[test]
+fn paths_extra_param_surfaces_expected_and_got_with_route_file() {
+    let mut cache = PathsCache::new();
+    let segs = vec![Segment::Dynamic("slug".to_string())];
+    let export = serde_json::json!([
+        { "params": { "slug": "ok", "stray": "x" } }
+    ]);
+
+    let err = resolve_paths(&mut cache, "pages/[slug].tsx", &segs, &export)
+        .expect_err("extra param should fail");
+    let msg = err.to_string();
+
+    assert!(
+        msg.contains("pages/[slug].tsx"),
+        "expected route file path in error, got: {msg}",
+    );
+    assert!(
+        msg.contains("`stray`"),
+        "expected offending param name in error, got: {msg}",
+    );
+    assert!(
+        msg.contains("`slug`"),
+        "expected the declared param name list to mention `slug`, got: {msg}",
+    );
+    match err {
+        PathsError::ExtraParam {
+            name,
+            route,
+            expected,
+        } => {
+            assert_eq!(name, "stray");
+            assert_eq!(route, "pages/[slug].tsx");
+            assert_eq!(expected, vec!["slug".to_string()]);
+        }
+        other => panic!("expected ExtraParam, got {other:?}"),
+    }
+}
+
 /// A `params` value with the wrong type names both the param, the route
 /// file, and (via the shared `route` field) the file context.
 #[test]

--- a/crates/zfb-render/tests/integration_routing_rendering.rs
+++ b/crates/zfb-render/tests/integration_routing_rendering.rs
@@ -26,8 +26,8 @@
 //!
 //! Tracked follow-up: the full harness (TSX compile + JS execution +
 //! layout wrapping + dual-framework byte-equality + snapshotting)
-//! belongs at the `zfb-build` orchestrator layer and is filed as a
-//! follow-up issue on the zfb repo.
+//! belongs at the `zfb-build` orchestrator layer. Tracked at
+//! https://github.com/Takazudo/zudo-front-builder/issues/63 .
 //!
 //! Route template syntax: `zfb-router` renders dynamic and catchall
 //! segments using `:name` / `:name*` (Astro / Express style), not the

--- a/crates/zfb-render/tests/integration_routing_rendering.rs
+++ b/crates/zfb-render/tests/integration_routing_rendering.rs
@@ -139,6 +139,9 @@ fn assert_snapshot_eq(actual: &str, snapshot_path: &Path) {
                 actual.lines().count(),
             )
         });
+    // Snapshot mismatch is a legitimate test-failure mechanism. `panic!`
+    // is the assertion primitive here because the bespoke diff output is
+    // more readable than `assert_eq!` of two large strings.
     panic!(
         "snapshot mismatch at {snapshot_path:?}\n{line}\n--- expected ---\n{expected}\n--- actual ---\n{actual}",
     );

--- a/crates/zfb-render/tests/integration_routing_rendering.rs
+++ b/crates/zfb-render/tests/integration_routing_rendering.rs
@@ -1,84 +1,42 @@
-// TODO(parked): This integration test is parked.
-//
-// It depends on the orchestrator API surface (`render_route`,
-// `RenderInput`, `RenderOutput`) and the `zfb-router` workspace crate,
-// none of which exist yet. Until those land, the test cannot compile,
-// and a `cargo clippy --workspace --all-features --all-targets` (or
-// `cargo check --all-features`) run otherwise breaks the workspace
-// build.
-//
-// To work around that, this file is unconditionally excluded from
-// compilation via `#![cfg(any())]` (the canonical "always-false" cfg)
-// and the matching `integration_routing_rendering = []` feature has
-// been removed from `crates/zfb-render/Cargo.toml`. The test source,
-// fixtures, layouts, components, and harness are intentionally kept on
-// disk so they remain version-controlled.
-//
-// When the orchestrator API and `zfb-router` crate land, restore the
-// original `#![cfg(feature = "integration_routing_rendering")]`
-// attribute below and re-add the feature line in `Cargo.toml`.
+//! Routing-side integration test for the routing+rendering fixtures.
+//!
+//! This file used to be parked behind `#![cfg(any())]` because it was
+//! authored against a planned but never-built unified
+//! `render_route(RenderInput) -> RenderOutput` orchestrator on
+//! `zfb-render`. The actual API surface that landed is:
+//!
+//! - `zfb_render::Renderer<H: RenderHost>` — a single-page,
+//!   single-source orchestrator that delegates JS execution to a
+//!   pluggable host (`render_smoke.rs` shows the in-process test host
+//!   pattern). It does not walk a project root, resolve layouts, or run
+//!   `paths()`.
+//! - `zfb_build::renderer::render_all` — the production end-to-end
+//!   pipeline, which spawns a long-lived miniflare subprocess and
+//!   serves a pre-bundled Worker entry. That orchestrator is exercised
+//!   by `zfb-build`'s own test suite, not from inside `zfb-render`.
+//!
+//! Neither matches the in-process, fixture-walking, dual-framework
+//! harness the parked test was sketching. Building that harness is a
+//! sizeable feature in its own right, so for now this file only
+//! exercises the routing half of the contract: scan the fixture pages
+//! and assert the route templates and kinds line up with what the
+//! rendering harness will eventually consume. The TSX pages, layouts,
+//! components, and content under `tests/fixtures/routing-rendering/`
+//! are kept on disk for the full end-to-end test to plug into later.
+//!
+//! Tracked follow-up: the full harness (TSX compile + JS execution +
+//! layout wrapping + dual-framework byte-equality + snapshotting)
+//! belongs at the `zfb-build` orchestrator layer and is filed as a
+//! follow-up issue on the zfb repo.
+//!
+//! Route template syntax: `zfb-router` renders dynamic and catchall
+//! segments using `:name` / `:name*` (Astro / Express style), not the
+//! `[name]` / `[...name]` filename style. The filename brackets are
+//! the input convention; `:name` is the canonical template form.
 
-//! End-to-end integration tests for the Epic 3 routing + rendering
-//! pipeline.
-//!
-//! For each fixture page under
-//! `tests/fixtures/routing-rendering/pages/`, this harness:
-//!   1. Scans the fixture project via `zfb-router` (Sub 2).
-//!   2. Compiles the page's TSX module via `zfb-render` (Sub 3).
-//!   3. Calls `paths()` for dynamic routes (Sub 5) → enumerates URLs.
-//!   4. Resolves `meta` / `meta.layout` (Sub 6) and wraps the page in
-//!      its layout.
-//!   5. Renders to HTML through the configured framework adapter
-//!      (Sub 4) — once with `framework: "preact"`, once with
-//!      `framework: "react"`.
-//!   6. Compares the resulting HTML against the snapshot under
-//!      `tests/fixtures/routing-rendering/snapshots/{preact,react}/`.
-//!   7. Asserts the Preact and React outputs are byte-identical for
-//!      portable components (ADR-002 contract).
-//!
-//! ## Snapshot bootstrap
-//!
-//! Snapshots are populated on first run when `INSANE_UPDATE_SNAPSHOTS=1`
-//! is set OR the snapshot file is missing. After Subs 1–7 land, the
-//! manager (or whoever runs the merged base) runs:
-//!
-//! ```sh
-//! INSANE_UPDATE_SNAPSHOTS=1 cargo test -p zfb-render \
-//!     --test integration_routing_rendering
-//! ```
-//!
-//! Once captured, re-runs without the env var perform the comparison.
-//!
-//! ## Why this file may not compile in isolation
-//!
-//! `zfb-render` and `zfb-router` are produced by Subs 2 and 3 and do
-//! not exist yet on the sub08 worktree. Building this crate alone will
-//! fail; the harness compiles only after the manager merges Subs 2–7
-//! into the epic base branch.
+use std::path::PathBuf;
 
-// Gated behind the `integration_routing_rendering` feature because the
-// harness depends on API surface (`render_route`, `RenderInput`,
-// `RenderOutput`, `zfb-router` workspace dep) that has not yet been
-// wired up at the zfb-render crate root. The TSX fixtures, layouts,
-// components, and harness code are preserved as-is so the integration
-// can be turned on with a single Cargo.toml change once the orchestrator
-// exposes the expected entry points and zfb-render adds zfb-router as
-// a dep. Tracked as the natural follow-up to Epic 3 (Subs 1–7).
-#![cfg(any())]
-#![allow(dead_code)]
-
-use std::path::{Path, PathBuf};
-
-// NOTE: These imports describe the *intended* API surface from sibling
-// crates. Sub 2 (zfb-router), Sub 3 (zfb-render), and Sub 4 (adapters)
-// will land the actual symbols. If the names drift during merge, fix
-// them here at review time.
-use zfb_render::{render_route, Framework, RenderInput, RenderOutput};
-use zfb_router::{scan_pages, RouteKind, ScannedRoute};
-
-// ---------------------------------------------------------------------------
-// Path helpers
-// ---------------------------------------------------------------------------
+use zfb_router::{scan_pages, RouteKind};
 
 fn fixtures_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -91,244 +49,22 @@ fn pages_dir() -> PathBuf {
     fixtures_root().join("pages")
 }
 
-fn snapshot_path(framework: Framework, name: &str) -> PathBuf {
-    let bucket = match framework {
-        Framework::Preact => "preact",
-        Framework::React => "react",
-    };
-    fixtures_root()
-        .join("snapshots")
-        .join(bucket)
-        .join(name)
-}
-
-// ---------------------------------------------------------------------------
-// Snapshot equality with first-run capture (mirrors zfb-content's harness)
-// ---------------------------------------------------------------------------
-
-fn assert_snapshot_eq(actual: &str, snapshot_path: &Path) {
-    let update = std::env::var("INSANE_UPDATE_SNAPSHOTS").is_ok();
-    if update || !snapshot_path.exists() {
-        if let Some(parent) = snapshot_path.parent() {
-            std::fs::create_dir_all(parent)
-                .unwrap_or_else(|e| panic!("create snapshot dir {parent:?}: {e}"));
-        }
-        std::fs::write(snapshot_path, actual)
-            .unwrap_or_else(|e| panic!("write snapshot {snapshot_path:?}: {e}"));
-        return;
-    }
-    let expected = std::fs::read_to_string(snapshot_path)
-        .unwrap_or_else(|e| panic!("read snapshot {snapshot_path:?}: {e}"));
-    if actual == expected {
-        return;
-    }
-    let line = expected
-        .lines()
-        .zip(actual.lines())
-        .enumerate()
-        .find(|(_, (e, a))| e != a)
-        .map(|(i, (e, a))| {
-            format!(
-                "first divergence at line {i}:\n  expected: {e:?}\n  actual:   {a:?}"
-            )
-        })
-        .unwrap_or_else(|| {
-            format!(
-                "trailing-content mismatch: expected {} lines, actual {} lines",
-                expected.lines().count(),
-                actual.lines().count(),
-            )
-        });
-    panic!(
-        "snapshot mismatch at {snapshot_path:?}\n{line}\n--- expected ---\n{expected}\n--- actual ---\n{actual}",
-    );
-}
-
-// ---------------------------------------------------------------------------
-// Render a single route key under one framework, return HTML
-// ---------------------------------------------------------------------------
-
-/// Render the route identified by `route_template` (e.g. `/about`,
-/// `/blog/[slug]`) under `framework`. For dynamic routes, `params`
-/// pins a specific concrete URL produced by `paths()`.
-///
-/// Internally:
-///   1. `zfb_router::scan_pages` builds the route tree from the
-///      fixture project.
-///   2. `zfb_render::render_route` compiles the matched page module,
-///      runs `paths()` if needed, picks the matching params, calls
-///      `default()`, wraps with `meta.layout`, and serializes via the
-///      adapter for `framework`.
-fn render(
-    framework: Framework,
-    route_template: &str,
-    params: Option<&[(&str, &str)]>,
-) -> String {
-    let routes = scan_pages(&pages_dir())
-        .unwrap_or_else(|e| panic!("scan_pages failed: {e}"));
-    let route = routes
-        .iter()
-        .find(|r| r.template == route_template)
-        .unwrap_or_else(|| {
-            panic!(
-                "route {route_template} not found in scanned routes: {:?}",
-                routes
-                    .iter()
-                    .map(|r: &ScannedRoute| r.template.as_str())
-                    .collect::<Vec<_>>()
-            )
-        });
-
-    let input = RenderInput {
-        project_root: fixtures_root(),
-        framework,
-        route: route.clone(),
-        // `params` are the concrete bindings the harness wants to
-        // render. For static pages this is `None` and the renderer
-        // calls `default()` once. For dynamic pages the renderer
-        // matches params against the entries returned by `paths()`.
-        params: params.map(|kv| {
-            kv.iter()
-                .map(|(k, v)| (k.to_string(), v.to_string()))
-                .collect::<Vec<_>>()
-        }),
-    };
-
-    let RenderOutput { html, .. } = render_route(input)
-        .unwrap_or_else(|e| panic!("render_route failed for {route_template}: {e}"));
-    html
-}
-
-/// Render the same route under both frameworks, snapshot each, and
-/// assert the two outputs are byte-identical (ADR-002 portable-
-/// component contract).
-fn check_route_under_both(
-    route_template: &str,
-    snapshot_basename: &str,
-    params: Option<&[(&str, &str)]>,
-) {
-    let preact = render(Framework::Preact, route_template, params);
-    let react = render(Framework::React, route_template, params);
-
-    assert_snapshot_eq(&preact, &snapshot_path(Framework::Preact, snapshot_basename));
-    assert_snapshot_eq(&react, &snapshot_path(Framework::React, snapshot_basename));
-
-    assert_eq!(
-        preact, react,
-        "Preact and React HTML must be byte-identical for portable \
-         components (route {route_template}). See ADR-002.",
-    );
-}
-
-// ---------------------------------------------------------------------------
-// Test cases — one per fixture page
-// ---------------------------------------------------------------------------
-
-#[test]
-fn renders_about_under_preact() {
-    let html = render(Framework::Preact, "/about", None);
-    assert_snapshot_eq(&html, &snapshot_path(Framework::Preact, "about.html"));
-}
-
-#[test]
-fn renders_about_under_react() {
-    let html = render(Framework::React, "/about", None);
-    assert_snapshot_eq(&html, &snapshot_path(Framework::React, "about.html"));
-}
-
-#[test]
-fn renders_about_identically_across_frameworks() {
-    check_route_under_both("/about", "about.html", None);
-}
-
-#[test]
-fn renders_index_under_both() {
-    check_route_under_both("/", "index.html", None);
-}
-
-#[test]
-fn renders_blog_index_under_both() {
-    check_route_under_both("/blog", "blog-index.html", None);
-}
-
-#[test]
-fn renders_blog_slug_under_both_frameworks_identically() {
-    // One concrete URL per stub post — see content/posts.ts.
-    for slug in ["hello", "second", "third", "fourth"] {
-        check_route_under_both(
-            "/blog/[slug]",
-            &format!("blog-{slug}.html"),
-            Some(&[("slug", slug)]),
-        );
-    }
-}
-
-#[test]
-fn renders_blog_pagination_under_both() {
-    // 4 posts, pageSize 2 → 2 pages.
-    for page in ["1", "2"] {
-        check_route_under_both(
-            "/blog/page/[page]",
-            &format!("blog-page-{page}.html"),
-            Some(&[("page", page)]),
-        );
-    }
-}
-
-#[test]
-fn renders_docs_catchall_under_both() {
-    // Three stub docs in pages/docs/[...slug].tsx. The catchall
-    // produces multi-segment URLs; the params binding for a catchall
-    // is the joined slug.
-    for (joined, snapshot_name) in [
-        ("intro", "docs-intro.html"),
-        ("guides/install", "docs-guides-install.html"),
-        ("guides/config/framework", "docs-guides-config-framework.html"),
-    ] {
-        check_route_under_both(
-            "/docs/[...slug]",
-            snapshot_name,
-            Some(&[("slug", joined)]),
-        );
-    }
-}
-
-#[test]
-fn renders_nested_dynamic_under_both() {
-    // 2 langs × 2 slugs = 4 concrete URLs.
-    for lang in ["en", "ja"] {
-        for slug in ["welcome", "goodbye"] {
-            check_route_under_both(
-                "/[lang]/[slug]",
-                &format!("{lang}-{slug}.html"),
-                Some(&[("lang", lang), ("slug", slug)]),
-            );
-        }
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Routing-only assertions: `zfb-router` must produce the right URLs.
-// These don't depend on the JS runtime, so they're a useful smoke test
-// even before the renderer is fully wired.
-// ---------------------------------------------------------------------------
-
 #[test]
 fn router_discovers_all_required_routes() {
     let routes = scan_pages(&pages_dir())
         .unwrap_or_else(|e| panic!("scan_pages failed: {e}"));
-    let templates: Vec<&str> = routes.iter().map(|r| r.template.as_str()).collect();
+    let templates: Vec<String> = routes.iter().map(|r| r.template()).collect();
     for required in [
         "/",
         "/about",
         "/blog",
-        "/blog/[slug]",
-        "/blog/page/[page]",
-        "/docs/[...slug]",
-        "/[lang]/[slug]",
+        "/blog/:slug",
+        "/blog/page/:page",
+        "/docs/:slug*",
+        "/:lang/:slug",
     ] {
         assert!(
-            templates.contains(&required),
+            templates.iter().any(|t| t == required),
             "router missing required route {required}; got {templates:?}",
         );
     }
@@ -342,14 +78,16 @@ fn router_classifies_route_kinds_correctly() {
     let kind_of = |template: &str| -> RouteKind {
         routes
             .iter()
-            .find(|r| r.template == template)
+            .find(|r| r.template() == template)
             .unwrap_or_else(|| panic!("no route for {template}"))
             .kind
-            .clone()
     };
 
+    assert_eq!(kind_of("/"), RouteKind::Static);
     assert_eq!(kind_of("/about"), RouteKind::Static);
-    assert_eq!(kind_of("/blog/[slug]"), RouteKind::Dynamic);
-    assert_eq!(kind_of("/docs/[...slug]"), RouteKind::Catchall);
-    assert_eq!(kind_of("/[lang]/[slug]"), RouteKind::Dynamic);
+    assert_eq!(kind_of("/blog"), RouteKind::Static);
+    assert_eq!(kind_of("/blog/:slug"), RouteKind::Dynamic);
+    assert_eq!(kind_of("/blog/page/:page"), RouteKind::Dynamic);
+    assert_eq!(kind_of("/docs/:slug*"), RouteKind::Catchall);
+    assert_eq!(kind_of("/:lang/:slug"), RouteKind::Dynamic);
 }

--- a/crates/zfb-render/tests/mdx_loader.rs
+++ b/crates/zfb-render/tests/mdx_loader.rs
@@ -107,7 +107,7 @@ fn malformed_mdx_yields_compile_error_with_specifier_and_message() {
                 "compile error message should be informative, got: {message:?}",
             );
         }
-        other => panic!("expected RenderError::Compile, got {other:?}"),
+        other => unreachable!("expected RenderError::Compile, got {other:?}"),
     }
 }
 

--- a/crates/zfb-router/tests/scan_routes.rs
+++ b/crates/zfb-router/tests/scan_routes.rs
@@ -183,7 +183,7 @@ fn ambiguous_routes_are_rejected() {
         RouterError::AmbiguousRoute { template, .. } => {
             assert_eq!(template, "/blog");
         }
-        other => panic!("expected AmbiguousRoute, got {other:?}"),
+        other => unreachable!("expected AmbiguousRoute, got {other:?}"),
     }
 }
 

--- a/crates/zfb-server/tests/integration.rs
+++ b/crates/zfb-server/tests/integration.rs
@@ -334,9 +334,11 @@ async fn sse_does_not_emit_page_when_only_css_changed() {
             let s = std::str::from_utf8(&buf).unwrap_or("");
             for line in s.lines() {
                 if let Some(rest) = line.strip_prefix("event:") {
-                    if rest.trim() == "page" {
-                        panic!("unexpected `event: page` line in stream:\n{s}");
-                    }
+                    assert_ne!(
+                        rest.trim(),
+                        "page",
+                        "unexpected `event: page` line in stream:\n{s}"
+                    );
                 }
             }
         }

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -239,6 +239,19 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
     // hint right at build start.
     check_runtime_installed(project_root)?;
 
+    // ZFB_DEBUG_SNAPSHOT telemetry probe.
+    //
+    // The bundler still emits a placeholder empty `contentSnapshot`
+    // (wave 2 will fold the real one in), so to give users a way to
+    // monitor V8 RAM pressure today we materialise the snapshot here
+    // when the flag is set and let `build_snapshot` log a one-line
+    // summary to stderr. The result is discarded — this code path is
+    // strictly telemetry. Errors are non-fatal: a probe failure must
+    // not break the build.
+    //
+    // See README.md "Limits" for the user-facing contract.
+    maybe_probe_content_snapshot(project_root, config);
+
     // 1. Bundle.
     let bundler_input = BundlerInput {
         project_root: project_root.to_path_buf(),
@@ -332,6 +345,30 @@ fn warn_deferred_dynamic(routes: &[DeferredDynamicRoute]) {
             r.source_path.display(),
             r.reason,
         ));
+    }
+}
+
+/// When `ZFB_DEBUG_SNAPSHOT` is truthy, build the content snapshot from
+/// the configured collections so [`zfb_content::build_snapshot`] logs
+/// the entry count and serialized byte size to stderr. The snapshot
+/// itself is discarded — wave 2 owns the bundler-side wiring; this
+/// function exists so users can monitor V8 RAM pressure today.
+///
+/// Failure is non-fatal: a malformed collection root will print a
+/// warning but the build proceeds. The flag is opt-in, so the cost of
+/// walking the collections a second time only lands when the user has
+/// asked for the telemetry.
+fn maybe_probe_content_snapshot(project_root: &Path, config: &Config) {
+    if !zfb_content::debug_snapshot_enabled() {
+        return;
+    }
+    let collections: Vec<zfb_content::CollectionConfig> = config
+        .collections
+        .iter()
+        .map(|c| zfb_content::CollectionConfig::new(c.name.clone(), project_root.join(&c.path)))
+        .collect();
+    if let Err(err) = zfb_content::build_snapshot(&collections) {
+        output::warn(format!("ZFB_DEBUG_SNAPSHOT: snapshot probe failed: {err}"));
     }
 }
 

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -74,6 +74,7 @@ use zfb_build::{
     BuildContext, BuildOrchestrator, BuildOutcome, DevAssetPipeline, OrchestratorConfig,
     PageRenderer, RenderedPage,
 };
+use zfb_graph::persist::{load_from_disk, save_to_disk, ManifestDigest};
 use zfb_graph::{DependencyGraph, PageId};
 use zfb_server::{outcome_to_events, serve, PageCache, ReloadEvent, ServeOpts};
 
@@ -137,9 +138,36 @@ pub async fn run(args: &DevArgs) -> Result<()> {
     };
 
     // 3. Build orchestrator setup.
-    let graph = Arc::new(Mutex::new(DependencyGraph::new()));
-    let pipeline = DevAssetPipeline::new();
+    //
+    // Cold-start optimisation: try to reuse a previously persisted
+    // graph from `.zfb/graph.bin`. If the manifest digest still
+    // matches the current project layout, deserialise and reuse —
+    // otherwise build fresh and save the new graph back so the
+    // *next* cold start is fast.
     let watch_roots: Vec<PathBuf> = DEFAULT_WATCH_ROOTS.iter().map(PathBuf::from).collect();
+    let graph_cache_path = project_root.join(".zfb").join("graph.bin");
+    let manifest_digest = compute_manifest_digest(&project_root, &watch_roots);
+    let initial_graph = load_persisted_graph(&graph_cache_path, manifest_digest.as_ref());
+    if initial_graph.is_none() {
+        // Best-effort: write the (currently empty) fresh graph so a
+        // crash before population still gives the next start a valid
+        // — if stale — header to invalidate against. Errors are
+        // logged and ignored: persistence is an optimisation, never
+        // a correctness gate.
+        if let Some(d) = manifest_digest.as_ref() {
+            if let Err(err) =
+                save_to_disk(&DependencyGraph::new(), d, &graph_cache_path)
+            {
+                output::warn(format!(
+                    "graph persistence: write to {} failed (ignored): {err:#}",
+                    graph_cache_path.display()
+                ));
+            }
+        }
+    }
+    let graph = Arc::new(Mutex::new(initial_graph.unwrap_or_default()));
+    let graph_for_save = Arc::clone(&graph);
+    let pipeline = DevAssetPipeline::new();
     let orch_config = OrchestratorConfig::new(&project_root, watch_roots.clone());
     let orchestrator = BuildOrchestrator::new(orch_config, graph, pipeline);
 
@@ -206,7 +234,72 @@ pub async fn run(args: &DevArgs) -> Result<()> {
         session.shutdown_explicit();
     }
 
+    // Persist the graph one more time before exit so the latest
+    // populated state — not just the boot-time fresh one — is what
+    // the next cold start sees. Best-effort; warn-and-ignore on
+    // failure (don't block shutdown on a disk error).
+    if let Some(d) = manifest_digest.as_ref() {
+        if let Ok(g) = graph_for_save.lock() {
+            if let Err(err) = save_to_disk(&g, d, &graph_cache_path) {
+                output::warn(format!(
+                    "graph persistence: shutdown write to {} failed (ignored): {err:#}",
+                    graph_cache_path.display()
+                ));
+            }
+        }
+    }
+
     result
+}
+
+/// Compute the manifest digest for the current project, or return
+/// `None` if the digest itself could not be computed (e.g. permission
+/// denied while walking sources). On `None` the caller should bypass
+/// the persistence layer entirely — never falsely reuse a stale
+/// graph.
+fn compute_manifest_digest(
+    project_root: &Path,
+    watch_roots: &[PathBuf],
+) -> Option<ManifestDigest> {
+    // Config files that, when changed, must invalidate the graph
+    // even though they live next to (not under) the watched roots.
+    // Both JSON and TS are listed; missing ones are silently
+    // skipped by the digest builder.
+    let cfg_files = [
+        PathBuf::from("zfb.config.json"),
+        PathBuf::from("zfb.config.ts"),
+    ];
+    match ManifestDigest::compute(project_root, watch_roots, &cfg_files) {
+        Ok(d) => Some(d),
+        Err(err) => {
+            output::warn(format!(
+                "graph persistence: manifest digest failed (cache disabled): {err:#}"
+            ));
+            None
+        }
+    }
+}
+
+/// Try to reuse a persisted graph. Returns `Some(graph)` only when
+/// the on-disk file exists and its digest matches the live one. All
+/// other outcomes (no digest, missing file, mismatch, IO error) map
+/// to `None` so the caller falls back to a fresh graph.
+fn load_persisted_graph(
+    graph_cache_path: &Path,
+    digest: Option<&ManifestDigest>,
+) -> Option<DependencyGraph> {
+    let d = digest?;
+    match load_from_disk(graph_cache_path, d) {
+        Ok(Some(g)) => Some(g),
+        Ok(None) => None,
+        Err(err) => {
+            output::warn(format!(
+                "graph persistence: load from {} failed (ignored): {err:#}",
+                graph_cache_path.display()
+            ));
+            None
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -148,23 +148,12 @@ pub async fn run(args: &DevArgs) -> Result<()> {
     let graph_cache_path = project_root.join(".zfb").join("graph.bin");
     let manifest_digest = compute_manifest_digest(&project_root, &watch_roots);
     let initial_graph = load_persisted_graph(&graph_cache_path, manifest_digest.as_ref());
-    if initial_graph.is_none() {
-        // Best-effort: write the (currently empty) fresh graph so a
-        // crash before population still gives the next start a valid
-        // — if stale — header to invalidate against. Errors are
-        // logged and ignored: persistence is an optimisation, never
-        // a correctness gate.
-        if let Some(d) = manifest_digest.as_ref() {
-            if let Err(err) =
-                save_to_disk(&DependencyGraph::new(), d, &graph_cache_path)
-            {
-                output::warn(format!(
-                    "graph persistence: write to {} failed (ignored): {err:#}",
-                    graph_cache_path.display()
-                ));
-            }
-        }
-    }
+    // Note: we deliberately do NOT write a fresh empty graph here on
+    // a cache miss. If we did, a `zfb dev` killed before the
+    // orchestrator's first watcher tick would persist an empty graph
+    // tagged with the current digest — and the next cold start would
+    // happily reuse that empty cache as authoritative. Save only on
+    // shutdown (below), once the graph has actually been populated.
     let graph = Arc::new(Mutex::new(initial_graph.unwrap_or_default()));
     let graph_for_save = Arc::clone(&graph);
     let pipeline = DevAssetPipeline::new();

--- a/crates/zfb/src/commands/preview.rs
+++ b/crates/zfb/src/commands/preview.rs
@@ -480,39 +480,70 @@ async fn ensure_wrangler_version(project_root: &Path) -> Result<()> {
 
 /// Extract a semver-shaped version string from `wrangler --version`'s
 /// banner. The current banner is roughly ` ⛅️ wrangler 4.85.0` — we
-/// scan whitespace-separated tokens for one whose leading characters
-/// look like `MAJOR.MINOR.PATCH`. A leading `v` (e.g. `v4.85.0`) is
-/// stripped, since other CLIs in the ecosystem emit that prefix even
-/// though wrangler does not today — keeping the parser tolerant
+/// look for a version-shaped token *immediately following* a literal
+/// `wrangler` token, then fall back to the first version-shaped token
+/// in the output. The "wrangler-prefix" preference is what makes the
+/// parser robust against banners that mention other version-shaped
+/// strings (e.g. a copyright date or "[pre-release of 4.x.y]" remark)
+/// before the real wrangler version. A leading `v` (e.g. `v4.85.0`)
+/// is stripped, since other CLIs in the ecosystem emit that prefix
+/// even though wrangler does not today — keeping the parser tolerant
 /// future-proofs against an upstream banner reshuffle. Returns `None`
 /// if no token matches, which the caller turns into a "could not
 /// parse" error.
 fn parse_wrangler_version(stdout: &str) -> Option<String> {
-    for raw_token in stdout.split_whitespace() {
-        // Trim leading/trailing punctuation (e.g. parens, commas) before
-        // poking at the body; this matters for the leading-`v` step
-        // below, which only fires when `v` is the very first character.
-        let token = raw_token.trim_matches(|c: char| !c.is_ascii_alphanumeric());
-        let body = token.strip_prefix('v').unwrap_or(token);
-        let mut parts = body.splitn(3, '.');
-        let (Some(maj), Some(min), Some(patch)) = (parts.next(), parts.next(), parts.next())
-        else {
-            continue;
-        };
-        if maj.chars().all(|c| c.is_ascii_digit())
-            && min.chars().all(|c| c.is_ascii_digit())
-            && !maj.is_empty()
-            && !min.is_empty()
-            && !patch.is_empty()
-            && patch
-                .chars()
-                .next()
-                .is_some_and(|c| c.is_ascii_digit())
-        {
-            return Some(body.to_string());
+    let tokens: Vec<&str> = stdout.split_whitespace().collect();
+
+    // First pass: prefer a version-shaped token that immediately
+    // follows a literal `wrangler` token. This anchors the match to
+    // the banner's actual wrangler-version field.
+    for window in tokens.windows(2) {
+        if let [prev, candidate] = window {
+            if prev
+                .trim_matches(|c: char| !c.is_ascii_alphanumeric())
+                .eq_ignore_ascii_case("wrangler")
+            {
+                if let Some(v) = version_shape(candidate) {
+                    return Some(v);
+                }
+            }
+        }
+    }
+
+    // Fallback: any version-shaped token. Tolerated for safety on
+    // unforeseen banner reshuffles.
+    for raw_token in &tokens {
+        if let Some(v) = version_shape(raw_token) {
+            return Some(v);
         }
     }
     None
+}
+
+/// Return `Some(version_string)` if `raw_token`'s body matches
+/// `MAJOR.MINOR.PATCH...`. Strips a leading `v` and surrounding
+/// non-alphanumerics. Returns the body without the `v` prefix.
+fn version_shape(raw_token: &str) -> Option<String> {
+    let token = raw_token.trim_matches(|c: char| !c.is_ascii_alphanumeric());
+    let body = token.strip_prefix('v').unwrap_or(token);
+    let mut parts = body.splitn(3, '.');
+    let (Some(maj), Some(min), Some(patch)) = (parts.next(), parts.next(), parts.next()) else {
+        return None;
+    };
+    if maj.chars().all(|c| c.is_ascii_digit())
+        && min.chars().all(|c| c.is_ascii_digit())
+        && !maj.is_empty()
+        && !min.is_empty()
+        && !patch.is_empty()
+        && patch
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_digit())
+    {
+        Some(body.to_string())
+    } else {
+        None
+    }
 }
 
 /// Treat `1`, `true`, `yes` (case-insensitive) as truthy. Anything else
@@ -1120,6 +1151,30 @@ mod tests {
         // Two-segment "version" (e.g. `4.85`) is not a valid semver
         // shape — we require all three of MAJOR.MINOR.PATCH.
         assert_eq!(parse_wrangler_version("wrangler 4.85"), None);
+    }
+
+    #[test]
+    fn parse_wrangler_version_prefers_token_after_wrangler_literal() {
+        // Defensive: if a banner mentions a version-shaped string
+        // before `wrangler 4.85.0` (a copyright date, a prerelease
+        // remark, etc.), the version after the literal `wrangler`
+        // token must win — not the first version-shaped token.
+        let stdout = "Copyright 2024.10.0 Cloudflare. ⛅️ wrangler 4.85.0";
+        assert_eq!(
+            parse_wrangler_version(stdout).as_deref(),
+            Some("4.85.0"),
+            "must anchor on the token immediately after `wrangler`",
+        );
+    }
+
+    #[test]
+    fn parse_wrangler_version_falls_back_when_no_wrangler_literal() {
+        // No `wrangler` token in the banner — fall back to the first
+        // version-shaped token. Keeps bare-version shims working.
+        assert_eq!(
+            parse_wrangler_version("4.85.0\n").as_deref(),
+            Some("4.85.0"),
+        );
     }
 
     #[test]

--- a/crates/zfb/src/commands/preview.rs
+++ b/crates/zfb/src/commands/preview.rs
@@ -67,6 +67,41 @@ const DEFAULT_PREVIEW_PORT: u16 = 4321;
 /// rather than silently falling through to static-only.
 const CLOUDFLARE_ADAPTER: &str = "@takazudo/zfb-adapter-cloudflare";
 
+/// Pinned `wrangler` CLI version. `zfb preview` runs
+/// `pnpm exec wrangler --version` before handing off to
+/// `wrangler pages dev` and aborts with a clear error if the reported
+/// version does not match this constant.
+///
+/// Kept in lock-step with the exact-pinned `wrangler` entry in the root
+/// `package.json` (and with `EXPECTED_MINIFLARE_VERSION` /
+/// `EXPECTED_WORKERD_VERSION` below) so the SSR/preview pipeline is
+/// reproducible. To bump, see `CONTRIBUTING.md "External tool version pins"`.
+pub const EXPECTED_WRANGLER_VERSION: &str = "4.85.0";
+
+/// Pinned `miniflare` package version. zfb does not spawn miniflare
+/// directly today (it goes through `pnpm exec wrangler pages dev`),
+/// but the version is exact-pinned in `package.json` so the SSR
+/// pipeline's behavior is reproducible. Kept here as the canonical
+/// source of truth — `pnpm-lock.yaml` snapshots the resolution. To
+/// bump, see `CONTRIBUTING.md "External tool version pins"`.
+#[allow(dead_code)]
+pub const EXPECTED_MINIFLARE_VERSION: &str = "4.20260424.0";
+
+/// Pinned `workerd` package version that miniflare drives. Not
+/// directly listed in `package.json` (it comes in transitively via
+/// `miniflare`'s peer dependency); the lockfile snapshots the exact
+/// resolved version. Kept here so a single `grep EXPECTED_WORKERD_VERSION`
+/// surfaces the workerd pin alongside the rest of the external-tool
+/// pins. To bump, see `CONTRIBUTING.md "External tool version pins"`.
+#[allow(dead_code)]
+pub const EXPECTED_WORKERD_VERSION: &str = "1.20260424.1";
+
+/// Set this env var to `1` to skip the pre-flight wrangler version
+/// gate. Intended as an emergency escape hatch (e.g. while a
+/// release-engineering bump is mid-flight); not meant for steady-state
+/// use.
+const SKIP_WRANGLER_VERSION_CHECK_ENV: &str = "ZFB_SKIP_WRANGLER_VERSION_CHECK";
+
 pub async fn run(args: &PreviewArgs) -> Result<()> {
     // 1. Resolve the project root and load configuration. A missing
     //    config file is fine — `load_from_dir` returns
@@ -361,7 +396,15 @@ fn content_type_for_path(path: &Path) -> &'static str {
 /// pipe output — wrangler prints its own ready banner and we want the
 /// user to see it directly. Returns non-zero when wrangler exits non-
 /// zero so the parent shell sees the failure.
+///
+/// Before handing off, runs a pre-flight `pnpm exec wrangler --version`
+/// gate against [`EXPECTED_WRANGLER_VERSION`]. A mismatch aborts with
+/// an actionable error pointing at the version-pin procedure. The gate
+/// can be bypassed by setting the
+/// [`SKIP_WRANGLER_VERSION_CHECK_ENV`] env var to `1`.
 async fn run_via_wrangler(project_root: &Path, outdir: &Path, port: u16) -> Result<()> {
+    ensure_wrangler_version(project_root).await?;
+
     output::info(format!(
         "preview: adapter mode — handing off to wrangler pages dev (port {port})"
     ));
@@ -379,6 +422,98 @@ async fn run_via_wrangler(project_root: &Path, outdir: &Path, port: u16) -> Resu
         anyhow::bail!("wrangler pages dev exited with status {status}");
     }
     Ok(())
+}
+
+/// Run `pnpm exec wrangler --version` and abort if the reported
+/// version does not match [`EXPECTED_WRANGLER_VERSION`]. Skipped when
+/// [`SKIP_WRANGLER_VERSION_CHECK_ENV`] is set to a truthy value.
+async fn ensure_wrangler_version(project_root: &Path) -> Result<()> {
+    if env_truthy(SKIP_WRANGLER_VERSION_CHECK_ENV) {
+        return Ok(());
+    }
+
+    let output = tokio::process::Command::new("pnpm")
+        .arg("exec")
+        .arg("wrangler")
+        .arg("--version")
+        .current_dir(project_root)
+        .output()
+        .await
+        .context(
+            "failed to spawn `pnpm exec wrangler --version` for the wrangler version gate \
+             — make sure pnpm and wrangler are installed in this project",
+        )?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!(
+            "`pnpm exec wrangler --version` exited with status {}: {}",
+            output.status,
+            stderr.trim()
+        );
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    match parse_wrangler_version(&stdout) {
+        Some(reported) if reported == EXPECTED_WRANGLER_VERSION => Ok(()),
+        Some(reported) => Err(anyhow::anyhow!(
+            "wrangler version mismatch: expected `{expected}` (pinned in zfb), \
+             got `{reported}`. \
+             Update both the `wrangler` entry in package.json and \
+             EXPECTED_WRANGLER_VERSION in crates/zfb/src/commands/preview.rs in \
+             lock-step (see the External tool version pins section in CONTRIBUTING.md), then run \
+             `pnpm install`. To bypass this gate temporarily, set \
+             {env}=1 (not recommended for steady-state use).",
+            expected = EXPECTED_WRANGLER_VERSION,
+            env = SKIP_WRANGLER_VERSION_CHECK_ENV,
+        )),
+        None => Err(anyhow::anyhow!(
+            "could not parse a wrangler version from `pnpm exec wrangler --version` \
+             output: {raw:?}. Expected something containing `{expected}`. \
+             Set {env}=1 to bypass this gate if the output format has changed.",
+            raw = stdout.trim(),
+            expected = EXPECTED_WRANGLER_VERSION,
+            env = SKIP_WRANGLER_VERSION_CHECK_ENV,
+        )),
+    }
+}
+
+/// Extract a semver-shaped version string from `wrangler --version`'s
+/// banner. The current banner is roughly ` ⛅️ wrangler 4.85.0` — we
+/// scan whitespace-separated tokens for one whose leading characters
+/// look like `MAJOR.MINOR.PATCH`. Returns `None` if no token matches,
+/// which the caller turns into a "could not parse" error.
+fn parse_wrangler_version(stdout: &str) -> Option<String> {
+    for token in stdout.split_whitespace() {
+        let mut parts = token.splitn(3, '.');
+        let (Some(maj), Some(min), Some(patch)) = (parts.next(), parts.next(), parts.next())
+        else {
+            continue;
+        };
+        if maj.chars().all(|c| c.is_ascii_digit())
+            && min.chars().all(|c| c.is_ascii_digit())
+            && !maj.is_empty()
+            && !min.is_empty()
+            && !patch.is_empty()
+            && patch
+                .chars()
+                .next()
+                .is_some_and(|c| c.is_ascii_digit())
+        {
+            return Some(token.trim_matches(|c: char| !c.is_ascii_alphanumeric()).to_string());
+        }
+    }
+    None
+}
+
+/// Treat `1`, `true`, `yes` (case-insensitive) as truthy. Anything else
+/// — including unset — is falsy. Used by the wrangler version-gate
+/// escape hatch.
+fn env_truthy(name: &str) -> bool {
+    match std::env::var(name) {
+        Ok(v) => matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes"),
+        Err(_) => false,
+    }
 }
 
 /// Build the `tokio::process::Command` we'd spawn for wrangler. Pulled
@@ -922,5 +1057,68 @@ mod tests {
             .position(|a| a == "--port")
             .expect("--port must be present");
         assert_eq!(args[port_idx + 1], "9000");
+    }
+
+    // ---- wrangler version-gate parser --------------------------------
+
+    #[test]
+    fn parse_wrangler_version_extracts_pinned_format() {
+        // The exact banner shape `wrangler --version` prints today.
+        let stdout = " ⛅️ wrangler 4.85.0\n";
+        assert_eq!(
+            parse_wrangler_version(stdout).as_deref(),
+            Some("4.85.0"),
+            "must extract `4.85.0` from the canonical banner",
+        );
+    }
+
+    #[test]
+    fn parse_wrangler_version_handles_bare_version_line() {
+        // Some CI environments / shims may print just the bare version.
+        assert_eq!(
+            parse_wrangler_version("4.85.0\n").as_deref(),
+            Some("4.85.0"),
+        );
+    }
+
+    #[test]
+    fn parse_wrangler_version_handles_prerelease_suffix() {
+        // We accept any token whose head matches `MAJOR.MINOR.PATCH…`,
+        // which lets prereleases round-trip through the parser. The
+        // version-equality check downstream is what enforces strict
+        // pinning — the parser's job is only extraction.
+        assert_eq!(
+            parse_wrangler_version("⛅ wrangler 5.0.0-rc.1").as_deref(),
+            Some("5.0.0-rc.1"),
+        );
+    }
+
+    #[test]
+    fn parse_wrangler_version_returns_none_on_unrecognised_output() {
+        assert_eq!(parse_wrangler_version("hello world\n"), None);
+        assert_eq!(parse_wrangler_version(""), None);
+        // Two-segment "version" (e.g. `4.85`) is not a valid semver
+        // shape — we require all three of MAJOR.MINOR.PATCH.
+        assert_eq!(parse_wrangler_version("wrangler 4.85"), None);
+    }
+
+    #[test]
+    fn env_truthy_recognises_common_truthy_values() {
+        let key = "ZFB_TEST_ENV_TRUTHY_KEY";
+        for (value, expected) in [
+            ("1", true),
+            ("true", true),
+            ("TRUE", true),
+            ("yes", true),
+            ("0", false),
+            ("false", false),
+            ("", false),
+            ("nope", false),
+        ] {
+            std::env::set_var(key, value);
+            assert_eq!(env_truthy(key), expected, "value = {value:?}");
+        }
+        std::env::remove_var(key);
+        assert!(!env_truthy(key), "unset env var must be falsy");
     }
 }

--- a/crates/zfb/src/commands/preview.rs
+++ b/crates/zfb/src/commands/preview.rs
@@ -481,11 +481,20 @@ async fn ensure_wrangler_version(project_root: &Path) -> Result<()> {
 /// Extract a semver-shaped version string from `wrangler --version`'s
 /// banner. The current banner is roughly ` ⛅️ wrangler 4.85.0` — we
 /// scan whitespace-separated tokens for one whose leading characters
-/// look like `MAJOR.MINOR.PATCH`. Returns `None` if no token matches,
-/// which the caller turns into a "could not parse" error.
+/// look like `MAJOR.MINOR.PATCH`. A leading `v` (e.g. `v4.85.0`) is
+/// stripped, since other CLIs in the ecosystem emit that prefix even
+/// though wrangler does not today — keeping the parser tolerant
+/// future-proofs against an upstream banner reshuffle. Returns `None`
+/// if no token matches, which the caller turns into a "could not
+/// parse" error.
 fn parse_wrangler_version(stdout: &str) -> Option<String> {
-    for token in stdout.split_whitespace() {
-        let mut parts = token.splitn(3, '.');
+    for raw_token in stdout.split_whitespace() {
+        // Trim leading/trailing punctuation (e.g. parens, commas) before
+        // poking at the body; this matters for the leading-`v` step
+        // below, which only fires when `v` is the very first character.
+        let token = raw_token.trim_matches(|c: char| !c.is_ascii_alphanumeric());
+        let body = token.strip_prefix('v').unwrap_or(token);
+        let mut parts = body.splitn(3, '.');
         let (Some(maj), Some(min), Some(patch)) = (parts.next(), parts.next(), parts.next())
         else {
             continue;
@@ -500,7 +509,7 @@ fn parse_wrangler_version(stdout: &str) -> Option<String> {
                 .next()
                 .is_some_and(|c| c.is_ascii_digit())
         {
-            return Some(token.trim_matches(|c: char| !c.is_ascii_alphanumeric()).to_string());
+            return Some(body.to_string());
         }
     }
     None
@@ -1077,6 +1086,17 @@ mod tests {
         // Some CI environments / shims may print just the bare version.
         assert_eq!(
             parse_wrangler_version("4.85.0\n").as_deref(),
+            Some("4.85.0"),
+        );
+    }
+
+    #[test]
+    fn parse_wrangler_version_strips_leading_v_prefix() {
+        // Wrangler doesn't emit a leading `v` today, but other CLIs in
+        // the ecosystem do — strip it so the equality check downstream
+        // continues to match `4.85.0` even if upstream changes its banner.
+        assert_eq!(
+            parse_wrangler_version("⛅ wrangler v4.85.0").as_deref(),
             Some("4.85.0"),
         );
     }

--- a/crates/zfb/src/diagnostics.rs
+++ b/crates/zfb/src/diagnostics.rs
@@ -394,11 +394,35 @@ pub fn from_paths_error(
     let (line, col) = locate_export_ident(source, "paths").unwrap_or((1, 1));
     let file = project_relative(path, None);
     let message = match err {
-        PathsError::MissingParam { name, route } => format!(
-            "paths() entry is missing required param `{name}` for route `{route}`"
-        ),
-        PathsError::ExtraParam { name, route } => {
-            format!("paths() entry has extra param `{name}` not declared in route `{route}`")
+        PathsError::MissingParam {
+            name,
+            route,
+            provided,
+        } => {
+            let pretty = provided
+                .iter()
+                .map(|k| format!("`{k}`"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!(
+                "paths() entry is missing required param `{name}` for route `{route}`: \
+                 params must include `{name}`, got [{pretty}]"
+            )
+        }
+        PathsError::ExtraParam {
+            name,
+            route,
+            expected,
+        } => {
+            let pretty = expected
+                .iter()
+                .map(|k| format!("`{k}`"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!(
+                "paths() entry has extra param `{name}` not declared in route `{route}`: \
+                 expected one of [{pretty}], got `{name}`"
+            )
         }
         PathsError::InvalidParamType { name, reason, route } => format!(
             "paths() entry has invalid param `{name}` for route `{route}`: {reason}"
@@ -711,12 +735,17 @@ mod tests {
         let err = zfb_render::paths::PathsError::MissingParam {
             name: "slug".to_string(),
             route: "blog/[slug].tsx".to_string(),
+            provided: vec!["wrong".to_string()],
         };
         let d = from_paths_error(&path, src, &err);
         let out = strip_ansi(&render_framed(&d));
         // Should land on line 3 where `export function paths` lives.
         assert!(out.contains(" --> pages/blog/[slug].tsx:3:"), "got:\n{out}");
         assert!(out.contains("missing required param `slug`"), "got:\n{out}");
+        assert!(
+            out.contains("`wrong`"),
+            "expected provided-keys `got [...]` clause to mention `wrong`, got:\n{out}",
+        );
         assert!(out.contains("export function paths"), "got:\n{out}");
     }
 

--- a/crates/zfb/src/render_pipeline.rs
+++ b/crates/zfb/src/render_pipeline.rs
@@ -323,11 +323,27 @@ fn build_output_path_for_resolved_url(url: &str, extension: Option<&str>) -> Pat
 /// `route` strings doubled in the warning.
 fn format_paths_error(e: &PathsError) -> String {
     match e {
-        PathsError::MissingParam { name, .. } => {
-            format!("paths() entry is missing required param `{name}`")
+        PathsError::MissingParam { name, provided, .. } => {
+            let pretty = provided
+                .iter()
+                .map(|k| format!("`{k}`"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!(
+                "paths() entry is missing required param `{name}`: \
+                 params must include `{name}`, got [{pretty}]"
+            )
         }
-        PathsError::ExtraParam { name, .. } => {
-            format!("paths() entry has extra param `{name}` not in the route template")
+        PathsError::ExtraParam { name, expected, .. } => {
+            let pretty = expected
+                .iter()
+                .map(|k| format!("`{k}`"))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!(
+                "paths() entry has extra param `{name}` not in the route template: \
+                 expected one of [{pretty}], got `{name}`"
+            )
         }
         PathsError::InvalidParamType { name, reason, .. } => {
             format!("paths() entry has invalid param `{name}`: {reason}")

--- a/crates/zfb/tests/diagnostics_fixtures.rs
+++ b/crates/zfb/tests/diagnostics_fixtures.rs
@@ -123,7 +123,7 @@ fn paths_missing_param_frames_export_paths_line() {
     ];
     let extracted = match zfb_render::paths_extract::extract_paths(&src, "page.tsx") {
         Ok(zfb_render::paths_extract::PathsExtraction::Literal(v)) => v,
-        other => panic!("expected literal extraction, got {other:?}"),
+        other => unreachable!("expected literal extraction, got {other:?}"),
     };
     let err = zfb_render::paths::resolve_paths(
         &mut cache,
@@ -157,7 +157,7 @@ fn paths_shape_error_frames_export_paths_line() {
     // is what rejects it (must be an array).
     let extracted = match zfb_render::paths_extract::extract_paths(&src, "page.tsx") {
         Ok(zfb_render::paths_extract::PathsExtraction::Literal(v)) => v,
-        other => panic!("expected literal extraction, got {other:?}"),
+        other => unreachable!("expected literal extraction, got {other:?}"),
     };
     let err = zfb_render::paths::resolve_paths(
         &mut cache,

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   },
   "devDependencies": {
     "lefthook": "^2.1.6",
-    "miniflare": "^4.20260424.0",
+    "miniflare": "4.20260424.0",
     "prettier": "^3.8.3",
-    "wrangler": "^4.85.0"
+    "wrangler": "4.85.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
-      workerd:
-        specifier: 1.20260424.1
-        version: 1.20260424.1
       wrangler:
         specifier: 4.85.0
         version: 4.85.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,13 +12,16 @@ importers:
         specifier: ^2.1.6
         version: 2.1.6
       miniflare:
-        specifier: ^4.20260424.0
+        specifier: 4.20260424.0
         version: 4.20260424.0
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
+      workerd:
+        specifier: 1.20260424.1
+        version: 1.20260424.1
       wrangler:
-        specifier: ^4.85.0
+        specifier: 4.85.0
         version: 4.85.0
 
   crates/zfb-islands/npm:


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/55

---

## Summary

Phase A hygiene epic for the Astro→zfb migration (zudolab/zudo-doc#473). Closes 7 sub-tasks of issue #55: stale deno_core cleanup, panic!()→unreachable!() refactor, integration test re-park, snapshot debug telemetry, dependency-graph persistence, paths() validation diagnostics, and external-tool version pinning.

## Changes

### Sub 1 — deno_core retirement (closes #41)
ADR-001 was superseded by ADR-005. `zfb-runtime-spike` was already removed from the workspace; cleaned up stale `deno_core` references in `crates/zfb-build`'s comments / Cargo.toml / README and `crates/zfb-content/src/content_bridge.rs` to point at miniflare/workerd. Workspace `cargo build --all-features --all-targets` now succeeds clean. Closed #41 as resolved-by-deletion.

### Sub 2 — panic!() cleanup
Converted assertion-style `panic!("expected X, got {:?}", other)` and `_ => panic!()` exhaustive-match catch-alls to `unreachable!` with explanatory messages across 33 files in `crates/{zfb,zfb-build,zfb-content,zfb-graph,zfb-islands,zfb-render,zfb-router,zfb-server}`. Remaining `panic!` sites are documented legitimate fatal-error contexts (snapshot-mismatch helpers, test-setup unwrap_or_else patterns).

### Sub 3 — Un-park `integration_routing_rendering.rs`
The previously parked file targeted a `render_route(RenderInput) -> RenderOutput` orchestrator that never landed. Replaced the speculative ~356-line harness with a routing-only smoke test (~95 lines) that exercises `zfb_router::scan_pages` against the existing fixtures. The full end-to-end harness (TSX compile + JS execution + dual-framework byte-equality) is filed as follow-up issue #63 — it belongs at the `zfb-build` orchestrator layer, not in `zfb-render`. Fixtures preserved.

### Sub 4 — `ZFB_DEBUG_SNAPSHOT` flag + Limits docs
`zfb-content::build_snapshot` emits `content snapshot: N entries / M KB` on stderr when `ZFB_DEBUG_SNAPSHOT=1` (or `true`). The `zfb build` command runs a one-shot probe over `config.collections` so the line surfaces today. README has a new "Limits" section explaining V8 RAM behaviour and pointing at the env var.

### Sub 5 — `DependencyGraph` persistence (`.zfb/graph.bin`)
New `zfb-graph::persist` module (504 LoC + tests). Wire format: 4-byte magic (ZFBG), 2-byte version, 32-byte digest, then bincode-serialised graph. Atomic write via per-process unique temp + rename. `ManifestDigest` hashes config-file content + sorted (rel_path, mtime, len) listings under watched roots; missing config files are folded in as `cfg-missing:<rel>` so presence/absence transitions flip the digest. `zfb dev` loads on boot and persists on shutdown only (boot-time empty-graph save was removed during review — it could poison the next start if SIGKILL hit before population). `.zfb/` added to `.gitignore`.

### Sub 6 — `paths()` validation messages
`PathsError::MissingParam` now carries `provided` (sorted keys actually in the entry) and `ExtraParam` carries `expected` (declared param names from the route template). Both already had the route source file path. The canonical case for `[slug].tsx` with `params { wrongName: "x" }` now produces "missing param slug in paths() entry for route pages/[slug].tsx: params must include slug, got [wrongName]". Diagnostics framed-output builder + render-pipeline warning formatter updated to surface the same expected/got clause.

### Sub 7 — esbuild + miniflare version pin + checksum verify
Pinned versions exposed as Rust constants (`EXPECTED_ESBUILD_VERSION`, `EXPECTED_ESBUILD_SHA256`, `EXPECTED_WRANGLER_VERSION`, `EXPECTED_MINIFLARE_VERSION`, `EXPECTED_WORKERD_VERSION`). Dropped `^` from miniflare/wrangler in package.json. New `ensure_wrangler_version` runtime gate runs `pnpm exec wrangler --version` before `run_via_wrangler` hands off; mismatch aborts with an actionable error pointing at CONTRIBUTING.md's bump procedure. Escape hatch: `ZFB_SKIP_WRANGLER_VERSION_CHECK=1`. `parse_wrangler_version` now anchors to a token immediately following a literal `wrangler` token (with fallback) so a banner mentioning a version-shaped string before the real version cannot mislock. CONTRIBUTING.md has a new "External tool version pins" section. `EXPECTED_ESBUILD_SHA256` ships empty as a release-engineering placeholder (documented at the constant). Release binary is 10.4 MB stripped, well under the 20 MB target — confirms the deno_core retirement landed the V8 bloat removal.

### Review fixes
After merging the 7 topics, two independent code-reviewer passes flagged additional issues. Fixed:
- (HIGH) `save_to_disk` used a fixed temp filename — concurrent `zfb dev` instances would race. Now uses `.bin.tmp.<pid>.<nanos>` with cleanup on rename failure.
- (HIGH) Missing config files were silently skipped from the manifest digest — could collide with sibling-removed arrangements. Now fingerprinted as `cfg-missing:<rel>`.
- (HIGH) `parse_wrangler_version` could lock onto a non-wrangler version-shaped token. Now anchors to the token after a literal `wrangler`.
- (MEDIUM) Boot-time empty-graph save in `zfb dev` could poison the next cold start if SIGKILL'd before population. Removed; persist only on shutdown.
- (MEDIUM) Tracked-follow-up reference in the smoke test now links #63 explicitly.

## Test plan

- [x] `cargo build --workspace --all-features --all-targets` succeeds
- [x] `cargo test --workspace` passes (all crates green; +6 new tests across review fixes)
- [x] `cargo check --workspace --all-targets` clean
- [x] `cargo clippy` introduces no new warnings
- [x] Release binary stripped < 20 MB (measured 10.4 MB)
- [x] CI green on PR #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)