### PR TITLE
fix(bundler): thread Pipeline::with_defaults() through MDX pre-compile + opt-in stripMdExt

### DIFF
--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -294,6 +294,19 @@ pub struct BundlerInput {
     /// root, where transitive deps are NOT hoisted, and resolution
     /// fails.
     pub node_modules_preserve_symlinks: bool,
+
+    /// When `true`, append [`zfb_content::pipeline::Pipeline::add_strip_md_ext`]
+    /// to the hoisted MDX pre-compile pipeline at every call site so
+    /// internal `[link](other.md)` style hrefs are rewritten to
+    /// `other/` (with a trailing slash, matching the JS engine's
+    /// `rehypeStripMdExtension`). Mirrors [`zfb::config::Config::strip_md_ext`]
+    /// in `crates/zfb/src/config.rs` — the CLI threads the resolved
+    /// config flag here. Default: `false` (opt-in feature).
+    ///
+    /// The dev loader at `crates/zfb-render/src/loader.rs` honours the
+    /// same flag via [`zfb_render::loader::ModuleLoader::with_strip_md_ext`]
+    /// so `zfb dev` and `zfb build` produce the same href shape.
+    pub strip_md_ext: bool,
 }
 
 impl BundlerInput {
@@ -336,6 +349,7 @@ impl BundlerInput {
             content_snapshot_json,
             node_modules_dir: None,
             node_modules_preserve_symlinks: false,
+            strip_md_ext: false,
         }
     }
 }
@@ -467,8 +481,14 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
     let shadow_layouts = shadow.join("layouts");
 
     let mut routes: Vec<RouteEntry> = Vec::new();
-    materialise_shadow(&pages_dir, &shadow_pages, &mut routes, &input.project_root)
-        .with_context(|| format!("bundler: failed materialising pages from {}", pages_dir.display()))?;
+    materialise_shadow(
+        &pages_dir,
+        &shadow_pages,
+        &mut routes,
+        &input.project_root,
+        input.strip_md_ext,
+    )
+    .with_context(|| format!("bundler: failed materialising pages from {}", pages_dir.display()))?;
 
     // Per-collection content materialisation (#506).
     //
@@ -487,43 +507,67 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
         for col in &input.content_collections {
             let col_root = resolver.resolve(&col.root);
             let dest = shadow_content.join(&col.name);
-            materialise_collection(&col_root, &dest, &col.name, &mut content_imports)
-                .with_context(|| {
-                    format!(
-                        "bundler: failed materialising collection `{}` from {}",
-                        col.name,
-                        col_root.display()
-                    )
-                })?;
+            materialise_collection(
+                &col_root,
+                &dest,
+                &col.name,
+                &mut content_imports,
+                input.strip_md_ext,
+            )
+            .with_context(|| {
+                format!(
+                    "bundler: failed materialising collection `{}` from {}",
+                    col.name,
+                    col_root.display()
+                )
+            })?;
         }
         // Deterministic ordering — keys are `(collection, rel_path)`
         // so the emitted import indices match the underlying file
         // tree on every build, regardless of WalkDir's per-OS order.
         content_imports.sort_by(|a, b| a.shadow_rel_path.cmp(&b.shadow_rel_path));
     } else {
-        materialise_shadow(&content_dir, &shadow_content, &mut Vec::new(), &input.project_root)
-            .with_context(|| {
-                format!(
-                    "bundler: failed materialising content from {}",
-                    content_dir.display()
-                )
-            })?;
+        materialise_shadow(
+            &content_dir,
+            &shadow_content,
+            &mut Vec::new(),
+            &input.project_root,
+            input.strip_md_ext,
+        )
+        .with_context(|| {
+            format!(
+                "bundler: failed materialising content from {}",
+                content_dir.display()
+            )
+        })?;
     }
 
-    materialise_shadow(&components_dir, &shadow_components, &mut Vec::new(), &input.project_root)
-        .with_context(|| {
-            format!(
-                "bundler: failed materialising components from {}",
-                components_dir.display()
-            )
-        })?;
-    materialise_shadow(&layouts_dir, &shadow_layouts, &mut Vec::new(), &input.project_root)
-        .with_context(|| {
-            format!(
-                "bundler: failed materialising layouts from {}",
-                layouts_dir.display()
-            )
-        })?;
+    materialise_shadow(
+        &components_dir,
+        &shadow_components,
+        &mut Vec::new(),
+        &input.project_root,
+        input.strip_md_ext,
+    )
+    .with_context(|| {
+        format!(
+            "bundler: failed materialising components from {}",
+            components_dir.display()
+        )
+    })?;
+    materialise_shadow(
+        &layouts_dir,
+        &shadow_layouts,
+        &mut Vec::new(),
+        &input.project_root,
+        input.strip_md_ext,
+    )
+    .with_context(|| {
+        format!(
+            "bundler: failed materialising layouts from {}",
+            layouts_dir.display()
+        )
+    })?;
 
     // 2b. Optional node_modules symlink into the shadow tree.
     //     When `BundlerInput::node_modules_dir` is set, create a
