### PR TITLE
Release engineering: pnpm fetch:tailwind script + ZFB_TAILWIND_BIN docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ worktrees/
 
 # Bundled third-party binaries (populated by release engineering, never committed)
 crates/zfb/binaries/tailwindcss-v4
+crates/zfb/binaries/tailwindcss-v4.exe
+crates/zfb/binaries/tailwindcss-v4.tmp
 crates/zfb/binaries/esbuild/esbuild
 
 # Ephemeral / temp files (e.g. agent prompts, review diffs)

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,0 +1,67 @@
+# Building zfb locally
+
+This document covers the toolchain and one-time setup needed to build, test, and develop the `zfb` workspace locally. For the project mission and architecture, see [README.md](./README.md).
+
+## Required toolchains
+
+| Tool   | Version            | Notes                                             |
+| ------ | ------------------ | ------------------------------------------------- |
+| Rust   | stable             | `rustup install stable && rustup default stable`  |
+| Node   | ≥ 20 (LTS)         | The fetch script and Node-side glue use ESM + `fetch`. |
+| pnpm   | as pinned          | The repo declares `packageManager` in `package.json`; use Corepack (`corepack enable`) or install the matching pnpm version directly. |
+
+CI uses Node 20 and Rust stable on `ubuntu-latest`.
+
+## Initial setup
+
+```sh
+# 1. Install JS deps
+pnpm install --frozen-lockfile
+
+# 2. Fetch the pinned tailwindcss v4 standalone CLI binary into
+#    crates/zfb/binaries/tailwindcss-v4 (idempotent — fast no-op on re-run)
+pnpm fetch:tailwind
+
+# 3. Build the Rust workspace
+cargo build --workspace
+```
+
+## The Tailwind binary
+
+The CSS pipeline shells out to the Tailwind v4 standalone CLI as a subprocess. The binary file is **not** committed to git — it is materialized on demand.
+
+There are two supported ways to provide it:
+
+1. **Default — `pnpm fetch:tailwind`**: downloads the pinned asset from the upstream GitHub release, verifies SHA-256 against `sha256sums.txt`, and places it at `crates/zfb/binaries/tailwindcss-v4` (or `tailwindcss-v4.exe` on Windows). Supported platforms: `darwin-x64`, `darwin-arm64`, `linux-x64`, `linux-arm64`, `win32-x64`. For musl-libc Linux, use the override below.
+2. **Override — `ZFB_TAILWIND_BIN`**: set this env var to an absolute path of any tailwindcss v4 standalone binary you already have on disk. The engine uses it directly and `pnpm fetch:tailwind` becomes a no-op. This is the right choice for CI images that already bundle tailwind, or for musl-libc systems.
+
+See [`crates/zfb-css/README.md`](./crates/zfb-css/README.md) ("Getting the binary") for the full contract and the [`crates/zfb/binaries/README.md`](./crates/zfb/binaries/README.md) for the runtime resolution layout.
+
+## Running tests
+
+```sh
+# Default — fast, mock-only, no external binary required
+cargo test --workspace
+
+# Heavyweight — runs the previously-`#[ignore]`-gated tests that exercise
+# the real Tailwind subprocess. Requires the binary to be available.
+ZFB_TAILWIND_BIN="$(pwd)/crates/zfb/binaries/tailwindcss-v4" \
+  cargo test -p zfb-css --tests -- --ignored
+```
+
+The `ZFB_TAILWIND_BIN` export is needed because `cargo test -p <crate>` runs with the package directory as CWD, while the engine's default relative path is resolved from the workspace root.
+
+## Format / lint
+
+```sh
+pnpm format:check         # check (TS/MD/MDX, runs in CI)
+pnpm format               # apply
+```
+
+## Useful scripts
+
+```sh
+pnpm docs:dev             # Astro dev server for the docs site
+pnpm docs:build           # static build into docs/dist/
+pnpm fetch:tailwind       # (re-)materialize the Tailwind v4 binary
+```

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ since that is the shape miniflare receives. Any other value (`0`,
 unset, `yes`, etc.) leaves the build silent so a stray export does
 not change CI output.
 
+## Building locally
+
+See [BUILDING.md](./BUILDING.md) for the toolchain, the one-time `pnpm fetch:tailwind` setup, and the `ZFB_TAILWIND_BIN` override.
+
 ## License
 
 MIT — see [LICENSE](./LICENSE).

--- a/crates/zfb-css/README.md
+++ b/crates/zfb-css/README.md
@@ -22,8 +22,62 @@ This crate invokes the **Tailwind CSS v4 standalone CLI** as a subprocess.
 
 > The pin **must be reviewed and refreshed before each `zfb` release**. Bump
 > `4.2.0` to whatever the latest stable Tailwind v4.x is at release-cut time,
-> and re-run the release-engineering binary-fetch step (future epic) to
-> materialize the matching binary.
+> and re-run `pnpm fetch:tailwind` to materialize the matching binary.
+> The version constant in `scripts/fetch-tailwind.mjs` must move in lockstep
+> with the version line above — both are the source of truth until we add a
+> shared workspace pin file.
+
+## Getting the binary
+
+The binary file is **not** committed to git. There are two supported ways to
+provide it for builds and tests that exercise the Tailwind subprocess path.
+
+### Option 1 (default): `pnpm fetch:tailwind`
+
+From the workspace root:
+
+```sh
+pnpm fetch:tailwind
+```
+
+The script (`scripts/fetch-tailwind.mjs`) detects your platform/arch, downloads
+the matching asset from the [pinned tailwindlabs/tailwindcss release](https://github.com/tailwindlabs/tailwindcss/releases),
+verifies its SHA-256 against the release's `sha256sums.txt`, places it at
+`crates/zfb/binaries/tailwindcss-v4` (or `tailwindcss-v4.exe` on Windows), and
+makes it executable. Re-runs are a fast no-op when the on-disk binary already
+matches the pinned checksum.
+
+Supported platforms: `darwin-x64`, `darwin-arm64`, `linux-x64`, `linux-arm64`,
+`win32-x64`. On musl-libc Linux distros (Alpine and friends), use the override
+below to point at a manually-fetched musl asset.
+
+### Option 2 (override): `ZFB_TAILWIND_BIN`
+
+If you already have a tailwindcss v4 standalone binary on disk — for example
+because your CI image bundles it, or because you maintain a system-wide copy —
+set the env var to its absolute path and the engine will use it directly:
+
+```sh
+export ZFB_TAILWIND_BIN=/usr/local/bin/tailwindcss
+cargo test -p zfb-css -- --ignored
+```
+
+When `ZFB_TAILWIND_BIN` is set, `pnpm fetch:tailwind` is a no-op (it trusts
+the override). The engine's path resolution is implemented at
+[`crates/zfb-css/src/engine.rs`](src/engine.rs).
+
+### Running the heavyweight tests locally
+
+Tests that need the real binary are gated with `#[ignore]` and run via:
+
+```sh
+ZFB_TAILWIND_BIN="$(pwd)/crates/zfb/binaries/tailwindcss-v4" \
+  cargo test -p zfb-css --tests -- --ignored
+```
+
+The `ZFB_TAILWIND_BIN` export is needed because `cargo test -p <crate>` runs
+with the package directory as CWD; the engine's default relative path
+(`crates/zfb/binaries/tailwindcss-v4`) is resolved from the workspace root.
 
 ### Why a pinned version
 

