### PR TITLE
review-loop-polish-followups: 5 deferred polish items from PR #64

### DIFF
--- a/crates/zfb-build/src/atomic.rs
+++ b/crates/zfb-build/src/atomic.rs
@@ -402,4 +402,99 @@ mod tests {
         validate_output_path(&dist_root, Path::new("nested/deep/index.html"))
             .expect("missing parent should not error");
     }
+
+    /// Case A: dist_root is passed as the symlink path itself.
+    ///
+    /// The lexical guard at line 164 dual-checks `starts_with(dist_root)` AND
+    /// `starts_with(canon_root)`. When dist_root is a symlink, canon_root is
+    /// the resolved target. Paths under the symlink path lexically satisfy
+    /// `starts_with(dist_root)`, so they pass the guard; when the symlink
+    /// itself is canonicalized during walk-up it resolves to canon_root,
+    /// satisfying the final containment check. This test locks that behaviour.
+    #[cfg(unix)]
+    #[test]
+    fn validate_output_path_accepts_symlinked_dist_root_via_symlink_path() {
+        use std::os::unix::fs::symlink;
+
+        let real_dir = tempdir().unwrap();
+        let link_parent = tempdir().unwrap();
+        let real_root = real_dir.path().canonicalize().unwrap();
+        // Create a symlink: link_parent/dist-link -> real_root
+        let link_path = link_parent.path().join("dist-link");
+        symlink(&real_root, &link_path).unwrap();
+
+        // Both output paths should be accepted when dist_root is the symlink path.
+        validate_output_path(&link_path, Path::new("blog/index.html"))
+            .expect("symlinked dist_root via symlink path: blog/index.html should be accepted");
+        validate_output_path(&link_path, Path::new("a/b/c/index.html"))
+            .expect("symlinked dist_root via symlink path: a/b/c/index.html should be accepted");
+    }
+
+    /// Case B: dist_root is passed as the canonical (resolved) path even though
+    /// a symlink alias for it exists. The function must accept writes identically
+    /// to Case A.
+    #[cfg(unix)]
+    #[test]
+    fn validate_output_path_accepts_symlinked_dist_root_via_canonical_path() {
+        use std::os::unix::fs::symlink;
+
+        let real_dir = tempdir().unwrap();
+        let link_parent = tempdir().unwrap();
+        let real_root = real_dir.path().canonicalize().unwrap();
+        let link_path = link_parent.path().join("dist-link");
+        symlink(&real_root, &link_path).unwrap();
+
+        // dist_root is the canonical path — must behave the same as the symlink alias form.
+        validate_output_path(&real_root, Path::new("blog/index.html"))
+            .expect("symlinked dist_root via canonical path: blog/index.html should be accepted");
+        validate_output_path(&real_root, Path::new("a/b/c/index.html"))
+            .expect("symlinked dist_root via canonical path: a/b/c/index.html should be accepted");
+    }
+
+    /// Case C: dist_root is the symlink path, and NONE of the intermediate
+    /// directories in the output path exist on disk. The walk-up must reach
+    /// dist_root itself (the symlink), canonicalize it, and accept the write.
+    #[cfg(unix)]
+    #[test]
+    fn validate_output_path_accepts_symlinked_dist_root_with_missing_child_components() {
+        use std::os::unix::fs::symlink;
+
+        let real_dir = tempdir().unwrap();
+        let link_parent = tempdir().unwrap();
+        let real_root = real_dir.path().canonicalize().unwrap();
+        let link_path = link_parent.path().join("dist-link");
+        symlink(&real_root, &link_path).unwrap();
+
+        // a/, a/b/, a/b/c/ do not exist inside real_root — the walk-up
+        // falls all the way back to the symlink itself and should accept.
+        validate_output_path(&link_path, Path::new("a/b/c/index.html"))
+            .expect("missing child components under symlinked dist_root should be accepted");
+    }
+
+    /// Partial-symlink case: an intermediate component of the output path is
+    /// itself a symlink, but it points BACK inside canon_root. The canonical
+    /// check must accept this (symlink resolves inside dist, not outside).
+    #[cfg(unix)]
+    #[test]
+    fn validate_output_path_accepts_inner_symlink_pointing_inside_dist() {
+        use std::os::unix::fs::symlink;
+
+        let real_dir = tempdir().unwrap();
+        let link_parent = tempdir().unwrap();
+        let real_root = real_dir.path().canonicalize().unwrap();
+        // dist-link -> real_root
+        let link_path = link_parent.path().join("dist-link");
+        symlink(&real_root, &link_path).unwrap();
+
+        // Create a real subdir inside dist and an internal symlink pointing at it.
+        let subdir = real_root.join("section");
+        fs::create_dir_all(&subdir).unwrap();
+        // dist/inner-link -> dist/section  (stays inside canon_root)
+        let inner_link = real_root.join("inner-link");
+        symlink(&subdir, &inner_link).unwrap();
+
+        // Writing through inner-link should be accepted: it resolves inside dist.
+        validate_output_path(&link_path, Path::new("inner-link/page.html"))
+            .expect("inner symlink pointing back inside dist should be accepted");
+    }
 }

--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -225,6 +225,48 @@ pub struct BundlerInput {
     pub node_modules_dir: Option<PathBuf>,
 }
 
