### PR TITLE
fix(content): activate mdx_esm_parse so named imports are stripped not rendered

### DIFF
--- a/crates/zfb-content/src/mdx_jsx_emit.rs
+++ b/crates/zfb-content/src/mdx_jsx_emit.rs
@@ -101,7 +101,25 @@ fn mdx_to_jsx_module_inner(
     opts: MdxJsxOptions,
     pipeline: Option<&mut Pipeline>,
 ) -> Result<String, PipelineError> {
-    let parse_options = markdown::ParseOptions::mdx();
+    // `ParseOptions::mdx()` enables the `mdx_esm` construct but does NOT
+    // activate it: the construct's start state checks `mdx_esm_parse.is_some()`
+    // before firing (see markdown-rs `crates/zfb-content/construct/mdx_esm.rs`).
+    // Without a parse function, `import { Foo } from "pkg"` is parsed as a
+    // Paragraph — the `{ Foo }` becomes an MdxTextExpression, leaving the
+    // skeletal text visible in the rendered output.
+    //
+    // We supply a permissive parser that always returns Ok. zfb does not need
+    // to validate ESM syntax here — the bundler (SWC) handles that later. All
+    // we need is for import/export statements to be classified as MdxjsEsm
+    // nodes so the emitter can silently drop them (they fall through to the
+    // `_ => String::new()` catch-all in `emit_node`).
+    let parse_options = markdown::ParseOptions {
+        constructs: markdown::Constructs::mdx(),
+        mdx_esm_parse: Some(Box::new(|_value: &str| -> markdown::MdxSignal {
+            markdown::MdxSignal::Ok
+        })),
+        ..markdown::ParseOptions::default()
+    };
     let mut root = markdown::to_mdast(input, &parse_options).map_err(|m| {
         // markdown-rs's Display already emits "line:col-line:col: reason".
         PipelineError::Parse(format!("{}: {m}", opts.filename))
@@ -1118,4 +1136,5 @@ mod tests {
         // Source survives, double-quote-escaped inside the JS literal.
         assert!(out.contains("<style>"), "got: {out}");
     }
+
 }

--- a/crates/zfb-content/tests/mdx_jsx_emit.rs
+++ b/crates/zfb-content/tests/mdx_jsx_emit.rs
@@ -272,6 +272,95 @@ fn default_components_are_alphabetised_and_unique() {
 }
 
 // ───────────────────────────────────────────────────────────────────
+// ESM import stripping (B-14-5 regression tests)
+//
+// markdown-rs requires `mdx_esm_parse` to be Some for the MdxjsEsm
+// construct to activate. Without it, import statements fall through
+// to Paragraph parsing: `import { Foo } from "pkg"` becomes a
+// paragraph where `{ Foo }` is an MdxTextExpression that evaluates to
+// the `Foo` identifier (undefined at runtime → empty string in the
+// rendered output, leaving the double-space skeleton visible).
+// ───────────────────────────────────────────────────────────────────
+
+/// Default import (`import X from 'pkg'`) must be stripped from output
+/// and must not appear inside the rendered JSX body.
+#[test]
+fn esm_default_import_is_stripped() {
+    let out = emit("import PresetGenerator from '@/components/preset-generator';\n\nhello\n");
+    // The import keyword and module specifier must NOT leak into the body.
+    assert!(
+        !out.contains("import PresetGenerator"),
+        "default import leaked into JSX output:\n{out}"
+    );
+    assert!(
+        !out.contains("components/preset-generator"),
+        "module path leaked into JSX output:\n{out}"
+    );
+    // The rest of the document still renders.
+    assert!(out.contains("\"hello\""), "body text missing:\n{out}");
+}
+
+/// Named import (`import { X } from 'pkg'`) must be stripped, not rendered
+/// as a paragraph. Before the fix, `{ X }` was parsed as an MdxTextExpression
+/// inside a Paragraph, producing `import  from "pkg"` (double-space) in the
+/// rendered output.
+#[test]
+fn esm_named_import_is_stripped() {
+    let out = emit("import { Island } from \"@takazudo/zfb\";\n\nhello\n");
+    // The source import must not appear in the JSX body. Check for the
+    // module specifier (not just "import" which also appears in the React
+    // preamble `import { Fragment as _Fragment } from "react/jsx-runtime"`).
+    assert!(
+        !out.contains("@takazudo/zfb"),
+        "module specifier leaked into JSX output:\n{out}"
+    );
+    // The "import " text (with trailing space as it appears in the source
+    // paragraph form) must not appear in the rendered body.
+    assert!(
+        !out.contains("\"import "),
+        "import text leaked as JS string literal:\n{out}"
+    );
+    // Body still renders.
+    assert!(out.contains("\"hello\""), "body text missing:\n{out}");
+}
+
+/// Two consecutive imports (default then named) must both be stripped.
+/// This is the exact pattern from /docs/getting-started/setup-preset-generator.
+#[test]
+fn esm_two_consecutive_imports_are_stripped() {
+    let src = "import PresetGenerator from '@/components/preset-generator';\nimport { Island } from \"@takazudo/zfb\";\n\nhello\n";
+    let out = emit(src);
+    // Neither module specifier must appear in the output body.
+    assert!(
+        !out.contains("preset-generator"),
+        "preset-generator module path leaked:\n{out}"
+    );
+    assert!(
+        !out.contains("@takazudo/zfb"),
+        "@takazudo/zfb module specifier leaked:\n{out}"
+    );
+    // The import text must not appear as a JS string literal (which would
+    // indicate it was emitted inside a paragraph).
+    assert!(
+        !out.contains("\"import "),
+        "import text leaked as JS string literal:\n{out}"
+    );
+    // Body still renders.
+    assert!(out.contains("\"hello\""), "body text missing:\n{out}");
+}
+
+/// ESM export statements must also be stripped (export const, export default, etc.).
+#[test]
+fn esm_export_statement_is_stripped() {
+    let out = emit("export const version = '1.0.0';\n\nhello\n");
+    assert!(
+        !out.contains("export const version"),
+        "export statement leaked:\n{out}"
+    );
+    assert!(out.contains("\"hello\""), "body text missing:\n{out}");
+}
+
+// ───────────────────────────────────────────────────────────────────
 // Error-path tests
 // ───────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

When MDX source contains `import { Island } from "@takazudo/zfb"`, the named import binding was stripped from the rendered output while leaving a visible skeleton `import  from "@takazudo/zfb"` (double-space) as a `<p>` element in the page.

**Root cause:** `markdown-rs` requires `mdx_esm_parse` to be `Some` for the `MdxjsEsm` construct to activate. The construct's `start` state function guards:
```rust
&& tokenizer.parse_state.options.mdx_esm_parse.is_some()
```
Without this guard, `import { Named } from "pkg"` falls through to Paragraph parsing. The `{ Named }` part becomes an `MdxTextExpression` that evaluates to the identifier `Named` at runtime — `undefined` in this context — so React/Preact renders it as an empty string, leaving the double-space skeleton.

## Fix

Supply a permissive `mdx_esm_parse` function (always returns `Ok`) in the `ParseOptions` used by `mdx_to_jsx_module_inner`. zfb doesn't need to validate ESM syntax here — SWC handles that in the bundler step. The only requirement is that import/export lines get classified as `MdxjsEsm` nodes so the emitter drops them via the `_ => String::new()` catch-all.

## Tests

Added 4 regression tests in `tests/mdx_jsx_emit.rs`:
- `esm_default_import_is_stripped` — default import (`import X from 'pkg'`)
- `esm_named_import_is_stripped` — named import (`import { X } from 'pkg'`)
- `esm_two_consecutive_imports_are_stripped` — exact pattern from `/docs/getting-started/setup-preset-generator`
- `esm_export_statement_is_stripped` — export statements

## Context

This fixes zudolab/zudo-doc#914 (Phase B-14-5 of the Astro→zfb migration parity harness).