### PR TITLE
docs: cover extending the markdown pipeline

### DIFF
--- a/docs/src/content/docs-ja/guides/customizing-markdown.mdx
+++ b/docs/src/content/docs-ja/guides/customizing-markdown.mdx
@@ -1,0 +1,23 @@
+---
+title: Markdown のカスタマイズ
+description: zfb の Markdown レンダリングパイプラインの現状、設定可能な範囲、ロードマップ
+sidebar_position: 3
+---
+
+<Info title="翻訳予定">
+
+このページは英語版のスタブです。完全な翻訳は別の PR で行われます。
+英語版: [Customizing Markdown](/guides/customizing-markdown)
+
+</Info>
+
+## 概要
+
+`zfb-content` クレートが Markdown / MDX をどう扱い、現時点で何をカスタマイズでき、何が今後の作業として残っているかをまとめたページです。コンテンツコレクションから受け取る `entry.body`（HTML 文字列）を起点にした「消費側」の視点でまとめています。
+
+エンジン側を Rust の visitor で拡張したい場合は
+[Extending the Markdown Pipeline](/guides/extending-the-markdown-pipeline)
+を参照してください。ディレクティブ（`:::name` / `::name` / `:name`）を追加するだけなら
+[Custom Directives](/concepts/custom-directives) で十分です。
+
+英語の最新ドキュメントは [Customizing Markdown](/guides/customizing-markdown) を参照してください。

--- a/docs/src/content/docs-ja/guides/extending-the-markdown-pipeline.mdx
+++ b/docs/src/content/docs-ja/guides/extending-the-markdown-pipeline.mdx
@@ -1,0 +1,27 @@
+---
+title: Markdown パイプラインの拡張
+description: zfb の Markdown / MDX パイプラインに新しい機能を追加する方法 — ディレクティブで足りるとき、Rust の visitor を書くとき、AST コンバーター自体に手を入れるとき
+sidebar_position: 3.5
+---
+
+<Info title="翻訳予定">
+
+このページは英語版のスタブです。完全な翻訳は別の PR で行われます。
+英語版: [Extending the Markdown Pipeline](/guides/extending-the-markdown-pipeline)
+
+</Info>
+
+## 概要
+
+`zfb-content` クレートの Markdown パイプラインをエンジン側で拡張する方法について解説します。新しいディレクティブを追加するだけなら
+[Custom Directives](/concepts/custom-directives) で十分ですが、AST レベルの書き換え（見出しスラッグ、コードブロック装飾、画像変換、リンク解決など）が必要な場合は `MdastVisitor` または `HastVisitor` を実装して in-tree のプラグインとして追加します。
+
+主なトピック:
+
+- 2 段階パイプライン（mdast → hast）と、どちらの段階で何をすべきか
+- visitor トレイトの形（`visit` メソッド一つ、再帰は呼び出し側責任、in-place 変更）
+- プラグインファイルの置き場所と `plugins.rs` への公開方法
+- `Pipeline::with_defaults` に組み込まれた依存順序のルール
+- markdown-rs がパースしているがコンバーターが捨てている構文（テーブル、脚注、定義、math など）を有効化するための `mdast_to_hast` 拡張手順
+
+英語の最新ドキュメントは [Extending the Markdown Pipeline](/guides/extending-the-markdown-pipeline) を参照してください。

--- a/docs/src/content/docs/guides/customizing-markdown.mdx
+++ b/docs/src/content/docs/guides/customizing-markdown.mdx
@@ -72,23 +72,45 @@ you accept Markdown from untrusted users, sanitize before storing.
   individual extensions off in v0.
 - **HTML wrapping** — fully under your control. The `entry.body` string
   is plain HTML; wrap, slot, and style it however you like.