--- a/crates/zfb/binaries/README.md
+++ b/crates/zfb/binaries/README.md
@@ -30,15 +30,25 @@ and `crates/zfb/binaries/esbuild/README.md` for the slot-shape rationale
 Binaries are large, platform-specific, and license-bound. They are **never**
 committed to this repository. Instead:
 
-- `.gitignore` excludes the actual binary file paths (e.g. `tailwindcss-v4`).
+- `.gitignore` excludes the actual binary file paths (e.g. `tailwindcss-v4`,
+  `tailwindcss-v4.exe`).
 - The slot directory is preserved in git via `.gitkeep`.
-- Release engineering (a separate, future epic) is responsible for downloading
-  the correct platform-specific binary, verifying its signature/checksum, and
-  placing it into this directory before the release tarball is assembled.
+- Workspace-level fetch tooling materializes the binary on demand:
+  `pnpm fetch:tailwind` (see `scripts/fetch-tailwind.mjs` at the repo root)
+  downloads the pinned asset from the upstream GitHub release, verifies its
+  SHA-256 against the release's `sha256sums.txt`, and places it here.
+  Re-runs are no-ops when the on-disk binary already matches the pinned
+  checksum.
+- The `ZFB_TAILWIND_BIN` env var is the documented escape hatch for
+  consumers and CI environments that already have a tailwindcss binary
+  available — see `crates/zfb-css/README.md` ("Getting the binary").
 
