### PR TITLE
fix(islands): pass --jsx=automatic --jsx-import-source=preact to esbuild

### DIFF
--- a/crates/zfb-islands/src/bundler.rs
+++ b/crates/zfb-islands/src/bundler.rs
@@ -165,6 +165,24 @@ pub struct BundleConfig {
     /// Public base URL prefix used by [`bundle_link_href`].
     /// Default: `"/"`.
     pub base_url: String,
+
+    /// JSX import source the esbuild subprocess should target via
+    /// `--jsx=automatic --jsx-import-source=<value>`. Mirrors
+    /// `zfb_render::adapters::Adapter::jsx_import_source()` and
+    /// `zfb_build::bundler::BundleConfig::jsx_import_source`.
+    ///
+    /// Why this matters: without `--jsx=automatic --jsx-import-source=…`
+    /// esbuild's default classic JSX transform emits bare
+    /// `React.createElement(…)` / `React.Fragment` references in the
+    /// bundled island code. When host components have been migrated to
+    /// `preact/compat` for hooks (no `React` namespace import), those
+    /// references are dangling and the bundle throws
+    /// `ReferenceError: React is not defined` at mount time
+    /// (issue #151 / zudolab/zudo-doc#1355 Wave 8). Setting this
+    /// field to `"preact"` (the default, matching
+    /// [`FrameworkKind::Preact`]) routes the JSX transform through
+    /// `preact/jsx-runtime` so no `React` symbol is ever emitted.
+    pub jsx_import_source: String,
 }
 
 impl Default for BundleConfig {
@@ -174,6 +192,7 @@ impl Default for BundleConfig {
             sourcemap: true,
             outdir: PathBuf::from("dist"),
             base_url: "/".to_string(),
+            jsx_import_source: FrameworkKind::default().jsx_import_source().to_string(),
         }
     }
 }
@@ -214,6 +233,17 @@ impl BundleConfig {
     /// Toggle sourcemap emission (chainable).
     pub fn with_sourcemap(mut self, sourcemap: bool) -> Self {
         self.sourcemap = sourcemap;
+        self
+    }
+
+    /// Override the JSX import source the esbuild subprocess targets via
+    /// `--jsx-import-source=<value>` (chainable). Use the framework's
+    /// `jsx_import_source` accessor (e.g.
+    /// `FrameworkKind::Preact.jsx_import_source()`,
+    /// `zfb_render::adapters::Adapter::jsx_import_source()`) to derive
+    /// the value rather than hardcoding a literal at the call site.
+    pub fn with_jsx_import_source(mut self, jsx_import_source: impl Into<String>) -> Self {
+        self.jsx_import_source = jsx_import_source.into();
         self
     }
 }