+- **`.mdx` entries** — content collections accept `.md`, `.mdx`, and
+  `.tsx` files side by side. MDX entries compile to JSX modules; see
+  [MDX Components](/concepts/mdx-components).
+- **Custom directives** — `:::name` (container), `::name[label]`
+  (leaf), and `:name[label]` (text) directive shapes are supported
+  by the engine and register against a runtime
+  [`DirectiveRegistry`](/concepts/custom-directives). The six built-in
+  admonitions (`:::note`, `:::tip`, `:::info`, `:::warning`,
+  `:::danger`, `:::details`) ship through that registry; your project
+  or framework adds its own directives the same way.
+- **Engine-side plugin chain** — `zfb-content` exposes
+  `MdastVisitor` and `HastVisitor` traits and a default plugin chain
+  via `Pipeline::with_defaults()`. New rewrites (custom code-block
+  treatment, link normalisation, heading anchors, etc.) ship as Rust
+  visitors. See
+  [Extending the Markdown Pipeline](/guides/extending-the-markdown-pipeline)
+  for the engine-extender path.
 
 ## What is planned, not built
 
 The following are deliberately out of scope for v0 and tracked for a
 later release:
 
-- Per-collection rehype / remark plugins.
-- Custom container directives — for example, `:::note` blocks that
-  expand into admonition components.
-- Shortcodes — inline component calls embedded in Markdown.
-- MDX support for content collections. (The docs site itself uses MDX,
-  but that runs through Astro and zudo-doc, not through zfb.)
+- **Userland-configurable plugins via `zfb.config`.** The config
+  schema reserves a `plugins: []` field, but it is not yet wired
+  into the build pipeline. For now, extending the chain means
+  modifying `Pipeline::with_defaults()` in-tree (see the engine
+  guide above).
+- **Per-collection plugin overrides** — running a different visitor
+  set for `blog` than for `docs` from config alone.
+- **A formal third-party plugin protocol** — there is no equivalent
+  of remark's npm-installable plugins. Visitors compile into the
+  binary today.
 
-If your site needs any of these today, the practical options are: do
-the post-processing yourself in the page component, or ship a small
-remark step outside zfb and feed the rendered HTML back through your
-collection.
+If your site needs an engine-level rewrite that does not fit the
+directive registry, write a `MdastVisitor` / `HastVisitor` and add
+it in-tree — the
+[engine extension guide](/guides/extending-the-markdown-pipeline)
+walks through the surface.
 
 <Tip>
 
@@ -96,3 +118,10 @@ collection.
   Markdown" requests turn out to be styling questions that CSS solves.
 
 </Tip>
+
+## See also
+
+- [Custom Directives](/concepts/custom-directives) — register new
+  directive names against the `DirectiveRegistry`, no Rust required.
+- [Extending the Markdown Pipeline](/guides/extending-the-markdown-pipeline) —
+  write a Rust visitor and wire it into the engine.

