### PR TITLE
fix(islands): scanner crashes when tsconfig path alias resolves to JSON file

### DIFF
--- a/crates/zfb-islands/src/scanner.rs
+++ b/crates/zfb-islands/src/scanner.rs
@@ -1129,6 +1129,16 @@ pub fn scan_islands<R: Resolver>(pages: &[PathBuf], resolver: &R) -> ScanResult<
             continue;
         }
 
+        // Skip files whose extension can't carry a `"use client"` directive
+        // the scanner needs to follow. After #139 the resolver follows
+        // tsconfig path aliases, so a specifier like `"#data"` can resolve
+        // to a `.json` (or `.css`, `.svg`, image/font binary, etc.) — none
+        // of those parse as TS/TSX. Treat them as terminal leaves; their
+        // imports are not walked further. See issue #141.
+        if !is_scannable_source(&current) {
+            continue;
+        }
+
         let source = resolver.read(&current).map_err(|message| ScanError::Resolver {
             path: current.clone(),
             message,
@@ -1169,6 +1179,25 @@ pub fn scan_islands<R: Resolver>(pages: &[PathBuf], resolver: &R) -> ScanResult<
     }
 
     Ok(found.into_values().collect())
+}
+
+/// Return `true` if `path` has an extension that can plausibly carry a
+/// `"use client"` directive that the scanner needs to follow.
+///
+/// Conservative whitelist: only TS/JS family source extensions. Anything
+/// else — `.json`, `.css`, `.svg`, image/font binaries, `.md`/`.mdx`, etc.
+/// — is a terminal leaf as far as the islands scanner is concerned, and
+/// must not be passed to SWC (which would parse it as TS and crash; see
+/// issue #141).
+///
+/// Files with no extension at all are also skipped: real source files in
+/// this codebase always carry an extension, and an unknown leaf is safer
+/// to skip than to feed to SWC.
+fn is_scannable_source(path: &Path) -> bool {
+    matches!(
+        path.extension().and_then(|s| s.to_str()),
+        Some("ts" | "tsx" | "js" | "jsx" | "mjs" | "cjs")
+    )
 }
 
 /// Parse a single TS/TSX source string into an SWC [`Module`].
