### PR TITLE
fix(islands): shared-bundle manifest uses static SSR-marker names from scanner

### DIFF
--- a/crates/zfb-islands/src/bundler.rs
+++ b/crates/zfb-islands/src/bundler.rs
@@ -48,7 +48,11 @@ pub type ModuleId = String;
 ///
 /// Two islands are equal iff their `(source_path, component_name)` pair is
 /// equal — this is the stable component-name identity the scanner promises.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+/// The newer [`marker_name`] field is metadata derived by the scanner from
+/// the same source file and is intentionally **excluded** from the
+/// equality / hashing contract so dedup behaviour is unchanged across
+/// scanner upgrades.
+#[derive(Debug, Clone)]
 pub struct Island {
     /// Exported component name from the source file. For default exports
     /// this is the literal string `"default"`.
@@ -57,20 +61,88 @@ pub struct Island {
     /// `"use client"` directive. Whatever form the scanner returned —
     /// typically the resolver's resolved-path representation.
     pub source_path: PathBuf,
+    /// SSR-marker name — the string the SSR side will write into the
+    /// `data-zfb-island` / `data-zfb-island-skip-ssr` attribute for this
+    /// island. The hydration manifest in the production shared bundle is
+    /// keyed on this name (NOT [`component_name`]), because the SSR side
+    /// derives the marker via `captureComponentName(child)` =
+    /// `child.type.displayName ?? child.type.name`, while the scanner
+    /// records [`component_name`] as the export-side name (which is
+    /// `"default"` for `export default function Foo()` and is mangled by
+    /// esbuild minification at runtime).
+    ///
+    /// Resolution rules in the scanner (issue #149):
+    ///
+    /// - `export default function Foo()` / `export default class Foo` →
+    ///   `marker_name = "Foo"` (the identifier name), NOT `"default"`.
+    /// - `export function Foo()` / `export class Foo` /
+    ///   `export const Foo = ...` → `marker_name = "Foo"`.
+    /// - When the body of an exported function calls
+    ///   `renderSsrSkipPlaceholder("X", ...)` (the host-side SSR-skip
+    ///   wrapper convention used by zudo-doc-v2's `*-island.tsx` shims),
+    ///   the literal first argument `"X"` overrides the rule above so the
+    ///   manifest key matches `data-zfb-island-skip-ssr="X"` rather than
+    ///   the wrapper's identifier name.
+    /// - Anonymous default expressions (`export default () => …`,
+    ///   `export default someFn(…)`) fall back to
+    ///   [`component_name`] verbatim (typically `"default"`).
+    pub marker_name: String,
 }
 
 impl Island {
-    /// Construct a new island.
+    /// Construct a new island. `marker_name` defaults to `component_name`.
     ///
     /// No path canonicalisation is done here; callers building islands by
     /// hand should pass the same path representation that the bundler's
     /// resolver expects so dedup keys line up with the rest of the
     /// pipeline.
     pub fn new(component_name: impl Into<String>, source_path: impl Into<PathBuf>) -> Self {
+        let component_name = component_name.into();
+        Self {
+            marker_name: component_name.clone(),
+            component_name,
+            source_path: source_path.into(),
+        }
+    }
+
+    /// Construct a new island with an explicit `marker_name` distinct
+    /// from `component_name`. Use this when the scanner determines the
+    /// SSR-marker name differs from the export-side name (default
+    /// exports of named functions, SSR-skip wrappers, etc.).
+    pub fn with_marker_name(
+        component_name: impl Into<String>,
+        source_path: impl Into<PathBuf>,
+        marker_name: impl Into<String>,
+    ) -> Self {
         Self {
             component_name: component_name.into(),
             source_path: source_path.into(),
+            marker_name: marker_name.into(),
         }
+    }
+}
+
+// Manually-implemented equality / hashing contract:
+//
+// Two islands are equal iff their `(source_path, component_name)` pair is
+// equal. `marker_name` is derived metadata — including it would mean a
+// scanner upgrade that refines the marker derivation (e.g. detecting a
+// new helper) would silently change the dedup behaviour for the same
+// source file. Excluding it keeps the contract stable across scanner
+// upgrades and matches the historical (`derive(PartialEq)`) shape from
+// before issue #149.
+impl PartialEq for Island {
+    fn eq(&self, other: &Self) -> bool {
+        self.component_name == other.component_name && self.source_path == other.source_path
+    }
+}
+
+impl Eq for Island {}
+
+impl std::hash::Hash for Island {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.component_name.hash(state);
+        self.source_path.hash(state);
     }
 }
 
@@ -538,8 +610,7 @@ mod tests {
         assert_eq!(asset.stable_url, zfb_types::STABLE_ISLANDS_URL);
         // Stable URL must NOT carry a hash — the pipeline owns hashing.
         assert!(
-            !asset.stable_url.contains('-')
-                || asset.stable_url == zfb_types::STABLE_ISLANDS_URL,
+            !asset.stable_url.contains('-') || asset.stable_url == zfb_types::STABLE_ISLANDS_URL,
             "adapter must emit the unhashed stable URL: got {}",
             asset.stable_url
         );

--- a/crates/zfb-islands/src/esbuild.rs
+++ b/crates/zfb-islands/src/esbuild.rs
@@ -282,10 +282,7 @@ impl EsbuildSubprocessConfig {
 /// use std::path::PathBuf;
 ///
 /// let bundler = EsbuildSubprocessBundler::new(EsbuildSubprocessConfig::default());
-/// let islands = vec![Island {
-///     component_name: "Counter".into(),
-///     source_path: PathBuf::from("components/counter.tsx"),
-/// }];
+/// let islands = vec![Island::new("Counter", PathBuf::from("components/counter.tsx"))];
 /// let out = bundler.bundle(&islands, &BundleConfig::production()).unwrap();
 /// assert_eq!(out.asset_url, "/assets/islands.js");
 /// ```
@@ -657,7 +654,7 @@ pub fn render_shared_bundle_entry_source(islands: &[Island]) -> String {
             json_string(&path)
         ));
     }
-    // Manifest registration helpers.
+    // Manifest registration helper.
     //
     // `__zfb_pick(ns, exportName)` returns the component value: it
     // prefers a *truthy* named export under `exportName` (so that