--- a/docs/src/content/docs/guides/extending-the-markdown-pipeline.mdx
+++ b/docs/src/content/docs/guides/extending-the-markdown-pipeline.mdx
@@ -1,0 +1,263 @@
+---
+title: Extending the Markdown Pipeline
+description: How to add a new Markdown / MDX feature to zfb — when a directive is enough, when to write a Rust visitor, and when the AST converter itself needs a new arm.
+sidebar_position: 3.5
+---
+
+<Info title="What this page covers">
+
+The engine-side extension surface for `zfb-content`'s Markdown
+pipeline. When you want a new syntax-level feature — admonition
+variants, heading rewrites, custom code-block treatment, link
+resolvers — this page tells you where to put it and how to wire it
+in.
+
+</Info>
+
+The pipeline that turns Markdown / MDX into HTML lives in
+`crates/zfb-content`. It is plugin-shaped: parse to mdast, run mdast
+visitors, convert to hast, run hast visitors, serialize. There is no
+runtime / userland plugin loader — every visitor compiles into the
+binary — but the surface for adding a new visitor in-tree is small
+and stable, and that is where almost every "I want a new Markdown
+feature" change lives.
+
+If your feature is just a new directive name (`:::callout`,
+`::youtube`, `:badge`), you do not need this page — the directive
+registry handles it without touching Rust beyond a one-line
+`register` call. See [Custom Directives](/concepts/custom-directives)
+for that path.
+
+## Decision: directive, visitor, or AST arm
+
+| You want to … | Path | Where it goes |
+|---|---|---|
+| Add `:::name` / `::name` / `:name` syntax that compiles to a JSX component | Register a directive | `Pipeline::with_defaults` + `DirectiveRegistry` ([Custom Directives](/concepts/custom-directives)) |
+| Rewrite existing AST nodes (slugify headings, wrap code blocks, swap `<img>` for a JSX marker, normalise links) | Write a visitor | New file under `crates/zfb-content/src/plugins/` |
+| Surface a Markdown construct that markdown-rs parses but zfb currently drops (tables, footnotes, math, definitions, reference-style links) | Extend the AST converter | `mdast_to_hast` in `crates/zfb-content/src/pipeline.rs` |
+| Add brand-new Markdown syntax that markdown-rs cannot parse | Out of scope | Upstream change against the `markdown` crate, then a converter arm in zfb |
+
+Most contributions land in the second row — a fresh visitor.
+
+## The two-phase pipeline
+
+The pipeline runs two distinct passes over two different ASTs:
+
+1. **Parse** the input into mdast (`markdown::mdast::Node`) using
+   markdown-rs with MDX-aware options.
+2. **mdast visitors** — `MdastVisitor` implementations rewrite the
+   markdown AST in place. Run first because some transforms only
+   make sense before HTML structure exists. The directive registry
+   is a mdast visitor: it folds runs of paragraphs delimited by
+   `:::name` / `:::` into a single MDX JSX element, which is much
+   easier on mdast than after `<p>` tags have appeared.
+3. **Convert** mdast → hast via `mdast_to_hast`. hast is zfb's
+   minimal HTML AST (`HastNode`).
+4. **hast visitors** — `HastVisitor` implementations rewrite the
+   HTML AST in place. Most rewrites that target HTML element
+   structure (heading anchors, `<figure>` wrappers, `<img>` → JSX
+   markers, syntax highlighting) live here.
+5. **Serialize** hast to an HTML string in
+   `zfb_content::serializer`.
+
+Pick the phase that matches what you are operating on. Rule of
+thumb: if you need to look at the original Markdown structure (a
+directive, a paragraph run, a particular link reference style),
+mdast. If you need to look at HTML element structure (a `<pre>`, a
+heading level, an `<img>` with a width attribute), hast.
+
+## Visitor trait shape
+
+Both visitor traits are intentionally small — one method, called
+once on a node, mutate in place:
+
+```rust
+pub trait MdastVisitor {
+    fn visit(&mut self, node: &mut MdastNode);
+}
+
+pub trait HastVisitor {
+    fn visit(&mut self, node: &mut HastNode);
+}
+```
+
+The pipeline calls `visit` exactly once, with the root node.
+Recursion is the visitor's responsibility — there is no auto-walk.
+A typical hast visitor looks like:
+
+```rust
+use crate::pipeline::{HastNode, HastVisitor};
+
+pub struct MyPlugin;
+
+impl HastVisitor for MyPlugin {
+    fn visit(&mut self, node: &mut HastNode) {
+        match node {
+            HastNode::Root { children }
+            | HastNode::Element { children, .. } => {
+                for child in children {
+                    // mutate `child` here, then recurse
+                    self.visit(child);
+                }
+            }
+            _ => {}
+        }
+    }
+}
+```
+
+Visitors can carry state (per-document slug counters, configuration
+options, references to a shared resource). `HeadingLinksPlugin` keeps
+a `HashMap<String, usize>` for github-slugger-equivalent dedup;
+`SyntectPlugin` holds an `Arc<Highlighter>` so the syntax theme is
+shared across all code blocks in the build.
+
+## Where files go
+
+Plugins live under `crates/zfb-content/src/plugins/`. The convention
+is one file per plugin, named after the feature:
+
+```
+crates/zfb-content/src/plugins/
+├── admonitions.rs
+├── code_title.rs
+├── directives.rs
+├── heading_links.rs
+├── image_enlarge.rs
+├── mermaid.rs
+├── resolve_links.rs
+├── strip_md_ext.rs
+├── syntect_plugin.rs
+└── util/        # helpers shared by multiple plugins
+```
+
+Add your file, then re-export the public type from
+`crates/zfb-content/src/plugins.rs`:
+
+```rust
+// in plugins.rs
+pub mod my_plugin;
+pub use my_plugin::MyPlugin;
+```
+
+Tests typically live in a `#[cfg(test)] mod tests {}` block alongside
+the plugin, with cross-plugin integration cases in
+`crates/zfb-content/tests/`. The existing
+`tests/integration_pipeline.rs` is the reference shape.
+
+## Wiring into the default pipeline
+
+`Pipeline::with_defaults()` is the project-wide default plugin chain.
+Adding your visitor there means every caller that uses the defaults
+picks it up automatically. Append it in the right phase:
+
+```rust
+// in crates/zfb-content/src/pipeline.rs, inside Pipeline::with_defaults()
+let mut p = Self::with_mdx();
+
+// mdast phase
+p.add_mdast_visitor(Box::new(AdmonitionsPlugin::new()));
+
+// hast phase
+p.add_hast_visitor(Box::new(HeadingLinksPlugin::new()));
+p.add_hast_visitor(Box::new(CodeTitlePlugin::new()));
+p.add_hast_visitor(Box::new(MyPlugin));     // <-- new
+p.add_hast_visitor(Box::new(ImageEnlargePlugin::new()));
+p.add_hast_visitor(Box::new(MermaidPlugin::new()));
+p.add_hast_visitor(Box::new(SyntectPlugin::new(highlighter)));
+p
+```
+
+If your plugin is opt-in (project-specific link rewriting, optional
+extensions a particular framework wants), do **not** put it in
+`with_defaults()`. Construct a pipeline via `Pipeline::with_mdx()`
+(which is plugin-free) and append the visitors the caller wants —
+that is exactly how `ResolveLinksPlugin` and
+`StripMdExtensionPlugin` are wired today, since both need a
+project-specific source map.
+
+## Ordering matters
+
+Visitor order is **load-bearing**. The defaults document the full
+rationale in `Pipeline::with_defaults`'s doc comment, but the rules
+that bite most often:
+
+- **`HeadingLinksPlugin` runs first in the hast phase.** Anything
+  that mutates headings later sees the slugified `id` attributes.
+- **`CodeTitlePlugin` runs before `SyntectPlugin`.** SyntectPlugin
+  replaces the entire `<pre>` element with a `HastNode::Raw` HTML
+  fragment; once that happens, the `data-meta` attribute that
+  carries `title="…"` is no longer reachable as structured AST.
+- **`MermaidPlugin` runs before `SyntectPlugin`.** MermaidPlugin
+  flags mermaid code blocks with `data-mermaid="true"`; SyntectPlugin
+  uses that flag to skip them rather than syntax-highlighting the
+  diagram source.
+- **`ImageEnlargePlugin` is order-independent** relative to the code
+  pipeline above — it only touches `<img>` elements.
+
+When inserting a new plugin, ask: do I need to see element shapes
+that a later plugin will erase? Run before that plugin. Do I need
+the results of an earlier plugin's rewrite (a generated `id`, a
+synthesised JSX element)? Run after it.
+
+## Adding genuinely new syntax
+
+Some Markdown constructs that markdown-rs parses are currently
+**dropped** by the mdast → hast converter. Look at `mdast_to_hast`
+in `crates/zfb-content/src/pipeline.rs`:
+
+```rust
+// Unhandled: degrade to empty Raw so we never crash on
+// unsupported input. Tables, footnotes, definitions, math,
+// reference links/images, ESM, frontmatter, etc. fall here.
+_ => HastNode::Raw(String::new()),
+```
+
+If you want zfb to surface tables, footnotes, definitions, math,
+reference-style links, or anything else that lives in the catch-all,
+two changes are needed:
+
+1. **Add a match arm** to `mdast_to_hast` that turns the mdast
+   variant into the right `HastNode::Element` (or `Raw` for
+   passthrough JSX/HTML). Mirror the existing arms — handle children
+   with `convert_children`, build attributes as
+   `Vec<(String, String)>`.
+2. **Possibly toggle `markdown::ParseOptions`** if the construct
+   needs an extension flag. The current `Pipeline::with_mdx()` uses
+   `markdown::ParseOptions::mdx()`; you may need a custom
+   `ParseOptions` with additional `constructs.*` fields enabled.
+   Check the `markdown` crate's docs for the exact flag.
+
+Tests for converter changes belong in `pipeline.rs`'s own
+`#[cfg(test)] mod tests {}` block (the file already covers headings,
+code blocks, links, images, lists, blockquotes, MDX JSX) plus a
+matching round-trip case in `crates/zfb-content/tests/`.
+
+## What about runtime / userland plugins?
+
+There is no plugin loader today. Every visitor compiles into the
+binary. The closest the user-facing config (`zfb.config`) gets to
+plugins is a `plugins: []` field reserved for future use; it is not
+yet wired into the build pipeline.
+
+For now the practical extension model is: add the visitor in-tree.
+The visitor traits are stable across the workspace, so a feature
+written as a fresh `plugins/` file rarely needs follow-up changes
+when the rest of the codebase moves.
+
+## See also
+
+- [Custom Directives](/concepts/custom-directives) — author-facing
+  story for `:::name` / `::name` / `:name` syntax, no Rust required.
+- [Customizing Markdown](/guides/customizing-markdown) — what the
+  Markdown rendering pipeline looks like from a content-collection
+  consumer's perspective.
+- `crates/zfb-content/src/pipeline.rs` — `Pipeline`, `MdastVisitor`
+  / `HastVisitor` traits, and the `Pipeline::with_defaults()`
+  ordering rationale in its doc comment.
+- `crates/zfb-content/src/plugins/code_title.rs` — small, stateless
+  `HastVisitor` example.
+- `crates/zfb-content/src/plugins/heading_links.rs` — stateful
+  `HastVisitor` (per-document slug counter) example.
+- `crates/zfb-content/src/plugins/admonitions.rs` — façade over
+  `DirectiveRegistry`, an `MdastVisitor` example.