@@ -322,6 +352,19 @@ pub enum FrameworkKind {
 impl FrameworkKind {
     /// Stable lowercase name. Mirrors `zfb_render::Adapter::name()`.
     pub fn name(self) -> &'static str {
+        match self {
+            FrameworkKind::Preact => "preact",
+            FrameworkKind::React => "react",
+        }
+    }
+
+    /// JSX import source for esbuild's automatic JSX transform.
+    /// Mirrors `zfb_render::adapters::Adapter::jsx_import_source()` —
+    /// the bundler passes this to esbuild as
+    /// `--jsx-import-source=<value>` so the compiled output routes
+    /// through `<value>/jsx-runtime` instead of the classic
+    /// `React.createElement` shape.
+    pub fn jsx_import_source(self) -> &'static str {
         match self {
             FrameworkKind::Preact => "preact",
             FrameworkKind::React => "react",
@@ -493,6 +536,34 @@ mod tests {
         assert_eq!(cfg.base_url, "https://cdn.example.com/");
         assert!(!cfg.minify);
         assert!(cfg.sourcemap);
+    }
+
+    #[test]
+    fn bundle_config_default_jsx_import_source_is_preact() {
+        // Issue #151: the default JSX import source must match the
+        // default `FrameworkKind` (Preact) so esbuild's
+        // --jsx=automatic transform routes through `preact/jsx-runtime`
+        // instead of emitting bare `React.createElement` references.
+        assert_eq!(BundleConfig::default().jsx_import_source, "preact");
+        assert_eq!(BundleConfig::production().jsx_import_source, "preact");
+        assert_eq!(BundleConfig::dev().jsx_import_source, "preact");
+    }
+
+    #[test]
+    fn bundle_config_with_jsx_import_source_overrides() {
+        let cfg = BundleConfig::default().with_jsx_import_source("react");
+        assert_eq!(cfg.jsx_import_source, "react");
+    }
+
+    #[test]
+    fn framework_kind_jsx_import_source_matches_zfb_render_adapter_contract() {
+        // Mirrors `zfb_render::adapters::Adapter::jsx_import_source()` —
+        // the value the bundler hands to esbuild via
+        // `--jsx-import-source=<value>` must agree with what the
+        // renderer's SWC pipeline targets, otherwise the SSR'd HTML
+        // and the hydrated bundle disagree on how JSX compiles.
+        assert_eq!(FrameworkKind::Preact.jsx_import_source(), "preact");
+        assert_eq!(FrameworkKind::React.jsx_import_source(), "react");
     }
 
     #[test]

--- a/crates/zfb-islands/src/esbuild.rs
+++ b/crates/zfb-islands/src/esbuild.rs
@@ -375,6 +375,16 @@ impl EsbuildSubprocessBundler {
         std::fs::create_dir_all(&islands_dir)
             .with_context(|| format!("failed to create {}", islands_dir.display()))?;
 
+        // Per-island path always knows the framework explicitly (it is
+        // a separate parameter), so override `BundleConfig::jsx_import_source`
+        // with the framework's accessor before handing it down. This
+        // keeps `bundle_one_entry` reading the JSX import source from a
+        // single source of truth (the config) regardless of which
+        // entrypoint started the bundle.
+        let mut framework_cfg = config.clone();
+        framework_cfg.jsx_import_source = framework.jsx_import_source().to_string();
+        let config = &framework_cfg;
+
         let mut bundle_entries: Vec<IslandBundle> = Vec::with_capacity(islands.len());
         let mut manifest: Vec<(String, String)> = Vec::with_capacity(islands.len());
 
@@ -495,37 +505,17 @@ impl EsbuildSubprocessBundler {
             .tempfile()
             .context("failed to allocate out temp file")?;
 
+        let args = build_esbuild_args(
+            config,
+            &self.config.extra_args,
+            out_tmp.path(),
+            entry_tmp.path(),
+        );
         let mut cmd = Command::new(&self.config.binary_path);
         cmd.current_dir(&self.config.working_dir);
-        cmd.arg("--bundle");
-        cmd.arg("--format=esm");
-        cmd.arg("--splitting=false");
-        cmd.arg("--tree-shaking=true");
-        // Per-island bundles ship to the browser. See `produce_bundle_js`
-        // for the full rationale; mirrored here so both the legacy
-        // shared-bundle and per-island paths stay aligned on platform
-        // target + node:* externalization.
-        cmd.arg("--platform=browser");
-        cmd.arg("--external:node:*");
-        if config.minify {
-            cmd.arg("--minify");
+        for arg in &args {
+            cmd.arg(arg);
         }
-        if config.sourcemap {
-            cmd.arg("--sourcemap=linked");
-        }
-        cmd.arg(format!("--outfile={}", out_tmp.path().display()));
-        // Inline NODE_ENV so React/Preact pick their production build
-        // when minifying. esbuild expects the define value to be a JS
-        // literal, hence the embedded quotes.
-        if config.minify {
-            cmd.arg("--define:process.env.NODE_ENV=\"production\"");
-        } else {
-            cmd.arg("--define:process.env.NODE_ENV=\"development\"");
-        }
-        for extra in &self.config.extra_args {
-            cmd.arg(extra);
-        }
-        cmd.arg(entry_tmp.path());
 
         let output = cmd
             .output()
@@ -543,6 +533,77 @@ impl EsbuildSubprocessBundler {
             std::fs::read_to_string(out_tmp.path()).context("failed to read esbuild output")?;
         Ok(js)
     }
+}
+
+/// Compose the esbuild CLI argument list for one entry-source bundle
+/// pass. Split out from `bundle_one_entry` so unit tests can assert
+/// against the flag list without spawning the subprocess.
+///
+/// The args mirror the historical `bundle_one_entry` shape verbatim
+/// **plus** the `--jsx=automatic --jsx-import-source=<value>` pair
+/// (issue #151). Without those two flags esbuild's default classic
+/// JSX transform emits bare `React.createElement(…)` references that
+/// throw `ReferenceError: React is not defined` at mount time when
+/// host components have been migrated to `preact/compat`.
+///
+/// Order is stable across calls so callers (and tests) can rely on a
+/// deterministic argv layout.
+pub(crate) fn build_esbuild_args(
+    config: &BundleConfig,
+    extra_args: &[OsString],
+    out_path: &Path,
+    entry_path: &Path,
+) -> Vec<OsString> {
+    let mut args: Vec<OsString> = Vec::new();
+    args.push(OsString::from("--bundle"));
+    args.push(OsString::from("--format=esm"));
+    args.push(OsString::from("--splitting=false"));
+    args.push(OsString::from("--tree-shaking=true"));
+    // Per-island bundles ship to the browser. See `produce_bundle_js`
+    // for the full rationale; mirrored here so both the legacy
+    // shared-bundle and per-island paths stay aligned on platform
+    // target + node:* externalization.
+    args.push(OsString::from("--platform=browser"));
+    args.push(OsString::from("--external:node:*"));
+    // Issue #151: route esbuild through the automatic JSX transform
+    // pointed at the host framework's import source (typically
+    // `"preact"`). Without these two flags esbuild defaults to the
+    // classic transform and emits bare `React.createElement` /
+    // `React.Fragment` references; islands using `preact/compat` for
+    // hooks have no `React` binding and crash at mount time
+    // (zudolab/zudo-doc#1355 Wave 8).
+    args.push(OsString::from("--jsx=automatic"));
+    args.push(OsString::from(format!(
+        "--jsx-import-source={}",
+        config.jsx_import_source
+    )));
+    if config.minify {
+        args.push(OsString::from("--minify"));
+    }
+    if config.sourcemap {
+        args.push(OsString::from("--sourcemap=linked"));
+    }
+    args.push(OsString::from(format!(
+        "--outfile={}",
+        out_path.display()
+    )));
+    // Inline NODE_ENV so React/Preact pick their production build
+    // when minifying. esbuild expects the define value to be a JS
+    // literal, hence the embedded quotes.
+    if config.minify {
+        args.push(OsString::from(
+            "--define:process.env.NODE_ENV=\"production\"",
+        ));
+    } else {
+        args.push(OsString::from(
+            "--define:process.env.NODE_ENV=\"development\"",
+        ));
+    }
+    for extra in extra_args {
+        args.push(extra.clone());
+    }
+    args.push(OsString::from(entry_path.as_os_str()));
+    args
 }
 
 /// Generate the synthetic single-entry source for the legacy shared
@@ -1398,6 +1459,81 @@ mod tests {
         assert_eq!(
             cfg.binary_path,
             PathBuf::from("crates/zfb/binaries/esbuild/esbuild")
+        );
+    }
+
+    /// Helper: collect the args produced by `build_esbuild_args` as
+    /// plain `String`s so test assertions can use `contains` / equality
+    /// without juggling `OsString` conversions.
+    fn args_as_strings(config: &BundleConfig) -> Vec<String> {
+        let entry = PathBuf::from("/tmp/entry.tsx");
+        let out = PathBuf::from("/tmp/out.js");
+        build_esbuild_args(config, &[], &out, &entry)
+            .into_iter()
+            .map(|os| os.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    /// Regression for issue #151 (zudolab/zudo-doc#1355 Wave 8).
+    ///
+    /// The esbuild subprocess argument list MUST include
+    /// `--jsx=automatic` AND `--jsx-import-source=preact` (the default
+    /// framework). Without those two flags esbuild's classic JSX
+    /// transform emits bare `React.createElement` references that
+    /// throw `ReferenceError: React is not defined` at mount time when
+    /// host components have been migrated to `preact/compat` for
+    /// hooks.
+    #[test]
+    fn build_esbuild_args_includes_automatic_jsx_flags_for_preact_default() {
+        let cfg = BundleConfig::default();
+        let args = args_as_strings(&cfg);
+        assert!(
+            args.iter().any(|a| a == "--jsx=automatic"),
+            "missing --jsx=automatic in args: {args:?}"
+        );
+        assert!(
+            args.iter().any(|a| a == "--jsx-import-source=preact"),
+            "missing --jsx-import-source=preact in args: {args:?}"
+        );
+        // Both flags must appear before the entry path (which is
+        // always last) so esbuild parses them as flags rather than as
+        // additional inputs.
+        let entry_idx = args
+            .iter()
+            .position(|a| a.ends_with("entry.tsx"))
+            .expect("entry path present");
+        let jsx_idx = args
+            .iter()
+            .position(|a| a == "--jsx=automatic")
+            .expect("--jsx=automatic present");
+        let import_idx = args
+            .iter()
+            .position(|a| a == "--jsx-import-source=preact")
+            .expect("--jsx-import-source=preact present");
+        assert!(jsx_idx < entry_idx);
+        assert!(import_idx < entry_idx);
+    }
+
+    /// `BundleConfig::jsx_import_source` is honoured verbatim — the
+    /// helper does not hardcode `"preact"`, so callers that bundle for
+    /// React (or any future adapter) get the right
+    /// `--jsx-import-source=<value>` flag.
+    #[test]
+    fn build_esbuild_args_honours_custom_jsx_import_source() {
+        let cfg = BundleConfig::default().with_jsx_import_source("react");
+        let args = args_as_strings(&cfg);
+        assert!(
+            args.iter().any(|a| a == "--jsx=automatic"),
+            "missing --jsx=automatic in args: {args:?}"
+        );
+        assert!(
+            args.iter().any(|a| a == "--jsx-import-source=react"),
+            "missing --jsx-import-source=react in args: {args:?}"
+        );
+        // The Preact default must NOT leak when the caller overrode it.
+        assert!(
+            !args.iter().any(|a| a == "--jsx-import-source=preact"),
+            "stale --jsx-import-source=preact present: {args:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Without `--jsx=automatic --jsx-import-source=<framework>` esbuild's default classic JSX transform emits bare `React.createElement(...)` / `React.Fragment` references in the bundled island code. When host components are migrated to `preact/compat` for hooks (no `React` namespace import), the bundle throws `ReferenceError: React is not defined` at mount time (zudolab/zudo-doc#1355 Wave 8 / closes #151).

## Changes

- Add `jsx_import_source: String` (default `"preact"`) and a `with_jsx_import_source` setter to `zfb_islands::BundleConfig`. Mirrors `zfb_render::adapters::Adapter::jsx_import_source()` and the existing `zfb_build::bundler::BundleConfig::jsx_import_source` field.
- Add `FrameworkKind::jsx_import_source()` accessor (returns `"preact"` / `"react"`).
- `EsbuildSubprocessBundler::bundle_per_island` now overrides `BundleConfig::jsx_import_source` from its `FrameworkKind` parameter so the per-island path stays framework-agnostic without callers having to remember to set the field.
- Refactor `bundle_one_entry`'s Command construction into `build_esbuild_args(...) -> Vec<OsString>` so unit tests can inspect the flag list without spawning esbuild.
- Append `--jsx=automatic --jsx-import-source=<value>` to the args. No other esbuild flags change.

## Tests

- `build_esbuild_args_includes_automatic_jsx_flags_for_preact_default` — asserts both flags appear in the default-config args, before the entry path.
- `build_esbuild_args_honours_custom_jsx_import_source` — asserts a `with_jsx_import_source("react")` override produces `--jsx-import-source=react` and no stale Preact value leaks.
- `bundle_config_default_jsx_import_source_is_preact` / `bundle_config_with_jsx_import_source_overrides` — `BundleConfig` field defaults + setter coverage.
- `framework_kind_jsx_import_source_matches_zfb_render_adapter_contract` — keeps the `FrameworkKind` accessor in sync with the renderer's `Adapter` trait.

`cargo test -p zfb-islands` and `cargo test --workspace` pass (no regressions). `cargo build` clean.

## Test plan

- [x] `cargo test -p zfb-islands` green
- [x] `cargo test --workspace` green
- [x] `cargo build` green
- [ ] Downstream consumer (zudolab/zudo-doc Wave 9 Phase 2) bumps the pin and verifies the bundle no longer throws `ReferenceError: React is not defined` at mount

Closes #151