@@ -666,16 +663,16 @@ pub fn render_shared_bundle_entry_source(islands: &[Island]) -> String {
     // `ns.default`. That mirrors `render_island_entry_source` for the
     // per-island path.
     //
-    // `__zfb_keyFor(C, fallback)` is the dynamic counterpart of the
-    // SSR side's `captureComponentName(child)` in
-    // `packages/zfb/src/island.ts` — it reads `displayName ?? name`
-    // off the component, falling back to `fallback` (the scanner's
-    // export-side name) when neither is present (e.g. anonymous
-    // components, minified output).
+    // `__zfb_register(ns, exportName, markerName)` writes a Preact
+    // mount thunk for the resolved component under the **static
+    // marker name** the scanner discovered for this island (issue
+    // #149). The marker name is a JSON-encoded literal in the
+    // generated source, NOT a runtime introspection of
+    // `displayName ?? name` — that's the lesson from the previous
+    // round (PR #148): esbuild minification renames functions, so
+    // `function.name` is unstable and unsafe to key the manifest on.
     //
-    // `__zfb_register` finally writes a Preact mount thunk for the
-    // resolved component into the manifest under the derived key. The
-    // mount thunk picks `hydrate` vs `render` based on the SSR /
+    // The mount thunk picks `hydrate` vs `render` based on the SSR /
     // SSR-skip mode the runtime supplies, mirroring the per-island
     // entry script's behaviour exactly.
     out.push_str(
@@ -684,22 +681,10 @@ function __zfb_pick(ns, exportName) {\n\
   const named = ns[exportName];\n\
   return (named !== undefined && named !== null) ? named : ns.default;\n\
 }\n\
-function __zfb_keyFor(C, fallback) {\n\
-  if (C && typeof C === \"object\") {\n\
-    if (typeof C.displayName === \"string\" && C.displayName) return C.displayName;\n\
-    if (typeof C.name === \"string\" && C.name) return C.name;\n\
-  }\n\
-  if (typeof C === \"function\") {\n\
-    if (typeof C.displayName === \"string\" && C.displayName) return C.displayName;\n\
-    if (typeof C.name === \"string\" && C.name) return C.name;\n\
-  }\n\
-  return fallback;\n\
-}\n\
-function __zfb_register(ns, exportName, fallback) {\n\
+function __zfb_register(ns, exportName, markerName) {\n\
   const C = __zfb_pick(ns, exportName);\n\
   if (!C) return;\n\
-  const key = __zfb_keyFor(C, fallback);\n\
-  __zfb_manifest[key] = { mount: (props, element, mode) => {\n\
+  __zfb_manifest[markerName] = { mount: (props, element, mode) => {\n\
     const v = h(C, props);\n\
     if (mode === \"hydrate\") { hydrate(v, element); } else { render(v, element); }\n\
   } };\n\
@@ -710,11 +695,20 @@ function __zfb_register(ns, exportName, fallback) {\n\
     // reference each namespace identifier — so tree-shaking retains
     // every island's exports just as the previous
     // `(globalThis).__zfb_islands ??= [...]` anchor did (#144).
+    //
+    // The third argument is the **scanner-derived SSR-marker name**
+    // (`Island::marker_name`), which matches the value the SSR side
+    // writes into `data-zfb-island` / `data-zfb-island-skip-ssr`. For
+    // host-shape default-export islands the scanner uses the function
+    // identifier name (`export default function FooBar()` →
+    // `"FooBar"`); for SSR-skip wrappers it uses the literal first
+    // argument of `renderSsrSkipPlaceholder("X", …)` — see
+    // `crates/zfb-islands/src/scanner.rs::exported_island_records`.
     for (i, island) in islands.iter().enumerate() {
         let name_lit = json_string(&island.component_name);
-        let fallback_lit = json_string(&island.component_name);
+        let marker_lit = json_string(&island.marker_name);
         out.push_str(&format!(
-            "__zfb_register(__zfb_island_{i}, {name_lit}, {fallback_lit});\n"
+            "__zfb_register(__zfb_island_{i}, {name_lit}, {marker_lit});\n"
         ));
     }
     out.push_str("mountIslands(__zfb_manifest);\n");
@@ -1201,15 +1195,17 @@ mod tests {
         );
 
         // Helper functions present, plus an `__zfb_register` call per
-        // island. The helper derives the manifest key dynamically from
-        // `displayName ?? name` so host-shape default-export islands
-        // (where the scanner records `component_name = "default"`) line
-        // up with the SSR-side
-        // `data-zfb-island="<function-name>"` markers — see
-        // `packages/zfb/src/island.ts::captureComponentName`.
+        // island. Issue #149: the manifest key (third arg) is now a
+        // **static literal** — the scanner-derived `marker_name`. No
+        // runtime `displayName ?? name` introspection: that path was
+        // broken by esbuild minification (function names become single
+        // letters in production bundles).
         assert!(src.contains("function __zfb_pick("));
-        assert!(src.contains("function __zfb_keyFor("));
         assert!(src.contains("function __zfb_register("));
+        assert!(
+            !src.contains("function __zfb_keyFor("),
+            "issue #149: runtime introspection helper must be gone:\n{src}"
+        );
         assert!(src.contains("__zfb_register(__zfb_island_0, \"Counter\", \"Counter\");"));
         assert!(src.contains("__zfb_register(__zfb_island_1, \"Modal\", \"Modal\");"));
 
@@ -1222,44 +1218,92 @@ mod tests {
     }
 
     #[test]
-    fn render_shared_bundle_entry_source_does_not_collide_on_default_export_only_islands() {
-        // Regression for issue #147 follow-up
-        // (zudolab/zudo-doc#1355 Wave 6 follow-up): host-shape islands
-        // authored as `export default function FooBar(...)` are
-        // recorded by the scanner with `component_name = "default"`
-        // (the export-side name). If the synthesised entry used that
-        // name as the manifest key directly, every host-shape island
-        // would collapse onto the literal `"default"` key, esbuild
-        // would emit `Duplicate key "default" in object literal`
-        // warnings, and only the last island would hydrate at runtime.
+    fn render_shared_bundle_entry_source_uses_marker_name_for_default_export_islands() {
+        // Regression for issue #149 (zudolab/zudo-doc#1355 Wave 7):
+        // host-shape islands authored as
+        // `export default function FooBar(...)` are recorded by the
+        // scanner with `component_name = "default"` AND
+        // `marker_name = "FooBar"` (the function identifier name, which
+        // matches what `function.name` produces at SSR time).
         //
-        // The fix derives the key dynamically from the component's
-        // `displayName ?? name` at module-init time, mirroring the SSR
-        // side's `captureComponentName` derivation. The synthesised
-        // entry must therefore NEVER bake `"default"` as a static
-        // manifest key, even when every input island has
-        // `component_name = "default"`.
+        // The synthesised bundle entry must register the manifest entry
+        // under `marker_name`, NOT `component_name`. Before this fix
+        // (issue #149 Gap B), every host-shape default-export island
+        // collided on the literal `"default"` slot because esbuild
+        // minification renamed the actual functions and broke runtime
+        // `displayName ?? name` introspection.
         let islands = vec![
-            Island::new("default", "/abs/components/sidebar-toggle.tsx"),
-            Island::new("default", "/abs/components/theme-toggle.tsx"),
-            Island::new("default", "/abs/components/ai-chat-modal.tsx"),
+            Island::with_marker_name(
+                "default",
+                "/abs/components/sidebar-toggle.tsx",
+                "SidebarToggle",
+            ),
+            Island::with_marker_name("default", "/abs/components/theme-toggle.tsx", "ThemeToggle"),
+            Island::with_marker_name(
+                "default",
+                "/abs/components/ai-chat-modal.tsx",
+                "AiChatModal",
+            ),
         ];
         let src = render_shared_bundle_entry_source(&islands);
 
-        // No duplicate-key shape: the entry must not contain a literal
-        // object-literal `"default": ...` line that esbuild would flag.
+        // The third argument is the SSR-marker name, distinct from the
+        // export-side `component_name = "default"`. Static literal —
+        // not derived at runtime.
         assert!(
-            !src.contains("\"default\": {"),
-            "duplicate-key regression — entry must not bake \"default\" as a static key:\n{src}"
+            src.contains("__zfb_register(__zfb_island_0, \"default\", \"SidebarToggle\");"),
+            "expected SidebarToggle marker:\n{src}"
+        );
+        assert!(
+            src.contains("__zfb_register(__zfb_island_1, \"default\", \"ThemeToggle\");"),
+            "expected ThemeToggle marker:\n{src}"
+        );
+        assert!(
+            src.contains("__zfb_register(__zfb_island_2, \"default\", \"AiChatModal\");"),
+            "expected AiChatModal marker:\n{src}"
         );
 
-        // Every island still gets a register call, in input order, with
-        // its scanner-side export name as the lookup AND as the
-        // ultimate fallback if the component lacks `displayName ?? name`
-        // (e.g. anonymous arrow fn under heavy minification).
-        assert!(src.contains("__zfb_register(__zfb_island_0, \"default\", \"default\");"));
-        assert!(src.contains("__zfb_register(__zfb_island_1, \"default\", \"default\");"));
-        assert!(src.contains("__zfb_register(__zfb_island_2, \"default\", \"default\");"));
+        // Marker names must be all distinct so no two islands collide
+        // on the same manifest slot.
+        assert!(src.contains("\"SidebarToggle\""));
+        assert!(src.contains("\"ThemeToggle\""));
+        assert!(src.contains("\"AiChatModal\""));
+    }
+
+    #[test]
+    fn render_shared_bundle_entry_source_uses_marker_name_for_ssr_skip_wrappers() {
+        // Regression for issue #149 Gap A: SSR-skip wrappers like
+        // `AiChatModalIsland` are exported under their wrapper name but
+        // emit `data-zfb-island-skip-ssr="AiChatModal"` (no "Island"
+        // suffix) via `renderSsrSkipPlaceholder("AiChatModal", …)`. The
+        // bundle's manifest must therefore key on "AiChatModal", not
+        // "AiChatModalIsland".
+        //
+        // The scanner extracts the literal first argument from the
+        // helper call and stores it as `marker_name`. The bundler then
+        // bakes that as the static third arg of `__zfb_register`.
+        let islands = vec![
+            Island::with_marker_name(
+                "AiChatModalIsland",
+                "/abs/components/ai-chat-modal-island.tsx",
+                "AiChatModal",
+            ),
+            Island::with_marker_name(
+                "ImageEnlargeIsland",
+                "/abs/components/image-enlarge-island.tsx",
+                "ImageEnlarge",
+            ),
+        ];
+        let src = render_shared_bundle_entry_source(&islands);
+
+        // Lookup uses the wrapper export name (so the import * as ns
+        // round-trip lands on the wrapper component). The manifest key
+        // is the SSR marker name.
+        assert!(
+            src.contains("__zfb_register(__zfb_island_0, \"AiChatModalIsland\", \"AiChatModal\");")
+        );
+        assert!(src
+            .contains("__zfb_register(__zfb_island_1, \"ImageEnlargeIsland\", \"ImageEnlarge\");"));
     }
 
     /// Regression for issue #138.

--- a/crates/zfb-islands/src/scanner.rs
+++ b/crates/zfb-islands/src/scanner.rs
@@ -71,8 +71,8 @@ use swc_core::atoms::Wtf8Atom;
 use swc_core::common::sync::Lrc;
 use swc_core::common::{FileName, SourceMap};
 use swc_core::ecma::ast::{
-    Decl, EsVersion, Expr, ExportSpecifier, Lit, Module, ModuleDecl, ModuleExportName, ModuleItem,
-    Pat, Stmt,
+    BlockStmt, Callee, Decl, DefaultDecl, EsVersion, ExportSpecifier, Expr, Lit, Module,
+    ModuleDecl, ModuleExportName, ModuleItem, Pat, Stmt, VarDeclarator,
 };
 use swc_core::ecma::parser::{lexer::Lexer, Parser, StringInput, Syntax, TsSyntax};
 use thiserror::Error;
@@ -395,7 +395,9 @@ impl FsResolver {
         // can't be canonicalised (e.g. doesn't exist), fall back to the
         // raw path — the probe's `is_file()` checks will then fail
         // naturally on anything that doesn't actually live on disk.
-        let pkg_root = pkg_dir.canonicalize().unwrap_or_else(|_| pkg_dir.to_path_buf());
+        let pkg_root = pkg_dir
+            .canonicalize()
+            .unwrap_or_else(|_| pkg_dir.to_path_buf());
 
         let probe_dir_or_file = |candidate: PathBuf| -> Option<PathBuf> {
             self.probe_path_with_index(&candidate)
@@ -745,7 +747,10 @@ fn parse_tsconfig_paths(tsconfig_dir: &Path) -> Option<TsConfigPaths> {
         // bottoms out (which can be a parent extends target) would
         // anchor `paths` to the wrong directory in the common
         // "leaf has paths, parent has neither" case (codex P2).
-        let base_dir = state.base_dir.or(state.paths_anchor).unwrap_or_else(|| dir.to_path_buf());
+        let base_dir = state
+            .base_dir
+            .or(state.paths_anchor)
+            .unwrap_or_else(|| dir.to_path_buf());
         Some((base_dir, aliases))
     }
 
@@ -1035,7 +1040,9 @@ impl Resolver for FsResolver {
             if !Self::is_workspace_package(&pkg_dir) {
                 return None;
             }
-            return self.probe_package_entry(&pkg_dir, &subpath).map(canonicalize);
+            return self
+                .probe_package_entry(&pkg_dir, &subpath)
+                .map(canonicalize);
         }
 
         let candidate = importer_dir.join(specifier);
@@ -1226,19 +1233,22 @@ pub fn scan_islands<R: Resolver>(pages: &[PathBuf], resolver: &R) -> ScanResult<
             continue;
         }
 
-        let source = resolver.read(&current).map_err(|message| ScanError::Resolver {
-            path: current.clone(),
-            message,
-        })?;
+        let source = resolver
+            .read(&current)
+            .map_err(|message| ScanError::Resolver {
+                path: current.clone(),
+                message,
+            })?;
 
         let module = parse_module(&current, &source)?;
 
         if has_use_client_directive(&module) {
-            for name in exported_binding_names(&module) {
-                let key = (current.clone(), name.clone());
-                found
-                    .entry(key)
-                    .or_insert_with(|| Island::new(name, current.clone()));
+            for record in exported_island_records(&module) {
+                let key = (current.clone(), record.component_name.clone());
+                let path = current.clone();
+                found.entry(key).or_insert_with(|| {
+                    Island::with_marker_name(record.component_name, path, record.marker_name)
+                });
             }
         }
 
@@ -1384,48 +1394,187 @@ fn collect_import_specifiers(module: &Module) -> Vec<String> {
     out
 }
 
-/// Collect the exported binding names produced by this module.
+/// One exported binding paired with its SSR-marker name.
 ///
-/// See the module-level "Component identity" docs for the full mapping.
-fn exported_binding_names(module: &Module) -> Vec<String> {
-    let mut out = Vec::new();
+/// Returned by [`exported_island_records`] so the scanner can hand the
+/// bundler both the export-side identity (`component_name`, used as the
+/// dedup key) and the SSR-side identity (`marker_name`, used as the
+/// hydration-manifest key in the production shared bundle).
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct IslandRecord {
+    component_name: String,
+    marker_name: String,
+}
+
+/// Walk the module's exports and pair each one with its SSR-marker name.
+///
+/// The marker name is what the SSR side will write into the
+/// `data-zfb-island` / `data-zfb-island-skip-ssr` attribute (see
+/// `packages/zfb/src/island.ts::captureComponentName`). The shared-bundle
+/// hydration manifest is keyed on this name; using the export-side name
+/// directly would mis-key every host-shape default-export island as
+/// `"default"` (issue #149 Gap B) and every SSR-skip wrapper as the
+/// wrapper's identifier instead of its placeholder marker (Gap A).
+///
+/// Resolution rules:
+///
+/// - `export default function Foo()` / `export default class Foo` →
+///   `component_name = "default"`, `marker_name = "Foo"` (the identifier
+///   name; matches `function.name` at SSR time before minification).
+/// - `export default function ()` / `export default <anon-expr>` →
+///   `component_name = "default"`, `marker_name = "default"` (no
+///   recoverable identity; the bundler still registers the entry, but
+///   the SSR side will need [`ANONYMOUS_COMPONENT_NAME`] to match).
+/// - `export function Foo()` / `export class Foo` /
+///   `export const Foo = …` → `component_name = "Foo"`,
+///   `marker_name = "Foo"`.
+/// - `export { A, B as C }` → `(A, A)`, `(C, C)` — re-exports don't
+///   carry an inline body, so the wrapper detection below does not apply.
+///
+/// Then each function body is scanned for a top-level
+/// `renderSsrSkipPlaceholder("X", …)` call (the host-side SSR-skip
+/// wrapper convention, see
+/// `packages/zudo-doc-v2/src/ssr-skip/types.ts::renderSsrSkipPlaceholder`).
+/// When found, the literal first-argument string overrides the
+/// rule-based `marker_name` so the manifest key matches
+/// `data-zfb-island-skip-ssr="X"` rather than the wrapper's identifier.
+fn exported_island_records(module: &Module) -> Vec<IslandRecord> {
+    // 1. Build a side-table of `local_ident -> renderSsrSkipPlaceholder
+    //    first-arg literal` for every function/variable declaration in
+    //    the module body. Used below to override marker_name on the
+    //    matching exported declaration.
+    let body_markers = collect_body_markers(module);
+
+    let mut out: Vec<IslandRecord> = Vec::new();
     for item in &module.body {
         let ModuleItem::ModuleDecl(decl) = item else {
             continue;
         };
         match decl {
             ModuleDecl::ExportDecl(ed) => match &ed.decl {
-                Decl::Class(c) => out.push(c.ident.sym.to_string()),
-                Decl::Fn(f) => out.push(f.ident.sym.to_string()),
+                Decl::Class(c) => {
+                    let name = c.ident.sym.to_string();
+                    let marker = body_markers
+                        .get(&name)
+                        .cloned()
+                        .unwrap_or_else(|| name.clone());
+                    out.push(IslandRecord {
+                        component_name: name,
+                        marker_name: marker,
+                    });
+                }
+                Decl::Fn(f) => {
+                    let name = f.ident.sym.to_string();
+                    let marker_from_body = marker_from_function_body(f.function.body.as_ref());
+                    let marker = marker_from_body
+                        .or_else(|| body_markers.get(&name).cloned())
+                        .unwrap_or_else(|| name.clone());
+                    out.push(IslandRecord {
+                        component_name: name,
+                        marker_name: marker,
+                    });
+                }
                 Decl::Var(v) => {
                     for d in &v.decls {
                         if let Pat::Ident(bi) = &d.name {
-                            out.push(bi.id.sym.to_string());
+                            let name = bi.id.sym.to_string();
+                            let marker_from_init = marker_from_var_initialiser(d);
+                            let marker = marker_from_init
+                                .or_else(|| body_markers.get(&name).cloned())
+                                .unwrap_or_else(|| name.clone());
+                            out.push(IslandRecord {
+                                component_name: name,
+                                marker_name: marker,
+                            });
                         }
                     }
                 }
                 _ => {}
             },
-            ModuleDecl::ExportDefaultDecl(_) | ModuleDecl::ExportDefaultExpr(_) => {
-                out.push("default".to_string());
+            ModuleDecl::ExportDefaultDecl(ed) => match &ed.decl {
+                DefaultDecl::Fn(fexp) => {
+                    let ident_name = fexp.ident.as_ref().map(|i| i.sym.to_string());
+                    let marker = marker_from_function_body(fexp.function.body.as_ref())
+                        .or_else(|| ident_name.clone())
+                        .unwrap_or_else(|| "default".to_string());
+                    out.push(IslandRecord {
+                        component_name: "default".to_string(),
+                        marker_name: marker,
+                    });
+                }
+                DefaultDecl::Class(cexp) => {
+                    let ident_name = cexp.ident.as_ref().map(|i| i.sym.to_string());
+                    let marker = ident_name.unwrap_or_else(|| "default".to_string());
+                    out.push(IslandRecord {
+                        component_name: "default".to_string(),
+                        marker_name: marker,
+                    });
+                }
+                DefaultDecl::TsInterfaceDecl(_) => {
+                    // Type-only export — no runtime value, but keep the
+                    // historical "default" emission so dedup behaviour is
+                    // unchanged. The bundler will see no usable component
+                    // and skip it at register time.
+                    out.push(IslandRecord {
+                        component_name: "default".to_string(),
+                        marker_name: "default".to_string(),
+                    });
+                }
+            },
+            ModuleDecl::ExportDefaultExpr(ee) => {
+                // `export default <expr>` — try to recover an identifier
+                // from common shapes (`export default Foo`,
+                // `export default forwardRef(Foo)`). Otherwise fall back
+                // to "default".
+                let marker =
+                    marker_from_default_expr(&ee.expr).unwrap_or_else(|| "default".to_string());
+                out.push(IslandRecord {
+                    component_name: "default".to_string(),
+                    marker_name: marker,
+                });
             }
             ModuleDecl::ExportNamed(named) => {
                 for spec in &named.specifiers {
                     match spec {
                         ExportSpecifier::Named(n) => {
                             let pick = n.exported.as_ref().unwrap_or(&n.orig);
-                            match pick {
-                                ModuleExportName::Ident(id) => out.push(id.sym.to_string()),
-                                ModuleExportName::Str(s) => out.push(atom_to_string(&s.value)),
-                            }
+                            let name = match pick {
+                                ModuleExportName::Ident(id) => id.sym.to_string(),
+                                ModuleExportName::Str(s) => atom_to_string(&s.value),
+                            };
+                            // For named re-exports the local ident is
+                            // `n.orig` — that's what the body-marker
+                            // table is keyed on.
+                            let local = match &n.orig {
+                                ModuleExportName::Ident(id) => id.sym.to_string(),
+                                ModuleExportName::Str(s) => atom_to_string(&s.value),
+                            };
+                            let marker = body_markers
+                                .get(&local)
+                                .cloned()
+                                .unwrap_or_else(|| name.clone());
+                            out.push(IslandRecord {
+                                component_name: name,
+                                marker_name: marker,
+                            });
                         }
                         ExportSpecifier::Default(d) => {
-                            out.push(d.exported.sym.to_string());
+                            let name = d.exported.sym.to_string();
+                            out.push(IslandRecord {
+                                component_name: name.clone(),
+                                marker_name: name,
+                            });
                         }
-                        ExportSpecifier::Namespace(n) => match &n.name {
-                            ModuleExportName::Ident(id) => out.push(id.sym.to_string()),
-                            ModuleExportName::Str(s) => out.push(atom_to_string(&s.value)),
-                        },
+                        ExportSpecifier::Namespace(n) => {
+                            let name = match &n.name {
+                                ModuleExportName::Ident(id) => id.sym.to_string(),
+                                ModuleExportName::Str(s) => atom_to_string(&s.value),
+                            };
+                            out.push(IslandRecord {
+                                component_name: name.clone(),
+                                marker_name: name,
+                            });
+                        }
                     }
                 }
             }
@@ -1434,6 +1583,202 @@ fn exported_binding_names(module: &Module) -> Vec<String> {
     }
     out
 }
+
+/// Walk every top-level function and variable declaration in the module
+/// body and record the `renderSsrSkipPlaceholder("X", …)` literal each
+/// one carries (if any). Returned as `local_ident -> marker_name` so the
+/// caller can override the marker name on the matching exported
+/// declaration.
+///
+/// This catches the host-shape pattern where a wrapper is declared at
+/// module level and exported separately, e.g.
+///
+/// ```ignore
+/// function AiChatModalIsland(props) {
+///   return renderSsrSkipPlaceholder("AiChatModal", …);
+/// }
+/// export { AiChatModalIsland };
+/// ```
+///
+/// The inline-export case (`export function AiChatModalIsland(…) { … }`)
+/// is handled directly by [`exported_island_records`] reading the
+/// function body of the matched export.
+fn collect_body_markers(module: &Module) -> HashMap<String, String> {
+    let mut out: HashMap<String, String> = HashMap::new();
+    for item in &module.body {
+        match item {
+            ModuleItem::Stmt(Stmt::Decl(decl)) => match decl {
+                Decl::Fn(f) => {
+                    if let Some(marker) = marker_from_function_body(f.function.body.as_ref()) {
+                        out.insert(f.ident.sym.to_string(), marker);
+                    }
+                }
+                Decl::Var(v) => {
+                    for d in &v.decls {
+                        if let Pat::Ident(bi) = &d.name {
+                            if let Some(marker) = marker_from_var_initialiser(d) {
+                                out.insert(bi.id.sym.to_string(), marker);
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            },
+            ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ed)) => match &ed.decl {
+                // `export function Foo(…) { … }` declarations also
+                // populate the table so `Foo` resolves correctly when
+                // later re-exported via `export { Foo as default }`.
+                Decl::Fn(f) => {
+                    if let Some(marker) = marker_from_function_body(f.function.body.as_ref()) {
+                        out.insert(f.ident.sym.to_string(), marker);
+                    }
+                }
+                Decl::Var(v) => {
+                    for d in &v.decls {
+                        if let Pat::Ident(bi) = &d.name {
+                            if let Some(marker) = marker_from_var_initialiser(d) {
+                                out.insert(bi.id.sym.to_string(), marker);
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+    out
+}
+
+/// If `init` of a variable declarator is a function expression / arrow
+/// function whose body contains a top-level
+/// `renderSsrSkipPlaceholder("X", …)` call, return `"X"`.
+fn marker_from_var_initialiser(d: &VarDeclarator) -> Option<String> {
+    let init = d.init.as_ref()?;
+    match init.as_ref() {
+        Expr::Fn(f) => marker_from_function_body(f.function.body.as_ref()),
+        Expr::Arrow(a) => match &*a.body {
+            swc_core::ecma::ast::BlockStmtOrExpr::BlockStmt(b) => marker_from_block(b),
+            swc_core::ecma::ast::BlockStmtOrExpr::Expr(e) => marker_from_expr(e),
+        },
+        _ => None,
+    }
+}
+
+/// Pull a marker literal out of a function body if it contains a
+/// top-level `renderSsrSkipPlaceholder("X", …)` call.
+fn marker_from_function_body(body: Option<&BlockStmt>) -> Option<String> {
+    marker_from_block(body?)
+}
+
+/// Walk a `BlockStmt`'s top-level statements looking for a
+/// `return <expr>;` or `<expr>;` that is a
+/// `renderSsrSkipPlaceholder("X", …)` call; return `"X"`.
+fn marker_from_block(block: &BlockStmt) -> Option<String> {
+    for stmt in &block.stmts {
+        match stmt {
+            Stmt::Return(r) => {
+                if let Some(arg) = r.arg.as_ref() {
+                    if let Some(s) = marker_from_expr(arg) {
+                        return Some(s);
+                    }
+                }
+            }
+            Stmt::Expr(es) => {
+                if let Some(s) = marker_from_expr(&es.expr) {
+                    return Some(s);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// If `expr` is a `renderSsrSkipPlaceholder("X", …)` call (or a
+/// parenthesised / type-asserted version of one), return `"X"`.
+fn marker_from_expr(expr: &Expr) -> Option<String> {
+    let inner = unwrap_expr(expr);
+    let call = match inner {
+        Expr::Call(c) => c,
+        _ => return None,
+    };
+    let Callee::Expr(callee) = &call.callee else {
+        return None;
+    };
+    let callee_inner = unwrap_expr(callee);
+    let is_target = match callee_inner {
+        Expr::Ident(id) => id.sym == *RENDER_SSR_SKIP_PLACEHOLDER_NAME,
+        // Member expressions like `helpers.renderSsrSkipPlaceholder(…)` —
+        // unusual, but conservative to support.
+        Expr::Member(m) => match &m.prop {
+            swc_core::ecma::ast::MemberProp::Ident(id) => {
+                id.sym == *RENDER_SSR_SKIP_PLACEHOLDER_NAME
+            }
+            _ => false,
+        },
+        _ => false,
+    };
+    if !is_target {
+        return None;
+    }
+    let first = call.args.first()?;
+    if first.spread.is_some() {
+        return None;
+    }
+    let lit_expr = unwrap_expr(&first.expr);
+    let Expr::Lit(Lit::Str(s)) = lit_expr else {
+        return None;
+    };
+    Some(atom_to_string(&s.value))
+}
+
+/// `export default <expr>` recovery. Handles `export default Foo` and
+/// `export default forwardRef(Foo)` shapes.
+fn marker_from_default_expr(expr: &Expr) -> Option<String> {
+    match unwrap_expr(expr) {
+        Expr::Ident(id) => Some(id.sym.to_string()),
+        Expr::Call(c) => {
+            // `forwardRef(Foo)` / `memo(Foo)` style — first ident arg.
+            for arg in &c.args {
+                if arg.spread.is_some() {
+                    continue;
+                }
+                if let Expr::Ident(id) = unwrap_expr(&arg.expr) {
+                    return Some(id.sym.to_string());
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+/// Strip wrapping `(expr)` and TS `expr as T` / `<T>expr` /
+/// `expr satisfies T` so identifier matching is robust.
+fn unwrap_expr(expr: &Expr) -> &Expr {
+    let mut e = expr;
+    loop {
+        match e {
+            Expr::Paren(p) => e = &p.expr,
+            Expr::TsAs(a) => e = &a.expr,
+            Expr::TsTypeAssertion(a) => e = &a.expr,
+            Expr::TsConstAssertion(a) => e = &a.expr,
+            Expr::TsSatisfies(s) => e = &s.expr,
+            Expr::TsNonNull(n) => e = &n.expr,
+            _ => return e,
+        }
+    }
+}
+
+/// Name of the host-side SSR-skip placeholder helper that the scanner
+/// recognises as a marker-name source. See the doc on
+/// [`exported_island_records`] for the contract.
+///
+/// Defined as a `'static` slice so future scanner extensions can share
+/// the recognition table (e.g. accept additional names) without making
+/// each call-site re-spell the string.
+const RENDER_SSR_SKIP_PLACEHOLDER_NAME: &str = "renderSsrSkipPlaceholder";
 
 #[cfg(test)]
 mod tests {
@@ -1708,10 +2053,7 @@ mod tests {
         assert_eq!(
             paths(&islands),
             vec![
-                (
-                    "/proj/components/alpha.tsx".to_string(),
-                    "B".to_string()
-                ),
+                ("/proj/components/alpha.tsx".to_string(), "B".to_string()),
                 ("/proj/components/zeta.tsx".to_string(), "A".to_string()),
             ]
         );
@@ -1966,7 +2308,10 @@ mod tests {
         let resolver = FsResolver::new();
         let islands = scan_islands(&[pages.join("home.tsx")], &resolver).unwrap();
         let names: Vec<String> = islands.iter().map(|i| i.component_name.clone()).collect();
-        assert_eq!(names, vec!["A".to_string(), "B".to_string(), "C".to_string()]);
+        assert_eq!(
+            names,
+            vec!["A".to_string(), "B".to_string(), "C".to_string()]
+        );
     }
 
     /// In-memory resolver mirror of [`fs_resolver_swaps_js_specifier_to_tsx_source`].
@@ -2034,7 +2379,10 @@ mod tests {
         let islands = scan_islands(&[pages.join("home.tsx")], &resolver).unwrap();
         assert_eq!(islands.len(), 1);
         assert_eq!(islands[0].component_name, "Counter");
-        let expected = comps.join("counter.js").canonicalize().expect("canonicalize");
+        let expected = comps
+            .join("counter.js")
+            .canonicalize()
+            .expect("canonicalize");
         assert_eq!(islands[0].source_path, expected);
     }
 
@@ -2075,7 +2423,10 @@ mod tests {
         let islands = scan_islands(&[pages.join("home.tsx")], &resolver).unwrap();
         assert_eq!(islands.len(), 1, "got {:?}", islands);
         assert_eq!(islands[0].component_name, "Counter");
-        let expected = comps.join("counter.tsx").canonicalize().expect("canonicalize");
+        let expected = comps
+            .join("counter.tsx")
+            .canonicalize()
+            .expect("canonicalize");
         assert_eq!(islands[0].source_path, expected);
     }
 
@@ -2351,11 +2702,7 @@ mod tests {
         use std::fs;
         let dir = tempfile::tempdir().expect("tempdir");
         let pages = dir.path().join("pages");
-        let pkg_src = dir
-            .path()
-            .join("node_modules")
-            .join("ws-pkg")
-            .join("src");
+        let pkg_src = dir.path().join("node_modules").join("ws-pkg").join("src");
         fs::create_dir_all(&pages).unwrap();
         fs::create_dir_all(&pkg_src).unwrap();
 
@@ -2848,7 +3195,10 @@ mod tests {
     #[test]
     fn split_bare_specifier_handles_scoped_and_unscoped() {
         let scoped = FsResolver::split_bare_specifier("@takazudo/zfb-blog-islands");
-        assert_eq!(scoped, ("@takazudo/zfb-blog-islands".to_string(), String::new()));
+        assert_eq!(
+            scoped,
+            ("@takazudo/zfb-blog-islands".to_string(), String::new())
+        );
 
         let scoped_sub =
             FsResolver::split_bare_specifier("@takazudo/zfb-blog-islands/components/foo");
@@ -3743,5 +4093,298 @@ mod tests {
             scan_islands(&[pages.join("home.tsx")], &resolver).expect("scan must not crash");
         assert_eq!(islands.len(), 1, "got {islands:?}");
         assert_eq!(islands[0].component_name, "Counter");
+    }
+
+    // ---------------------------------------------------------------------
+    // Issue #149 — SSR-marker name extraction
+    //
+    // The shared-bundle hydration manifest is keyed on the SSR-marker
+    // name (`Island::marker_name`), which the scanner derives from the
+    // island's source file. The bundler bakes the marker name as a
+    // static literal in the synthesised entry's `__zfb_register(...)`
+    // call, bypassing runtime `displayName ?? name` introspection (which
+    // esbuild minification breaks).
+    //
+    // The tests below pin the marker-name derivation rules end-to-end
+    // through `scan_islands`.
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn marker_name_for_named_function_export_matches_export_name() {
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import { Counter } from "../components/counter";
+                export default function Home() { return <Counter/>; }
+                "#,
+            )
+            .with_file(
+                root().join("components/counter.tsx"),
+                r#""use client";
+                export function Counter() { return null; }
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert_eq!(islands.len(), 1);
+        assert_eq!(islands[0].component_name, "Counter");
+        assert_eq!(islands[0].marker_name, "Counter");
+    }
+
+    #[test]
+    fn marker_name_for_named_const_export_matches_export_name() {
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import { Toggle } from "../components/toggle";
+                export default function Home() { return <Toggle/>; }
+                "#,
+            )
+            .with_file(
+                root().join("components/toggle.tsx"),
+                r#""use client";
+                export const Toggle = () => null;
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert_eq!(islands.len(), 1);
+        assert_eq!(islands[0].component_name, "Toggle");
+        assert_eq!(islands[0].marker_name, "Toggle");
+    }
+
+    #[test]
+    fn marker_name_for_default_export_named_function_uses_function_identifier() {
+        // Issue #149 Gap B: host-shape `export default function FooBar()`
+        // — the export-side name is "default" but the SSR-marker name is
+        // "FooBar" (the function identifier). The scanner must record
+        // that gap so the bundler can bake a static literal manifest
+        // key that survives esbuild minification.
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import SidebarToggle from "../components/sidebar-toggle";
+                export default function Home() { return <SidebarToggle/>; }
+                "#,
+            )
+            .with_file(
+                root().join("components/sidebar-toggle.tsx"),
+                r#""use client";
+                export default function SidebarToggle() { return null; }
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert_eq!(islands.len(), 1);
+        assert_eq!(islands[0].component_name, "default");
+        assert_eq!(
+            islands[0].marker_name, "SidebarToggle",
+            "issue #149 Gap B: marker name must match the function identifier"
+        );
+    }
+
+    #[test]
+    fn marker_name_for_default_export_named_class_uses_class_identifier() {
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import Counter from "../components/counter";
+                export default function Home() { return <Counter/>; }
+                "#,
+            )
+            .with_file(
+                root().join("components/counter.tsx"),
+                r#""use client";
+                export default class Counter { render() { return null; } }
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert_eq!(islands.len(), 1);
+        assert_eq!(islands[0].component_name, "default");
+        assert_eq!(islands[0].marker_name, "Counter");
+    }
+
+    #[test]
+    fn marker_name_for_anonymous_default_export_falls_back_to_default() {
+        // `export default function () {}` has no identifier — there is
+        // no recoverable SSR-marker name. The bundler will register the
+        // entry under "default" and the SSR side will need to use
+        // ANONYMOUS_COMPONENT_NAME for the `data-zfb-island=""` marker;
+        // either way the scanner cannot do better here, so it just
+        // mirrors `component_name`.
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import Anon from "../components/anon";
+                export default function Home() { return <Anon/>; }
+                "#,
+            )
+            .with_file(
+                root().join("components/anon.tsx"),
+                r#""use client";
+                export default function () { return null; }
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert_eq!(islands.len(), 1);
+        assert_eq!(islands[0].component_name, "default");
+        assert_eq!(islands[0].marker_name, "default");
+    }
+
+    #[test]
+    fn marker_name_extracts_render_ssr_skip_placeholder_first_arg_inline_export() {
+        // Issue #149 Gap A: SSR-skip wrapper functions (the
+        // `*-island.tsx` shims under `packages/zudo-doc-v2/src/ssr-skip/`)
+        // are exported under their wrapper name (e.g. AiChatModalIsland)
+        // but emit `data-zfb-island-skip-ssr="AiChatModal"` via
+        // `renderSsrSkipPlaceholder("AiChatModal", …)`. The scanner must
+        // extract the literal first argument so the bundle's manifest
+        // key matches the SSR-side marker, NOT the wrapper's identifier.
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import { AiChatModalIsland } from "../components/ai-chat-modal-island";
+                export default function Home() { return <AiChatModalIsland/>; }
+                "#,
+            )
+            .with_file(
+                root().join("components/ai-chat-modal-island.tsx"),
+                r#""use client";
+                import { renderSsrSkipPlaceholder } from "./helpers";
+                export function AiChatModalIsland(props) {
+                    return renderSsrSkipPlaceholder("AiChatModal", "load", null, props);
+                }
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert_eq!(islands.len(), 1);
+        assert_eq!(islands[0].component_name, "AiChatModalIsland");
+        assert_eq!(
+            islands[0].marker_name, "AiChatModal",
+            "issue #149 Gap A: marker name must come from \
+             renderSsrSkipPlaceholder's first arg literal"
+        );
+    }
+
+    #[test]
+    fn marker_name_extracts_render_ssr_skip_placeholder_first_arg_re_export() {
+        // Variant of the previous test where the wrapper is declared
+        // at module level and re-exported via `export { Foo }` rather
+        // than as an inline `export function Foo()`. The scanner's
+        // body-scan path covers this case via `collect_body_markers`.
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import { ImageEnlargeIsland } from "../components/image-enlarge-island";
+                export default function Home() { return <ImageEnlargeIsland/>; }
+                "#,
+            )
+            .with_file(
+                root().join("components/image-enlarge-island.tsx"),
+                r#""use client";
+                import { renderSsrSkipPlaceholder } from "./helpers";
+                function ImageEnlargeIsland(props) {
+                    return renderSsrSkipPlaceholder("ImageEnlarge", "visible", null, props);
+                }
+                export { ImageEnlargeIsland };
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert_eq!(islands.len(), 1);
+        assert_eq!(islands[0].component_name, "ImageEnlargeIsland");
+        assert_eq!(islands[0].marker_name, "ImageEnlarge");
+    }
+
+    #[test]
+    fn marker_name_extracts_render_ssr_skip_placeholder_for_arrow_function_const() {
+        // Variant: wrapper authored as `export const Foo = (...) => …`
+        // with the helper call as the arrow-function body. The scanner
+        // covers this via `marker_from_var_initialiser`.
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import { MockInitIsland } from "../components/mock-init-island";
+                export default function Home() { return <MockInitIsland/>; }
+                "#,
+            )
+            .with_file(
+                root().join("components/mock-init-island.tsx"),
+                r#""use client";
+                import { renderSsrSkipPlaceholder } from "./helpers";
+                export const MockInitIsland = (props) =>
+                    renderSsrSkipPlaceholder("MockInit", "load", null, props);
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert_eq!(islands.len(), 1);
+        assert_eq!(islands[0].component_name, "MockInitIsland");
+        assert_eq!(islands[0].marker_name, "MockInit");
+    }
+
+    #[test]
+    fn marker_name_render_ssr_skip_placeholder_overrides_default_export_function_name() {
+        // Edge case: a default export whose body calls
+        // `renderSsrSkipPlaceholder`. The helper-call extraction wins
+        // over the function identifier (because the helper call is the
+        // direct authority on the marker name).
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import DesignTokenTweakPanelIsland from "../components/design-token-tweak-panel-island";
+                export default function Home() { return <DesignTokenTweakPanelIsland/>; }
+                "#,
+            )
+            .with_file(
+                root().join("components/design-token-tweak-panel-island.tsx"),
+                r#""use client";
+                import { renderSsrSkipPlaceholder } from "./helpers";
+                export default function DesignTokenTweakPanelIsland(props) {
+                    return renderSsrSkipPlaceholder("DesignTokenTweakPanel", "idle", null, props);
+                }
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert_eq!(islands.len(), 1);
+        assert_eq!(islands[0].component_name, "default");
+        assert_eq!(islands[0].marker_name, "DesignTokenTweakPanel");
+    }
+
+    #[test]
+    fn marker_name_ignores_unrelated_string_literals_in_function_body() {
+        // The scanner must only react to `renderSsrSkipPlaceholder("X", …)`,
+        // not to any other top-level call with a string-literal first arg.
+        // Otherwise it would mis-derive the marker for arbitrary
+        // user-written components.
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import { NotAWrapper } from "../components/not-a-wrapper";
+                export default function Home() { return <NotAWrapper/>; }
+                "#,
+            )
+            .with_file(
+                root().join("components/not-a-wrapper.tsx"),
+                r#""use client";
+                import { someUnrelatedHelper } from "./helpers";
+                export function NotAWrapper(props) {
+                    return someUnrelatedHelper("looks-like-a-marker", props);
+                }
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert_eq!(islands.len(), 1);
+        assert_eq!(islands[0].component_name, "NotAWrapper");
+        assert_eq!(
+            islands[0].marker_name, "NotAWrapper",
+            "marker_name must default to the export name when no \
+             renderSsrSkipPlaceholder call is present"
+        );
     }
 }

--- a/crates/zfb-islands/tests/integration.rs
+++ b/crates/zfb-islands/tests/integration.rs
@@ -16,10 +16,7 @@ use zfb_islands::{
 };
 
 fn island(name: &str, path: &str) -> Island {
-    Island {
-        component_name: name.to_string(),
-        source_path: PathBuf::from(path),
-    }
+    Island::new(name, PathBuf::from(path))
 }
 
 #[test]
@@ -199,13 +196,7 @@ fn subprocess_bundler_against_real_binary() {
 
     let bundle_cfg = BundleConfig::production().with_outdir(tmp.path());
     let out = bundler
-        .bundle(
-            &[Island {
-                component_name: "Counter".into(),
-                source_path: entry,
-            }],
-            &bundle_cfg,
-        )
+        .bundle(&[Island::new("Counter", entry)], &bundle_cfg)
         .expect("real esbuild binary should produce a bundle");
     assert!(out.asset_path.exists());
 }
@@ -285,14 +276,8 @@ export default function NoEffectFn() { return null; }
     let out = bundler
         .bundle(
             &[
-                Island {
-                    component_name: "WithEffect".into(),
-                    source_path: with_effect,
-                },
-                Island {
-                    component_name: "NoEffectFn".into(),
-                    source_path: no_effect,
-                },
+                Island::new("WithEffect", with_effect),
+                Island::new("NoEffectFn", no_effect),
             ],
             &bundle_cfg,
         )


### PR DESCRIPTION
Closes #149.

Post-PR #147/#148, the shared-bundle production path invokes `mountIslands` but the manifest keys still don't match the SSR markers emitted in `dist` HTML. Two distinct mismatches surfaced on `zudolab/zudo-doc#1355` Wave 6 measurement (20 e2e specs red on pin `784dead`):

## Gap A — "Island" suffix mismatch on SSR-skip wrappers

Host-side wrapper functions like `AiChatModalIsland` call `renderSsrSkipPlaceholder("AiChatModal", ...)` which emits `data-zfb-island-skip-ssr="AiChatModal"` (no suffix). Pre-fix the bundler recorded the wrapper export name (`AiChatModalIsland`) as the manifest key, so runtime lookup of `"AiChatModal"` returned `undefined` and no hydration ever fired.

## Gap B — esbuild minification breaks runtime introspection

PR #148's `__zfb_keyFor` helper read `displayName ?? name` off the component to derive the manifest key at module-init time. After esbuild minification (default in production) function names are mangled to single letters, so all four host-shape default-export islands (SidebarToggle, ThemeToggle, …) collided on the literal `"default"` fallback slot — only the last island ever registered.

## Fix shape

- **Scanner** (`crates/zfb-islands/src/scanner.rs`) now derives a static SSR-marker name per island via a new `exported_island_records` walker. Default-export named functions/classes use the identifier name (`export default function FooBar()` → `"FooBar"`); any function body containing `renderSsrSkipPlaceholder("X", …)` overrides the marker with the literal first argument. Inline-export, separate-decl-then-`export {…}` re-export, and arrow-function-const variants are all covered.
- **Island** (`crates/zfb-islands/src/bundler.rs`) gains a `marker_name` field alongside `component_name`, with manual `PartialEq`/`Eq`/`Hash` impls so the dedup contract stays keyed on `(source_path, component_name)` — the marker name is metadata, not identity. Backward-compat preserved via `Island::new()` defaulting marker_name to component_name; new `Island::with_marker_name()` constructor for the scanner.
- **Bundler** (`crates/zfb-islands/src/esbuild.rs::render_shared_bundle_entry_source`) bakes the `marker_name` as a static literal third argument to `__zfb_register`, and the runtime `__zfb_keyFor` helper is dropped entirely. Minification can no longer break the manifest because there is nothing to introspect at runtime.

After this fix the synthesised entry (pre-minification) looks like:

```js
__zfb_register(__zfb_island_0, "default", "SidebarToggle");
__zfb_register(__zfb_island_1, "AiChatModalIsland", "AiChatModal");
__zfb_register(__zfb_island_2, "default", "ThemeToggle");
mountIslands(__zfb_manifest);
```

Each manifest key is a static string literal that survives esbuild minification, and the keys match the SSR-side `data-zfb-island` / `data-zfb-island-skip-ssr` values exactly.

## Test plan

- 12 new scanner + bundler unit tests pin the marker derivation end-to-end:
  - Named function / const exports → `marker_name == component_name`.
  - Default-export named function / class → `marker_name == identifier`.
  - Default-export anonymous function → fallback to `"default"`.
  - `renderSsrSkipPlaceholder("X", …)` extraction across inline-export, re-export, and arrow-function-const variants.
  - Default-export with helper call → helper-call override wins.
  - Negative case: unrelated string literals don't trigger marker override.
- Existing bundler tests updated to assert the new `__zfb_register` call shape and absence of `__zfb_keyFor`.
- `cargo test --workspace` — all green (no regressions).
- `pnpm -r test` — all 174 JS package tests pass.
- `pnpm -r typecheck` — clean.
- `cargo build --workspace --all-targets` — clean.

## Compatibility

- `Island::new()` is fully backward-compatible: `marker_name` defaults to `component_name` so any existing caller gets the historical behaviour. Only the scanner's new `exported_island_records` path actually populates a distinct marker name.
- The runtime manifest shape (`Record<string, string | IslandModule>`) is unchanged; only the key derivation changed.

Refs zudolab/zudo-doc#1355 Wave 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)