### PR DESCRIPTION
## Summary

- Refresh `docs/guides/customizing-markdown.mdx` so it stops calling shipped features ("custom container directives", `.mdx` in collections) "planned, not built".
- Add a new `docs/guides/extending-the-markdown-pipeline.mdx` guide covering the Rust-side engine extension surface (`MdastVisitor` / `HastVisitor` traits, where plugins live, how `Pipeline::with_defaults` is wired).
- Mirror both pages into `docs-ja/guides/` as Japanese stubs following the existing convention (Japanese summary + link back to English).

## Changes

### New: `docs/guides/extending-the-markdown-pipeline.mdx`

A practical guide for adding new Markdown / MDX features at the engine level. Covers:

- The two-phase pipeline (mdast → hast) and how to choose which phase a rewrite belongs in.
- The `MdastVisitor` / `HastVisitor` trait shape — one method, manual recursion, mutate in place — with a minimal example.
- File-layout convention under `crates/zfb-content/src/plugins/` and how to re-export from `plugins.rs`.
- The load-bearing visitor ordering inside `Pipeline::with_defaults` (`HeadingLinks` first, `CodeTitle` before `Syntect`, `Mermaid` before `Syntect`) — previously only documented in a Rust doc-comment.
- The `mdast_to_hast` catch-all in `pipeline.rs` and what falls through it (tables, footnotes, definitions, math, reference-style links) for anyone who wants to surface genuinely new Markdown syntax.
- A decision table: directive (no Rust) vs. visitor vs. AST converter arm.
- Cross-links to `concepts/custom-directives` and `guides/customizing-markdown`.