+impl BundlerInput {
+    /// Construct a `BundlerInput` with the shared project-wide defaults,
+    /// overriding only the fields that differ per command.
+    ///
+    /// Shared defaults:
+    /// - Standard relative directory names (`pages`, `content`, `components`,
+    ///   `layouts`).
+    /// - Empty `define_vars`, `tsconfig_paths`, `external`.
+    /// - `minify: false`, `esbuild_binary: None`, `mock_subprocess_output:
+    ///   None`, `node_modules_dir: None`.
+    ///
+    /// Callers that need to override additional fields (e.g. test escape
+    /// hatches) should use struct-update syntax: `BundlerInput { field:
+    /// new_value, ..BundlerInput::for_project(...) }`.
+    pub fn for_project(
+        project_root: PathBuf,
+        framework: Framework,
+        mode: BundleMode,
+        outdir: PathBuf,
+        content_snapshot_json: Option<String>,
+    ) -> Self {
+        Self {
+            project_root,
+            pages_dir: PathBuf::from("pages"),
+            content_dir: PathBuf::from("content"),
+            components_dir: PathBuf::from("components"),
+            layouts_dir: PathBuf::from("layouts"),
+            framework,
+            define_vars: Default::default(),
+            tsconfig_paths: Default::default(),
+            external: Vec::new(),
+            outdir,
+            mode,
+            minify: false,
+            esbuild_binary: None,
+            mock_subprocess_output: None,
+            content_snapshot_json,
+            node_modules_dir: None,
+        }
+    }
+}
+
 /// Output of [`bundle`].
 #[derive(Debug, Clone)]
 pub struct BundlerOutput {

--- a/crates/zfb-server/src/livereload.js
+++ b/crates/zfb-server/src/livereload.js
@@ -32,6 +32,8 @@
       link.setAttribute("href", base + "?v=" + ts);
     }
   });