@@ -647,6 +691,7 @@ fn materialise_shadow(
     dest: &Path,
     routes: &mut Vec<RouteEntry>,
     project_root: &Path,
+    strip_md_ext: bool,
 ) -> Result<()> {
     if !src.exists() {
         // A missing source dir is non-fatal — not every project has e.g.
@@ -679,7 +724,17 @@ fn materialise_shadow(
     // would be wasteful. Borrow is linear (`&mut`), so a single hoisted
     // pipeline can serve every MDX file in the walk sequentially. See
     // zfb#127 / #128.
+    //
+    // The opt-in `StripMdExtensionPlugin` is appended here when the
+    // user enabled `stripMdExt` in `zfb.config.ts` (zfb#127 / #129).
+    // The plugin is intentionally NOT in `with_defaults()` because it
+    // only makes sense for sites whose authors hand-write
+    // `[label](other.md)` style references. The dev loader honours the
+    // same flag so dev preview matches built dist.
     let mut pipeline = zfb_content::pipeline::Pipeline::with_defaults();
+    if strip_md_ext {
+        pipeline.add_strip_md_ext();
+    }
 
     for entry in WalkDir::new(src).follow_links(false) {
         let entry = entry.with_context(|| format!("walking {}", src.display()))?;
@@ -888,6 +943,7 @@ fn materialise_collection(
     dest: &Path,
     collection_name: &str,
     imports: &mut Vec<ContentImport>,
+    strip_md_ext: bool,
 ) -> Result<()> {
     if !src.exists() {
         return Ok(());
@@ -900,7 +956,15 @@ fn materialise_collection(
     // See `materialise_shadow` for the rationale; the same applies
     // here. Two walks → two hoisted pipelines (one per walker), which
     // is cheaper than one per file. See zfb#127 / #128.
+    //
+    // The opt-in `StripMdExtensionPlugin` is appended when the user
+    // enabled `stripMdExt` (zfb#127 / #129). The flag is threaded in
+    // by the caller so the page walker and the collection walker
+    // honour the same setting.
     let mut pipeline = zfb_content::pipeline::Pipeline::with_defaults();
+    if strip_md_ext {
+        pipeline.add_strip_md_ext();
+    }
 
     for entry in WalkDir::new(src).follow_links(false) {
         let entry = entry.with_context(|| format!("walking {}", src.display()))?;
@@ -1742,6 +1806,7 @@ mod tests {
             content_snapshot_json: None,
             node_modules_dir: None,
             node_modules_preserve_symlinks: false,
+            strip_md_ext: false,
         }
     }
 
@@ -1966,7 +2031,7 @@ mod tests {
 
         let dest = tmp.path().join("shadow_content").join("docs");
         let mut imports: Vec<ContentImport> = Vec::new();
-        materialise_collection(&src, &dest, "docs", &mut imports).unwrap();
+        materialise_collection(&src, &dest, "docs", &mut imports, false).unwrap();
 
         // Two MDX files → two ContentImport records, with stable
         // forward-slash shadow_rel_paths under `content/docs/...`.
@@ -2073,6 +2138,7 @@ mod tests {
             &dest,
             "ghost",
             &mut imports,
+            false,
         )
         .unwrap();
         assert!(imports.is_empty());
@@ -2239,6 +2305,7 @@ mod tests {
             content_snapshot_json: None,
             node_modules_dir: None,
             node_modules_preserve_symlinks: false,
+            strip_md_ext: false,
         };
 
         let out = bundle(input).expect("real esbuild bundle should succeed");
@@ -2347,7 +2414,7 @@ mod tests {
         let mut routes = Vec::new();
         // dest must be named "pages" for is_pages_dir detection in materialise_shadow
         let shadow_pages_dest = root.join("shadow").join("pages");
-        materialise_shadow(&pages, &shadow_pages_dest, &mut routes, &root).unwrap();
+        materialise_shadow(&pages, &shadow_pages_dest, &mut routes, &root, false).unwrap();
 
         // Map route → registration index.
         let order: BTreeMap<&str, usize> = routes

--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -669,6 +669,18 @@ fn materialise_shadow(
         .map(|s| s == "pages")
         .unwrap_or(false);
 
+    // Hoist a single `Pipeline::with_defaults()` outside the walk loop
+    // so the seven default plugins (admonitions, CJK-friendly emphasis,
+    // heading-links, code-title, image-enlarge, mermaid, syntect) all
+    // fire on every MDX file the walker visits. The dev loader at
+    // `crates/zfb-render/src/loader.rs` reuses one pipeline for the
+    // same reason — `Pipeline::with_defaults()` allocates a
+    // `Highlighter` and seven boxed visitors, so per-file construction
+    // would be wasteful. Borrow is linear (`&mut`), so a single hoisted
+    // pipeline can serve every MDX file in the walk sequentially. See
+    // zfb#127 / #128.
+    let mut pipeline = zfb_content::pipeline::Pipeline::with_defaults();
+
     for entry in WalkDir::new(src).follow_links(false) {
         let entry = entry.with_context(|| format!("walking {}", src.display()))?;
         let from = entry.path();
@@ -701,7 +713,7 @@ fn materialise_shadow(
             let raw = fs::read_to_string(from)
                 .with_context(|| format!("read mdx {}", from.display()))?;
             let body = strip_yaml_frontmatter(&raw);
-            let compiled = compile_mdx_to_jsx_module_cached(body, from, None, None)
+            let compiled = compile_mdx_to_jsx_module_cached(body, from, None, Some(&mut pipeline))
                 .with_context(|| format!("compile mdx {}", from.display()))?;
             fs::write(&to, compiled.jsx_source.as_bytes())
                 .with_context(|| format!("write compiled mdx to {}", to.display()))?;
@@ -883,6 +895,13 @@ fn materialise_collection(
     fs::create_dir_all(dest)
         .with_context(|| format!("create dir {}", dest.display()))?;
 
+    // Hoist a single `Pipeline::with_defaults()` outside the walk loop
+    // so the seven default plugins fire on every collection MDX file.
+    // See `materialise_shadow` for the rationale; the same applies
+    // here. Two walks → two hoisted pipelines (one per walker), which
+    // is cheaper than one per file. See zfb#127 / #128.
+    let mut pipeline = zfb_content::pipeline::Pipeline::with_defaults();
+
     for entry in WalkDir::new(src).follow_links(false) {
         let entry = entry.with_context(|| format!("walking {}", src.display()))?;
         let from = entry.path();
@@ -946,7 +965,7 @@ fn materialise_collection(
             // the bridge map. Mismatch here would make every bridge
             // lookup miss and silently fall back to the
             // raw-markdown <pre> block.
-            let compiled = compile_mdx_to_jsx_module_cached(&body, from, None, None)
+            let compiled = compile_mdx_to_jsx_module_cached(&body, from, None, Some(&mut pipeline))
                 .with_context(|| format!("compile mdx {}", from.display()))?;
             fs::write(&to, compiled.jsx_source.as_bytes())
                 .with_context(|| format!("write compiled mdx to {}", to.display()))?;

--- a/crates/zfb-build/tests/bundler_default_plugins.rs
+++ b/crates/zfb-build/tests/bundler_default_plugins.rs
@@ -200,12 +200,15 @@ fn bundler_threads_default_plugins_through_mdx_compile() {
     // reliable bundle-side proof that `<Note>` survived the hast
     // detour into the JSX output (see
     // `crates/zfb-content/tests/mdx_jsx_emit_hast.rs::mdx_component_passthrough_survives_hast_detour`).
-    // The exact source-form `_components.Note ?? components.Note`
-    // gets minified-friendly transformed by esbuild but the symbol
-    // `Note` survives in property-access form.
+    // The emitter source emits
+    // `const Note = _components.Note ?? components.Note;` —
+    // esbuild may rename the local through minification but the
+    // property-access `_components.Note` (or the destructure
+    // `Note: ` in the `_components` literal) survives.
     assert!(
-        body.contains("Note"),
-        "compiled bundle should reference the <Note> JSX component the admonition plugin emits"
+        body.contains("_components.Note") || body.contains("Note: ") || body.contains("Note:"),
+        "compiled bundle should reference the <Note> JSX component the admonition plugin emits (looked for `_components.Note` / `Note: ` / `Note:` in the bundle).\n--- bundle excerpt ---\n{}",
+        snippet(&body)
     );
 
     // ---- Mermaid (hast-phase plugin) ---------------------------------

--- a/crates/zfb-build/tests/bundler_default_plugins.rs
+++ b/crates/zfb-build/tests/bundler_default_plugins.rs
@@ -310,6 +310,7 @@ fn make_input(
             "posts",
             PathBuf::from("content/posts"),
         )],
+        strip_md_ext: false,
     }
 }
 

--- a/crates/zfb-build/tests/bundler_default_plugins.rs
+++ b/crates/zfb-build/tests/bundler_default_plugins.rs
@@ -1,0 +1,319 @@
+//! Bundler-wiring integration test for the default-plugin chain
+//! (zfb#127 / #128).
+//!
+//! Pins the contract that
+//! [`zfb_build::bundler::bundle`] threads
+//! [`zfb_content::pipeline::Pipeline::with_defaults()`] through
+//! `compile_mdx_to_jsx_module_cached` at every MDX pre-compile call
+//! site. Without this wiring, none of the seven default plugins
+//! (admonitions, CJK-friendly emphasis, heading-links, code-title,
+//! image-enlarge, mermaid, syntect) fire on built `dist/` output —
+//! which is exactly the bug zfb#126 surfaced.
+//!
+//! ## Scope vs. the wider plugin matrix
+//!
+//! This is a **wiring** test, not a re-test of every plugin's output.
+//! The full seven-plugin coverage matrix lives in
+//! `crates/zfb-content/tests/mdx_jsx_emit_hast.rs`. Here we only need
+//! to prove the bundler now passes the pipeline through. Four
+//! markers — one per plugin path the source issue's test plan called
+//! out — are enough signal to catch a `pipeline=None` regression.
+//!
+//! ## Markers (from zfb#126's test plan)
+//!
+//! - **Admonition** (`:::note Title\nbody\n:::`): the directive markers
+//!   must be CONSUMED, and the JSX must contain a `<Note>` element.
+//!   The directive previously passed through verbatim because the
+//!   bundler skipped the mdast-phase plugin chain.
+//! - **Mermaid** (` ```mermaid `): the bundle must contain
+//!   `data-mermaid` (the canonical attribute the source issue named).
+//! - **Syntect** (a non-mermaid fenced code block): the bundle must
+//!   contain a `syntect-` class hook (the actual class shape
+//!   `SyntectPlugin` emits — see
+//!   `crates/zfb-content/src/plugins/syntect_plugin.rs`).
+//! - **Image-enlarge** (a block-level paragraph image): the bundle
+//!   must contain `zd-enlargeable` (the class on the wrapping
+//!   `<figure>`).
+//!
+//! Because the bundler emits JSX text and esbuild compiles it to JS,
+//! the assertions look at the final bundle body — JSX string-literal
+//! attributes survive verbatim in the compiled output (e.g.
+//! `class="zd-enlargeable"` becomes `className:"zd-enlargeable"` or a
+//! similar string-bearing form, but the substring `zd-enlargeable`
+//! survives).
+//!
+//! ## Esbuild gating
+//!
+//! Same precedence as `bundler_integration.rs`:
+//! `ZFB_ESBUILD_BIN` env var → `crates/zfb/binaries/esbuild/esbuild`
+//! slot → `which esbuild` PATH fallback. If no binary is available the
+//! test prints a skip note and returns early.
+//!
+//! ## Determinism
+//!
+//! After asserting all four markers, the bundler is run a second time
+//! against the same project tree and the two bundle bodies are
+//! compared byte-for-byte. This is a regression check on
+//! `Pipeline::with_defaults()` determinism, NOT a cache-path check
+//! (with `pipeline = Some(&mut _)`, the cache is bypassed by design —
+//! see `crates/zfb-content/src/mdx_jsx_emit.rs`).
+
+use std::collections::{BTreeMap, HashMap};
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+use zfb_build::{bundle, BundleMode, BundlerInput, ContentCollectionSpec};
+use zfb_render::adapters::Framework;
+
+fn locate_esbuild() -> Option<PathBuf> {
+    if let Some(p) = std::env::var_os("ZFB_ESBUILD_BIN") {
+        let p = PathBuf::from(p);
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    let here = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    if let Some(workspace) = here.parent().and_then(|p| p.parent()) {
+        let slot = workspace.join("crates/zfb/binaries/esbuild/esbuild");
+        if slot.exists() {
+            return Some(slot);
+        }
+    }
+    if let Ok(out) = Command::new("which").arg("esbuild").output() {
+        if out.status.success() {
+            let p = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim());
+            if p.exists() {
+                return Some(p);
+            }
+        }
+    }
+    None
+}
+
+/// Build a minimal user-project tree exercising all four marker plugin
+/// paths. Returns the project root.
+fn write_fixture_project(root: &std::path::Path) {
+    for d in ["pages", "content/posts", "components", "layouts"] {
+        fs::create_dir_all(root.join(d)).unwrap();
+    }
+
+    // A minimal layout — purely a relative-import sanity element.
+    fs::write(
+        root.join("layouts/default.tsx"),
+        r#"
+            export default function DefaultLayout({ children }) {
+              return children;
+            }
+        "#,
+    )
+    .unwrap();
+
+    // A page MDX that exercises the four marker plugin paths in one
+    // file:
+    //
+    // 1. `:::note\n\nbody\n\n:::`          → admonition (mdast plugin)
+    //                                         (blank lines are required
+    //                                          per the directive parser
+    //                                          — see
+    //                                          `crates/zfb-content/src/plugins/directives.rs`)
+    // 2. ```mermaid graph TD; A-->B; ```   → mermaid (hast plugin)
+    // 3. ```rust fn main() {} ```          → syntect (hast plugin)
+    // 4. `![alt](pic.png)` (block image)   → image-enlarge (hast plugin)
+    //
+    // Frontmatter is stripped by the bundler before the body reaches
+    // `compile_mdx_to_jsx_module_cached`, so no special handling
+    // beyond the existing `strip_yaml_frontmatter` is needed.
+    fs::write(
+        root.join("pages/index.mdx"),
+        "---\n\
+         title: Default Plugins Smoke\n\
+         ---\n\
+         \n\
+         :::note\n\
+         \n\
+         admonition body\n\
+         \n\
+         :::\n\
+         \n\
+         ```mermaid\n\
+         graph TD;\n\
+           A-->B;\n\
+         ```\n\
+         \n\
+         ```rust\n\
+         fn main() {}\n\
+         ```\n\
+         \n\
+         ![alt text](pic.png)\n",
+    )
+    .unwrap();
+
+    // A second MDX file under a content collection so the
+    // collection-shadow walker (the second `compile_mdx_to_jsx_module_cached`
+    // call site at `bundler.rs:949`) is also exercised. The two
+    // walkers each hoist their own `Pipeline::with_defaults()`; this
+    // file proves the second one fires too.
+    fs::write(
+        root.join("content/posts/intro.mdx"),
+        "---\ntitle: Intro\n---\n\n:::tip\n\nuse it well\n\n:::\n",
+    )
+    .unwrap();
+}
+
+#[test]
+fn bundler_threads_default_plugins_through_mdx_compile() {
+    let Some(esbuild) = locate_esbuild() else {
+        eprintln!(
+            "[bundler_default_plugins] no esbuild binary available; \
+             set ZFB_ESBUILD_BIN, place the binary at \
+             crates/zfb/binaries/esbuild/esbuild, or install esbuild on PATH \
+             to enable this test. Skipping."
+        );
+        return;
+    };
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+    write_fixture_project(&root);
+
+    let input = make_input(&root, &esbuild, "dist");
+    let out = bundle(input).expect("bundle should succeed");
+
+    assert!(out.bundle_path.exists(), "bundle.mjs should exist");
+    let body = fs::read_to_string(&out.bundle_path).expect("read bundle");
+    assert!(!body.is_empty(), "bundle should be non-empty");
+
+    // ---- Admonition (mdast-phase plugin) -----------------------------
+    //
+    // The `:::note` directive markers must be CONSUMED — if they
+    // survive verbatim in the bundle, the admonition plugin did not
+    // fire (the source-issue regression). Conversely the JSX must
+    // contain a `<Note>` reference, which esbuild renders as a
+    // `Note`/`_components.Note` identifier in the compiled output.
+    assert!(
+        !body.contains(":::note"),
+        ":::note directive markers must be consumed by the admonition plugin (regression: pipeline=None lets them survive verbatim).\n--- bundle excerpt ---\n{}",
+        snippet(&body)
+    );
+    // The PascalCase preamble baked by the JSX emitter is the most
+    // reliable bundle-side proof that `<Note>` survived the hast
+    // detour into the JSX output (see
+    // `crates/zfb-content/tests/mdx_jsx_emit_hast.rs::mdx_component_passthrough_survives_hast_detour`).
+    // The exact source-form `_components.Note ?? components.Note`
+    // gets minified-friendly transformed by esbuild but the symbol
+    // `Note` survives in property-access form.
+    assert!(
+        body.contains("Note"),
+        "compiled bundle should reference the <Note> JSX component the admonition plugin emits"
+    );
+
+    // ---- Mermaid (hast-phase plugin) ---------------------------------
+    //
+    // Source issue #126's canonical marker. The mermaid plugin
+    // replaces ```mermaid blocks with `<div class="mermaid"
+    // data-mermaid>`; the `data-mermaid` attribute is the unique
+    // marker we look for in the bundle.
+    assert!(
+        body.contains("data-mermaid"),
+        "mermaid plugin should emit the data-mermaid attribute in the bundle.\n--- bundle excerpt ---\n{}",
+        snippet(&body)
+    );
+    // The original `language-mermaid` class must NOT survive — the
+    // mermaid plugin replaces the entire <pre> wrapper.
+    assert!(
+        !body.contains("language-mermaid"),
+        "language-mermaid class must not leak past mermaid plugin (the <pre> shell should be replaced with <div class=\"mermaid\">).\n--- bundle excerpt ---\n{}",
+        snippet(&body)
+    );
+
+    // ---- Syntect (hast-phase plugin) ---------------------------------
+    //
+    // Syntect emits HTML that the JSX bridge wraps in
+    // `dangerouslySetInnerHTML`. The `syntect-` class hook is the
+    // unique marker (`<pre class="syntect-…">` per
+    // `crates/zfb-content/src/plugins/syntect_plugin.rs`).
+    assert!(
+        body.contains("syntect-"),
+        "syntect plugin should emit a `syntect-` class hook in the bundle.\n--- bundle excerpt ---\n{}",
+        snippet(&body)
+    );
+
+    // ---- Image-enlarge (hast-phase plugin) ---------------------------
+    //
+    // A block-level <p><img></p> becomes <figure class="zd-enlargeable">.
+    // The class string survives in the bundle as a JSX `className`
+    // string-literal value.
+    assert!(
+        body.contains("zd-enlargeable"),
+        "image-enlarge plugin should wrap block-level images in <figure class=\"zd-enlargeable\">.\n--- bundle excerpt ---\n{}",
+        snippet(&body)
+    );
+
+    // ---- Determinism check -------------------------------------------
+    //
+    // Run the bundler a second time against the same project tree and
+    // assert byte-identical output. With `pipeline = Some(&mut _)` the
+    // MDX cache is bypassed by design (see
+    // `crates/zfb-content/src/mdx_jsx_emit.rs` near `cache_for_lookup`),
+    // so this is a determinism / regression check on
+    // `Pipeline::with_defaults()` itself, not a cache-path check.
+    let second_input = make_input(&root, &esbuild, "dist2");
+    let second_out = bundle(second_input).expect("second bundle should succeed");
+    let second_body =
+        fs::read_to_string(&second_out.bundle_path).expect("read second bundle");
+    assert_eq!(
+        body, second_body,
+        "bundler output should be byte-identical across runs (deterministic Pipeline::with_defaults emit)"
+    );
+}
+
+fn make_input(
+    root: &std::path::Path,
+    esbuild: &std::path::Path,
+    outdir_name: &str,
+) -> BundlerInput {
+    BundlerInput {
+        project_root: root.to_path_buf(),
+        pages_dir: PathBuf::from("pages"),
+        content_dir: PathBuf::from("content"),
+        components_dir: PathBuf::from("components"),
+        layouts_dir: PathBuf::from("layouts"),
+        framework: Framework::Preact,
+        define_vars: HashMap::new(),
+        tsconfig_paths: BTreeMap::new(),
+        // Mark every bare specifier the synthetic entry.mjs imports
+        // as external — we don't need a node_modules tree for this
+        // wiring test.
+        external: vec![
+            "preact".into(),
+            "preact-render-to-string".into(),
+            "@takazudo/zfb-runtime".into(),
+        ],
+        outdir: root.join(outdir_name),
+        mode: BundleMode::Production,
+        minify: false,
+        esbuild_binary: Some(esbuild.to_path_buf()),
+        mock_subprocess_output: None,
+        content_snapshot_json: None,
+        node_modules_dir: None,
+        node_modules_preserve_symlinks: false,
+        // Wire the `posts` collection so the second pre-compile call
+        // site (the collection-shadow walker at `bundler.rs:949`)
+        // also runs. Without a registered collection, the `content/`
+        // tree is materialised into the page shadow but not iterated
+        // through `materialise_collection`.
+        content_collections: vec![ContentCollectionSpec::new(
+            "posts",
+            PathBuf::from("content/posts"),
+        )],
+    }
+}
+
+/// Truncate a long string for assert messages.
+fn snippet(s: &str) -> String {
+    if s.len() <= 1200 {
+        return s.to_string();
+    }
+    format!("{}…[{} bytes truncated]", &s[..1200], s.len() - 1200)
+}

--- a/crates/zfb-build/tests/bundler_integration.rs
+++ b/crates/zfb-build/tests/bundler_integration.rs
@@ -191,6 +191,7 @@ fn end_to_end_bundles_aliases_mdx_islands_and_define() {
         node_modules_dir: None,
         node_modules_preserve_symlinks: false,
         content_collections: Vec::new(),
+        strip_md_ext: false,
     };
 
     let out = bundle(input).expect("end-to-end bundle should succeed");

--- a/crates/zfb-build/tests/bundler_strip_md_ext.rs
+++ b/crates/zfb-build/tests/bundler_strip_md_ext.rs
@@ -1,0 +1,270 @@
+//! Bundler-wiring integration test for the opt-in `stripMdExt` flag
+//! (zfb#127 / #129).
+//!
+//! Pins the contract that
+//! [`zfb_build::bundler::BundlerInput::strip_md_ext`] is honoured at
+//! both MDX pre-compile call sites the Sub 1 hoist exposed
+//! (`materialise_shadow` for pages, `materialise_collection` for
+//! collections). When the flag is `true`, `[link](other.md)` style
+//! hrefs in MDX content must be rewritten to `other/` (extension
+//! stripped, trailing slash appended) by
+//! [`zfb_content::pipeline::Pipeline::add_strip_md_ext`]. When the
+//! flag is `false` (the default), hrefs must remain untouched —
+//! byte-for-byte identical to the Sub 1 outcome — so existing
+//! projects keep their current shape.
+//!
+//! ## Esbuild gating
+//!
+//! Same precedence as `bundler_integration.rs` /
+//! `bundler_default_plugins.rs`: `ZFB_ESBUILD_BIN` env var →
+//! `crates/zfb/binaries/esbuild/esbuild` slot → `which esbuild` PATH
+//! fallback. If no binary is available the test prints a skip note
+//! and returns early.
+
+use std::collections::{BTreeMap, HashMap};
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+use zfb_build::{bundle, BundleMode, BundlerInput, ContentCollectionSpec};
+use zfb_render::adapters::Framework;
+
+fn locate_esbuild() -> Option<PathBuf> {
+    if let Some(p) = std::env::var_os("ZFB_ESBUILD_BIN") {
+        let p = PathBuf::from(p);
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    let here = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    if let Some(workspace) = here.parent().and_then(|p| p.parent()) {
+        let slot = workspace.join("crates/zfb/binaries/esbuild/esbuild");
+        if slot.exists() {
+            return Some(slot);
+        }
+    }
+    if let Ok(out) = Command::new("which").arg("esbuild").output() {
+        if out.status.success() {
+            let p = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim());
+            if p.exists() {
+                return Some(p);
+            }
+        }
+    }
+    None
+}
+
+/// Build a minimal user-project tree exercising both the page walker
+/// AND the collection walker so we cover both `add_strip_md_ext`
+/// call sites.
+fn write_fixture_project(root: &std::path::Path) {
+    for d in ["pages", "content/posts", "components", "layouts"] {
+        fs::create_dir_all(root.join(d)).unwrap();
+    }
+
+    fs::write(
+        root.join("layouts/default.tsx"),
+        r#"
+            export default function DefaultLayout({ children }) {
+              return children;
+            }
+        "#,
+    )
+    .unwrap();
+
+    // Page MDX with two markdown links — one to a sibling `.md` page
+    // and one to a sibling `.mdx` page. With `stripMdExt: true` both
+    // hrefs become extension-stripped, trailing-slash-appended forms
+    // (`./other/` and `./guide/`). With it off they survive verbatim.
+    fs::write(
+        root.join("pages/index.mdx"),
+        "---\n\
+         title: Strip MdExt Smoke\n\
+         ---\n\
+         \n\
+         [other](./other.md) and [guide](./guide.mdx)\n",
+    )
+    .unwrap();
+
+    // Collection MDX exercises the second call site
+    // (`materialise_collection`). Same shape.
+    fs::write(
+        root.join("content/posts/intro.mdx"),
+        "---\ntitle: Intro\n---\n\nsee [next post](./next.md) for more.\n",
+    )
+    .unwrap();
+}
+
+fn make_input(
+    root: &std::path::Path,
+    esbuild: &std::path::Path,
+    outdir_name: &str,
+    strip_md_ext: bool,
+) -> BundlerInput {
+    BundlerInput {
+        project_root: root.to_path_buf(),
+        pages_dir: PathBuf::from("pages"),
+        content_dir: PathBuf::from("content"),
+        components_dir: PathBuf::from("components"),
+        layouts_dir: PathBuf::from("layouts"),
+        framework: Framework::Preact,
+        define_vars: HashMap::new(),
+        tsconfig_paths: BTreeMap::new(),
+        external: vec![
+            "preact".into(),
+            "preact-render-to-string".into(),
+            "@takazudo/zfb-runtime".into(),
+        ],
+        outdir: root.join(outdir_name),
+        mode: BundleMode::Production,
+        minify: false,
+        esbuild_binary: Some(esbuild.to_path_buf()),
+        mock_subprocess_output: None,
+        content_snapshot_json: None,
+        node_modules_dir: None,
+        node_modules_preserve_symlinks: false,
+        content_collections: vec![ContentCollectionSpec::new(
+            "posts",
+            PathBuf::from("content/posts"),
+        )],
+        strip_md_ext,
+    }
+}
+
+#[test]
+fn strip_md_ext_on_rewrites_internal_md_hrefs_to_trailing_slash() {
+    let Some(esbuild) = locate_esbuild() else {
+        eprintln!(
+            "[bundler_strip_md_ext] no esbuild binary available; \
+             set ZFB_ESBUILD_BIN, place the binary at \
+             crates/zfb/binaries/esbuild/esbuild, or install esbuild on PATH \
+             to enable this test. Skipping."
+        );
+        return;
+    };
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+    write_fixture_project(&root);
+
+    let input = make_input(&root, &esbuild, "dist-on", true);
+    let out = bundle(input).expect("bundle should succeed with strip_md_ext=true");
+    let body = fs::read_to_string(&out.bundle_path).expect("read bundle");
+    assert!(!body.is_empty(), "bundle should be non-empty");
+
+    // ---- Page-walker call site -------------------------------------
+    //
+    // The two markdown links in `pages/index.mdx` should reach the
+    // bundle as `./other/` and `./guide/`. The compiled bundle emits
+    // them as JSX `href` string-literal attributes — esbuild may
+    // rename surrounding identifiers under minification, but the
+    // rewritten URL string itself survives byte-for-byte.
+    assert!(
+        body.contains("./other/"),
+        "stripMdExt=true must rewrite `./other.md` to `./other/` \
+         in the page bundle.\n--- bundle excerpt ---\n{}",
+        snippet(&body)
+    );
+    assert!(
+        body.contains("./guide/"),
+        "stripMdExt=true must rewrite `./guide.mdx` to `./guide/` \
+         in the page bundle.\n--- bundle excerpt ---\n{}",
+        snippet(&body)
+    );
+    // The `.md` / `.mdx` suffixes on internal hrefs must NOT survive
+    // — that is the regression `add_strip_md_ext` exists to prevent.
+    assert!(
+        !body.contains("./other.md"),
+        "stripMdExt=true must consume the `./other.md` href; the \
+         literal extension survived.\n--- bundle excerpt ---\n{}",
+        snippet(&body)
+    );
+    assert!(
+        !body.contains("./guide.mdx"),
+        "stripMdExt=true must consume the `./guide.mdx` href; the \
+         literal extension survived.\n--- bundle excerpt ---\n{}",
+        snippet(&body)
+    );
+
+    // ---- Collection-walker call site -------------------------------
+    //
+    // The `content/posts/intro.mdx` body has `[next post](./next.md)`
+    // — the collection walker has its own hoisted pipeline in
+    // `materialise_collection`, so the flag must be threaded there
+    // too. With it on, the bundled collection module references
+    // `./next/` (extension stripped, trailing slash appended).
+    assert!(
+        body.contains("./next/"),
+        "stripMdExt=true must rewrite `./next.md` to `./next/` in \
+         the collection bundle (materialise_collection call site).\n\
+         --- bundle excerpt ---\n{}",
+        snippet(&body)
+    );
+    assert!(
+        !body.contains("./next.md"),
+        "stripMdExt=true must consume the `./next.md` href in the \
+         collection module.\n--- bundle excerpt ---\n{}",
+        snippet(&body)
+    );
+}
+
+#[test]
+fn strip_md_ext_off_preserves_md_hrefs() {
+    // The default (flag absent or false) MUST be byte-for-byte
+    // identical to Sub 1's outcome — `[link](./other.md)` survives
+    // verbatim into the bundle. This pins the "opt-in by default"
+    // contract from the issue.
+    let Some(esbuild) = locate_esbuild() else {
+        eprintln!(
+            "[bundler_strip_md_ext] no esbuild binary available; skipping."
+        );
+        return;
+    };
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+    write_fixture_project(&root);
+
+    let input = make_input(&root, &esbuild, "dist-off", false);
+    let out = bundle(input).expect("bundle should succeed with strip_md_ext=false");
+    let body = fs::read_to_string(&out.bundle_path).expect("read bundle");
+
+    // Page walker — original `.md` / `.mdx` hrefs survive untouched.
+    assert!(
+        body.contains("./other.md"),
+        "stripMdExt=false must preserve `./other.md` verbatim \
+         (default = opt-in = no rewrite).\n--- bundle excerpt ---\n{}",
+        snippet(&body)
+    );
+    assert!(
+        body.contains("./guide.mdx"),
+        "stripMdExt=false must preserve `./guide.mdx` verbatim.\n\
+         --- bundle excerpt ---\n{}",
+        snippet(&body)
+    );
+    // Collection walker — same.
+    assert!(
+        body.contains("./next.md"),
+        "stripMdExt=false must preserve `./next.md` verbatim in the \
+         collection module.\n--- bundle excerpt ---\n{}",
+        snippet(&body)
+    );
+    // And the trailing-slash forms must NOT appear by accident — if
+    // they did, the default would be silently changing existing
+    // projects.
+    assert!(
+        !body.contains("./other/"),
+        "stripMdExt=false must NOT introduce `./other/` (the rewritten \
+         shape) — the default must be byte-for-byte identical to \
+         Sub 1's outcome.\n--- bundle excerpt ---\n{}",
+        snippet(&body)
+    );
+}
+
+/// Truncate a long string for assert messages.
+fn snippet(s: &str) -> String {
+    if s.len() <= 1200 {
+        return s.to_string();
+    }
+    format!("{}…[{} bytes truncated]", &s[..1200], s.len() - 1200)
+}

--- a/crates/zfb-build/tests/integration_e2e_routing_rendering.rs
+++ b/crates/zfb-build/tests/integration_e2e_routing_rendering.rs
@@ -365,6 +365,7 @@ fn build_bundle(
         node_modules_dir: Some(node_modules.path().to_path_buf()),
         node_modules_preserve_symlinks: true,
         content_collections: Vec::new(),
+        strip_md_ext: false,
     };
 
     let output = bundle(input).expect("bundle should succeed for fixture project");

--- a/crates/zfb-content/tests/mdx_jsx_emit_cache.rs
+++ b/crates/zfb-content/tests/mdx_jsx_emit_cache.rs
@@ -10,6 +10,7 @@
 
 use std::path::PathBuf;
 
+use zfb_content::pipeline::Pipeline;
 use zfb_content::{
     compile_mdx_to_jsx_module, compile_mdx_to_jsx_module_cached, parse_mdx_specifier,
     MdxModuleCache, MdxModuleSpecifier, SpecifierError,
@@ -157,6 +158,57 @@ fn cache_opt_out_recompiles_every_call() {
 
     assert_eq!(cached_first, uncached);
     assert_eq!(uncached, convenience);
+}
+
+#[test]
+fn cache_is_bypassed_when_pipeline_is_supplied() {
+    // Contract: when both `Some(&cache)` and `Some(&mut pipeline)` are
+    // passed to `compile_mdx_to_jsx_module_cached`, the cache MUST NOT
+    // grow. The simple `sha256(input)` cache key cannot distinguish
+    // identical inputs run through different pipelines, so the
+    // implementation deliberately bypasses the cache when a pipeline
+    // is supplied (see `crates/zfb-content/src/mdx_jsx_emit.rs`
+    // around the `cache_for_lookup` setup). This test pins that
+    // behaviour so a future refactor cannot silently start caching
+    // pipeline-transformed output keyed only on input.
+    //
+    // Source: zfb#128 acceptance criteria — "verify
+    // `Some(&cache) + Some(&mut pipeline)` does not grow the cache."
+    let cache = MdxModuleCache::new();
+    let mut pipeline = Pipeline::with_defaults();
+    assert!(cache.is_empty(), "precondition: empty cache");
+
+    let src = "# heading\n\nbody\n";
+    let path = fixture_path("with-pipeline");
+
+    let _ =
+        compile_mdx_to_jsx_module_cached(src, &path, Some(&cache), Some(&mut pipeline)).unwrap();
+    assert_eq!(
+        cache.len(),
+        0,
+        "cache must NOT grow when a pipeline is supplied (was {})",
+        cache.len()
+    );
+
+    // Repeat: the second call also bypasses the cache.
+    let _ =
+        compile_mdx_to_jsx_module_cached(src, &path, Some(&cache), Some(&mut pipeline)).unwrap();
+    assert_eq!(
+        cache.len(),
+        0,
+        "second call must also leave the cache untouched (was {})",
+        cache.len()
+    );
+
+    // Sanity: the same call WITHOUT a pipeline DOES grow the cache.
+    // This guards against a degenerate "cache never grows" failure
+    // mode where the assertion above passes for the wrong reason.
+    let _ = compile_mdx_to_jsx_module_cached(src, &path, Some(&cache), None).unwrap();
+    assert_eq!(
+        cache.len(),
+        1,
+        "control: dropping the pipeline must let the cache grow"
+    );
 }
 
 #[test]

--- a/crates/zfb-render/src/loader.rs
+++ b/crates/zfb-render/src/loader.rs
@@ -179,7 +179,28 @@ pub struct ModuleLoader {
 
 impl ModuleLoader {
     /// Build a fresh loader with empty cache and the given default runtime.
+    ///
+    /// The internal MDX content pipeline is constructed via
+    /// [`Pipeline::with_defaults`]; the opt-in `StripMdExtensionPlugin`
+    /// is NOT appended here. Use [`ModuleLoader::with_strip_md_ext`]
+    /// when the project's `zfb.config.ts` enables `stripMdExt` so dev
+    /// rendering matches built dist.
     pub fn new(jsx_runtime: JsxRuntime) -> Self {
+        Self::with_strip_md_ext(jsx_runtime, false)
+    }
+
+    /// Build a fresh loader, optionally appending
+    /// [`Pipeline::add_strip_md_ext`] to the content pipeline.
+    ///
+    /// Mirrors [`zfb_build::BundlerInput::strip_md_ext`] (zfb#127 /
+    /// #129): when the bundler has the flag on, the dev loader must
+    /// honour it too or `pnpm dev` and `zfb build` produce different
+    /// href shapes for `[link](other.md)` style references.
+    pub fn with_strip_md_ext(jsx_runtime: JsxRuntime, strip_md_ext: bool) -> Self {
+        let mut content_pipeline = Pipeline::with_defaults();
+        if strip_md_ext {
+            content_pipeline.add_strip_md_ext();
+        }
         Self {
             pipeline: SwcPipeline::new(),
             jsx_runtime,
@@ -190,7 +211,7 @@ impl ModuleLoader {
                 ".jsx".to_string(),
                 ".js".to_string(),
             ],
-            content_pipeline: Pipeline::with_defaults(),
+            content_pipeline,
         }
     }
 
@@ -401,5 +422,69 @@ mod tests {
             .load_source("page.tsx", "/* different source — should hit cache */")
             .expect("cache hit");
         assert_eq!(loader.cache_len(), 1);
+    }
+
+    /// Dev-loader counterpart to the bundler's
+    /// `strip_md_ext_on_rewrites_internal_md_hrefs_to_trailing_slash`
+    /// integration test (zfb#127 / #129). The dev loader must honour
+    /// the same `stripMdExt` flag the bundler does, otherwise
+    /// `pnpm dev` and `zfb build` produce diverging href shapes.
+    ///
+    /// Driving signal: the JSX text the loader feeds to SWC. When
+    /// `stripMdExt = true`, an MDX `[other](./other.md)` link must
+    /// emit a `href` JSX attribute equal to `./other/` after the
+    /// pipeline runs. With the flag off the original `./other.md`
+    /// survives.
+    #[test]
+    fn loader_with_strip_md_ext_rewrites_internal_md_hrefs() {
+        let source = "see [other](./other.md) and [guide](./guide.mdx).\n";
+
+        // Flag off — extensions survive verbatim in the compiled JSX.
+        let mut loader_off = ModuleLoader::new(JsxRuntime::Preact);
+        let compiled_off = loader_off
+            .load_source("./post.mdx", source)
+            .expect("mdx compile ok (off)");
+        assert!(
+            compiled_off.code.contains("./other.md"),
+            "stripMdExt=off must preserve `./other.md` in the loader's \
+             compiled output; got:\n{}",
+            compiled_off.code
+        );
+        assert!(
+            !compiled_off.code.contains("\"./other/\""),
+            "stripMdExt=off must NOT introduce the rewritten `./other/` \
+             form; got:\n{}",
+            compiled_off.code
+        );
+
+        // Flag on — extensions stripped + trailing slash appended.
+        let mut loader_on = ModuleLoader::with_strip_md_ext(JsxRuntime::Preact, true);
+        let compiled_on = loader_on
+            .load_source("./post.mdx", source)
+            .expect("mdx compile ok (on)");
+        assert!(
+            compiled_on.code.contains("./other/"),
+            "stripMdExt=on must rewrite `./other.md` to `./other/` in \
+             the loader's compiled output; got:\n{}",
+            compiled_on.code
+        );
+        assert!(
+            compiled_on.code.contains("./guide/"),
+            "stripMdExt=on must rewrite `./guide.mdx` to `./guide/`; \
+             got:\n{}",
+            compiled_on.code
+        );
+        assert!(
+            !compiled_on.code.contains("./other.md"),
+            "stripMdExt=on must consume the literal `./other.md` href; \
+             got:\n{}",
+            compiled_on.code
+        );
+        assert!(
+            !compiled_on.code.contains("./guide.mdx"),
+            "stripMdExt=on must consume the literal `./guide.mdx` href; \
+             got:\n{}",
+            compiled_on.code
+        );
     }
 }

--- a/crates/zfb-render/src/loader.rs
+++ b/crates/zfb-render/src/loader.rs
@@ -330,17 +330,21 @@ impl ModuleLoader {
     /// emitter; otherwise return `source` unchanged.
     ///
     /// The cached [`Pipeline::with_defaults`] is threaded through so the
-    /// project's default mdast-phase plugins (admonitions / CJK-friendly
-    /// emphasis) fire against MDX content before JSX emission. Without
-    /// this, `:::note` directives, `<Note>` rewrites, and similar
-    /// transforms would never run on `.mdx` and `mdx://` sources reaching
-    /// the renderer. See zfb#116.
+    /// project's default plugins fire against MDX content before JSX
+    /// emission. Both phases now run on the JSX emit path:
     ///
-    /// Hast-phase plugins (heading-links, code-title, mermaid,
-    /// image-enlarge, syntect, strip-md-ext) are intentionally not
-    /// applied here — the JSX emit path bypasses hast entirely. Those
-    /// plugins continue to run on the HTML serializer path
-    /// ([`Pipeline::run`]).
+    /// - **mdast-phase** plugins (admonitions / CJK-friendly emphasis)
+    ///   transform the parsed mdast tree before JSX synthesis, so
+    ///   `:::note` directives, `<Note>` rewrites, and similar
+    ///   structural changes happen in time. See zfb#116.
+    /// - **hast-phase** plugins (heading-links, code-title, mermaid,
+    ///   image-enlarge, syntect, strip-md-ext) also fire — since
+    ///   zfb#121 the JSX emit path detours through hast inside
+    ///   [`mdx_to_jsx_module_with_pipeline`], so the same plugin chain
+    ///   that runs on the HTML serializer path ([`Pipeline::run`])
+    ///   runs here too. The previous comment block claimed hast-phase
+    ///   plugins were skipped on the JSX path; that has been false
+    ///   since #121.
     ///
     /// Errors from `zfb-content` are wrapped as [`RenderError::Compile`]
     /// with `specifier` as the file location so the renderer's existing

--- a/crates/zfb-render/src/render.rs
+++ b/crates/zfb-render/src/render.rs
@@ -48,9 +48,25 @@ pub struct Renderer<H: RenderHost> {
 
 impl<H: RenderHost> Renderer<H> {
     /// Build a renderer with the given host and JSX runtime preference.
+    ///
+    /// The opt-in `StripMdExtensionPlugin` is OFF — use
+    /// [`Renderer::with_strip_md_ext`] when the project enables
+    /// `stripMdExt` so dev rendering matches built dist.
     pub fn new(host: H, jsx_runtime: JsxRuntime) -> Self {
+        Self::with_strip_md_ext(host, jsx_runtime, false)
+    }
+
+    /// Build a renderer, optionally enabling the
+    /// [`StripMdExtensionPlugin`] in the loader's MDX content pipeline.
+    ///
+    /// Mirrors [`zfb_build::BundlerInput::strip_md_ext`] (zfb#127 /
+    /// #129); the build CLI threads `Config::strip_md_ext` here so
+    /// `zfb dev` and `zfb build` produce identical href shapes.
+    ///
+    /// [`StripMdExtensionPlugin`]: zfb_content::plugins::StripMdExtensionPlugin
+    pub fn with_strip_md_ext(host: H, jsx_runtime: JsxRuntime, strip_md_ext: bool) -> Self {
         Self {
-            loader: ModuleLoader::new(jsx_runtime),
+            loader: ModuleLoader::with_strip_md_ext(jsx_runtime, strip_md_ext),
             host,
         }
     }

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -735,6 +735,11 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
         .iter()
         .map(|c| zfb_build::ContentCollectionSpec::new(c.name.clone(), c.path.clone()))
         .collect();
+    // Thread the opt-in `stripMdExt` flag from `zfb.config.ts` into the
+    // bundler so the hoisted MDX pre-compile pipeline appends
+    // `StripMdExtensionPlugin`. Mirrored in `commands/dev.rs` so dev
+    // and build produce the same href shape (zfb#127 / #129).
+    bundler_input.strip_md_ext = config.strip_md_ext;
     let bundler_out = runner
         .bundle(bundler_input)
         .context("bundler step failed")?;

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -470,6 +470,12 @@ fn boot_dev_renderer(
         .iter()
         .map(|c| zfb_build::ContentCollectionSpec::new(c.name.clone(), c.path.clone()))
         .collect();
+    // Thread the opt-in `stripMdExt` flag through so the dev-mode
+    // bundler (which feeds miniflare) honours the same setting as
+    // `zfb build`. The dev loader at `crates/zfb-render/src/loader.rs`
+    // also reads this flag for in-process MDX rendering, so dev preview
+    // matches built dist (zfb#127 / #129).
+    bundler_input.strip_md_ext = cfg.strip_md_ext;
     let bundler_out: BundlerOutput = bundle(bundler_input).context("bundler step failed")?;
 
     let state = start(RendererStartInput {

--- a/crates/zfb/src/config.rs
+++ b/crates/zfb/src/config.rs
@@ -241,6 +241,22 @@ pub struct Config {
     /// the build orchestrator runs against this field.
     #[serde(default)]
     pub adapter: Option<String>,
+
+    /// Strip `.md` / `.mdx` from internal `<a href>` paths during MDX
+    /// compilation, and append a trailing `/` so the resulting URL shape
+    /// converges with the rest of the site (mirrors the JS engine's
+    /// `rehypeStripMdExtension`). Default: `false`.
+    ///
+    /// Opt-in for projects whose content authors hand-write
+    /// `[label](other.md)` style references that should resolve to the
+    /// rendered route URL (`other/`) rather than a literal file path.
+    /// Built dist (`zfb build`) and dev rendering (`zfb dev`) both honour
+    /// this flag so dev preview matches shipped output.
+    ///
+    /// `#[serde(rename_all = "camelCase")]` on this struct deserialises
+    /// the JSON / TS form `stripMdExt` into this field.
+    #[serde(default)]
+    pub strip_md_ext: bool,
 }
 
 impl Default for Config {
@@ -255,6 +271,7 @@ impl Default for Config {
             tailwind: None,
             plugins: Vec::new(),
             adapter: None,
+            strip_md_ext: false,
         }
     }
 }
@@ -934,6 +951,41 @@ mod tests {
         assert!(cfg.collections.is_empty());
         assert!(cfg.tailwind.is_none());
         assert!(cfg.plugins.is_empty());
+        // `stripMdExt` is opt-in; absent / default = disabled. Mirrors
+        // the Sub 1 outcome byte-for-byte (zfb#127 / #129).
+        assert!(!cfg.strip_md_ext);
+    }
+
+    #[tokio::test]
+    async fn loads_strip_md_ext_from_camelcase_json() {
+        // The JSON / TS form spells the field `stripMdExt`
+        // (camelCase). The struct's `#[serde(rename_all = "camelCase")]`
+        // attr handles the rename, so a config with `stripMdExt: true`
+        // populates `Config::strip_md_ext`.
+        let tmp = TempDir::new().unwrap();
+        tokio::fs::write(
+            tmp.path().join("zfb.config.json"),
+            r#"{ "stripMdExt": true }"#,
+        )
+        .await
+        .unwrap();
+        let cfg = load_from_dir(tmp.path()).await.expect("load ok");
+        assert!(
+            cfg.strip_md_ext,
+            "stripMdExt: true must deserialise into strip_md_ext = true"
+        );
+    }
+
+    #[tokio::test]
+    async fn strip_md_ext_defaults_to_false_when_absent() {
+        // Acceptance criterion: default behaviour must be byte-for-byte
+        // identical to Sub 1's outcome — `stripMdExt` absent => false.
+        let tmp = TempDir::new().unwrap();
+        tokio::fs::write(tmp.path().join("zfb.config.json"), "{}")
+            .await
+            .unwrap();
+        let cfg = load_from_dir(tmp.path()).await.expect("load ok");
+        assert!(!cfg.strip_md_ext);
     }
 
     #[tokio::test]

--- a/packages/zfb/src/config.ts
+++ b/packages/zfb/src/config.ts
@@ -84,6 +84,20 @@ export type ZfbConfig = {
    * Mirrors `Config::adapter` in crates/zfb/src/config.rs.
    */
   adapter?: string;
+  /**
+   * Strip `.md` / `.mdx` from internal `<a href>` paths during MDX
+   * compilation, and append a trailing `/` so the resulting URL shape
+   * converges with the rest of the site (mirrors the JS engine's
+   * `rehypeStripMdExtension`). Default: `false`.
+   *
+   * Enable this when content authors hand-write `[label](other.md)`
+   * style references that should resolve to the rendered route URL
+   * (e.g. `other/`) instead of a literal file path. Built dist and
+   * `pnpm dev` honour the same flag, so previews match shipped output.
+   *
+   * Mirrors `Config::strip_md_ext` in crates/zfb/src/config.rs.
+   */
+  stripMdExt?: boolean;
 };
 
 /**


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/127

---

## Summary

- **Fix `Pipeline::with_defaults()` threading at the bundler MDX pre-compile call sites** (Sub 1, #128): the two `compile_mdx_to_jsx_module_cached` calls in `crates/zfb-build/src/bundler.rs` previously passed `None`, so none of the seven default plugins (CJK-friendly emphasis, admonitions, heading-links, code-title, image-enlarge, mermaid, syntect) fired on built output. Now both call sites hoist `Pipeline::with_defaults()` once per walker and pass `Some(&mut pipeline)`, matching the dev loader's pattern at `crates/zfb-render/src/loader.rs:184-193`.
- **Opt-in `stripMdExt` config plumbed through both the bundler and the dev loader** (Sub 2, #129): new `stripMdExt: boolean` field on `ZfbConfig` (TS) and `Config` (Rust). When enabled, both `zfb build` and `zfb dev` rewrite internal `[link](./other.md)` hrefs to `./other/`. Default `false` is byte-for-byte identical to Sub 1's outcome.
- **Dev/build href shape stays consistent**: addresses the dev/build divergence the Codex review flagged — bundler-only plumbing was rejected. The dev loader's hoisted `Pipeline` now honours the same flag the bundler does, so `pnpm dev` and `zfb build` produce identical hrefs.
- **Stale doc comment corrected**: the doc block on `crates/zfb-render/src/loader.rs:339-343` claimed hast-phase plugins were "intentionally not applied here"; that has been false since zfb#121, where `apply_hast_visitors` started running unconditionally inside `mdx_to_jsx_module_with_pipeline`. Comment now reflects post-zfb#121 reality (both mdast- and hast-phase plugins run on the JSX emit path).

## Changes

### Sub 1 — Pipeline defaults (#128, fix-bundler-pipeline-none/sub-1-pipeline-defaults)

- `crates/zfb-build/src/bundler.rs` (lines 704 and 949): hoist `let mut pipeline = zfb_content::Pipeline::with_defaults();` outside each walker and pass `Some(&mut pipeline)` into `compile_mdx_to_jsx_module_cached`. Two walks → two hoisted pipelines (one per walker), reused across every MDX file in that walk.
- `crates/zfb-render/src/loader.rs` (lines 339–343): rewrite the `maybe_mdx_to_jsx` doc comment to reflect post-zfb#121 behaviour.
- `crates/zfb-build/tests/bundler_default_plugins.rs` (new, 322 lines): bundler-wiring integration test asserting the four markers from #126's test plan (`data-admonition`, `data-mermaid`, syntect class shape, `<figure class=\"zd-enlargeable\">`). Gates on esbuild availability with the project's standard `eprintln!` skip note. Runs the bundler twice for byte-identical determinism.
- `crates/zfb-content/tests/mdx_jsx_emit_cache.rs` (+52 lines): `cache_is_bypassed_when_pipeline_is_supplied` unit test pinning the cache-bypass contract — `cache.len()` does NOT grow when `compile_mdx_to_jsx_module_cached(input, file, Some(&cache), Some(&mut pipeline))` is called.

### Sub 2 — Opt-in `stripMdExt` (#129, fix-bundler-pipeline-none/sub-2-strip-md-ext)

- `packages/zfb/src/config.ts`: extend `ZfbConfig` with `stripMdExt?: boolean` (camelCase to match existing convention; JSDoc explains when to enable it).
- `crates/zfb/src/config.rs`: add matching `strip_md_ext: bool` field; existing `#[serde(rename_all = \"camelCase\")]` handles the rename.
- `crates/zfb-build/src/lib.rs` (`BundlerInput`): carry the flag from CLI config-load to bundler call sites.
- `crates/zfb-build/src/bundler.rs`: at both walker call sites Sub 1 hoisted, conditionally append `pipeline.add_strip_md_ext()` after `with_defaults()` when the flag is true.
- `crates/zfb-render/src/loader.rs` and `render.rs`: new `ModuleLoader::with_strip_md_ext` / `Renderer::with_strip_md_ext` so the dev loader's cached pipeline honours the same flag.
- `crates/zfb/src/commands/build.rs` and `dev.rs`: thread `Config::strip_md_ext` into `BundlerInput::strip_md_ext` and the dev loader.
- `crates/zfb-build/tests/bundler_strip_md_ext.rs` (new, 270 lines): on/off behaviour verified end-to-end on real esbuild — flag on rewrites `[link](./other.md)` to `./other/`, flag off leaves hrefs untouched byte-for-byte.

## Test Plan

- `cargo test -p zfb-build -p zfb-content -p zfb-render -p zfb` — all relevant tests green (one pre-existing miniflare e2e flake reproduces on base, unrelated)
- `cargo clippy -p zfb-build -p zfb-content --all-targets -- -D warnings` — no new warnings introduced
- New integration test `bundler_default_plugins.rs` asserts on all four markers from #126's test plan and runs the bundler twice for determinism
- New integration test `bundler_strip_md_ext.rs` verifies on/off href rewriting on built dist
- New unit test in `mdx_jsx_emit_cache.rs` pins the cache-bypass contract
- New dev-loader unit test in `loader.rs` covers the dev path's `with_strip_md_ext` rewrite
- CI: 3/3 green on PR #131