### Updated: `docs/guides/customizing-markdown.mdx`

- "What is customisable today" gains entries for `.mdx` collection entries, custom directives via `DirectiveRegistry`, and the engine-side plugin chain — with links to the relevant pages.
- "What is planned, not built" now reflects reality: drops the directive bullet (shipped) and the `.mdx`-collections bullet (shipped), keeps userland config-driven plugins, per-collection overrides, and the absence of a third-party plugin protocol as the remaining roadmap items.
- Adds a "See also" section linking to `concepts/custom-directives` and the new engine guide.

### Mirrored: `docs-ja/guides/customizing-markdown.mdx`, `docs-ja/guides/extending-the-markdown-pipeline.mdx`

Two new Japanese stubs under a freshly created `docs-ja/guides/` directory. Each follows the existing `docs-ja/concepts/custom-directives.mdx` convention: Japanese title and brief summary, an `<Info title="翻訳予定">` notice, and a link back to the English page for the full content.

## Test Plan

- [x] `pnpm build` in `docs/` produces 91 pages with no errors; new EN + JA pages emit under `dist/`.
- [x] Cross-links between the guides and `concepts/custom-directives.mdx` resolve in the rendered HTML.
- [x] Japanese stubs land under `docs-ja/guides/` and link back to the English versions.
- [x] CI is green (Build docs site + health checks).
- [x] `/gcoc-review` (gpt-4.1) verified the Rust references against `crates/zfb-content/src/pipeline.rs` and `crates/zfb-content/src/plugins/`; no factual issues.