### PR TITLE
fix(content): build_snapshot must drive walk_collection with the default Pipeline

### DIFF
--- a/crates/zfb-content/src/content_bridge.rs
+++ b/crates/zfb-content/src/content_bridge.rs
@@ -40,6 +40,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
 use crate::collection::{walk_collection, CollectionError, Entry};
+use crate::pipeline::Pipeline;
 
 /// A single content entry, in the shape the JS bridge sees.
 ///
@@ -121,10 +122,20 @@ pub enum BridgeError {
 /// Build a deterministic [`ContentSnapshot`] from the configured
 /// collections.
 ///
-/// Walks each collection in `collections` via [`walk_collection`] (with
-/// `pipeline = None`), converts each entry into an [`EntrySnapshot`],
-/// and inserts the resulting `Vec` into a [`BTreeMap`] keyed by
-/// collection name.
+/// Walks each collection in `collections` via [`walk_collection`],
+/// driving the walker through a single hoisted
+/// [`Pipeline::with_defaults()`] so the resulting JSX (and the
+/// [`module_specifier`](EntrySnapshot::module_specifier) hash baked from
+/// it) is **byte-identical** to what the bundler emits in
+/// `crates/zfb-build/src/bundler.rs`. Snapshot specifiers must agree
+/// with the bundler's bridge map keys byte-for-byte; otherwise every
+/// `globalThis.__zfb.content.get(specifier)` lookup misses and the page
+/// renders the raw-markdown `<pre data-zfb-content-fallback>` fallback.
+/// Driving both code paths through the same default pipeline is what
+/// keeps the two hashes in lock-step (zfb #131 / #132).
+///
+/// Each entry is converted into an [`EntrySnapshot`] and the resulting
+/// `Vec` is inserted into a [`BTreeMap`] keyed by collection name.
 ///
 /// Sort order:
 /// - top-level: collection name ascending (free, courtesy of `BTreeMap`).
@@ -148,15 +159,29 @@ pub enum BridgeError {
 pub fn build_snapshot(collections: &[CollectionConfig]) -> Result<ContentSnapshot, BridgeError> {
     let mut out: BTreeMap<String, Vec<EntrySnapshot>> = BTreeMap::new();
 
+    // Hoist a single `Pipeline::with_defaults()` outside the loop so
+    // the seven default plugins (admonitions, CJK-friendly emphasis,
+    // heading-links, code-title, image-enlarge, mermaid, syntect) all
+    // run on every MDX entry, exactly mirroring the bundler's pattern
+    // at `crates/zfb-build/src/bundler.rs:734` and `:964`. This is what
+    // keeps the snapshot's `module_specifier` hash in lock-step with
+    // the bundler's bridge map keys (see the doc comment on
+    // `build_snapshot`). Borrow is linear (`&mut`), so a single
+    // hoisted pipeline serves every entry across every collection
+    // sequentially.
+    let mut pipeline = Pipeline::with_defaults();
+
     for cfg in collections {
         // The bridge ships frontmatter as raw JSON, so we walk with the
         // no-op `UntypedFrontmatter` schema. See module-level docs for
         // why the parallel walker is implemented as a `T` substitution
         // rather than a duplicate FS traversal.
-        let entries: Vec<Entry<UntypedFrontmatter>> = walk_collection(&cfg.root, None)
-            .map_err(|source| BridgeError::Walk {
-                collection: cfg.name.clone(),
-                source,
+        let entries: Vec<Entry<UntypedFrontmatter>> =
+            walk_collection(&cfg.root, Some(&mut pipeline)).map_err(|source| {
+                BridgeError::Walk {
+                    collection: cfg.name.clone(),
+                    source,
+                }
             })?;
 
         let mut snapshots: Vec<EntrySnapshot> = entries
@@ -497,6 +522,74 @@ mod tests {
         for raw in ["", "0", "false", "no", "yes", "on", "off", "TRUE!"] {
             assert!(!parse_debug_truthy(raw), "{raw:?} should be falsy");
         }
+    }
+
+    #[test]
+    fn snapshot_specifier_matches_bridge_hash_for_pipeline_transformed_entry() {
+        // Regression guard for zfb #132: `build_snapshot` must drive
+        // `walk_collection` through the same default `Pipeline` the
+        // bundler uses, so the `module_specifier` baked into the
+        // snapshot agrees byte-for-byte with the bridge map key the
+        // bundler emits. Without the fix, `walk_collection` ran with
+        // `pipeline = None` (pre-pipeline JSX, pre-pipeline hash) while
+        // the bundler ran with `Some(&mut Pipeline::with_defaults())`
+        // (post-pipeline JSX, post-pipeline hash). Any page whose body
+        // the pipeline actually transformed — admonitions, mermaid,
+        // syntect-highlighted fences, image-enlarge, heading-links,
+        // CJK-friendly emphasis — produced two divergent specifiers,
+        // and `globalThis.__zfb.content.get(snapshot.module_specifier)`
+        // missed at render time → silent fallback render.
+        //
+        // We reproduce that hazard with the cheapest signal we have:
+        // a `:::note` admonition. `AdmonitionsPlugin` rewrites the
+        // mdast subtree into an `<MdxJsxFlowElement name="Note">`, so
+        // the post-pipeline JSX (and therefore its `content_hash`)
+        // differs from the pre-pipeline JSX. Asserting that the
+        // snapshot's hash component matches the hash an independent
+        // `compile_mdx_to_jsx_module_cached(... Some(&mut Pipeline::with_defaults()))`
+        // call produces is the explicit "snapshot hash matches bridge
+        // hash" guarantee.
+        use crate::mdx_jsx_emit::{compile_mdx_to_jsx_module_cached, parse_mdx_specifier};
+
+        let tmp = TmpDir::new("snapshot-pipeline-hash");
+        // The `:::note` directive is the canonical pipeline-transformable
+        // signal — without the default pipeline it survives as raw text;
+        // with it, it becomes an `<MdxJsxFlowElement name="Note">`.
+        let mdx = "---\ntitle: \"Admon\"\n---\n\n:::note\nhi\n:::\n";
+        let path = tmp.write("docs/admon.mdx", mdx);
+
+        let snap = build_snapshot(&[CollectionConfig::new("docs", tmp.path.join("docs"))])
+            .expect("build_snapshot must succeed");
+        let docs = snap
+            .collections
+            .get("docs")
+            .expect("docs collection present");
+        let entry = docs
+            .iter()
+            .find(|e| e.slug == "admon")
+            .expect("admon entry");
+
+        // Independently compile the same body through the same default
+        // pipeline the bundler uses, then compare hash components.
+        let body = "\n:::note\nhi\n:::\n"; // post-frontmatter body, mirrors `walk_collection`'s split.
+        let mut pipeline = Pipeline::with_defaults();
+        let compiled = compile_mdx_to_jsx_module_cached(body, &path, None, Some(&mut pipeline))
+            .expect("independent compile must succeed");
+
+        let snap_spec = parse_mdx_specifier(&entry.module_specifier)
+            .expect("snapshot specifier parses as `mdx://...#hash`");
+        let bridge_spec = parse_mdx_specifier(&compiled.specifier)
+            .expect("bundler-style specifier parses as `mdx://...#hash`");
+
+        assert_eq!(
+            snap_spec.content_hash, bridge_spec.content_hash,
+            "snapshot module_specifier hash ({snap}) must equal the bundler's bridge key hash ({bridge}); a divergence here is the zfb #132 regression — the snapshot path is walking with `pipeline = None` while the bundler walks with `Some(&mut Pipeline::with_defaults())`, so transformed pages render the raw-markdown fallback",
+            snap = snap_spec.content_hash,
+            bridge = bridge_spec.content_hash,
+        );
+        // Sanity: collection + slug also agree.
+        assert_eq!(snap_spec.collection, bridge_spec.collection);
+        assert_eq!(snap_spec.slug, bridge_spec.slug);
     }
 
     #[test]

--- a/crates/zfb-content/src/content_bridge.rs
+++ b/crates/zfb-content/src/content_bridge.rs
@@ -123,7 +123,7 @@ pub enum BridgeError {
 /// collections.
 ///
 /// Walks each collection in `collections` via [`walk_collection`],
-/// driving the walker through a single hoisted
+/// driving the walker through a fresh-per-collection
 /// [`Pipeline::with_defaults()`] so the resulting JSX (and the
 /// [`module_specifier`](EntrySnapshot::module_specifier) hash baked from
 /// it) is **byte-identical** to what the bundler emits in
@@ -131,8 +131,10 @@ pub enum BridgeError {
 /// with the bundler's bridge map keys byte-for-byte; otherwise every
 /// `globalThis.__zfb.content.get(specifier)` lookup misses and the page
 /// renders the raw-markdown `<pre data-zfb-content-fallback>` fallback.
-/// Driving both code paths through the same default pipeline is what
-/// keeps the two hashes in lock-step (zfb #131 / #132).
+/// Driving both code paths through the same default pipeline shape —
+/// one pipeline per collection, reused across files within that
+/// collection — is what keeps the two hashes in lock-step
+/// (zfb #131 / #132).
 ///
 /// Each entry is converted into an [`EntrySnapshot`] and the resulting
 /// `Vec` is inserted into a [`BTreeMap`] keyed by collection name.
@@ -159,19 +161,27 @@ pub enum BridgeError {
 pub fn build_snapshot(collections: &[CollectionConfig]) -> Result<ContentSnapshot, BridgeError> {
     let mut out: BTreeMap<String, Vec<EntrySnapshot>> = BTreeMap::new();
 
-    // Hoist a single `Pipeline::with_defaults()` outside the loop so
-    // the seven default plugins (admonitions, CJK-friendly emphasis,
-    // heading-links, code-title, image-enlarge, mermaid, syntect) all
-    // run on every MDX entry, exactly mirroring the bundler's pattern
-    // at `crates/zfb-build/src/bundler.rs:734` and `:964`. This is what
-    // keeps the snapshot's `module_specifier` hash in lock-step with
-    // the bundler's bridge map keys (see the doc comment on
-    // `build_snapshot`). Borrow is linear (`&mut`), so a single
-    // hoisted pipeline serves every entry across every collection
-    // sequentially.
-    let mut pipeline = Pipeline::with_defaults();
-
     for cfg in collections {
+        // Construct a fresh `Pipeline::with_defaults()` per collection,
+        // mirroring the bundler's two call sites at
+        // `crates/zfb-build/src/bundler.rs:734` and `:964` — each
+        // `materialise_*` call hoists its own pipeline outside the
+        // walk loop, so within one collection a single pipeline serves
+        // every entry sequentially while no state leaks across
+        // collection boundaries. Per-collection instantiation matters
+        // because some default plugins (notably `HeadingLinksPlugin`)
+        // carry per-document state (the slug-dedupe `seen` map):
+        // reusing one pipeline across collections would mean a heading
+        // like "Intro" in collection B would slugify to `intro-1` if
+        // collection A already used `intro`, leaking unrelated
+        // collections' headings into B's compiled JSX (and into the
+        // hash that drives `module_specifier`). The snapshot must
+        // agree byte-for-byte with the bundler's bridge map keys (see
+        // the doc comment on `build_snapshot`); the fastest way to
+        // hold that contract is to drive `walk_collection` with the
+        // same pipeline shape the bundler uses.
+        let mut pipeline = Pipeline::with_defaults();
+
         // The bridge ships frontmatter as raw JSON, so we walk with the
         // no-op `UntypedFrontmatter` schema. See module-level docs for
         // why the parallel walker is implemented as a `T` substitution
@@ -590,6 +600,53 @@ mod tests {
         // Sanity: collection + slug also agree.
         assert_eq!(snap_spec.collection, bridge_spec.collection);
         assert_eq!(snap_spec.slug, bridge_spec.slug);
+    }
+
+    #[test]
+    fn pipeline_state_does_not_leak_across_collections() {
+        // Companion guard for the per-collection pipeline shape:
+        // `HeadingLinksPlugin` carries a `seen: HashMap<String, usize>`
+        // slug-dedupe counter on the pipeline instance. If
+        // `build_snapshot` reused one `Pipeline::with_defaults()` across
+        // every collection in the for-loop, a heading like `## Intro`
+        // in collection B would emit `id="intro-1"` after collection A
+        // already consumed `intro` — and the snapshot bytes for B would
+        // depend on which other collections were configured alongside
+        // it. The bundler dodges this by hoisting one pipeline per
+        // `materialise_*` call (one per collection), and `build_snapshot`
+        // mirrors that shape for the same reason.
+        //
+        // We assert the contract by building the snapshot for two
+        // single-collection configs in isolation, then for the same two
+        // collections together, and proving the per-collection slice of
+        // the combined snapshot matches the isolated build byte-for-byte.
+        let tmp = TmpDir::new("collection-isolation");
+        // Both files have the same heading text — without per-collection
+        // pipelines the second one walked would slug to `intro-1`.
+        let mdx_with_h2 = "---\ntitle: \"X\"\n---\n\n## Intro\n\nbody\n";
+        tmp.write("a/page.mdx", mdx_with_h2);
+        tmp.write("b/page.mdx", mdx_with_h2);
+
+        let cfg_a = CollectionConfig::new("a", tmp.path.join("a"));
+        let cfg_b = CollectionConfig::new("b", tmp.path.join("b"));
+
+        let solo_a = build_snapshot(&[cfg_a.clone()]).expect("solo a");
+        let solo_b = build_snapshot(&[cfg_b.clone()]).expect("solo b");
+        let combined = build_snapshot(&[cfg_a, cfg_b]).expect("combined");
+
+        let combined_a = combined.collections.get("a").expect("combined a");
+        let combined_b = combined.collections.get("b").expect("combined b");
+        let solo_a_entries = solo_a.collections.get("a").expect("solo a entries");
+        let solo_b_entries = solo_b.collections.get("b").expect("solo b entries");
+
+        assert_eq!(
+            combined_a[0].module_specifier, solo_a_entries[0].module_specifier,
+            "collection a's specifier must not depend on whether collection b is also configured (heading-link state leak)",
+        );
+        assert_eq!(
+            combined_b[0].module_specifier, solo_b_entries[0].module_specifier,
+            "collection b's specifier must not depend on whether collection a is also configured (heading-link state leak)",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

PR #131 threaded `Pipeline::with_defaults()` through the bundler at `crates/zfb-build/src/bundler.rs:771` and `:1032`, so the bundler now emits **post-pipeline** JSX with a **post-pipeline** `content_hash`. But `build_snapshot` at `crates/zfb-content/src/content_bridge.rs` was still calling `walk_collection(&cfg.root, None)` — i.e. **pre-pipeline** JSX, **pre-pipeline** hash.

For any page whose body the default pipeline plugins actually transform (admonition `:::note` directives, mermaid fences, syntect-highlighted code, image-enlarge `<figure>`, heading-links, cjk-friendly emphasis), the snapshot's `module_specifier` and the bundler's bridge map keys disagreed byte-for-byte. At render time, `globalThis.__zfb.content.get(snapshot.module_specifier)` returned `undefined` and the page silently fell back to `<pre data-zfb-content-fallback>raw markdown</pre>`. Pages with no pipeline-transformable content were unaffected (their pre/post-pipeline JSX is byte-identical, so the hash matches in both call paths).

The bundler.rs:994-1009 comment block already warned about this hazard:

> the bridge map and the snapshot's `module_specifier` field MUST agree on the hash byte-for-byte; otherwise every `bridge.get(spec)` lookup misses and the page renders the raw-markdown fallback.

The constraint was correct — the snapshot side just was not pulling its weight.

## Smoking gun

For a page containing a `:::note` admonition, the bundler emits two divergent specifiers in the generated bundle. Synthesising the shape from a fixture project's smoke build that surfaced the regression:

```
mdx://docs/admon#b8569618   ← bridge map key (post-pipeline; bundler.rs:1032)
mdx://docs/admon#da6eb337   ← snapshot.module_specifier (pre-pipeline; content_bridge.rs:148)
```

Same `(collection, slug)`, divergent hash → bridge lookup misses → fallback render. Pages with no pipeline-transformable content (paragraph-only entries) round-trip identically because the pipeline produces byte-identical JSX, so the regression is silent and content-shape-dependent — exactly the failure mode the bundler comment block was guarding against.

## Fix

`build_snapshot` now constructs a fresh `Pipeline::with_defaults()` **inside the for-loop, once per collection** — exactly mirroring the bundler's pattern at `bundler.rs:734` (`materialise_shadow`) and `:964` (`materialise_collection`). Each `materialise_*` call there hoists its own pipeline outside the WalkDir loop, so within one collection a single pipeline serves every file sequentially, but state stays scoped to that collection.

Per-collection (rather than once-per-`build_snapshot`) instantiation matters because some default plugins carry per-document state on the pipeline instance — notably `HeadingLinksPlugin`'s `seen: HashMap<String, usize>` slug-dedupe counter. Sharing one pipeline across all collections would make a heading like `## Intro` in collection B slugify to `intro-1` if collection A already consumed `intro`, which leaks unrelated collections' headings into B's compiled JSX (and into the hash that drives `module_specifier`). The bundler dodges this by construction (its two `materialise_*` entry points each get their own pipeline); `build_snapshot` now matches that shape exactly.

The doc-comment on `build_snapshot` was updated to spell out the contract.

## Regression tests

Two new `#[test]`s in the existing `content_bridge.rs` test module:

1. `snapshot_specifier_matches_bridge_hash_for_pipeline_transformed_entry` — builds a snapshot for a tmpdir-based fixture containing a `:::note` admonition, then independently compiles the same body through `compile_mdx_to_jsx_module_cached(... Some(&mut Pipeline::with_defaults()))` and asserts the two specifiers' `content_hash` components are equal. Without the snapshot-pipeline fix the hashes differ — the explicit "snapshot hash matches bridge hash" guarantee.
2. `pipeline_state_does_not_leak_across_collections` — companion guard for the per-collection pipeline shape: builds two collections that share heading text (`## Intro`) both in isolation and combined, asserts each per-collection slice matches its solo build byte-for-byte. Verified failure under the once-hoisted variant: the two collections produce divergent hashes (`#54b780f1` vs `#d0aeab3e`). With the per-collection fix, both pass.

## Verification

- `cargo test -p zfb-content content_bridge` — 11 passed, 0 failed (includes both new regression tests).
- `cargo test --workspace` — 1043 passed, 0 failed, 12 ignored.
- `cargo test -p zfb-build` — `bundler_default_plugins` integration test continues to pass.
- The fix touches one file (`crates/zfb-content/src/content_bridge.rs`); no API changes.

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)