@@ -3200,5 +3229,171 @@ mod tests {
             .expect("second load (cache hit)");
         assert_eq!(first.aliases.len(), second.aliases.len());
         assert_eq!(first.aliases[0].targets, second.aliases[0].targets);
+    }
+
+    // -------------------------------------------------------------------
+    // Non-source extension gate (issue #141)
+    // -------------------------------------------------------------------
+
+    /// `is_scannable_source` accepts the TS/JS family extensions and
+    /// rejects everything else.
+    #[test]
+    fn is_scannable_source_accepts_ts_and_js_family() {
+        for ext in ["ts", "tsx", "js", "jsx", "mjs", "cjs"] {
+            let p = PathBuf::from(format!("/proj/foo.{ext}"));
+            assert!(
+                is_scannable_source(&p),
+                "expected source extension to be scannable: {p:?}"
+            );
+        }
+    }
+
+    /// Concrete extensions a tsconfig path alias can point at — none of
+    /// these can carry a `"use client"` directive, and (per #141) feeding
+    /// them to SWC crashes the scanner. The gate must skip them.
+    #[test]
+    fn is_scannable_source_rejects_non_source_extensions() {
+        for ext in [
+            "json", "css", "svg", "png", "jpg", "jpeg", "gif", "webp", "avif", "ico", "woff",
+            "woff2", "ttf", "eot", "mp4", "webm", "mp3", "wav", "txt", "md", "mdx",
+        ] {
+            let p = PathBuf::from(format!("/proj/foo.{ext}"));
+            assert!(
+                !is_scannable_source(&p),
+                "expected non-source extension to be rejected: {p:?}"
+            );
+        }
+    }
+
+    /// Files with no extension at all are skipped — the scanner has no
+    /// safe way to know what they are, and source files in this codebase
+    /// always carry an extension.
+    #[test]
+    fn is_scannable_source_rejects_extensionless_path() {
+        assert!(!is_scannable_source(&PathBuf::from("/proj/Makefile")));
+    }
+
+    /// Mirrors the downstream issue #141 repro at the in-memory scanner
+    /// level: a page imports `"#data"`; the resolver maps that to a
+    /// populated `.json` file (multiple keys — empty `{}` happens to
+    /// parse as a TS expression statement, masking the bug). Pre-fix the
+    /// scanner crashed with `ExpectedSemiForExprStmt` inside SWC. The gate
+    /// treats `.json` as a terminal leaf, so the scan completes and the
+    /// reachable `"use client"` island is still discovered.
+    #[test]
+    fn scan_islands_skips_json_file_resolved_via_alias() {
+        // A bespoke resolver that mimics a tsconfig path alias mapping
+        // `"#data"` → `data.json`. Not `is_bare_specifier`-restricted so
+        // the bare-looking specifier resolves successfully (matches what
+        // FsResolver does with `compilerOptions.paths` after #139).
+        struct AliasingResolver {
+            inner: InMemoryResolver,
+            json_path: PathBuf,
+        }
+        impl Resolver for AliasingResolver {
+            fn resolve(&self, importer_dir: &Path, specifier: &str) -> Option<PathBuf> {
+                if specifier == "#data" {
+                    return Some(self.json_path.clone());
+                }
+                self.inner.resolve(importer_dir, specifier)
+            }
+            fn read(&self, path: &Path) -> std::result::Result<String, String> {
+                self.inner.read(path)
+            }
+        }
+
+        let json_path = root().join("data/payload.json");
+        let inner = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r##"import data from "#data";
+                import { Counter } from "../components/counter";
+                export default function Home() { return <Counter data={data}/>; }
+                "##,
+            )
+            .with_file(
+                root().join("components/counter.tsx"),
+                r#""use client";
+                export function Counter() {}
+                "#,
+            )
+            // Populated JSON (multiple keys). Empty `{}` parses as a
+            // legal TS expression statement and would mask the bug; with
+            // multiple keys SWC trips on the second key's colon. We add
+            // it to the resolver's file map so anything that does try to
+            // read it would succeed — proving the skip happens *before*
+            // parse, not via a lucky read failure.
+            .with_file(json_path.clone(), r#"{"a": 1, "b": 2, "c": 3}"#);
+        let resolver = AliasingResolver { inner, json_path };
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert_eq!(
+            paths(&islands),
+            vec![(
+                "/proj/components/counter.tsx".to_string(),
+                "Counter".to_string()
+            )],
+            "scan must skip the JSON leaf without aborting and still reach the island",
+        );
+    }
+
+    /// End-to-end via `FsResolver`: mirrors the exact downstream
+    /// `zudolab/zudo-doc#1355` Wave 4 shape — `tsconfig.json` declares
+    /// `"#doc-history-meta": [".zfb/doc-history-meta.json"]`, the page
+    /// imports it, and the scanner must not crash on the JSON.
+    #[test]
+    fn fs_resolver_skips_json_file_resolved_via_tsconfig_alias() {
+        use std::fs;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let project = dir.path();
+        let pages = project.join("pages");
+        let components = project.join("src").join("components");
+        let zfb_dir = project.join(".zfb");
+        fs::create_dir_all(&pages).unwrap();
+        fs::create_dir_all(&components).unwrap();
+        fs::create_dir_all(&zfb_dir).unwrap();
+
+        fs::write(
+            project.join("tsconfig.json"),
+            r##"{
+              "compilerOptions": {
+                "paths": {
+                  "@/*": ["src/*"],
+                  "#doc-history-meta": [".zfb/doc-history-meta.json"]
+                }
+              }
+            }"##,
+        )
+        .unwrap();
+        // Populated JSON — empty `{}` happens to parse as a TS
+        // expression statement, masking the bug. Multiple keys trip
+        // SWC's parser at the second key's colon, which is the real
+        // crash the downstream hit.
+        fs::write(
+            zfb_dir.join("doc-history-meta.json"),
+            r#"{"docs/foo": {"sha": "abc"}, "docs/bar": {"sha": "def"}}"#,
+        )
+        .unwrap();
+        fs::write(
+            pages.join("home.tsx"),
+            r##"import historyMeta from "#doc-history-meta";
+            import { Counter } from "@/components/counter";
+            export default function Home() { return <Counter meta={historyMeta}/>; }
+            "##,
+        )
+        .unwrap();
+        fs::write(
+            components.join("counter.tsx"),
+            r#""use client";
+            export function Counter() {}
+            "#,
+        )
+        .unwrap();
+
+        let resolver = FsResolver::new();
+        let islands =
+            scan_islands(&[pages.join("home.tsx")], &resolver).expect("scan must not crash");
+        assert_eq!(islands.len(), 1, "got {islands:?}");
+        assert_eq!(islands[0].component_name, "Counter");
     }
 }

--- a/crates/zfb-islands/src/scanner.rs
+++ b/crates/zfb-islands/src/scanner.rs
@@ -1193,10 +1193,18 @@ pub fn scan_islands<R: Resolver>(pages: &[PathBuf], resolver: &R) -> ScanResult<
 /// Files with no extension at all are also skipped: real source files in
 /// this codebase always carry an extension, and an unknown leaf is safer
 /// to skip than to feed to SWC.
