### PR TITLE
fix(islands): unblock multi-island bundling and tsconfig path aliases

### DIFF
--- a/crates/zfb-islands/src/esbuild.rs
+++ b/crates/zfb-islands/src/esbuild.rs
@@ -313,78 +313,18 @@ impl EsbuildSubprocessBundler {
     /// Internal: produce the JS payload for the given islands. Split out so
     /// tests can drive it directly without going through `bundle`'s
     /// asset-write step.
+    ///
+    /// Implementation: synthesizes a single-entry source that imports
+    /// every island module by absolute path, then routes through
+    /// [`Self::bundle_one_entry`] (single input + `--outfile`). This
+    /// keeps the on-disk contract for the shared bundle
+    /// (`dist/assets/islands.js`) stable while sidestepping esbuild's
+    /// "Must use \"outdir\" when there are multiple input files" rule
+    /// (issue #138): passing N island `source_path`s as N separate
+    /// inputs trips it for any N >= 2.
     fn produce_bundle_js(&self, islands: &[Island], config: &BundleConfig) -> Result<String> {
-        if self.config.mock_subprocess {
-            return Ok(self.config.mock_output.clone());
-        }
-
-        ensure_binary_verified(&self.config.binary_path, false)?;
-
-        // Allocate a temp file in this engine's working dir so esbuild's
-        // `--outfile` can be a relative path resolvable from the subprocess
-        // cwd. Drop happens when we return — file vanishes after read.
-        let tmp = tempfile::Builder::new()
-            .prefix("zfb-esbuild-")
-            .suffix(".js")
-            .tempfile()
-            .context("failed to allocate temp file for esbuild output")?;
-
-        let mut cmd = Command::new(&self.config.binary_path);
-        cmd.current_dir(&self.config.working_dir);
-        cmd.arg("--bundle");
-        cmd.arg("--format=esm");
-        cmd.arg("--splitting=false");
-        // Tree-shaking is on by default for ESM in esbuild; we set the
-        // flag explicitly so the contract is visible at the call site.
-        cmd.arg("--tree-shaking=true");
-        // Islands ship to the browser, so pin the platform target
-        // explicitly. Combined with `--external:node:*`, any `node:*`
-        // import that bleeds into a chain reachable from an island module
-        // (e.g. via a barrel re-export) is externalized — the runtime
-        // surfaces a clear "module not found" error in the browser
-        // instead of esbuild failing the build with "Could not resolve
-        // node:fs". (See packages/zfb/src/content.ts top-of-file note for
-        // the original symptom that motivated this defensive flagging.)
-        cmd.arg("--platform=browser");
-        cmd.arg("--external:node:*");
-        if config.minify {
-            cmd.arg("--minify");
-        }
-        if config.sourcemap {
-            cmd.arg("--sourcemap=linked");
-        }
-        cmd.arg(format!("--outfile={}", tmp.path().display()));
-        // Inline NODE_ENV so the React/Preact build picks the
-        // production flavour. Without this, prod islands ship the dev
-        // builds (extra warnings + larger bytes). esbuild expects the
-        // value to be a JS literal, hence the embedded quotes.
-        if config.minify {
-            cmd.arg("--define:process.env.NODE_ENV=\"production\"");
-        } else {
-            cmd.arg("--define:process.env.NODE_ENV=\"development\"");
-        }
-        for extra in &self.config.extra_args {
-            cmd.arg(extra);
-        }
-        for island in islands {
-            cmd.arg(&island.source_path);
-        }
-
-        let output = cmd
-            .output()
-            .with_context(|| format!("failed to spawn {}", self.config.binary_path.display()))?;
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(anyhow!(
-                "esbuild exited with status {}: {}",
-                output.status,
-                stderr.trim()
-            ));
-        }
-
-        let js =
-            std::fs::read_to_string(tmp.path()).context("failed to read esbuild output file")?;
-        Ok(js)
+        let entry_source = render_shared_bundle_entry_source(islands);
+        self.bundle_one_entry(&entry_source, config)
     }
 
     /// Per-island bundle pass.
@@ -574,6 +514,34 @@ impl EsbuildSubprocessBundler {
             std::fs::read_to_string(out_tmp.path()).context("failed to read esbuild output")?;
         Ok(js)
     }
+}
+
+/// Generate the synthetic single-entry source for the legacy shared
+/// bundle.
+///
+/// The shared bundle's contract is "all island modules' side-effects
+/// run when the script tag is evaluated" — exactly what an entry that
+/// does `import "<path>";` for every island achieves once esbuild
+/// resolves & inlines the chain. Producing one synthetic entry
+/// sidesteps esbuild's multi-input + `--outfile` restriction (issue
+/// #138) without changing the public on-disk shape
+/// (`dist/assets/islands.js`).
+///
+/// Each island path is JSON-encoded to defang stray quotes / backslashes
+/// from absolute paths on Windows or arbitrary file names; the order
+/// follows the input slice so the resulting bytes are deterministic
+/// for a given `(islands, config)` pair (downstream tests rely on this
+/// for the bundle's content hash to be stable across runs).
+pub fn render_shared_bundle_entry_source(islands: &[Island]) -> String {
+    let mut out =
+        String::from("// Generated by zfb-islands::EsbuildSubprocessBundler::produce_bundle_js\n");
+    for island in islands {
+        let path = island.source_path.to_string_lossy();
+        out.push_str("import ");
+        out.push_str(&json_string(&path));
+        out.push_str(";\n");
+    }
+    out
 }
 
 /// Generate the per-island entry script for `framework`.