-This sub-task (Sub 4 of [issue #5](https://github.com/Takazudo/zudo-front-builder/issues/5))
-only **reserves the slot** — it does not implement the download or
-release-tarball assembly logic.
+The original Sub 4 of [issue #5](https://github.com/Takazudo/zudo-front-builder/issues/5)
+only **reserved** the slot. The fetch + verify step is now wired up via the
+workspace `fetch:tailwind` script. Release-tarball assembly (bundling the
+binary alongside the `zfb` executable for distribution) is still a separate,
+future concern — this directory's contract is just "where the binary ends up
+at runtime".
 
 ## Runtime contract (sketch)
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   "scripts": {
     "//// === ROOT ===": "",
     "prepare": "lefthook install --reset-hooks-path",
+    "//// === BINARIES ===": "",
+    "fetch:tailwind": "node scripts/fetch-tailwind.mjs",
     "//// === DOCS ===": "",
     "docs:install": "pnpm --filter docs install",
     "docs:dev": "pnpm --filter docs dev",

--- a/scripts/fetch-tailwind.mjs
+++ b/scripts/fetch-tailwind.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+// Fetches the pinned tailwindcss v4 standalone CLI binary into
+// crates/zfb/binaries/tailwindcss-v4 (or .exe on Windows). Idempotent:
+// re-runs are a fast no-op when the on-disk binary already matches the
+// pinned sha256. Honours ZFB_TAILWIND_BIN to skip entirely when the user
+// has supplied their own binary.
+//
+// Run via `pnpm fetch:tailwind` from the workspace root.
+//
+// The version below MUST stay in sync with the pin documented in
+// crates/zfb-css/README.md ("Tailwind CSS Version" section). When that
+// pin is bumped, bump this constant in the same commit. Until we add a
+// shared workspace pin file, this is the only sync point.
+const TAILWIND_VERSION = "4.2.0";
+
+import { createHash } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "..");
+const BINARY_DIR = join(REPO_ROOT, "crates", "zfb", "binaries");
+const IS_WINDOWS = process.platform === "win32";
+const BINARY_NAME = IS_WINDOWS ? "tailwindcss-v4.exe" : "tailwindcss-v4";
+const BINARY_PATH = join(BINARY_DIR, BINARY_NAME);
+
+const RELEASE_BASE = `https://github.com/tailwindlabs/tailwindcss/releases/download/v${TAILWIND_VERSION}`;
+
+function detectAssetName() {
+  const platform = process.platform;
+  const arch = process.arch;
+  if (platform === "darwin" && arch === "x64") return "tailwindcss-macos-x64";
+  if (platform === "darwin" && arch === "arm64") return "tailwindcss-macos-arm64";
+  if (platform === "linux" && arch === "x64") return "tailwindcss-linux-x64";
+  if (platform === "linux" && arch === "arm64") return "tailwindcss-linux-arm64";
+  if (platform === "win32" && arch === "x64") return "tailwindcss-windows-x64.exe";
+  throw new Error(
+    `Unsupported platform/arch: ${platform}/${arch}. Supported: ` +
+      `darwin-x64, darwin-arm64, linux-x64, linux-arm64, win32-x64. ` +
+      `For musl-libc Linux, set ZFB_TAILWIND_BIN to a manually-fetched binary.`,
+  );
+}
+
+async function fetchToBuffer(url) {
+  const res = await fetch(url, { redirect: "follow" });
+  if (!res.ok) {
+    throw new Error(`GET ${url} failed: ${res.status} ${res.statusText}`);
+  }
+  return Buffer.from(await res.arrayBuffer());
+}
+
+function sha256(buf) {
+  return createHash("sha256").update(buf).digest("hex");
+}
+
+function parseSha256Sums(text, assetName) {
+  // Format: "<hex>  <filename>" per line. Filenames may carry a leading
+  // "./" (the tailwindlabs release uses this form) or a "*" binary-mode
+  // marker (GNU coreutils sha256sum -c convention).
+  for (const line of text.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const match = trimmed.match(/^([0-9a-f]{64})\s+\*?(\S+)$/i);
+    if (!match) continue;
+    const [, hex, rawName] = match;
+    const name = rawName.replace(/^\.\//, "");
+    if (name === assetName) return hex.toLowerCase();
+  }
+  throw new Error(`Asset ${assetName} not found in sha256sums.txt for v${TAILWIND_VERSION}.`);
+}
+
+function existingBinaryMatches(expectedSha) {
+  if (!existsSync(BINARY_PATH)) return false;
+  const buf = readFileSync(BINARY_PATH);
+  return sha256(buf) === expectedSha;
+}
+
+async function main() {
+  if (process.env.ZFB_TAILWIND_BIN) {
+    const overridePath = process.env.ZFB_TAILWIND_BIN;
+    if (!existsSync(overridePath)) {
+      console.error(
+        `ZFB_TAILWIND_BIN is set to ${overridePath} but the file does not exist. ` +
+          `Either fix the path or unset the variable to fall back to the workspace fetch.`,
+      );
+      process.exit(1);
+    }
+    console.log(`ZFB_TAILWIND_BIN points at ${overridePath} — skipping workspace fetch.`);
+    return;
+  }
+
+  const assetName = detectAssetName();
+  console.log(
+    `Resolving tailwindcss v${TAILWIND_VERSION} for ${process.platform}-${process.arch} (${assetName})...`,
+  );
+
+  const sumsUrl = `${RELEASE_BASE}/sha256sums.txt`;
+  const sumsBuf = await fetchToBuffer(sumsUrl);
+  const expectedSha = parseSha256Sums(sumsBuf.toString("utf8"), assetName);
+
+  if (existingBinaryMatches(expectedSha)) {
+    console.log(`✓ ${BINARY_PATH} already matches sha256 ${expectedSha} — nothing to do.`);
+    return;
+  }
+
+  mkdirSync(BINARY_DIR, { recursive: true });
+
+  const binaryUrl = `${RELEASE_BASE}/${assetName}`;
+  console.log(`Downloading ${binaryUrl}...`);
+  const binaryBuf = await fetchToBuffer(binaryUrl);
+
+  const actualSha = sha256(binaryBuf);
+  if (actualSha !== expectedSha) {
+    throw new Error(
+      `Checksum mismatch for ${assetName}: expected ${expectedSha}, got ${actualSha}. ` +
+        `Refusing to install. The release may have been re-cut, or the download was corrupted.`,
+    );
+  }
+
+  // Atomic-ish replace: write to .tmp then rename.
+  const tmpPath = `${BINARY_PATH}.tmp`;
+  writeFileSync(tmpPath, binaryBuf);
+  if (!IS_WINDOWS) chmodSync(tmpPath, 0o755);
+  renameSync(tmpPath, BINARY_PATH);
+
+  console.log(`✓ Verified sha256 ${actualSha}`);
+  console.log(`✓ Installed at ${BINARY_PATH}`);
+}
+
+main().catch((err) => {
+  console.error(`fetch-tailwind: ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/fetch-tailwind.mjs
+++ b/scripts/fetch-tailwind.mjs
@@ -14,7 +14,15 @@
 const TAILWIND_VERSION = "4.2.0";
 
 import { createHash } from "node:crypto";
-import { chmodSync, existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -83,6 +91,13 @@ async function main() {
       console.error(
         `ZFB_TAILWIND_BIN is set to ${overridePath} but the file does not exist. ` +
           `Either fix the path or unset the variable to fall back to the workspace fetch.`,
+      );
+      process.exit(1);
+    }
+    if (!statSync(overridePath).isFile()) {
+      console.error(
+        `ZFB_TAILWIND_BIN is set to ${overridePath} but it is not a regular file ` +
+          `(directory, device, or broken symlink). Point it at the tailwindcss binary itself.`,
       );
       process.exit(1);
     }


### PR DESCRIPTION
## Summary

- Closes the empty `crates/zfb/binaries/tailwindcss-v4` slot reserved in commit `9442f6c` so downstream builds (e.g. zudolab/zudo-doc super-PR #1338) no longer hit "tailwindcss v4 binary not found".
- Adds `scripts/fetch-tailwind.mjs` — a Node ESM, zero-extra-deps script that downloads the pinned tailwindcss v4.2.0 standalone binary from the upstream GitHub release, sha256-verifies against the release's `sha256sums.txt`, and places it at the slot.
- Promotes the existing `ZFB_TAILWIND_BIN` env var to a first-class documented override (it was already in the engine code at `crates/zfb-css/src/engine.rs:126`, but undocumented).
- Adds `BUILDING.md` as the canonical "how to set up locally" entry point, linked from the main `README.md`.

## Changes

### Code

- `scripts/fetch-tailwind.mjs` (new) — fetch + verify + atomic install. Idempotent (checksum-matched re-runs are a fast no-op). Honours `ZFB_TAILWIND_BIN` to skip when the user supplies their own binary; rejects the env var when it points at a directory or other non-file path (post-review fix).
- `package.json` — `pnpm fetch:tailwind` script.
- `.gitignore` — adds `tailwindcss-v4.exe` (Windows) and `tailwindcss-v4.tmp` (atomic-rename intermediate).

### Docs

- `crates/zfb-css/README.md` — new "Getting the binary" section documenting both paths (`pnpm fetch:tailwind` default, `ZFB_TAILWIND_BIN` override) and how to run the heavyweight `--ignored` tests locally.
- `crates/zfb/binaries/README.md` — updated the "no binaries committed" section: fetch+verify is no longer a future epic, only release-tarball assembly remains.
- `BUILDING.md` (new, repo root) — toolchain, one-time setup, the two binary-source paths, test-running notes.
- `README.md` — link to `BUILDING.md`.

## CI workflows — intentionally not modified

The original spec mentioned wiring the fetch into CI, but inspection confirmed none of the current workflows actually exercise the Tailwind subprocess path:

- `health.yml` runs `cargo build --workspace --all-targets` — compiles tests, doesn't run them.
- `pr-checks.yml` / `main-deploy.yml` / `preview-deploy.yml` run `pnpm --filter docs build`, which is Astro + `@tailwindcss/vite` (an npm-distributed Vite plugin), not the zfb subprocess pipeline.

Adding fetch+cache steps to workflows that don't need them would be cargo-cult CI. Once a workflow does need the binary (or once the `#[ignore]`-gated heavyweight tests are un-gated), the one-line `pnpm fetch:tailwind` is ready.

## Out of scope

- Distributing the Rust `zfb` binary itself via npm — separate, much larger release-engineering epic.
- Un-ignoring the `#[ignore]`-gated tailwind tests — gated for CI cost reasons; un-gating is a separate decision.
- Any change to the `CssEngine` trait or the engine's path resolution logic.

## Pre-existing issues found during testing (raised separately)

- #114 — `touching_md_via_real_watcher_triggers_one_page_rebuild` flakes on a clean `main` checkout (verified; not introduced here).
- #115 — `cargo test -p zfb-css -- --ignored` includes a doctest that fails to compile (uses an undeclared `NativeRustEngine` type); fenced as `\`\`\`ignore` so it normally doesn't run, but `--ignored` picks it up.

## Test Plan

- [x] `pnpm fetch:tailwind` from a clean checkout downloads + sha256-verifies + chmods. Verified locally (darwin-arm64).
- [x] Re-run is a fast no-op (checksum match → skip).
- [x] `ZFB_TAILWIND_BIN` set to a missing path → exits with a clear error.
- [x] `ZFB_TAILWIND_BIN` set to a directory → exits with a clear error (post-review fix).
- [x] `ZFB_TAILWIND_BIN` set to a valid binary → script skips workspace fetch, exits 0.
- [x] `ZFB_TAILWIND_BIN="$(pwd)/crates/zfb/binaries/tailwindcss-v4" cargo test -p zfb-css --tests -- --ignored` passes the previously-ignored real-binary tests.
- [x] `cargo build --workspace --all-targets` green; `pnpm format:check` green on all touched files.
- [x] CI checks (`health`, `Build docs site`) green on this branch.