+  // Wire contract: component="" means "bundle changed, unknown components;
+  // reload the whole bundle by re-importing bundleUrl". Must NOT short-circuit on empty component.
   src.addEventListener("islands", function (ev) {
     var payload;
     try {

--- a/crates/zfb-server/src/livereload.rs
+++ b/crates/zfb-server/src/livereload.rs
@@ -129,6 +129,11 @@ pub use zfb_build::IslandsBundleInfo;
 /// should observe.
 ///
 /// See module docs for the rules.
+///
+/// Wire contract: `component: ""` means "the bundle changed but we don't
+/// know which components — reload the whole bundle by re-importing
+/// `bundle_url`". The JS consumer must NOT short-circuit on empty
+/// `component`; it reads only `bundleUrl` to construct the swap URL.
 pub fn outcome_to_events(outcome: &BuildOutcome) -> Vec<ReloadEvent> {
     let mut events = Vec::new();
     if !outcome.pages_written.is_empty() {
@@ -348,6 +353,36 @@ mod tests {
         assert_eq!(events.len(), 2);
         assert_eq!(events[0], ReloadEvent::Page);
         assert!(matches!(events[1], ReloadEvent::Islands { .. }));
+    }
+
+    #[test]
+    fn islands_bundle_changed_empty_components_emits_single_generic_event() {
+        // Contract: when the islands bundle changes but the component list is
+        // empty (runtime-only diff), outcome_to_events must emit exactly one
+        // ReloadEvent::Islands { component: "", bundle_url: <expected> }.
+        // The browser consumer keys the reload on bundleUrl, not on component,
+        // so the empty-string component must NOT suppress the event — removing
+        // the empty-component branch in outcome_to_events must break this test.
+        let outcome = BuildOutcome {
+            islands_rerun: true,
+            islands_changed: true,
+            islands_bundle: Some(IslandsBundleInfo {
+                changed: true,
+                bundle_url: "/assets/islands-abc12345.js".to_string(),
+                components: vec![],
+            }),
+            ..Default::default()
+        };
+        let events = outcome_to_events(&outcome);
+        assert_eq!(events.len(), 1, "expected exactly one event for empty components");
+        assert_eq!(
+            events[0],
+            ReloadEvent::Islands {
+                component: String::new(),
+                bundle_url: "/assets/islands-abc12345.js".to_string(),
+            },
+            "empty-component event must carry the bundle_url so the consumer can re-import it"
+        );
     }
 
     #[test]

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -38,7 +38,7 @@
 //! handling, `✓ N pages built in X.XXs` summary) is unchanged.
 
 use std::env;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::time::Instant;
 
 use anyhow::{anyhow, Context, Result};
@@ -53,6 +53,7 @@ use zfb_router::Router;
 use zfb_render::paths::PathsCache;
 
 use crate::cli::BuildArgs;
+use crate::commands::resolve::resolve_outdir;
 use crate::config::Config;
 use crate::output;
 use crate::render_pipeline::{
@@ -375,24 +376,13 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
     //
     // The content snapshot (when present) is embedded in the worker
     // bundle so runtime `paths()` calls can resolve `getCollection(...)`.
-    let bundler_input = BundlerInput {
-        project_root: project_root.to_path_buf(),
-        pages_dir: PathBuf::from("pages"),
-        content_dir: PathBuf::from("content"),
-        components_dir: PathBuf::from("components"),
-        layouts_dir: PathBuf::from("layouts"),
-        framework: cfg_framework_to_render(config.framework),
-        define_vars: Default::default(),
-        tsconfig_paths: Default::default(),
-        external: Vec::new(),
-        outdir: outdir.join(".zfb-build"),
-        mode: BundleMode::Production,
-        minify: false,
-        esbuild_binary: None,
-        mock_subprocess_output: None,
+    let bundler_input = BundlerInput::for_project(
+        project_root.to_path_buf(),
+        cfg_framework_to_render(config.framework),
+        BundleMode::Production,
+        outdir.join(".zfb-build"),
         content_snapshot_json,
-        node_modules_dir: None,
-    };
+    );
     let bundler_out = runner
         .bundle(bundler_input)
         .context("bundler step failed")?;
@@ -518,16 +508,6 @@ fn maybe_probe_content_snapshot(project_root: &Path, config: &Config) {
         .collect();
     if let Err(err) = zfb_content::build_snapshot(&collections) {
         output::warn(format!("ZFB_DEBUG_SNAPSHOT: snapshot probe failed: {err}"));
-    }
-}
-
-/// Resolve `outdir` against `project_root`. If `outdir` is absolute it is
-/// used as-is; if relative it is joined onto `project_root`.
-fn resolve_outdir(project_root: &Path, outdir: &Path) -> PathBuf {
-    if outdir.is_absolute() {
-        outdir.to_path_buf()
-    } else {
-        project_root.join(outdir)
     }
 }
 
@@ -1106,20 +1086,6 @@ mod tests {
         .unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("empty string"), "{msg}");
-    }
-
-    #[test]
-    fn resolve_outdir_keeps_absolute_paths() {
-        let root = Path::new("/proj");
-        let abs = PathBuf::from("/tmp/zfb-out");
-        assert_eq!(resolve_outdir(root, &abs), abs);
-    }
-
-    #[test]
-    fn resolve_outdir_joins_relative_paths_onto_root() {
-        let root = Path::new("/proj");
-        let rel = PathBuf::from("dist");
-        assert_eq!(resolve_outdir(root, &rel), PathBuf::from("/proj/dist"));
     }
 
     /// Ignored end-to-end test: runs `cargo run -p zfb -- build` on

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -79,6 +79,7 @@ use zfb_graph::{DependencyGraph, PageId};
 use zfb_server::{outcome_to_events, serve, PageCache, ReloadEvent, ServeOpts};
 
 use crate::cli::DevArgs;
+use crate::commands::resolve::{resolve_port, resolve_under_root};
 use crate::config;
 use crate::output;
 use crate::render_pipeline::{
@@ -116,7 +117,7 @@ pub async fn run(args: &DevArgs) -> Result<()> {
     }
 
     let host = resolve_host(args.host.as_deref(), cfg.host.as_deref());
-    let port = resolve_port(args.port, cfg.port);
+    let port = resolve_port(args.port, cfg.port, DEFAULT_DEV_PORT);
     let addr = resolve_addr(host.as_str(), port)?;
 
     let (tx, _rx) = broadcast::channel::<ReloadEvent>(64);
@@ -409,27 +410,16 @@ fn boot_dev_renderer(
         ));
     }
 
-    let bundler_input = BundlerInput {
-        project_root: project_root.to_path_buf(),
-        pages_dir: PathBuf::from("pages"),
-        content_dir: PathBuf::from("content"),
-        components_dir: PathBuf::from("components"),
-        layouts_dir: PathBuf::from("layouts"),
-        framework: cfg_framework_to_render(cfg.framework),
-        define_vars: Default::default(),
-        tsconfig_paths: Default::default(),
-        external: Vec::new(),
-        outdir: dist_root.join(".zfb-build"),
-        mode: BundleMode::Development,
-        minify: false,
-        esbuild_binary: None,
-        mock_subprocess_output: None,
-        // Dev mode does not embed a content snapshot — runtime paths()
-        // evaluation is a build-mode feature. When dev mode starts the
-        // worker, `getCollection(...)` will see an empty snapshot.
-        content_snapshot_json: None,
-        node_modules_dir: None,
-    };
+    // Dev mode does not embed a content snapshot — runtime paths()
+    // evaluation is a build-mode feature. When dev mode starts the
+    // worker, `getCollection(...)` will see an empty snapshot.
+    let bundler_input = BundlerInput::for_project(
+        project_root.to_path_buf(),
+        cfg_framework_to_render(cfg.framework),
+        BundleMode::Development,
+        dist_root.join(".zfb-build"),
+        None,
+    );
     let bundler_out: BundlerOutput = bundle(bundler_input).context("bundler step failed")?;
 
     let state = start(RendererStartInput {
@@ -501,10 +491,6 @@ fn resolve_host(cli: Option<&str>, cfg: Option<&str>) -> String {
     cli.or(cfg).unwrap_or(DEFAULT_DEV_HOST).to_owned()
 }
 
-fn resolve_port(cli: Option<u16>, cfg: Option<u16>) -> u16 {
-    cli.or(cfg).unwrap_or(DEFAULT_DEV_PORT)
-}
-
 fn resolve_addr(host: &str, port: u16) -> Result<SocketAddr> {
     let pair = format!("{host}:{port}");
     let mut iter = pair
@@ -514,43 +500,10 @@ fn resolve_addr(host: &str, port: u16) -> Result<SocketAddr> {
         .ok_or_else(|| anyhow::anyhow!("no socket addresses resolved for {pair}"))
 }
 
-fn resolve_under_root(project_root: &Path, p: &Path) -> PathBuf {
-    if p.is_absolute() {
-        p.to_path_buf()
-    } else {
-        project_root.join(p)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::path::PathBuf;
-
-    #[test]
-    fn resolve_under_root_joins_relative_paths() {
-        let root = Path::new("/tmp/proj");
-        let p = Path::new("dist");
-        assert_eq!(resolve_under_root(root, p), PathBuf::from("/tmp/proj/dist"));
-    }
-
-    #[test]
-    fn resolve_under_root_joins_nested_relative_paths() {
-        let root = Path::new("/tmp/proj");
-        let p = Path::new("build/out");
-        assert_eq!(
-            resolve_under_root(root, p),
-            PathBuf::from("/tmp/proj/build/out")
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn resolve_under_root_keeps_absolute_paths_as_is() {
-        let root = Path::new("/tmp/proj");
-        let p = Path::new("/var/www/dist");
-        assert_eq!(resolve_under_root(root, p), PathBuf::from("/var/www/dist"));
-    }
 
     #[test]
     fn resolve_host_prefers_cli_over_config() {
@@ -568,35 +521,9 @@ mod tests {
     }
 
     #[test]
-    fn resolve_port_prefers_cli_over_config() {
-        assert_eq!(resolve_port(Some(8080), Some(4000)), 8080);
-    }
-
-    #[test]
-    fn resolve_port_falls_back_to_config_when_cli_absent() {
-        assert_eq!(resolve_port(None, Some(4000)), 4000);
-    }
-
-    #[test]
-    fn resolve_port_falls_back_to_builtin_when_neither_supplied() {
-        assert_eq!(resolve_port(None, None), DEFAULT_DEV_PORT);
-    }
-
-    #[test]
     fn default_watch_roots_includes_zfb_config_json() {
         assert!(DEFAULT_WATCH_ROOTS.contains(&"zfb.config.json"));
         assert!(DEFAULT_WATCH_ROOTS.contains(&"zfb.config.ts"));
-    }
-
-    #[test]
-    fn resolve_under_root_handles_dot_relative() {
-        let root = Path::new("/tmp/proj");
-        let p = Path::new("./public");
-        let resolved = resolve_under_root(root, p);
-        assert!(
-            resolved.starts_with(root),
-            "expected {resolved:?} to start with {root:?}"
-        );
     }
 
     /// The render callback must:

--- a/crates/zfb/src/commands/mod.rs
+++ b/crates/zfb/src/commands/mod.rs
@@ -8,3 +8,4 @@ pub mod check;
 pub mod dev;
 pub mod new;
 pub mod preview;
+pub mod resolve;

--- a/crates/zfb/src/commands/preview.rs
+++ b/crates/zfb/src/commands/preview.rs
@@ -54,6 +54,7 @@ use axum::Router;
 use zfb_build::AdapterChoice;
 
 use crate::cli::PreviewArgs;
+use crate::commands::resolve::{resolve_port, resolve_under_root};
 use crate::config;
 use crate::output;
 
@@ -95,7 +96,7 @@ pub async fn run(args: &PreviewArgs) -> Result<()> {
     //    unambiguous path. CLI wins over config unconditionally — see
     //    the precedence note in the module doc comment.
     let outdir = resolve_under_root(&project_root, &args.outdir);
-    let port = resolve_port(args.port, cfg.port);
+    let port = resolve_port(args.port, cfg.port, DEFAULT_PREVIEW_PORT);
 
     // Verify the output directory exists *before* binding the port so
     // missing-build errors don't leave a half-started server behind.
@@ -328,41 +329,18 @@ async fn not_found_response(dist_root: &Path) -> Response {
         .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
 }
 
-/// Map a file extension to a `Content-Type` value. Mirrors the
-/// short-and-pragmatic mapping in `zfb-server::routes` plus the
-/// extra binary types preview is more likely to need (images, fonts,
-/// wasm). Unknown extensions fall back to `application/octet-stream`
-/// — preview is read-only, so the worst case is a download prompt
-/// rather than a wrong-render bug.
-fn content_type_for_path(path: &Path) -> &'static str {
+/// Map a file path to a `Content-Type` value by delegating to the canonical
+/// [`zfb_server::content_type_for_extension`] helper. That helper handles the
+/// same pragmatic extension set (HTML, CSS, JS, JSON, SVG, images, fonts,
+/// wasm, …) with `mime_guess` as a catch-all fallback; keeping preview on the
+/// same code path avoids the two tables drifting over time.
+fn content_type_for_path(path: &Path) -> String {
+    // Extract the extension without allocating when there is none.
     let ext = path
         .extension()
         .and_then(|e| e.to_str())
-        .unwrap_or("")
-        .to_ascii_lowercase();
-    match ext.as_str() {
-        "html" | "htm" => "text/html; charset=utf-8",
-        "css" => "text/css; charset=utf-8",
-        "js" | "mjs" | "cjs" => "application/javascript; charset=utf-8",
-        "json" | "map" => "application/json",
-        "xml" => "application/xml",
-        "rss" => "application/rss+xml",
-        "atom" => "application/atom+xml",
-        "txt" => "text/plain; charset=utf-8",
-        "svg" => "image/svg+xml",
-        "png" => "image/png",
-        "jpg" | "jpeg" => "image/jpeg",
-        "gif" => "image/gif",
-        "webp" => "image/webp",
-        "avif" => "image/avif",
-        "ico" => "image/x-icon",
-        "wasm" => "application/wasm",
-        "woff" => "font/woff",
-        "woff2" => "font/woff2",
-        "ttf" => "font/ttf",
-        "otf" => "font/otf",
-        _ => "application/octet-stream",
-    }
+        .unwrap_or("");
+    zfb_server::content_type_for_extension(ext)
 }
 
 // ---------------------------------------------------------------------------
@@ -563,22 +541,6 @@ fn build_wrangler_command(
 // Pure helpers
 // ---------------------------------------------------------------------------
 
-/// Resolve `path` against `root` if it is relative; absolute paths are
-/// returned unchanged. Pure path arithmetic — no I/O, so it works
-/// equally for paths that don't yet exist.
-fn resolve_under_root(root: &Path, path: &Path) -> PathBuf {
-    if path.is_absolute() {
-        path.to_path_buf()
-    } else {
-        root.join(path)
-    }
-}
-
-/// Resolution helper: CLI override > config value > built-in default.
-fn resolve_port(cli: Option<u16>, cfg: Option<u16>) -> u16 {
-    cli.or(cfg).unwrap_or(DEFAULT_PREVIEW_PORT)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -588,48 +550,6 @@ mod tests {
     use std::fs;
     use tempfile::TempDir;
     use tower::ServiceExt;
-
-    // ---- pure helpers --------------------------------------------------
-
-    #[test]
-    fn resolve_under_root_joins_relative_paths() {
-        let root = Path::new("/tmp/project");
-        assert_eq!(
-            resolve_under_root(root, Path::new("dist")),
-            PathBuf::from("/tmp/project/dist")
-        );
-        assert_eq!(
-            resolve_under_root(root, Path::new("build/out")),
-            PathBuf::from("/tmp/project/build/out")
-        );
-    }
-
-    #[test]
-    fn resolve_under_root_passes_absolute_paths_through() {
-        let root = Path::new("/tmp/project");
-        let abs = if cfg!(windows) {
-            PathBuf::from("C:/elsewhere/dist")
-        } else {
-            PathBuf::from("/elsewhere/dist")
-        };
-        assert_eq!(resolve_under_root(root, &abs), abs);
-    }
-
-    #[test]
-    fn resolve_port_prefers_cli_over_config() {
-        assert_eq!(resolve_port(Some(9000), Some(4000)), 9000);
-    }
-
-    #[test]
-    fn resolve_port_falls_back_to_config_when_cli_absent() {
-        assert_eq!(resolve_port(None, Some(4000)), 4000);
-    }
-
-    #[test]
-    fn resolve_port_falls_back_to_builtin_when_neither_supplied() {
-        assert_eq!(resolve_port(None, None), DEFAULT_PREVIEW_PORT);
-        assert_eq!(DEFAULT_PREVIEW_PORT, 4321);
-    }
 
     // ---- path safety ---------------------------------------------------
 

--- a/crates/zfb/src/commands/resolve.rs
+++ b/crates/zfb/src/commands/resolve.rs
@@ -1,0 +1,116 @@
+//! Shared path and port resolution helpers for the `build`, `dev`, and
+//! `preview` commands.
+//!
+//! All three commands share the same logic for resolving user-supplied paths
+//! against the project root and for picking a port using the
+//! CLI > config > built-in-default precedence rule. Centralising the helpers
+//! here prevents the implementations from drifting independently and gives
+//! one place to add tests.
+
+use std::path::{Path, PathBuf};
+
+/// Resolve `path` against `root` if it is relative; absolute paths are
+/// returned unchanged. Pure path arithmetic — no I/O, so it works equally
+/// for paths that do not yet exist.
+pub fn resolve_under_root(root: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        root.join(path)
+    }
+}
+
+/// Alias of [`resolve_under_root`] for the `build` command context where
+/// the resolved value is specifically the output directory.
+pub fn resolve_outdir(root: &Path, path: &Path) -> PathBuf {
+    resolve_under_root(root, path)
+}
+
+/// CLI override > config value > built-in default precedence rule.
+///
+/// `default_port` is the caller's built-in constant (e.g. `DEFAULT_DEV_PORT`
+/// in `dev.rs` or `DEFAULT_PREVIEW_PORT` in `preview.rs`). Passing the
+/// default explicitly keeps this function pure and avoids coupling it to
+/// either command's constant.
+pub fn resolve_port(cli: Option<u16>, cfg: Option<u16>, default_port: u16) -> u16 {
+    cli.or(cfg).unwrap_or(default_port)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- resolve_under_root / resolve_outdir --------------------------------
+
+    #[test]
+    fn resolve_under_root_joins_relative_paths_onto_root() {
+        let root = Path::new("/tmp/proj");
+        assert_eq!(
+            resolve_under_root(root, Path::new("dist")),
+            PathBuf::from("/tmp/proj/dist")
+        );
+        assert_eq!(
+            resolve_under_root(root, Path::new("build/out")),
+            PathBuf::from("/tmp/proj/build/out")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_under_root_keeps_absolute_paths_as_is() {
+        let root = Path::new("/tmp/proj");
+        assert_eq!(
+            resolve_under_root(root, Path::new("/var/www/dist")),
+            PathBuf::from("/var/www/dist")
+        );
+    }
+
+    #[test]
+    fn resolve_under_root_handles_dot_relative() {
+        let root = Path::new("/tmp/proj");
+        let resolved = resolve_under_root(root, Path::new("./public"));
+        assert!(
+            resolved.starts_with(root),
+            "expected {resolved:?} to start with {root:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_outdir_joins_relative_paths_onto_root() {
+        let root = Path::new("/proj");
+        assert_eq!(
+            resolve_outdir(root, Path::new("dist")),
+            PathBuf::from("/proj/dist")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_outdir_keeps_absolute_paths_as_is() {
+        let root = Path::new("/proj");
+        assert_eq!(
+            resolve_outdir(root, Path::new("/tmp/zfb-out")),
+            PathBuf::from("/tmp/zfb-out")
+        );
+    }
+
+    // ---- resolve_port -------------------------------------------------------
+
+    #[test]
+    fn resolve_port_prefers_cli_over_config() {
+        assert_eq!(resolve_port(Some(8080), Some(4000), 3000), 8080);
+    }
+
+    #[test]
+    fn resolve_port_falls_back_to_config_when_cli_absent() {
+        assert_eq!(resolve_port(None, Some(4000), 3000), 4000);
+    }
+
+    #[test]
+    fn resolve_port_falls_back_to_builtin_when_neither_supplied() {
+        // The default is chosen by the caller; test with the two
+        // concrete built-in values used by dev (3000) and preview (4321).
+        assert_eq!(resolve_port(None, None, 3000), 3000);
+        assert_eq!(resolve_port(None, None, 4321), 4321);
+    }
+}

--- a/crates/zfb/src/render_pipeline.rs
+++ b/crates/zfb/src/render_pipeline.rs
@@ -70,9 +70,9 @@ use zfb_router::{Route, RouteKind, Segment};
 /// Carries enough metadata for [`expand_dynamic_routes`] to:
 ///
 /// 1. Read the source file and try static `paths()` extraction.
-/// 2. Convert the parsed segments to
-///    [`zfb_render::paths::Segment`] so [`zfb_render::paths::resolve_paths`]
-///    can reassemble the URLs.
+/// 2. Pass the segments (now shared [`zfb_types::Segment`], re-exported
+///    by both `zfb_router` and `zfb_render`) to
+///    [`zfb_render::paths::resolve_paths`] for URL reassembly.
 /// 3. Honour the route's filename-convention `output_extension` when
 ///    deriving each resolved entry's output path (e.g. a dynamic
 ///    `[slug].xml.tsx` should still produce `<slug>.xml`, not
@@ -269,7 +269,7 @@ fn try_expand_one(
     let segs: Vec<PathsSegment> = route
         .segments
         .iter()
-        .map(router_segment_to_paths_segment)
+        .cloned()
         .collect();
     let resolved = resolve_paths(cache, &route.template, &segs, &json)
         .map_err(|e| format!("{}: {}", abs.display(), format_paths_error(&e)))?;
@@ -286,19 +286,6 @@ fn try_expand_one(
         });
     }
     Ok(out)
-}
-
-/// Convert a `zfb_router::Segment` (the canonical router segment) into
-/// the local stub used by [`zfb_render::paths::Segment`]. The variants
-/// match exactly today; the conversion exists because `zfb-render` does
-/// not depend on `zfb-router` (per the deliberate cyclical-dep
-/// avoidance in the workspace layout).
-fn router_segment_to_paths_segment(seg: &Segment) -> PathsSegment {
-    match seg {
-        Segment::Static(s) => PathsSegment::Static(s.clone()),
-        Segment::Dynamic(name) => PathsSegment::Dynamic(name.clone()),
-        Segment::Catchall(name) => PathsSegment::Catchall(name.clone()),
-    }
 }
 
 /// Compute the on-disk output path for a resolved dynamic URL, mirroring
@@ -490,7 +477,7 @@ fn eval_one_deferred_path(
     let segs: Vec<PathsSegment> = route
         .segments
         .iter()
-        .map(router_segment_to_paths_segment)
+        .cloned()
         .collect();
 
     let resolved = resolve_paths(cache, &route.template, &segs, &json)

--- a/packages/zfb/src/__tests__/island.test.ts
+++ b/packages/zfb/src/__tests__/island.test.ts
@@ -9,6 +9,7 @@ import {
   resolveWhen,
 } from "../island.js";
 import { DEFAULT_WHEN, isWhen, WHEN_VALUES } from "../types.js";
+import type { VNodeObject } from "../jsx-types.js";
 
 /**
  * Build a minimal, JSX-runtime-agnostic VNode.
@@ -17,7 +18,10 @@ import { DEFAULT_WHEN, isWhen, WHEN_VALUES } from "../types.js";
  * mirror the shape both Preact and React produce so the test does not
  * depend on either framework being installed.
  */
-function vnode(type: unknown, props: Record<string, unknown> = {}) {
+function vnode(
+  type: string | ((...args: unknown[]) => unknown),
+  props: Record<string, unknown> = {},
+): VNodeObject {
   return { type, props, key: null };
 }
 
@@ -148,7 +152,7 @@ describe("captureComponentName", () => {
   });
 
   it("falls back to Anonymous for arrow functions with no name and no displayName", () => {
-    const anon = (() => null) as unknown;
+    const anon = (() => null) as (...args: unknown[]) => unknown;
     Object.defineProperty(anon, "name", { value: "" });
     expect(captureComponentName(vnode(anon))).toBe(ANONYMOUS_COMPONENT_NAME);
   });

--- a/packages/zfb/src/__tests__/livereload.test.ts
+++ b/packages/zfb/src/__tests__/livereload.test.ts
@@ -64,7 +64,7 @@ describe("livereload.js SSE consumer — islands wire contract", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
-    delete (window as Record<string, unknown>)["__zfbIslandsReload"];
+    delete (window as unknown as Record<string, unknown>)["__zfbIslandsReload"];
   });
 
   it("empty component triggers bundle re-import keyed by bundleUrl (core contract)", () => {
@@ -73,7 +73,7 @@ describe("livereload.js SSE consumer — islands wire contract", () => {
     // consumer must still fire __zfbIslandsReload / dynamic-import using bundleUrl.
     // If a future refactor short-circuits on component=="" this test must FAIL.
     const hook = vi.fn();
-    (window as Record<string, unknown>)["__zfbIslandsReload"] = hook;
+    (window as unknown as Record<string, unknown>)["__zfbIslandsReload"] = hook;
 
     src.dispatch("islands", JSON.stringify({ bundleUrl: "/assets/islands-abc.js", component: "" }));
 
@@ -87,7 +87,7 @@ describe("livereload.js SSE consumer — islands wire contract", () => {
 
   it("named component also triggers the hook (normal hot-swap path)", () => {
     const hook = vi.fn();
-    (window as Record<string, unknown>)["__zfbIslandsReload"] = hook;
+    (window as unknown as Record<string, unknown>)["__zfbIslandsReload"] = hook;
 
     src.dispatch(
       "islands",
@@ -102,7 +102,7 @@ describe("livereload.js SSE consumer — islands wire contract", () => {
 
   it("missing bundleUrl is silently ignored (no crash, no hook call)", () => {
     const hook = vi.fn();
-    (window as Record<string, unknown>)["__zfbIslandsReload"] = hook;
+    (window as unknown as Record<string, unknown>)["__zfbIslandsReload"] = hook;
 
     // Only component, no bundleUrl — the handler bails early
     src.dispatch("islands", JSON.stringify({ component: "Counter" }));
@@ -113,7 +113,7 @@ describe("livereload.js SSE consumer — islands wire contract", () => {
   it("malformed JSON payload is silently ignored (no crash)", () => {
     const hook = vi.fn();
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    (window as Record<string, unknown>)["__zfbIslandsReload"] = hook;
+    (window as unknown as Record<string, unknown>)["__zfbIslandsReload"] = hook;
 
     expect(() => src.dispatch("islands", "not-json{{{")).not.toThrow();
     expect(hook).not.toHaveBeenCalled();

--- a/packages/zfb/src/__tests__/livereload.test.ts
+++ b/packages/zfb/src/__tests__/livereload.test.ts
@@ -1,0 +1,123 @@
+// Pin the SSE wire contract between the Rust emitter (livereload.rs) and the
+// browser consumer (crates/zfb-server/src/livereload.js).
+//
+// The critical invariant: when the islands bundle changes via a runtime-only
+// diff, the Rust side emits component="" (empty string) because it doesn't know
+// which components were affected. The JS consumer must NOT short-circuit on an
+// empty component — it reads only `bundleUrl` to build the swap URL and must
+// still trigger the full bundle re-import.
+//
+// These tests exercise the actual livereload.js source so that a future refactor
+// which starts rejecting component=="" will fail here immediately.
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+// Cross-package path: from packages/zfb/src/__tests__/ up to the worktree root,
+// then into the Rust crate that owns the browser-side SSE client.
+const LIVERELOAD_JS = resolve(here, "../../../../crates/zfb-server/src/livereload.js");
+
+type EventHandler = (ev: { data: string }) => void;
+
+interface FakeSourceInstance {
+  dispatch(event: string, data: string): void;
+}
+
+function setupLivereloadScript(): FakeSourceInstance {
+  const listeners: Record<string, EventHandler[]> = {};
+
+  function FakeEventSource(_url: string) {
+    return {
+      addEventListener(name: string, handler: EventHandler) {
+        listeners[name] ??= [];
+        listeners[name].push(handler);
+      },
+    };
+  }
+
+  vi.stubGlobal("EventSource", FakeEventSource);
+
+  // Execute livereload.js in the global scope via new Function so the IIFE
+  // sees window (set by happy-dom) and our stubbed EventSource.
+  const code = readFileSync(LIVERELOAD_JS, "utf-8");
+  new Function(code)();
+
+  return {
+    dispatch(event: string, data: string) {
+      for (const fn of listeners[event] ?? []) {
+        fn({ data });
+      }
+    },
+  };
+}
+
+describe("livereload.js SSE consumer — islands wire contract", () => {
+  let src: FakeSourceInstance;
+
+  beforeEach(() => {
+    src = setupLivereloadScript();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete (window as Record<string, unknown>)["__zfbIslandsReload"];
+  });
+
+  it("empty component triggers bundle re-import keyed by bundleUrl (core contract)", () => {
+    // This is the critical regression guard. The Rust emitter sends component=""
+    // when only a runtime-only file changed (no specific component known). The
+    // consumer must still fire __zfbIslandsReload / dynamic-import using bundleUrl.
+    // If a future refactor short-circuits on component=="" this test must FAIL.
+    const hook = vi.fn();
+    (window as Record<string, unknown>)["__zfbIslandsReload"] = hook;
+
+    src.dispatch("islands", JSON.stringify({ bundleUrl: "/assets/islands-abc.js", component: "" }));
+
+    expect(hook).toHaveBeenCalledTimes(1);
+    const [component, swapUrl] = hook.mock.calls[0] as [string, string];
+    // Consumer passes component through unchanged — empty string is fine
+    expect(component).toBe("");
+    // swapUrl is bundleUrl with a ?v=<timestamp> cache-buster appended
+    expect(swapUrl).toMatch(/^\/assets\/islands-abc\.js\?v=\d+$/);
+  });
+
+  it("named component also triggers the hook (normal hot-swap path)", () => {
+    const hook = vi.fn();
+    (window as Record<string, unknown>)["__zfbIslandsReload"] = hook;
+
+    src.dispatch(
+      "islands",
+      JSON.stringify({ bundleUrl: "/assets/islands-abc.js", component: "Counter" }),
+    );
+
+    expect(hook).toHaveBeenCalledTimes(1);
+    const [component, swapUrl] = hook.mock.calls[0] as [string, string];
+    expect(component).toBe("Counter");
+    expect(swapUrl).toMatch(/^\/assets\/islands-abc\.js\?v=\d+$/);
+  });
+
+  it("missing bundleUrl is silently ignored (no crash, no hook call)", () => {
+    const hook = vi.fn();
+    (window as Record<string, unknown>)["__zfbIslandsReload"] = hook;
+
+    // Only component, no bundleUrl — the handler bails early
+    src.dispatch("islands", JSON.stringify({ component: "Counter" }));
+
+    expect(hook).not.toHaveBeenCalled();
+  });
+
+  it("malformed JSON payload is silently ignored (no crash)", () => {
+    const hook = vi.fn();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    (window as Record<string, unknown>)["__zfbIslandsReload"] = hook;
+
+    expect(() => src.dispatch("islands", "not-json{{{")).not.toThrow();
+    expect(hook).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/86
- parent PR
    - https://github.com/Takazudo/zudo-front-builder/pull/64

---

## Summary

- Apply 5 deferred polish items from `/deep-review` on PR #64 (originally tracked under #80, now closed) — pure cleanup, refactors, contract pinning, and a test-fixture typing fix
- Targets `topic/review-loop-polish` (PR #64's branch), so the polish flows into PR #64 → `main`
- Verified locally: 863 Rust tests + 98 TS tests passing; typecheck clean; `gcoc-review` on the combined diff returned "all clear"

## Changes

### Refactors

- **#87 — Deduplicate CLI helpers (`78e27dc`)**
  - Extract `resolve_under_root`, `resolve_port`, `resolve_outdir` into the new `crates/zfb/src/commands/resolve.rs`. Consolidates three near-identical copies (across `build.rs`, `dev.rs`, `preview.rs`) plus their per-file test modules into one shared module.
  - Replace local `content_type_for_path` in `preview.rs` with delegation to the public `zfb_server::routes::content_type_for_extension`. Eliminates a hand-curated table that was drifting from the server's.
  - Add `BundlerInput::for_project(project_root, framework, mode, outdir, content_snapshot_json)` factory in `crates/zfb-build/src/bundler.rs`. `build.rs` and `dev.rs` now call it and override only their distinctive fields (Production vs Development mode, snapshot embedding). Prevents drift the next time a `BundlerInput` field is added.

- **#88 — Remove identity `router_segment_to_paths_segment` (`2503319`)**
  - After PR #73 canonicalised `Segment` into `zfb-types`, the conversion at `crates/zfb/src/render_pipeline.rs:296` became identity-with-clone. Remove the function and its 2 call sites; replace with `.cloned()`.
  - Refresh the stale doc comment that still claimed `zfb_render::paths::Segment` was a "local stub" to avoid a cyclical dep.

### Contract pinning + tests

- **#89 — Pin SSE empty-component reload contract (`02c0fb8`)**
  - Rust emitter test in `crates/zfb-server/src/livereload.rs`: asserts `outcome_to_events` emits exactly one `ReloadEvent::Islands { component: "", bundle_url }` when `outcome.islands_bundle.changed = true` and `components.is_empty()`. Fails if the empty-component branch is removed.
  - JS consumer regression guard in `packages/zfb/src/__tests__/livereload.test.ts` (vitest + happy-dom): loads `livereload.js` via `readFileSync` + `new Function(code)()` into the test global, stubs `EventSource`, dispatches synthetic `islands` events, asserts `__zfbIslandsReload` is invoked with the swap URL even when `component` is empty. Fails if a future client refactor short-circuits on `component === ""`.
  - One-line wire-contract comments in both `livereload.rs` and `livereload.js`: "empty component means reload-the-whole-bundle by re-importing `bundleUrl`; consumer must NOT short-circuit."

- **#90 — Positive tests for symlinked `dist_root` (`10eab5e`)**
  - Investigated the alleged walk-up symlink false-positive in `crates/zfb-build/src/atomic.rs` `validate_output_path`. **No false-positive reproduced** — the dual-check at line 164 (`starts_with(dist_root) || starts_with(canon_root)`) correctly handles all three cases.
  - Added 4 positive `#[cfg(unix)]` tests pinning the dual-check guarantee: `accepts_symlinked_dist_root_via_symlink_path`, `..._via_canonical_path`, `..._with_missing_child_components`, and `accepts_inner_symlink_pointing_inside_dist`.

### Test fixture fix

- **#91 — Tighten `vnode` factory typing (`995771a`)**
  - `packages/zfb/src/__tests__/island.test.ts` had 9 TS2322 errors against `VNodeObject` after BCI-4 type tightening (the `vnode(type: unknown, ...)` factory no longer satisfied `VNodeObject.type`).
  - Tighten the factory to `vnode(type: string \| ((...args: unknown[]) => unknown), ...): VNodeObject`. Drops the count from 9 to 0 with no `as VNode` / `as any` casts.

### Manager fix (cross-topic regression)

- **`fix(test): two-step cast for window` (`218529d`)**
  - After merging #89, `livereload.test.ts` introduced 5 TS2352 errors (`Conversion of type 'Window & typeof globalThis' to type 'Record<string, unknown>'`) that no individual topic saw because each was clean in isolation. Fixed with the suggested `as unknown as Record<...>` two-step cast in 5 places.

## Test Plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` — 863 passed, 0 failed, 11 ignored
- [x] `pnpm --filter @takazudo/zfb typecheck` — 0 errors
- [x] `pnpm --filter @takazudo/zfb test` — 98/98 passing (94 existing + 4 new in `livereload.test.ts`)
- [x] `gcoc-review` on the combined 5-topic diff — all clear, no high/medium/low findings
- [ ] CI on PR #64 (after this merges into `topic/review-loop-polish`) — workflows fire only on `main`-targeted PRs, so this PR has no checks of its own

## Closes

- #86 (epic)
- #87, #88, #89, #90, #91 (sub-issues — closed via `/pr-complete -c -w` after merge)