@@ -874,11 +842,7 @@ mod tests {
             assert!(entry.asset_path.starts_with(dir.path().join("islands")));
             let expected_filename = format!("{}.js", entry.component_name);
             assert_eq!(
-                entry
-                    .asset_path
-                    .file_name()
-                    .unwrap()
-                    .to_string_lossy(),
+                entry.asset_path.file_name().unwrap().to_string_lossy(),
                 expected_filename,
             );
             // Public URL is the stable `/islands/<Component>.js`.
@@ -921,6 +885,108 @@ mod tests {
         assert_eq!(a.islands[0].hash, b.islands[0].hash);
         assert_eq!(a.islands[0].asset_url, b.islands[0].asset_url);
         assert_eq!(a.runtime_asset_url, b.runtime_asset_url);
+    }
+
+    #[test]
+    fn render_shared_bundle_entry_source_imports_each_island_in_order() {
+        // The shared-bundle entry source must reference every island's
+        // resolved `source_path` as an `import "<path>";` so esbuild's
+        // single-input + `--outfile` invocation pulls them all into one
+        // bundled output (issue #138 fix). Order follows the input slice
+        // so the resulting bytes are deterministic across runs.
+        let islands = vec![
+            Island::new("Counter", "/abs/components/Counter.tsx"),
+            Island::new("Modal", "/abs/components/Modal.tsx"),
+        ];
+        let src = render_shared_bundle_entry_source(&islands);
+        assert!(
+            src.contains(r#"import "/abs/components/Counter.tsx";"#),
+            "missing Counter import: {src}"
+        );
+        assert!(
+            src.contains(r#"import "/abs/components/Modal.tsx";"#),
+            "missing Modal import: {src}"
+        );
+        // Order check — Counter must appear before Modal.
+        let i_counter = src.find("Counter.tsx").expect("counter present");
+        let i_modal = src.find("Modal.tsx").expect("modal present");
+        assert!(i_counter < i_modal, "expected Counter before Modal");
+    }
+
+    #[test]
+    fn render_shared_bundle_entry_source_escapes_quotes_in_paths() {
+        // Path containing a literal double-quote (rare but legal on
+        // macOS / Linux) must not break the synthesized JS — it gets
+        // JSON-escaped just like component names.
+        let islands = vec![Island::new("Weird", "/abs/components/has\"quote/Weird.tsx")];
+        let src = render_shared_bundle_entry_source(&islands);
+        assert!(
+            src.contains(r#"import "/abs/components/has\"quote/Weird.tsx";"#),
+            "expected escaped quote in path: {src}"
+        );
+    }
+
+    #[test]
+    fn render_shared_bundle_entry_source_handles_empty_islands_slice() {
+        // Empty input emits a header-only entry (no `import` lines) —
+        // `build_production_islands_asset` already short-circuits on an
+        // empty islands slice, so this code path is mostly defensive,
+        // but we still want it to produce valid JS rather than panic.
+        let src = render_shared_bundle_entry_source(&[]);
+        assert!(!src.contains("import"));
+        assert!(src.starts_with("// Generated"));
+    }
+
+    /// Regression for issue #138.
+    ///
+    /// Before the fix, `produce_bundle_js` passed N island
+    /// `source_path`s as N separate inputs to esbuild plus a single
+    /// `--outfile`, and esbuild bailed with "Must use \"outdir\" when
+    /// there are multiple input files" for any N >= 2. The fix
+    /// synthesizes a single-entry source via
+    /// [`render_shared_bundle_entry_source`] and routes through
+    /// [`EsbuildSubprocessBundler::bundle_one_entry`] so esbuild always
+    /// sees exactly one input.
+    ///
+    /// We exercise the mock path with an empty `mock_output` so
+    /// `bundle_one_entry` echoes the synthesized entry source back; the
+    /// test then asserts the echoed string contains the multi-island
+    /// import shape (which is what would have made esbuild fail with
+    /// the old multi-input code path).
+    #[test]
+    fn bundle_handles_multiple_islands_via_synthetic_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let bundler = EsbuildSubprocessBundler::new(EsbuildSubprocessConfig {
+            mock_subprocess: true,
+            // Empty mock_output → bundle_one_entry returns the entry
+            // source verbatim. That lets us assert against the
+            // synthesized shape end-to-end.
+            ..EsbuildSubprocessConfig::default()
+        });
+        let islands = vec![
+            Island::new("Counter", "/abs/components/Counter.tsx"),
+            Island::new("Modal", "/abs/components/Modal.tsx"),
+            Island::new("Sidebar", "/abs/components/Sidebar.tsx"),
+        ];
+        let cfg = BundleConfig::default().with_outdir(dir.path().to_path_buf());
+
+        let out = bundler.bundle(&islands, &cfg).expect("multi-island bundle");
+
+        // Stable filename + URL — the multi-input fix must NOT change
+        // the on-disk shape (the legacy contract S0 / S4 depend on).
+        assert_eq!(out.asset_url, "/assets/islands.js");
+        assert_eq!(out.asset_path, dir.path().join("assets").join("islands.js"));
+        assert!(out.asset_path.exists());
+
+        // Module IDs preserve input order.
+        assert_eq!(out.module_ids, vec!["Counter", "Modal", "Sidebar"]);
+
+        // The bytes on disk are the synthesized entry source (echoed by
+        // mock mode) — verify each island path appears in it.
+        let on_disk = std::fs::read_to_string(&out.asset_path).expect("read asset");
+        assert!(on_disk.contains(r#"import "/abs/components/Counter.tsx";"#));
+        assert!(on_disk.contains(r#"import "/abs/components/Modal.tsx";"#));
+        assert!(on_disk.contains(r#"import "/abs/components/Sidebar.tsx";"#));
     }
 
     #[test]

--- a/crates/zfb-islands/src/lib.rs
+++ b/crates/zfb-islands/src/lib.rs
@@ -42,8 +42,9 @@ pub use bundler::{
     ProductionIslandsAsset,
 };
 pub use esbuild::{
-    hash_8, render_island_entry_source, render_runtime_entry_source, EsbuildSubprocessBundler,
-    EsbuildSubprocessConfig, EXPECTED_ESBUILD_SHA256, EXPECTED_ESBUILD_VERSION,
+    hash_8, render_island_entry_source, render_runtime_entry_source,
+    render_shared_bundle_entry_source, EsbuildSubprocessBundler, EsbuildSubprocessConfig,
+    EXPECTED_ESBUILD_SHA256, EXPECTED_ESBUILD_VERSION,
 };
 pub use future_rust_native::NativeRustBundler;
 pub use html_tree::HtmlTree;

--- a/crates/zfb-islands/src/scanner.rs
+++ b/crates/zfb-islands/src/scanner.rs
@@ -65,6 +65,7 @@
 
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::{Component, Path, PathBuf};
+use std::sync::{Arc, Mutex};
 
 use swc_core::atoms::Wtf8Atom;
 use swc_core::common::sync::Lrc;
@@ -188,6 +189,18 @@ pub fn is_bare_specifier(specifier: &str) -> bool {
 /// consumer's page module `import "@takazudo/zfb-blog-islands"` route
 /// the scanner into the workspace package's source `.tsx` files so any
 /// `"use client"` islands actually emit a production bundle.
+///
+/// The resolver also honours TypeScript path aliases declared in the
+/// project's `tsconfig.json` (`compilerOptions.paths` +
+/// `compilerOptions.baseUrl`). The nearest `tsconfig.json` is
+/// auto-discovered by walking up from each importer's directory the
+/// first time it's seen; the parsed alias table is cached on the
+/// resolver so subsequent imports from the same project re-use it
+/// without re-reading disk. Wildcard patterns of the form
+/// `"@/*": ["src/*"]` are supported (the common case downstream
+/// projects use); literal patterns also work. Conditional priorities
+/// (`browser`, `node`, …) and the full Node.js `paths` spec are out of
+/// scope for now — see issue #139 for the upstream tracker.
 #[derive(Debug, Clone)]
 pub struct FsResolver {
     /// File extensions probed for relative imports without an extension.
@@ -197,6 +210,39 @@ pub struct FsResolver {
     /// want the legacy "skip every bare specifier" shape can flip it
     /// off via [`FsResolver::without_workspace_probe`].
     pub workspace_probe_enabled: bool,
+    /// Cache of `tsconfig_dir → parsed paths` for the nearest
+    /// `tsconfig.json` discovered above each importer. Populated on
+    /// first lookup; subsequent imports from the same project hit the
+    /// in-memory entry instead of re-reading disk. `Arc<Mutex<…>>` so
+    /// `Clone` is cheap and the cache is shared across clones (which
+    /// the scanner makes when running in parallel test harnesses).
+    tsconfig_cache: Arc<Mutex<HashMap<PathBuf, Option<TsConfigPaths>>>>,
+}
+
+/// Parsed `compilerOptions.paths` + `baseUrl` from a discovered
+/// `tsconfig.json`, normalised to absolute paths so wildcard
+/// substitution works without repeatedly re-resolving relative bits.
+#[derive(Debug, Clone)]
+struct TsConfigPaths {
+    /// Absolute base directory. `compilerOptions.baseUrl` is resolved
+    /// relative to the `tsconfig.json` directory; when `baseUrl` is
+    /// unset, this is the `tsconfig.json` directory itself (matching
+    /// TypeScript's documented default of "`.`").
+    base_dir: PathBuf,
+    /// Parsed alias entries, in `compilerOptions.paths` source order.
+    aliases: Vec<TsPathAlias>,
+}
+
+/// One entry from `compilerOptions.paths`.
+#[derive(Debug, Clone)]
+struct TsPathAlias {
+    /// Pattern as authored — e.g. `"@/*"` or `"~"`. The TypeScript
+    /// spec allows at most one `*` per pattern (the wildcard form).
+    pattern: String,
+    /// Substitution targets, in priority order. Each target is the
+    /// raw (post-baseUrl) string from `tsconfig.json`; substitution
+    /// joins it onto `base_dir` and probes the file system.
+    targets: Vec<String>,
 }
 
 impl Default for FsResolver {
@@ -209,6 +255,7 @@ impl Default for FsResolver {
                 ".js".to_string(),
             ],
             workspace_probe_enabled: true,
+            tsconfig_cache: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 }
@@ -457,6 +504,294 @@ impl FsResolver {
         };
         canon.starts_with(root)
     }
+
+    /// Walk up from `start` looking for the nearest `tsconfig.json`.
+    /// Returns the directory containing it, not the file path itself
+    /// (callers join `tsconfig.json` themselves where needed). The
+    /// shape mirrors [`Self::locate_node_modules_pkg`] — same
+    /// "ancestor walk" pattern, no canonicalisation (callers handle
+    /// that on the resolved file).
+    fn locate_tsconfig_dir(start: &Path) -> Option<PathBuf> {
+        let mut dir: Option<&Path> = Some(start);
+        while let Some(d) = dir {
+            if d.join("tsconfig.json").is_file() {
+                return Some(d.to_path_buf());
+            }
+            dir = d.parent();
+        }
+        None
+    }
+
+    /// Try to resolve `specifier` against `tsconfig.json`
+    /// `compilerOptions.paths`. Returns the first probe hit, or
+    /// `None` when:
+    ///
+    /// - There is no `tsconfig.json` above `importer_dir`.
+    /// - The tsconfig has no `compilerOptions.paths` entries.
+    /// - No alias pattern matches the specifier.
+    /// - A pattern matches but every substitution target's probe
+    ///   (extension + index walk) misses.
+    fn try_resolve_tsconfig_alias(&self, importer_dir: &Path, specifier: &str) -> Option<PathBuf> {
+        let tsconfig_dir = Self::locate_tsconfig_dir(importer_dir)?;
+        let entry = self.load_tsconfig_paths(&tsconfig_dir)?;
+        for alias in &entry.aliases {
+            if let Some(rest) = match_alias_pattern(&alias.pattern, specifier) {
+                for target in &alias.targets {
+                    let substituted = substitute_alias_target(target, rest.as_deref());
+                    let candidate = entry.base_dir.join(&substituted);
+                    if let Some(found) = self.probe_path_with_index(&candidate) {
+                        return Some(found);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    /// Look up — and lazily populate — the parsed `paths` table for the
+    /// `tsconfig.json` at `tsconfig_dir`. Cached on the resolver so a
+    /// project's tsconfig is read at most once per resolver instance,
+    /// and shared across `Clone`s.
+    fn load_tsconfig_paths(&self, tsconfig_dir: &Path) -> Option<TsConfigPaths> {
+        let key = tsconfig_dir.to_path_buf();
+        // Check cache first.
+        {
+            let cache = self.tsconfig_cache.lock().unwrap_or_else(|p| {
+                tracing::warn!(
+                    site = "FsResolver::tsconfig_cache",
+                    "mutex poisoned, recovered"
+                );
+                p.into_inner()
+            });
+            if let Some(cached) = cache.get(&key) {
+                return cached.clone();
+            }
+        }
+
+        // Cache miss — parse from disk.
+        let parsed = parse_tsconfig_paths(&key);
+        let mut cache = self.tsconfig_cache.lock().unwrap_or_else(|p| {
+            tracing::warn!(
+                site = "FsResolver::tsconfig_cache",
+                "mutex poisoned, recovered"
+            );
+            p.into_inner()
+        });
+        cache.insert(key, parsed.clone());
+        parsed
+    }
+}
+
+/// Parse the `compilerOptions.paths` + `baseUrl` declared by the
+/// `tsconfig.json` at `tsconfig_dir`, walking through any `extends`
+/// chain. Returns `None` when the file cannot be read, the JSON cannot
+/// be parsed, or no usable `paths` entry survives the merge.
+///
+/// Notes on the parser:
+///
+/// - We use `serde_json` rather than a JSONC parser. `tsconfig.json`
+///   files in the wild often contain trailing commas or `// comments`
+///   — a future hardening pass could swap in a JSONC parser, but the
+///   common case (Astro / Next.js scaffolds, including the downstream
+///   zudo-doc consumer that motivated this fix) is plain JSON.
+/// - `extends` is a single string today (Node-style). Arrays-of-extends
+///   landed in TS 5.0 but we only follow the first entry as a
+///   conservative default; the rest is documented as "out of scope" in
+///   the issue body.
+/// - The `extends` chain is followed up to a depth of 8 to defend
+///   against hand-rolled cycles.
+fn parse_tsconfig_paths(tsconfig_dir: &Path) -> Option<TsConfigPaths> {
+    fn walk(
+        dir: &Path,
+        depth: usize,
+        // Carry the *highest-priority* (= most-overridden) values
+        // discovered so far. Earlier — i.e. the leaf tsconfig that
+        // started the walk — wins for both `baseUrl` and `paths` per
+        // TypeScript's documented semantics.
+        merged_base_dir: Option<PathBuf>,
+        merged_aliases: Option<Vec<TsPathAlias>>,
+    ) -> Option<(PathBuf, Vec<TsPathAlias>)> {
+        if depth > 8 {
+            return None;
+        }
+        let path = dir.join("tsconfig.json");
+        let text = std::fs::read_to_string(&path).ok()?;
+        let value: serde_json::Value = serde_json::from_str(&text).ok()?;
+
+        let compiler_options = value.get("compilerOptions");
+
+        let local_base_dir = compiler_options
+            .and_then(|c| c.get("baseUrl"))
+            .and_then(|b| b.as_str())
+            .map(|raw| dir.join(raw));
+
+        let local_aliases = compiler_options
+            .and_then(|c| c.get("paths"))
+            .and_then(|p| p.as_object())
+            .map(|map| {
+                map.iter()
+                    .filter_map(|(pattern, targets_value)| {
+                        let targets = targets_value.as_array()?;
+                        let collected: Vec<String> = targets
+                            .iter()
+                            .filter_map(|t| t.as_str().map(|s| s.to_string()))
+                            .collect();
+                        if collected.is_empty() {
+                            None
+                        } else {
+                            Some(TsPathAlias {
+                                pattern: pattern.clone(),
+                                targets: collected,
+                            })
+                        }
+                    })
+                    .collect::<Vec<_>>()
+            });
+
+        // Leaf-wins merge: only adopt the local fields when the caller
+        // hasn't already supplied a closer (= leaf-ier) override.
+        let next_base_dir = merged_base_dir.or(local_base_dir);
+        let next_aliases = merged_aliases.or(local_aliases);
+
+        // If we have everything, stop here — no need to walk extends
+        // when the leaf already declared baseUrl + paths.
+        if let (Some(b), Some(a)) = (&next_base_dir, &next_aliases) {
+            return Some((b.clone(), a.clone()));
+        }
+
+        // Follow `extends` if present.
+        if let Some(extends) = value.get("extends").and_then(|e| e.as_str()) {
+            if let Some(parent_dir) = resolve_extends_target(dir, extends) {
+                if let Some(found) = walk(
+                    &parent_dir,
+                    depth + 1,
+                    next_base_dir.clone(),
+                    next_aliases.clone(),
+                ) {
+                    return Some(found);
+                }
+            }
+        }
+
+        // No extends (or extends couldn't resolve): only return
+        // something if we ended up with a `paths` table — without
+        // patterns there is nothing to alias-match against.
+        let aliases = next_aliases?;
+        // Default `baseUrl` is the tsconfig directory itself (the
+        // directory whose `paths` entries we're returning) — this
+        // matches TypeScript's documented behaviour that `paths` is
+        // resolved relative to `baseUrl ?? "."` and that the `"."`
+        // default is interpreted relative to the tsconfig.
+        let base_dir = next_base_dir.unwrap_or_else(|| dir.to_path_buf());
+        Some((base_dir, aliases))
+    }
+
+    let (base_dir, aliases) = walk(tsconfig_dir, 0, None, None)?;
+    if aliases.is_empty() {
+        return None;
+    }
+    Some(TsConfigPaths { base_dir, aliases })
+}
+
+/// Resolve a `tsconfig.json` `extends` value to the directory
+/// containing the extended config.
+///
+/// Two shapes are supported:
+///
+/// 1. Relative path: `"./base.json"` or `"../shared/tsconfig.base.json"`.
+///    The path is resolved relative to the extending tsconfig's
+///    directory. The trailing filename is stripped — callers expect a
+///    directory containing `tsconfig.json`. (This implies the extends
+///    target must literally be named `tsconfig.json`; configs that
+///    extend `tsconfig.base.json` next to a tsconfig.json fall back to
+///    "extends couldn't resolve" and the leaf's own paths are used. A
+///    follow-up could probe the literal `extends` filename instead.)
+/// 2. Bare `node_modules` package: `"@scope/configs/tsconfig.base"` or
+///    `"shared-tsconfig"` — out of scope. Returns `None`.
+fn resolve_extends_target(extending_dir: &Path, extends: &str) -> Option<PathBuf> {
+    let is_relative =
+        extends.starts_with("./") || extends.starts_with("../") || extends.starts_with('/');
+    if !is_relative {
+        return None;
+    }
+    let raw = extending_dir.join(extends);
+    // The extends value may point at the directory or at a literal
+    // file. We need the *directory* the recursive walker can join
+    // `tsconfig.json` onto.
+    if raw.is_dir() {
+        return Some(raw);
+    }
+    // A file path that ends in `tsconfig.json` is canonical: the
+    // parent is the directory.
+    if raw.is_file() && raw.file_name().and_then(|n| n.to_str()) == Some("tsconfig.json") {
+        return raw.parent().map(|p| p.to_path_buf());
+    }
+    // Either a non-tsconfig.json file (e.g. `tsconfig.base.json`),
+    // doesn't exist, or some other shape we don't support yet.
+    None
+}
+
+/// Match `specifier` against an alias `pattern` from
+/// `compilerOptions.paths`.
+///
+/// Returns:
+///
+/// - `Some(None)` — pattern is a literal (no `*`) and matches the
+///   specifier exactly.
+/// - `Some(Some(rest))` — pattern is a wildcard (`prefix*` / `prefix*suffix`)
+///   and matches; `rest` is the substring that fills the `*`.
+/// - `None` — no match.
+///
+/// At most one `*` is honoured (the TypeScript spec). Patterns with
+/// multiple `*`s are skipped (`None`) rather than treated as literals
+/// — silently matching nothing is safer than half-supporting the
+/// shape.
+fn match_alias_pattern(pattern: &str, specifier: &str) -> Option<Option<String>> {
+    let star_count = pattern.matches('*').count();
+    match star_count {
+        0 => {
+            if pattern == specifier {
+                Some(None)
+            } else {
+                None
+            }
+        }
+        1 => {
+            let star_idx = pattern.find('*')?;
+            let prefix = &pattern[..star_idx];
+            let suffix = &pattern[star_idx + 1..];
+            if specifier.starts_with(prefix) && specifier.ends_with(suffix) {
+                let captured =
+                    &specifier[prefix.len()..specifier.len().saturating_sub(suffix.len())];
+                Some(Some(captured.to_string()))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Substitute the captured wildcard fragment back into a
+/// `compilerOptions.paths` target.
+///
+/// `target` mirrors the alias-pattern shape: zero `*` means the target
+/// is a literal substitution (used as-is); one `*` means we splice
+/// `rest` (the captured fragment from [`match_alias_pattern`]) into
+/// the wildcard slot. Unbalanced shapes (literal pattern paired with
+/// wildcard target, or vice versa) are tolerated by treating the
+/// missing `rest` as the empty string.
+fn substitute_alias_target(target: &str, rest: Option<&str>) -> String {
+    let captured = rest.unwrap_or("");
+    if let Some(star_idx) = target.find('*') {
+        let mut out = String::with_capacity(target.len() + captured.len().saturating_sub(1));
+        out.push_str(&target[..star_idx]);
+        out.push_str(captured);
+        out.push_str(&target[star_idx + 1..]);
+        out
+    } else {
+        target.to_string()
+    }
 }
 
 /// Look up `exports["./<subpath>"]` in a parsed `package.json` and
@@ -529,6 +864,18 @@ impl Resolver for FsResolver {
         let canonicalize = |p: PathBuf| p.canonicalize().unwrap_or(p);
 
         if is_bare_specifier(specifier) {
+            // 1) tsconfig path aliases (issue #139). Bare specifiers
+            //    like `@/components/foo` are not on the
+            //    relative-import path, so they would otherwise fall
+            //    through to the node_modules / workspace probe. Walk
+            //    up from the importer to find the nearest
+            //    `tsconfig.json`, parse `compilerOptions.paths`, and
+            //    if the specifier matches an alias, probe the
+            //    substitution targets like a relative path.
+            if let Some(found) = self.try_resolve_tsconfig_alias(importer_dir, specifier) {
+                return Some(canonicalize(found));
+            }
+
             if !self.workspace_probe_enabled {
                 return None;
             }
@@ -2180,5 +2527,446 @@ mod tests {
             vec!["WorkspaceCounter"],
             "expected only the workspace island; preact must be skipped: {islands:?}",
         );
+    }
+
+    // ---------------------------------------------------------------
+    // tsconfig.json `compilerOptions.paths` (issue #139)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn match_alias_pattern_literal_match() {
+        assert_eq!(match_alias_pattern("@foo/bar", "@foo/bar"), Some(None));
+    }
+
+    #[test]
+    fn match_alias_pattern_literal_no_match() {
+        assert_eq!(match_alias_pattern("@foo/bar", "@foo/baz"), None);
+    }
+
+    #[test]
+    fn match_alias_pattern_wildcard_captures_suffix() {
+        assert_eq!(
+            match_alias_pattern("@/*", "@/components/foo"),
+            Some(Some("components/foo".to_string()))
+        );
+    }
+
+    #[test]
+    fn match_alias_pattern_wildcard_must_match_prefix_and_suffix() {
+        assert_eq!(
+            match_alias_pattern("lib/*/index", "lib/foo/index"),
+            Some(Some("foo".to_string()))
+        );
+        // Suffix mismatch → no match.
+        assert_eq!(match_alias_pattern("lib/*/index", "lib/foo/other"), None);
+    }
+
+    #[test]
+    fn match_alias_pattern_rejects_multi_wildcards() {
+        // We don't support patterns with more than one `*`.
+        assert_eq!(match_alias_pattern("a/*/b/*", "a/x/b/y"), None);
+    }
+
+    #[test]
+    fn substitute_alias_target_wildcard_splices_captured_segment() {
+        assert_eq!(
+            substitute_alias_target("src/*", Some("components/foo")),
+            "src/components/foo"
+        );
+        assert_eq!(
+            substitute_alias_target("vendored/*/index.ts", Some("foo")),
+            "vendored/foo/index.ts"
+        );
+    }
+
+    #[test]
+    fn substitute_alias_target_literal_passes_through() {
+        assert_eq!(
+            substitute_alias_target("src/index.ts", None),
+            "src/index.ts"
+        );
+    }
+
+    /// End-to-end: a project with `"@/*": ["src/*"]` in tsconfig.json
+    /// imports `@/components/counter`. The resolver must discover
+    /// tsconfig, match the alias, substitute, probe the file system,
+    /// and return the resolved island file. This is the exact downstream
+    /// shape that motivated issue #139 (zudo-doc Wave 4).
+    #[test]
+    fn fs_resolver_resolves_tsconfig_path_alias_in_tempdir() {
+        use std::fs;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project = dir.path();
+        let pages = project.join("pages");
+        let components = project.join("src").join("components");
+        fs::create_dir_all(&pages).unwrap();
+        fs::create_dir_all(&components).unwrap();
+
+        fs::write(
+            project.join("tsconfig.json"),
+            r#"{
+              "compilerOptions": {
+                "paths": {
+                  "@/*": ["src/*"]
+                }
+              }
+            }"#,
+        )
+        .unwrap();
+        fs::write(
+            pages.join("home.tsx"),
+            r#"import { Counter } from "@/components/counter";
+            export default function Home() {}
+            "#,
+        )
+        .unwrap();
+        fs::write(
+            components.join("counter.tsx"),
+            r#""use client";
+            export function Counter() {}
+            "#,
+        )
+        .unwrap();
+
+        let resolver = FsResolver::new();
+        let islands = scan_islands(&[pages.join("home.tsx")], &resolver).unwrap();
+        assert_eq!(islands.len(), 1, "got {islands:?}");
+        assert_eq!(islands[0].component_name, "Counter");
+        let expected = components
+            .join("counter.tsx")
+            .canonicalize()
+            .expect("canon");
+        assert_eq!(islands[0].source_path, expected);
+    }
+
+    /// `compilerOptions.baseUrl` shifts the substitution target:
+    /// `"baseUrl": "./src", "paths": { "@/*": ["./*"] }` resolves
+    /// `@/foo` to `<project>/src/foo`. Same end state as the
+    /// `["src/*"]` shape above; this exercises the explicit baseUrl
+    /// path so the join math stays right when `baseUrl` is non-default.
+    #[test]
+    fn fs_resolver_honours_explicit_base_url() {
+        use std::fs;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project = dir.path();
+        let pages = project.join("pages");
+        let components = project.join("src").join("components");
+        fs::create_dir_all(&pages).unwrap();
+        fs::create_dir_all(&components).unwrap();
+
+        fs::write(
+            project.join("tsconfig.json"),
+            r#"{
+              "compilerOptions": {
+                "baseUrl": "./src",
+                "paths": {
+                  "@/*": ["./*"]
+                }
+              }
+            }"#,
+        )
+        .unwrap();
+        fs::write(
+            pages.join("home.tsx"),
+            r#"import { Counter } from "@/components/counter";
+            export default function Home() {}
+            "#,
+        )
+        .unwrap();
+        fs::write(
+            components.join("counter.tsx"),
+            r#""use client";
+            export function Counter() {}
+            "#,
+        )
+        .unwrap();
+
+        let resolver = FsResolver::new();
+        let islands = scan_islands(&[pages.join("home.tsx")], &resolver).unwrap();
+        assert_eq!(islands.len(), 1, "got {islands:?}");
+        assert_eq!(islands[0].component_name, "Counter");
+    }
+
+    /// Multiple substitution targets are tried in order. The first
+    /// hit wins; misses fall through. Mirrors the TypeScript spec's
+    /// "fallback list" behaviour.
+    #[test]
+    fn fs_resolver_falls_through_alias_targets_in_order() {
+        use std::fs;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project = dir.path();
+        let pages = project.join("pages");
+        // First target points at a non-existent dir; second points at
+        // the real one. The resolver must skip the miss and try the
+        // next target rather than giving up after the first.
+        let components = project.join("real").join("components");
+        fs::create_dir_all(&pages).unwrap();
+        fs::create_dir_all(&components).unwrap();
+
+        fs::write(
+            project.join("tsconfig.json"),
+            r#"{
+              "compilerOptions": {
+                "paths": {
+                  "@/*": ["does-not-exist/*", "real/*"]
+                }
+              }
+            }"#,
+        )
+        .unwrap();
+        fs::write(
+            pages.join("home.tsx"),
+            r#"import { Counter } from "@/components/counter";
+            export default function Home() {}
+            "#,
+        )
+        .unwrap();
+        fs::write(
+            components.join("counter.tsx"),
+            r#""use client";
+            export function Counter() {}
+            "#,
+        )
+        .unwrap();
+
+        let resolver = FsResolver::new();
+        let islands = scan_islands(&[pages.join("home.tsx")], &resolver).unwrap();
+        assert_eq!(
+            islands.len(),
+            1,
+            "expected fallback target to win: {islands:?}"
+        );
+    }
+
+    /// A literal alias (no `*` in the pattern) maps the whole
+    /// specifier to a single file. Validates the non-wildcard branch
+    /// of `match_alias_pattern` end-to-end.
+    #[test]
+    fn fs_resolver_resolves_literal_alias_pattern() {
+        use std::fs;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project = dir.path();
+        let pages = project.join("pages");
+        let lib = project.join("src").join("lib");
+        fs::create_dir_all(&pages).unwrap();
+        fs::create_dir_all(&lib).unwrap();
+
+        fs::write(
+            project.join("tsconfig.json"),
+            r#"{
+              "compilerOptions": {
+                "paths": {
+                  "~theme": ["src/lib/theme.tsx"]
+                }
+              }
+            }"#,
+        )
+        .unwrap();
+        fs::write(
+            pages.join("home.tsx"),
+            r#"import { Theme } from "~theme";
+            export default function Home() {}
+            "#,
+        )
+        .unwrap();
+        fs::write(
+            lib.join("theme.tsx"),
+            r#""use client";
+            export function Theme() {}
+            "#,
+        )
+        .unwrap();
+
+        let resolver = FsResolver::new();
+        let islands = scan_islands(&[pages.join("home.tsx")], &resolver).unwrap();
+        assert_eq!(islands.len(), 1, "got {islands:?}");
+        assert_eq!(islands[0].component_name, "Theme");
+    }
+
+    /// Tsconfig with no matching pattern → resolver falls through to
+    /// the existing bare-specifier / workspace-probe path. Specifier
+    /// resolves to nothing (no node_modules entry exists) and the
+    /// scanner skips it cleanly without panicking.
+    #[test]
+    fn fs_resolver_skips_specifier_when_no_alias_matches() {
+        use std::fs;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project = dir.path();
+        let pages = project.join("pages");
+        fs::create_dir_all(&pages).unwrap();
+
+        fs::write(
+            project.join("tsconfig.json"),
+            r#"{
+              "compilerOptions": {
+                "paths": {
+                  "@/*": ["src/*"]
+                }
+              }
+            }"#,
+        )
+        .unwrap();
+        fs::write(
+            pages.join("home.tsx"),
+            // Bare specifier that is NOT covered by `@/*` — falls
+            // through to the bare-specifier branch, hits no
+            // node_modules entry, returns None.
+            r#"import { Foo } from "preact";
+            export default function Home() {}
+            "#,
+        )
+        .unwrap();
+
+        let resolver = FsResolver::new();
+        let islands = scan_islands(&[pages.join("home.tsx")], &resolver).unwrap();
+        assert!(islands.is_empty(), "got {islands:?}");
+    }
+
+    /// Alias target whose substitution does not exist on disk → the
+    /// resolver returns `None` cleanly (no panic, no spurious island).
+    /// Mirrors the existing relative-import branch: the resolver does
+    /// not invent files, it only follows what's actually on disk.
+    /// (The `probe_package_entry` clamp inside `is_inside` only
+    /// applies to `node_modules/<pkg>` entries; alias resolution
+    /// inherits the relative-path branch's freedom to follow `..`,
+    /// just as a hand-written `import "../../something"` would.)
+    #[test]
+    fn fs_resolver_alias_substitution_miss_returns_no_island() {
+        use std::fs;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project = dir.path();
+        let pages = project.join("pages");
+        fs::create_dir_all(&pages).unwrap();
+
+        fs::write(
+            project.join("tsconfig.json"),
+            r#"{
+              "compilerOptions": {
+                "paths": {
+                  "@/*": ["src/*"]
+                }
+              }
+            }"#,
+        )
+        .unwrap();
+        fs::write(
+            pages.join("home.tsx"),
+            // `@/components/missing` substitutes to
+            // `<project>/src/components/missing.{tsx,ts,…}` — no such
+            // file exists, so the resolver returns None and the
+            // scanner produces no islands for this specifier.
+            r#"import { Missing } from "@/components/missing";
+            export default function Home() {}
+            "#,
+        )
+        .unwrap();
+
+        let resolver = FsResolver::new();
+        let islands = scan_islands(&[pages.join("home.tsx")], &resolver).unwrap();
+        assert!(islands.is_empty(), "got {islands:?}");
+    }
+
+    /// `extends` chain is followed: the leaf has no `paths`, but its
+    /// `extends` parent does. Models the common Astro / Next.js
+    /// scaffold where a `tsconfig.json` extends a `tsconfig.base.json`
+    /// (same directory) only — note the extends-target file MUST be
+    /// named `tsconfig.json` for the current parser to follow it (see
+    /// `resolve_extends_target` doc).
+    #[test]
+    fn fs_resolver_follows_extends_chain_to_inherit_paths() {
+        use std::fs;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project = dir.path();
+        let base_dir = project.join("config");
+        let pages = project.join("pages");
+        let components = project.join("src").join("components");
+        fs::create_dir_all(&base_dir).unwrap();
+        fs::create_dir_all(&pages).unwrap();
+        fs::create_dir_all(&components).unwrap();
+
+        // Base config in a sibling directory: it owns `paths`. The
+        // base's `compilerOptions.baseUrl` is the BASE's directory
+        // (`config/`), but absent here, so it defaults to that
+        // directory. To resolve `src/*` correctly the base also sets
+        // `baseUrl` two levels up via "../".
+        fs::write(
+            base_dir.join("tsconfig.json"),
+            r#"{
+              "compilerOptions": {
+                "baseUrl": "..",
+                "paths": {
+                  "@/*": ["src/*"]
+                }
+              }
+            }"#,
+        )
+        .unwrap();
+        // Leaf config extends the base via a relative path.
+        fs::write(
+            project.join("tsconfig.json"),
+            r#"{
+              "extends": "./config/tsconfig.json"
+            }"#,
+        )
+        .unwrap();
+        fs::write(
+            pages.join("home.tsx"),
+            r#"import { Counter } from "@/components/counter";
+            export default function Home() {}
+            "#,
+        )
+        .unwrap();
+        fs::write(
+            components.join("counter.tsx"),
+            r#""use client";
+            export function Counter() {}
+            "#,
+        )
+        .unwrap();
+
+        let resolver = FsResolver::new();
+        let islands = scan_islands(&[pages.join("home.tsx")], &resolver).unwrap();
+        assert_eq!(islands.len(), 1, "got {islands:?}");
+        assert_eq!(islands[0].component_name, "Counter");
+    }
+
+    /// Cache hit: parsing the same tsconfig twice via `load_tsconfig_paths`
+    /// returns the same data, and the on-disk file change between the
+    /// two calls is NOT reflected (the cache is intentionally write-once
+    /// per resolver instance — the build is a single short-lived pass,
+    /// and we don't want IO churn).
+    #[test]
+    fn fs_resolver_caches_parsed_tsconfig() {
+        use std::fs;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project = dir.path();
+        fs::write(
+            project.join("tsconfig.json"),
+            r#"{
+              "compilerOptions": {
+                "paths": { "@/*": ["src/*"] }
+              }
+            }"#,
+        )
+        .unwrap();
+
+        let resolver = FsResolver::new();
+        let first = resolver.load_tsconfig_paths(project).expect("first load");
+        // Mutate the on-disk file so a re-read would change the
+        // result — and verify the cached entry is returned unchanged.
+        fs::write(
+            project.join("tsconfig.json"),
+            r#"{
+              "compilerOptions": {
+                "paths": { "@/*": ["completely/different/*"] }
+              }
+            }"#,
+        )
+        .unwrap();
+        let second = resolver
+            .load_tsconfig_paths(project)
+            .expect("second load (cache hit)");
+        assert_eq!(first.aliases.len(), second.aliases.len());
+        assert_eq!(first.aliases[0].targets, second.aliases[0].targets);
     }
 }

--- a/crates/zfb-islands/src/scanner.rs
+++ b/crates/zfb-islands/src/scanner.rs
@@ -534,14 +534,33 @@ impl FsResolver {
     fn try_resolve_tsconfig_alias(&self, importer_dir: &Path, specifier: &str) -> Option<PathBuf> {
         let tsconfig_dir = Self::locate_tsconfig_dir(importer_dir)?;
         let entry = self.load_tsconfig_paths(&tsconfig_dir)?;
-        for alias in &entry.aliases {
-            if let Some(rest) = match_alias_pattern(&alias.pattern, specifier) {
-                for target in &alias.targets {
-                    let substituted = substitute_alias_target(target, rest.as_deref());
-                    let candidate = entry.base_dir.join(&substituted);
-                    if let Some(found) = self.probe_path_with_index(&candidate) {
-                        return Some(found);
-                    }
+        // Collect every alias whose pattern matches the specifier,
+        // then iterate in TypeScript's documented priority order:
+        // most-specific (longest non-wildcard prefix) wins. With the
+        // overlapping shape `{"@/*": [...], "@/components/*": [...]}`,
+        // resolving `@/components/Button` must try `@/components/*`
+        // first; only fall through to `@/*` when the more-specific
+        // probe misses. Map order in the source `paths` object is
+        // **not** stable across JSON parsers, so we cannot rely on
+        // declaration order — we must rank by pattern shape.
+        let mut matches: Vec<(&TsPathAlias, Option<String>, usize)> = entry
+            .aliases
+            .iter()
+            .filter_map(|alias| {
+                let captured = match_alias_pattern(&alias.pattern, specifier)?;
+                Some((alias, captured, pattern_specificity(&alias.pattern)))
+            })
+            .collect();
+        // Higher specificity score first. `sort_by_key` is stable,
+        // so ties (e.g. two literal patterns of the same length)
+        // keep declaration order and remain deterministic.
+        matches.sort_by_key(|m| std::cmp::Reverse(m.2));
+        for (alias, captured, _score) in matches {
+            for target in &alias.targets {
+                let substituted = substitute_alias_target(target, captured.as_deref());
+                let candidate = entry.base_dir.join(&substituted);
+                if let Some(found) = self.probe_path_with_index(&candidate) {
+                    return Some(found);
                 }
             }
         }
@@ -601,16 +620,26 @@ impl FsResolver {
 /// - The `extends` chain is followed up to a depth of 8 to defend
 ///   against hand-rolled cycles.
 fn parse_tsconfig_paths(tsconfig_dir: &Path) -> Option<TsConfigPaths> {
-    fn walk(
-        dir: &Path,
-        depth: usize,
-        // Carry the *highest-priority* (= most-overridden) values
-        // discovered so far. Earlier — i.e. the leaf tsconfig that
-        // started the walk — wins for both `baseUrl` and `paths` per
-        // TypeScript's documented semantics.
-        merged_base_dir: Option<PathBuf>,
-        merged_aliases: Option<Vec<TsPathAlias>>,
-    ) -> Option<(PathBuf, Vec<TsPathAlias>)> {
+    /// State threaded through the walk:
+    ///
+    /// - `base_dir` — the resolved `compilerOptions.baseUrl` from the
+    ///   leafiest config that declared one. `None` until we hit a
+    ///   `baseUrl`.
+    /// - `aliases` — the leafiest `compilerOptions.paths` table
+    ///   encountered. `None` until we hit one.
+    /// - `paths_anchor` — the directory of the tsconfig that *declared*
+    ///   `aliases`. When `base_dir` is never explicitly set anywhere
+    ///   in the chain, TypeScript anchors `paths` resolution to **that
+    ///   config's directory**, not to the deepest extends parent. This
+    ///   field captures it at the moment we adopt `aliases` so the
+    ///   fallback at the end of the walk picks the right anchor.
+    struct WalkState {
+        base_dir: Option<PathBuf>,
+        aliases: Option<Vec<TsPathAlias>>,
+        paths_anchor: Option<PathBuf>,
+    }
+
+    fn walk(dir: &Path, depth: usize, mut state: WalkState) -> Option<(PathBuf, Vec<TsPathAlias>)> {
         if depth > 8 {
             return None;
         }
@@ -650,24 +679,35 @@ fn parse_tsconfig_paths(tsconfig_dir: &Path) -> Option<TsConfigPaths> {
 
         // Leaf-wins merge: only adopt the local fields when the caller
         // hasn't already supplied a closer (= leaf-ier) override.
-        let next_base_dir = merged_base_dir.or(local_base_dir);
-        let next_aliases = merged_aliases.or(local_aliases);
+        if state.base_dir.is_none() {
+            state.base_dir = local_base_dir;
+        }
+        if state.aliases.is_none() {
+            if let Some(local) = local_aliases {
+                state.aliases = Some(local);
+                // Capture *this* config's directory as the implicit
+                // baseUrl anchor for `paths` — TypeScript resolves
+                // `paths` against the config that declared them when
+                // no `baseUrl` is specified anywhere in the chain.
+                state.paths_anchor = Some(dir.to_path_buf());
+            }
+        }
 
         // If we have everything, stop here — no need to walk extends
         // when the leaf already declared baseUrl + paths.
-        if let (Some(b), Some(a)) = (&next_base_dir, &next_aliases) {
+        if let (Some(b), Some(a)) = (&state.base_dir, &state.aliases) {
             return Some((b.clone(), a.clone()));
         }
 
         // Follow `extends` if present.
         if let Some(extends) = value.get("extends").and_then(|e| e.as_str()) {
             if let Some(parent_dir) = resolve_extends_target(dir, extends) {
-                if let Some(found) = walk(
-                    &parent_dir,
-                    depth + 1,
-                    next_base_dir.clone(),
-                    next_aliases.clone(),
-                ) {
+                let recurse_state = WalkState {
+                    base_dir: state.base_dir.clone(),
+                    aliases: state.aliases.clone(),
+                    paths_anchor: state.paths_anchor.clone(),
+                };
+                if let Some(found) = walk(&parent_dir, depth + 1, recurse_state) {
                     return Some(found);
                 }
             }
@@ -676,17 +716,26 @@ fn parse_tsconfig_paths(tsconfig_dir: &Path) -> Option<TsConfigPaths> {
         // No extends (or extends couldn't resolve): only return
         // something if we ended up with a `paths` table — without
         // patterns there is nothing to alias-match against.
-        let aliases = next_aliases?;
-        // Default `baseUrl` is the tsconfig directory itself (the
-        // directory whose `paths` entries we're returning) — this
-        // matches TypeScript's documented behaviour that `paths` is
-        // resolved relative to `baseUrl ?? "."` and that the `"."`
-        // default is interpreted relative to the tsconfig.
-        let base_dir = next_base_dir.unwrap_or_else(|| dir.to_path_buf());
+        let aliases = state.aliases?;
+        // Default `baseUrl` is the directory of the tsconfig that
+        // **declared** `paths` — captured in `paths_anchor` above.
+        // Falling back to whatever `dir` happens to be when the walker
+        // bottoms out (which can be a parent extends target) would
+        // anchor `paths` to the wrong directory in the common
+        // "leaf has paths, parent has neither" case (codex P2).
+        let base_dir = state.base_dir.or(state.paths_anchor).unwrap_or_else(|| dir.to_path_buf());
         Some((base_dir, aliases))
     }
 
-    let (base_dir, aliases) = walk(tsconfig_dir, 0, None, None)?;
+    let (base_dir, aliases) = walk(
+        tsconfig_dir,
+        0,
+        WalkState {
+            base_dir: None,
+            aliases: None,
+            paths_anchor: None,
+        },
+    )?;
     if aliases.is_empty() {
         return None;
     }
@@ -729,6 +778,30 @@ fn resolve_extends_target(extending_dir: &Path, extends: &str) -> Option<PathBuf
     // Either a non-tsconfig.json file (e.g. `tsconfig.base.json`),
     // doesn't exist, or some other shape we don't support yet.
     None
+}
+
+/// Score `pattern`'s specificity for the
+/// most-specific-pattern-wins rule TypeScript applies when more than
+/// one `compilerOptions.paths` key matches the specifier.
+///
+/// The score is the length of the longest non-wildcard run in the
+/// pattern. Literal patterns (no `*`) score their full length, so
+/// they always beat any wildcard form of the same prefix; wildcards
+/// score the longer of the prefix-before-`*` and suffix-after-`*`
+/// runs. Two patterns with identical scores keep their declaration
+/// order (the caller uses a stable sort).
+///
+/// This deliberately mirrors the TypeScript Compiler's own
+/// `getBestPathPattern` shape: the longest fixed prefix is the
+/// dominant tiebreaker; an exact match wins by sheer length.
+fn pattern_specificity(pattern: &str) -> usize {
+    if let Some(star_idx) = pattern.find('*') {
+        let prefix_len = star_idx;
+        let suffix_len = pattern.len().saturating_sub(star_idx + 1);
+        prefix_len.max(suffix_len)
+    } else {
+        pattern.len()
+    }
 }
 
 /// Match `specifier` against an alias `pattern` from
@@ -2927,6 +3000,165 @@ mod tests {
         let resolver = FsResolver::new();
         let islands = scan_islands(&[pages.join("home.tsx")], &resolver).unwrap();
         assert_eq!(islands.len(), 1, "got {islands:?}");
+        assert_eq!(islands[0].component_name, "Counter");
+    }
+
+    #[test]
+    fn pattern_specificity_literal_beats_wildcard() {
+        // A literal pattern (no `*`) of length 12 outranks a wildcard
+        // whose longest fixed run is shorter. This is the dominant
+        // tiebreaker used by `try_resolve_tsconfig_alias`.
+        assert!(pattern_specificity("@theme/dark") > pattern_specificity("@theme/*"));
+    }
+
+    #[test]
+    fn pattern_specificity_longer_prefix_wins() {
+        // Both patterns end in `*`; the one with the longer fixed
+        // prefix is more specific. With the codex P1 finding's
+        // example, `@/components/*` (specificity 13) must outrank
+        // `@/*` (specificity 2).
+        assert!(pattern_specificity("@/components/*") > pattern_specificity("@/*"));
+    }
+
+    /// Codex P1 regression: with overlapping patterns, the more
+    /// specific one must win regardless of declaration order in the
+    /// tsconfig. A specifier of `@/components/Button` previously
+    /// resolved through the broader `@/*` rule because `try_resolve`
+    /// returned on first map-iteration hit; now it must consult the
+    /// narrower `@/components/*` rule first.
+    #[test]
+    fn fs_resolver_prefers_more_specific_alias_pattern() {
+        use std::fs;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project = dir.path();
+        let pages = project.join("pages");
+        // The broader `@/*` rule's substitution exists on disk too
+        // (`src/components/Button.tsx`) and would yield a different
+        // island name without the specificity rule. The narrower
+        // `@/components/*` rule maps to `ui/Button.tsx`. The test
+        // asserts the narrower rule wins.
+        let src_components = project.join("src").join("components");
+        let ui = project.join("ui");
+        fs::create_dir_all(&pages).unwrap();
+        fs::create_dir_all(&src_components).unwrap();
+        fs::create_dir_all(&ui).unwrap();
+
+        fs::write(
+            project.join("tsconfig.json"),
+            r#"{
+              "compilerOptions": {
+                "paths": {
+                  "@/*": ["src/*"],
+                  "@/components/*": ["ui/*"]
+                }
+              }
+            }"#,
+        )
+        .unwrap();
+        fs::write(
+            pages.join("home.tsx"),
+            r#"import { Narrow } from "@/components/button";
+            export default function Home() {}
+            "#,
+        )
+        .unwrap();
+        // Broader `@/*` substitutes to `src/components/button` —
+        // exists, but should NOT be the winner.
+        fs::write(
+            src_components.join("button.tsx"),
+            r#""use client";
+            export function Wide() {}
+            "#,
+        )
+        .unwrap();
+        // Narrower `@/components/*` substitutes to `ui/button` —
+        // this is what the resolver MUST pick.
+        fs::write(
+            ui.join("button.tsx"),
+            r#""use client";
+            export function Narrow() {}
+            "#,
+        )
+        .unwrap();
+
+        let resolver = FsResolver::new();
+        let islands = scan_islands(&[pages.join("home.tsx")], &resolver).unwrap();
+        // The narrower rule picked ui/button.tsx → component Narrow.
+        // If the broader rule had won, `Wide` would be in the set
+        // instead.
+        let names: Vec<&str> = islands.iter().map(|i| i.component_name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["Narrow"],
+            "more-specific @/components/* must win over @/*: {islands:?}"
+        );
+    }
+
+    /// Codex P2 regression: leaf tsconfig declares `paths` but no
+    /// `baseUrl`; extends a parent that also lacks `baseUrl`. The
+    /// implicit baseUrl must anchor to the LEAF tsconfig's directory
+    /// (the one that declared `paths`), not the parent extends
+    /// target's directory. Before the fix, the walker fell through
+    /// to the parent's `dir` and resolved `@/*` against the wrong
+    /// project root.
+    #[test]
+    fn fs_resolver_extends_implicit_baseurl_anchors_to_leaf() {
+        use std::fs;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project = dir.path();
+        // The parent base config lives in a sibling dir. It has NO
+        // `paths`, NO `baseUrl` — just unrelated compiler options.
+        let parent_config_dir = project.join("shared");
+        let pages = project.join("pages");
+        let leaf_components = project.join("src").join("components");
+        // Notably, `shared/src/components/` does NOT exist — if the
+        // walker mistakenly anchored to `shared/`, the probe would
+        // miss and the test would fail.
+        fs::create_dir_all(&parent_config_dir).unwrap();
+        fs::create_dir_all(&pages).unwrap();
+        fs::create_dir_all(&leaf_components).unwrap();
+
+        fs::write(
+            parent_config_dir.join("tsconfig.json"),
+            r#"{
+              "compilerOptions": {
+                "strict": true
+              }
+            }"#,
+        )
+        .unwrap();
+        fs::write(
+            project.join("tsconfig.json"),
+            r#"{
+              "extends": "./shared/tsconfig.json",
+              "compilerOptions": {
+                "paths": { "@/*": ["src/*"] }
+              }
+            }"#,
+        )
+        .unwrap();
+        fs::write(
+            pages.join("home.tsx"),
+            r#"import { Counter } from "@/components/counter";
+            export default function Home() {}
+            "#,
+        )
+        .unwrap();
+        fs::write(
+            leaf_components.join("counter.tsx"),
+            r#""use client";
+            export function Counter() {}
+            "#,
+        )
+        .unwrap();
+
+        let resolver = FsResolver::new();
+        let islands = scan_islands(&[pages.join("home.tsx")], &resolver).unwrap();
+        assert_eq!(
+            islands.len(),
+            1,
+            "leaf-anchored paths must resolve against the leaf tsconfig dir: {islands:?}"
+        );
         assert_eq!(islands[0].component_name, "Counter");
     }
 


### PR DESCRIPTION
## Summary

Two upstream fixes blocking [zudolab/zudo-doc#1355](https://github.com/zudolab/zudo-doc/issues/1355) Wave 4 island hydration. Each is a self-contained logical change; the third commit applies `/codex-review` findings on the second.

- **closes #138** — `produce_bundle_js` failed with N >= 2 islands because esbuild rejects multi-input + `--outfile`. Fix synthesizes a single-entry source that imports every island and routes through the existing `bundle_one_entry` helper (one input + `--outfile`). On-disk contract for `dist/assets/islands.js` is preserved.
- **closes #139** — `FsResolver` did not honour `tsconfig.json` `compilerOptions.paths`. Downstream projects using `"@/*": ["src/*"]` had every host-side `import "@/components/foo"` come back as `None` from the scanner. Fix walks up to the nearest `tsconfig.json`, parses `paths` + `baseUrl` (with `extends` chain support), and probes substitution targets like a relative path.

## Commits

1. `fix(islands): synthesize single-entry source for shared bundle` — Fix #138 plus regression test (mock-mode multi-island bundle exercises the synthetic-entry shape).
2. `feat(islands): resolve TypeScript path aliases in FsResolver` — Fix #139, lazy tsconfig discovery + per-resolver cache, wildcard + literal patterns, `extends` chain following, 13 new tests.
3. `fix(islands): apply codex review findings on tsconfig path resolution` — Fixes two correctness gaps caught during self-review: most-specific pattern now wins (P1), and implicit `baseUrl` anchors to the config that **declared** `paths` rather than the deepest extends parent (P2). Both regressions are pinned with new tests.

## Verification

- `cargo test -p zfb-islands`: 111 unit + 10 integration + 3 doc tests, all passing.
- `cargo clippy -p zfb-islands --all-targets`: clean.
- `cargo check --workspace`: clean.

## Out of scope

Documented as known limitations in the new code's doc-comments; will be follow-up tickets if downstream consumers hit them:

- JSONC parsing of `tsconfig.json` (trailing commas, `// comments`).
- `extends` targets must be relative paths whose target file is literally named `tsconfig.json` (the common Astro / Next.js / zudo-doc shape works; bare-package extends and `extends: ["./a", "./b"]` arrays are not handled).
- Patterns with multiple `*` wildcards are rejected (no-match) rather than half-supported.

## Test plan

- [x] Unit tests cover pattern matching (literal, wildcard, multi-star rejection), target substitution, alias resolution, explicit baseUrl, multi-target fallthrough, no-match fall-through, substitution misses, `extends` chain, cache hits, P1 specificity ordering, P2 implicit-baseUrl anchoring.
- [x] Mock-mode integration regression test for the multi-island bundle (issue #138).
- [ ] Downstream verification at zudolab/zudo-doc#1355 Wave 4 — bumps the upstream pin to the merged SHA and re-runs the host-island hydration smoke.