### PR TITLE
fix(mdx): emit remark-math $$/$ blocks as KaTeX-friendly elements (#93)

### DIFF
--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -952,21 +952,23 @@ fn materialise_collection(
                 .with_context(|| format!("write compiled mdx to {}", to.display()))?;
 
             // Defensive skip — see [`jsx_likely_breaks_downstream_parser`].
-            // The MDX → JSX emitter does not understand `remark-math`-flavoured
-            // `$$...$$` blocks, so LaTeX content ends up emitted as raw
-            // JSX expression containers like `{\infty}` / `{-\infty}` —
-            // syntactically invalid JS that esbuild rejects, aborting
-            // the entire bundle. Rather than fail every build that
-            // happens to ship one math file, omit the broken module
-            // from the bridge map: the page that consumes it falls
-            // back to the `<pre data-zfb-content-fallback>` shape
-            // (matching the pre-S4e behaviour for ALL pages, scoped
-            // here to the unparseable subset only). The shadow file
-            // is left on disk so downstream debugging can see the
-            // emitter output.
+            // The original trigger for this guard was `remark-math`
+            // `$$...$$` blocks leaking into the JSX as bare expression
+            // containers like `{\infty}` (zfb#93). The emitter now
+            // recognises `Math` / `InlineMath` mdast nodes natively
+            // (see `crates/zfb-content/src/mdx_jsx_emit.rs`), so the
+            // intended math path no longer trips this heuristic. We
+            // keep the skip in place as a defensive net for any
+            // future leak — bare `{\foo}` expressions in the emitted
+            // JSX are unparseable by esbuild and would abort the
+            // whole bundle. When the heuristic does fire, omitting
+            // the broken module from the bridge map falls the page
+            // back to the `<pre data-zfb-content-fallback>` shape;
+            // the shadow file is left on disk so downstream debugging
+            // can see the emitter output.
             if jsx_likely_breaks_downstream_parser(&compiled.jsx_source) {
                 eprintln!(
-                    "zfb bundler: skipping MDX content bridge for {} — compiled JSX contains expressions that downstream parsers (esbuild) cannot accept (likely LaTeX without remark-math). The page will render via the <pre data-zfb-content-fallback> shape.",
+                    "zfb bundler: skipping MDX content bridge for {} — compiled JSX contains bare `{{\\letter}}` expressions that esbuild rejects. The page will render via the <pre data-zfb-content-fallback> shape.",
                     from.display(),
                 );
                 continue;

--- a/crates/zfb-content/src/mdx_jsx_emit.rs
+++ b/crates/zfb-content/src/mdx_jsx_emit.rs
@@ -113,8 +113,21 @@ fn mdx_to_jsx_module_inner(
     // we need is for import/export statements to be classified as MdxjsEsm
     // nodes so the emitter can silently drop them (they fall through to the
     // `_ => String::new()` catch-all in `emit_node`).
+    // `math_flow` / `math_text` aren't part of `Constructs::mdx()` by
+    // default. We turn them on so `$$...$$` and `$...$` blocks parse
+    // into proper `Math` / `InlineMath` mdast nodes (see the dedicated
+    // arms in `emit_node` below). Without these, the LaTeX content
+    // would leak into the emitted JSX as bare expression containers
+    // like `{\infty}` — syntactically invalid JS that esbuild rejects,
+    // forcing the bundler's defensive skip in
+    // `crates/zfb-build/src/bundler.rs` to fall the whole page back to
+    // `<pre data-zfb-content-fallback>`. See zfb#93.
     let parse_options = markdown::ParseOptions {
-        constructs: markdown::Constructs::mdx(),
+        constructs: markdown::Constructs {
+            math_flow: true,
+            math_text: true,
+            ..markdown::Constructs::mdx()
+        },
         mdx_esm_parse: Some(Box::new(|_value: &str| -> markdown::MdxSignal {
             markdown::MdxSignal::Ok
         })),
@@ -306,6 +319,14 @@ fn push_inline_text(node: &MdastNode, out: &mut String) {
         }
         MdastNode::Image(i) => out.push_str(&i.alt),
         MdastNode::Break(_) => out.push(' '),
+        // Math nodes contribute their raw LaTeX as plain text — best
+        // available projection for a TOC entry like `## Limit as $x \to
+        // \infty$`. `extract_text` over the rendered `<code class="math
+        // math-inline">…raw LaTeX…</code>` would surface the same
+        // bytes, so this keeps `headings[i].text` consistent with the
+        // rendered DOM.
+        MdastNode::Math(m) => out.push_str(&m.value),
+        MdastNode::InlineMath(m) => out.push_str(&m.value),
         // Everything else (MDX expressions, raw HTML literals, JSX
         // elements, …) contributes no plain text — TOCs cannot do
         // anything useful with `{count}` or `<Note/>` tokens.
@@ -467,9 +488,36 @@ impl JsxEmitter {
             }
             MdastNode::MdxFlowExpression(e) => format!("{{{}}}", e.value),
             MdastNode::MdxTextExpression(e) => format!("{{{}}}", e.value),
+            // remark-math `$$...$$` block. Mirrors the shape
+            // markdown-rs's HTML serializer (`on_enter_raw_flow`)
+            // produces — `<pre><code class="language-math math-display">`
+            // — routed through `_components` so MDX consumers can still
+            // override `<pre>` / `<code>`. The LaTeX body goes in as a
+            // JS string literal (`{"…"}`) so backslash sequences never
+            // surface as raw JSX expressions, which is the bug in #93.
+            // Client-side KaTeX auto-render keys on `math-display`.
+            MdastNode::Math(m) => {
+                self.html_tags.insert("pre".to_string());
+                self.html_tags.insert("code".to_string());
+                format!(
+                    "<_components.pre><_components.code className=\"language-math math-display\">{}</_components.code></_components.pre>",
+                    js_string_literal_in_braces(&m.value),
+                )
+            }
+            // remark-math `$...$` inline. Same shape as inline code
+            // with an added `language-math math-inline` class — the
+            // companion to `Math` above and to markdown-rs's
+            // `on_enter_raw_text` HTML output.
+            MdastNode::InlineMath(m) => {
+                self.html_tags.insert("code".to_string());
+                format!(
+                    "<_components.code className=\"language-math math-inline\">{}</_components.code>",
+                    js_string_literal_in_braces(&m.value),
+                )
+            }
             // Unhandled node kinds (tables, footnotes, definitions,
-            // math, references, ESM, frontmatter, …) emit nothing
-            // rather than panicking. Sub 4+ can broaden coverage.
+            // references, ESM, frontmatter, …) emit nothing rather
+            // than panicking. Sub 4+ can broaden coverage.
             _ => String::new(),
         }
     }
@@ -1137,4 +1185,70 @@ mod tests {
         assert!(out.contains("<style>"), "got: {out}");
     }
 
+    /// Block math (`$$...$$`) emits a `<pre><code class="language-math
+    /// math-display">…</code></pre>` shape with the LaTeX wrapped as a
+    /// JS string literal — never as a bare `{\foo}` JSX expression.
+    /// This is the headline regression test for zfb#93.
+    #[test]
+    fn block_math_emits_safe_jsx_with_display_class() {
+        let src = "$$\n\\int_{-\\infty}^{\\infty} f(x)\\,dx\n$$\n";
+        let out = emit(src);
+        assert!(
+            out.contains("language-math math-display"),
+            "missing math-display class: {out}"
+        );
+        assert!(
+            out.contains("<_components.pre><_components.code"),
+            "math should route through _components.pre/code: {out}"
+        );
+        // The LaTeX body is wrapped in a JS string literal — the
+        // backslashes must be doubled, not bare. If any bare `{\letter}`
+        // pattern leaked through, the bundler heuristic
+        // `jsx_likely_breaks_downstream_parser` would skip the bridge.
+        assert!(
+            out.contains("\\\\int_"),
+            "expected backslash-escaped LaTeX inside JS string: {out}"
+        );
+        assert!(
+            !out.contains("{\\int") && !out.contains("{-\\infty}"),
+            "raw LaTeX leaked into JSX expression containers: {out}"
+        );
+    }
+
+    /// Inline math (`$x$`) emits a single `<code class="language-math
+    /// math-inline">…</code>` with the LaTeX as a JS string literal.
+    #[test]
+    fn inline_math_emits_safe_jsx_with_inline_class() {
+        let src = "When $x \\to \\infty$ the limit holds.\n";
+        let out = emit(src);
+        assert!(
+            out.contains("language-math math-inline"),
+            "missing math-inline class: {out}"
+        );
+        assert!(
+            out.contains("<_components.code className=\"language-math math-inline\">"),
+            "inline math should route through _components.code with class: {out}"
+        );
+        // Same bare-backslash safety check as block math.
+        assert!(
+            !out.contains("{\\to") && !out.contains("{\\infty}"),
+            "raw LaTeX leaked into JSX expression containers: {out}"
+        );
+    }
+
+    /// Headings with inline math contribute the raw LaTeX as plain
+    /// text in the `headings` projection. Without this, the slug for
+    /// `## Limit as $x \\to \\infty$` would drop the math entirely
+    /// (everything after `Limit as `), producing a slug that no longer
+    /// matches what a runtime TOC consumer expects.
+    #[test]
+    fn heading_with_inline_math_keeps_latex_in_text_projection() {
+        let src = "## Limit as $x \\to \\infty$\n";
+        let out = emit(src);
+        // The plain-text projection includes the raw LaTeX body.
+        assert!(
+            out.contains("text: \"Limit as x \\\\to \\\\infty\""),
+            "expected LaTeX in heading text projection: {out}"
+        );
+    }
 }

--- a/crates/zfb-content/src/mdx_jsx_emit.rs
+++ b/crates/zfb-content/src/mdx_jsx_emit.rs
@@ -122,6 +122,11 @@ fn mdx_to_jsx_module_inner(
     // forcing the bundler's defensive skip in
     // `crates/zfb-build/src/bundler.rs` to fall the whole page back to
     // `<pre data-zfb-content-fallback>`. See zfb#93.
+    //
+    // Side effect: a literal `$` in prose is now parsed as the start
+    // of inline math (markdown-rs's `math_text_single_dollar` defaults
+    // to true). Authors who want a literal dollar sign must escape it
+    // as `\$` — same convention as the upstream remark-math ecosystem.
     let parse_options = markdown::ParseOptions {
         constructs: markdown::Constructs {
             math_flow: true,

--- a/crates/zfb-content/tests/mdx_jsx_emit.rs
+++ b/crates/zfb-content/tests/mdx_jsx_emit.rs
@@ -442,6 +442,19 @@ fn smoke_self_closing_jsx_compiles_via_swc() {
     assert_swc_accepts(&jsx, "self-closing");
 }
 
+/// remark-math `$$...$$` and `$...$` flow through the emitter cleanly
+/// — historically (zfb#93) LaTeX content leaked into the JSX as bare
+/// `{\foo}` expression containers and SWC/esbuild rejected the
+/// resulting module. This smoke test guards that regression by
+/// piping a real-world-flavoured math fixture through the full
+/// emitter → SWC pipeline.
+#[test]
+fn smoke_math_block_and_inline_compile_via_swc() {
+    let src = "## Limit\n\nWhen $x \\to \\infty$ the integral converges:\n\n$$\n\\int_{-\\infty}^{\\infty} f(x)\\,dx\n$$\n";
+    let jsx = emit(src);
+    assert_swc_accepts(&jsx, "remark-math");
+}
+
 // ───────────────────────────────────────────────────────────────────
 // Real-world fixtures from zudo-doc
 // ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/93

---

## Summary

Closes #93.

The MDX → JSX emitter (`crates/zfb-content/src/mdx_jsx_emit.rs`) did not enable markdown-rs's math constructs and dropped any `Math` / `InlineMath` nodes through the unhandled-arm catch-all. As a result, `$$…$$` / `$…$` content leaked into the JSX output as bare expression containers like `{\infty}`, which esbuild rejects. The bundler defensively skipped the bridge for those files (see `jsx_likely_breaks_downstream_parser` in `crates/zfb-build/src/bundler.rs`), so `math-equations.mdx` pages rendered only the `<pre data-zfb-content-fallback>` shape — losing all headings and prose.

## Fix

- Enable `math_flow: true` and `math_text: true` on the `Constructs` used by `mdx_to_jsx_module_inner`.
- Add `MdastNode::Math` and `MdastNode::InlineMath` arms in `JsxEmitter::emit_node` that emit the same shape markdown-rs's HTML serializer (`on_enter_raw_flow` / `on_enter_raw_text`) produces, routed through the `_components` map: `<_components.pre><_components.code className="language-math math-display">{"…raw LaTeX…"}</_components.code></_components.pre>` for block math and `<_components.code className="language-math math-inline">{"…raw LaTeX…"}</_components.code>` for inline math. The LaTeX body is wrapped as a JS string literal so backslash sequences are escaped at the JS level — no `{\letter}` leakage.
- Project math text into `mdast_inline_text` so headings that include inline math still get a sensible plain-text projection in the exported `headings` array.
- Update the bundler's defensive-skip comment + log message; the heuristic stays as a net for any future leak.

This matches the standard `remark-math` ecosystem class names — KaTeX auto-render (and similar tools) key on `math-display` / `math-inline` to render the LaTeX client-side.

### Author-visible side effect

`math_text_single_dollar` defaults to `true` in markdown-rs, so a literal `$` in prose now starts inline math. Authors who need a real dollar sign must escape it as `\$` — same convention as the upstream remark-math ecosystem. Documented in the inline comment on the constructs config.

## Test plan

- [x] Three new unit tests in `mdx_jsx_emit.rs` — block / inline math emit safe JSX with the right class, and headings with inline math keep the LaTeX in their plain-text projection. Each asserts no `{\letter}` leakage.
- [x] New `smoke_math_block_and_inline_compile_via_swc` integration test pipes a remark-math fixture through the full emitter → SWC pipeline so a regression here would fail the build.
- [x] Existing `mdx_jsx_emit` lib + integration tests stay green.
- [x] Bundler heuristic test (`jsx_breakage_heuristic_flags_bare_backslash_expressions`) still passes.
- [x] Full `cargo test --workspace` is clean.
- [x] CI green (build docs site + health).