+///
+/// The match is ASCII-case-insensitive so that on case-insensitive
+/// filesystems (macOS default, Windows) a `Foo.TSX` file is still
+/// recognised — pre-#141 the scanner accepted any extension, so case
+/// folding here preserves parity for legitimate source files.
 fn is_scannable_source(path: &Path) -> bool {
+    let Some(ext) = path.extension().and_then(|s| s.to_str()) else {
+        return false;
+    };
     matches!(
-        path.extension().and_then(|s| s.to_str()),
-        Some("ts" | "tsx" | "js" | "jsx" | "mjs" | "cjs")
+        ext.to_ascii_lowercase().as_str(),
+        "ts" | "tsx" | "js" | "jsx" | "mjs" | "cjs"
     )
 }
 
@@ -3271,6 +3279,22 @@ mod tests {
     #[test]
     fn is_scannable_source_rejects_extensionless_path() {
         assert!(!is_scannable_source(&PathBuf::from("/proj/Makefile")));
+    }
+
+    /// Case-insensitive extension match: case-insensitive filesystems
+    /// (macOS default, Windows) can produce `.TSX` / `.Js` etc. Pre-#141
+    /// the scanner accepted any extension, so the gate must keep
+    /// uppercase source extensions scannable to avoid regressing those
+    /// platforms.
+    #[test]
+    fn is_scannable_source_is_case_insensitive() {
+        for ext in ["TS", "Tsx", "JSX", "MJS", "Cjs", "tSx"] {
+            let p = PathBuf::from(format!("/proj/Foo.{ext}"));
+            assert!(
+                is_scannable_source(&p),
+                "expected case-insensitive accept: {p:?}"
+            );
+        }
     }
 
     /// Mirrors the downstream issue #141 repro at the in-memory scanner


### PR DESCRIPTION
## Summary

After PR #140 the FsResolver follows tsconfig `compilerOptions.paths` aliases. When such an alias resolves to a `.json` file (or any other non-source asset), the islands scanner fed the file to SWC's TypeScript parser and crashed with `ExpectedSemiForExprStmt` as soon as the JSON had more than one top-level key. The whole islands pipeline aborted, `dist/assets/islands.js` was not emitted, and downstream client-island hydration broke for any project with a JSON path alias.

Closes #141. Discovered downstream in `zudolab/zudo-doc#1355` Wave 4 immediately after the #140 pin bump (`bea6364` → `db40216`).

## Fix

`crates/zfb-islands/src/scanner.rs` — gate the dependency walk on a conservative TS/JS-family extension whitelist (`.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`, `.cjs`). Anything else — `.json`, `.css`, `.svg`, image/font binaries, `.md`/`.mdx`, etc. — is treated as a terminal leaf: no parse, no further import walk. Only those source extensions can carry a `"use client"` directive that the scanner needs to follow, so the whitelist is sound. Match is ASCII-case-insensitive so case-insensitive filesystems (macOS default, Windows) keep `.TSX`/`.Js` scannable, preserving pre-#141 parity for source files.

This is also a defensive improvement: any future user mapping a tsconfig alias to a data file would have hit the same crash.

## Tests

Six new unit tests in `scanner.rs`:

- `is_scannable_source_accepts_ts_and_js_family` — whitelist accepts every TS/JS extension.
- `is_scannable_source_rejects_non_source_extensions` — rejects `.json`, `.css`, `.svg`, image/font binaries, `.md`/`.mdx`, etc.
- `is_scannable_source_rejects_extensionless_path` — extensionless leaves are skipped.
- `is_scannable_source_is_case_insensitive` — `.TSX`/`.Js`/etc. accepted.
- `scan_islands_skips_json_file_resolved_via_alias` — InMemoryResolver repro: a custom resolver maps `#data` → populated `.json` (multiple keys, which trip SWC; empty `{}` happens to parse as a TS expression and would mask the bug). Pre-fix, this test reproduces the exact `ExpectedSemiForExprStmt` panic; post-fix the scan completes and the reachable `"use client"` island is still discovered.
- `fs_resolver_skips_json_file_resolved_via_tsconfig_alias` — end-to-end via the real `FsResolver`. Mirrors the downstream shape exactly: `tsconfig.json` declares `"#doc-history-meta": [".zfb/doc-history-meta.json"]`, the page imports `"#doc-history-meta"`, the JSON is populated with multiple keys.

I verified both `*_skips_json_*` tests fail without the gate (with the same `ExpectedSemiForExprStmt` error from the issue).

`cargo test -p zfb-islands` — 117 unit + 10 integration + 3 doc tests pass.
`cargo clippy -p zfb-islands --all-targets -- -D warnings` — clean.

## Test plan

- [x] `cargo test -p zfb-islands`
- [x] `cargo clippy -p zfb-islands --all-targets -- -D warnings`
- [x] Pre-fix repro confirmed: both skip-tests fail with the original `ExpectedSemiForExprStmt` error when the gate is bypassed
- [ ] Downstream pin bump to this SHA in `zudolab/zudo-doc#1355` Wave 4 (manager will follow up)