### PR TITLE
feat(config): support `base` for HTML asset URLs

### DIFF
--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -776,9 +776,10 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
     //      never written would leak the unhashed `/assets/styles.css`
     //      URL into shipped HTML (the prod pipeline only rewrites
     //      stable→hashed for slots it actually emits).
-    let prod_asset_inputs = runner
+    let mut prod_asset_inputs = runner
         .emit_prod_assets(project_root, outdir, config)
         .context("production asset emitters failed")?;
+    apply_asset_url_base(&mut prod_asset_inputs, config.base.as_deref());
     let prod_head_assets = derive_prod_head_assets(&prod_asset_inputs);
 
     // Snapshot the route universe *before* moving it into RendererInput
@@ -876,6 +877,35 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
     Ok(render_out.ssg_files_written.len())
 }
 
+/// Mount each emitter's `stable_url` under the project's configured
+/// `base` prefix.
+///
+/// Both halves of the prod asset rewrite — the URL spliced into the
+/// rendered `<head>` AND the stable→hashed mapping
+/// `ProductionAssetPipeline` applies — read off
+/// [`AssetEmitterPayload::stable_url`]. Mutating the payload in one
+/// place therefore keeps the renderer-emitted reference and the
+/// rewrite key in sync; if we prefixed only the head injection, the
+/// `boundary_replace` rewrite would never match and the unhashed
+/// `/assets/...` URL would leak into shipped HTML.
+///
+/// `None` / empty / `"/"` bases are no-ops (see
+/// [`crate::config::asset_url_base_prefix`] for the canonical
+/// normalisation rules), so projects that do not deploy under a
+/// sub-path see byte-identical output to the pre-`base` build.
+fn apply_asset_url_base(inputs: &mut ProdAssetEmitterInputs, base: Option<&str>) {
+    let prefix = crate::config::asset_url_base_prefix(base);
+    if prefix.is_empty() {
+        return;
+    }
+    if let Some(css) = inputs.css.as_mut() {
+        css.stable_url = format!("{prefix}{}", css.stable_url);
+    }
+    if let Some(islands) = inputs.islands.as_mut() {
+        islands.stable_url = format!("{prefix}{}", islands.stable_url);
+    }
+}
+
 /// Derive the [`ProdHeadAssets`] payload for [`RendererInput`] from
 /// the bytes-only emitter inputs. Returns `None` when no slot has
 /// bytes — the renderer then ships HTML untouched (matching today's
@@ -884,8 +914,10 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
 /// The stable URLs come straight from
 /// [`zfb_build::pipeline::AssetEmitterPayload::stable_url`] (which the
 /// CSS / islands adapters seed from `zfb_types::asset_urls`
-/// constants). This lets a future caller mount assets at a non-default
-/// URL prefix without rewriting this function.
+/// constants, optionally re-prefixed by [`apply_asset_url_base`] when
+/// the project mounts under a sub-path). This lets a caller mount
+/// assets at a non-default URL prefix without rewriting this
+/// function.
 fn derive_prod_head_assets(inputs: &ProdAssetEmitterInputs) -> Option<ProdHeadAssets> {
     let css_url = inputs.css.as_ref().map(|p| p.stable_url.clone());
     let mut island_module_urls: Vec<String> = Vec::new();
@@ -1878,6 +1910,178 @@ mod tests {
             .expect("prod build must populate prod_head_assets when emitter has bytes");
         assert_eq!(prod_assets.css_url.as_deref(), Some("/assets/styles.css"));
         assert!(prod_assets.island_module_urls.is_empty());
+    }
+
+    /// `apply_asset_url_base` mounts each emitter slot's `stable_url`
+    /// under the configured `base` prefix. None / empty / "/" bases
+    /// are pure no-ops (byte-identical to the pre-`base` engine).
+    /// Subpath and absolute-URL bases prefix every populated slot.
+    /// The function only mutates populated slots — `None` slots stay
+    /// `None`.
+    #[test]
+    fn apply_asset_url_base_prefixes_populated_slots() {
+        fn fixture() -> ProdAssetEmitterInputs {
+            ProdAssetEmitterInputs {
+                css: Some(zfb_build::pipeline::AssetEmitterPayload {
+                    bytes: b".x{}".to_vec(),
+                    relative_path: PathBuf::from("assets/styles.css"),
+                    stable_url: "/assets/styles.css".to_string(),
+                }),
+                islands: Some(zfb_build::pipeline::AssetEmitterPayload {
+                    bytes: b"// js".to_vec(),
+                    relative_path: PathBuf::from("assets/islands.js"),
+                    stable_url: "/assets/islands.js".to_string(),
+                }),
+            }
+        }
+
+        // None ⇒ no mutation.
+        let mut inputs = fixture();
+        apply_asset_url_base(&mut inputs, None);
+        assert_eq!(inputs.css.as_ref().unwrap().stable_url, "/assets/styles.css");
+        assert_eq!(inputs.islands.as_ref().unwrap().stable_url, "/assets/islands.js");
+
+        // "" ⇒ no mutation.
+        let mut inputs = fixture();
+        apply_asset_url_base(&mut inputs, Some(""));
+        assert_eq!(inputs.css.as_ref().unwrap().stable_url, "/assets/styles.css");
+        assert_eq!(inputs.islands.as_ref().unwrap().stable_url, "/assets/islands.js");
+
+        // "/" ⇒ no mutation (root-mounted site).
+        let mut inputs = fixture();
+        apply_asset_url_base(&mut inputs, Some("/"));
+        assert_eq!(inputs.css.as_ref().unwrap().stable_url, "/assets/styles.css");
+        assert_eq!(inputs.islands.as_ref().unwrap().stable_url, "/assets/islands.js");
+
+        // "/pj/zudo-doc/" ⇒ subpath prefix.
+        let mut inputs = fixture();
+        apply_asset_url_base(&mut inputs, Some("/pj/zudo-doc/"));
+        assert_eq!(
+            inputs.css.as_ref().unwrap().stable_url,
+            "/pj/zudo-doc/assets/styles.css"
+        );
+        assert_eq!(
+            inputs.islands.as_ref().unwrap().stable_url,
+            "/pj/zudo-doc/assets/islands.js"
+        );
+
+        // "/pj/zudo-doc" (no trailing slash) ⇒ same prefix.
+        let mut inputs = fixture();
+        apply_asset_url_base(&mut inputs, Some("/pj/zudo-doc"));
+        assert_eq!(
+            inputs.css.as_ref().unwrap().stable_url,
+            "/pj/zudo-doc/assets/styles.css"
+        );
+
+        // CDN-hosted absolute URL ⇒ absolute prefix.
+        let mut inputs = fixture();
+        apply_asset_url_base(&mut inputs, Some("https://cdn.example.com/"));
+        assert_eq!(
+            inputs.css.as_ref().unwrap().stable_url,
+            "https://cdn.example.com/assets/styles.css"
+        );
+        assert_eq!(
+            inputs.islands.as_ref().unwrap().stable_url,
+            "https://cdn.example.com/assets/islands.js"
+        );
+
+        // None slots stay None.
+        let mut inputs = ProdAssetEmitterInputs {
+            css: None,
+            islands: None,
+        };
+        apply_asset_url_base(&mut inputs, Some("/pj/zudo-doc/"));
+        assert!(inputs.css.is_none());
+        assert!(inputs.islands.is_none());
+    }
+
+    /// End-to-end: with `config.base = "/pj/zudo-doc/"` set, the
+    /// hashed asset URL the rewrite pass injects into HTML is
+    /// `/pj/zudo-doc/assets/styles-<hash>.css` — NOT
+    /// `/assets/styles-<hash>.css`. This is the PR #1361 acceptance
+    /// case the upstream PR is opened against.
+    ///
+    /// The pairing matters: the renderer-emitted reference and the
+    /// `boundary_replace` rewrite key must both see the prefixed
+    /// stable_url, otherwise the rewrite never fires and the
+    /// unprefixed URL leaks through.
+    #[test]
+    fn run_build_with_base_emits_prefixed_hashed_css_url_in_html() {
+        let tmp = tempdir().unwrap();
+        let project_root = tmp.path();
+        let outdir = project_root.join("dist");
+        make_runtime(project_root);
+        let routes = vec![static_route(vec![], "pages/index.tsx")];
+        let runner = FakeRunner::new(outdir.join(".zfb-build/bundle.mjs"))
+            .with_prod_asset_inputs(ProdAssetEmitterInputs {
+                css: Some(zfb_build::pipeline::AssetEmitterPayload {
+                    bytes: b".btn{color:red}".to_vec(),
+                    relative_path: PathBuf::from("assets/styles.css"),
+                    // The CSS emitter seeds this from
+                    // `zfb_types::STABLE_CSS_URL`; the build path
+                    // re-prefixes with `config.base` before handing
+                    // it to the renderer.
+                    stable_url: "/assets/styles.css".to_string(),
+                }),
+                islands: None,
+            });
+        let mut cfg = Config::default();
+        cfg.base = Some("/pj/zudo-doc/".to_string());
+        let fake_adapter = FakeAdapterRunner::new();
+        run_build(BuildArgsResolved {
+            project_root,
+            outdir: &outdir,
+            config: &cfg,
+            routes: &routes,
+            runner: &runner,
+            adapter_runner: &fake_adapter,
+        })
+        .unwrap();
+
+        // (a) The hashed asset still lands at dist/assets/styles-<8hex>.css
+        // — `base` only affects the public URL, not the on-disk layout.
+        let assets_entries: Vec<String> = std::fs::read_dir(outdir.join("assets"))
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(assets_entries.len(), 1);
+        let name = &assets_entries[0];
+        assert!(
+            name.starts_with("styles-") && name.ends_with(".css"),
+            "expected styles-<hash>.css; got {name}",
+        );
+
+        // (b) The HTML carries the PREFIXED hashed URL.
+        let prefixed_hashed = format!("/pj/zudo-doc/assets/{name}");
+        let html = std::fs::read_to_string(outdir.join("index.html")).unwrap();
+        assert!(
+            html.contains(&prefixed_hashed),
+            "prefixed hashed URL {prefixed_hashed} missing from HTML: {html}",
+        );
+
+        // (c) Neither the unprefixed stable URL nor the unprefixed
+        // hashed URL leaked through the rewrite.
+        assert!(
+            !html.contains("\"/assets/styles.css\""),
+            "stable URL leaked: {html}",
+        );
+        let unprefixed_hashed = format!("\"/assets/{name}\"");
+        assert!(
+            !html.contains(&unprefixed_hashed),
+            "unprefixed hashed URL leaked: {html}",
+        );
+
+        // (d) The renderer was handed the PREFIXED stable URL — the
+        // load-bearing wiring this PR adds.
+        let render_calls = runner.render_calls.borrow();
+        let prod_assets = render_calls[0]
+            .prod_head_assets
+            .as_ref()
+            .expect("prod_head_assets must be populated");
+        assert_eq!(
+            prod_assets.css_url.as_deref(),
+            Some("/pj/zudo-doc/assets/styles.css"),
+        );
     }
 
     /// Dev-no-regression assertion (S4 spec): with no emitter bytes

--- a/crates/zfb/src/config.rs
+++ b/crates/zfb/src/config.rs
@@ -257,6 +257,31 @@ pub struct Config {
     /// the JSON / TS form `stripMdExt` into this field.
     #[serde(default)]
     pub strip_md_ext: bool,
+
+    /// Public URL prefix mounted in front of every absolute HTML asset
+    /// URL the build emits (`<link rel="stylesheet">`,
+    /// `<script type="module">`, and any other `/assets/...`-prefixed
+    /// reference the production asset pipeline rewrites).
+    ///
+    /// Use this when the site is deployed under a sub-path
+    /// (`https://example.com/pj/zudo-doc/`). With `base = "/pj/zudo-doc/"`
+    /// the dist HTML emits
+    /// `<link rel="stylesheet" href="/pj/zudo-doc/assets/styles-<hash>.css">`
+    /// instead of the unprefixed `/assets/styles-<hash>.css`.
+    ///
+    /// Accepted shapes:
+    ///
+    /// - `None`, omitted, `""`, `"/"` — no prefix; behaviour matches
+    ///   the pre-`base` build byte-for-byte.
+    /// - leading-and-trailing-slash path like `"/pj/zudo-doc/"`.
+    /// - absolute URL like `"https://cdn.example.com/"`.
+    ///
+    /// Normalisation lives at the asset-URL emission boundary
+    /// ([`asset_url_base_prefix`]) — the field stores the value as
+    /// authored. `#[serde(rename_all = "camelCase")]` on this struct
+    /// deserialises the JSON / TS form `base` 1:1.
+    #[serde(default)]
+    pub base: Option<String>,
 }
 
 impl Default for Config {
@@ -272,6 +297,7 @@ impl Default for Config {
             plugins: Vec::new(),
             adapter: None,
             strip_md_ext: false,
+            base: None,
         }
     }
 }
@@ -343,6 +369,48 @@ pub struct PluginConfig {
     /// for JSON-only configs and synthetic test configs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolved_module: Option<String>,
+}
+
+// --- helpers ----------------------------------------------------------------
+
+/// Normalise a `base` config value into the prefix string the build
+/// concatenates onto the leading `/` of an asset URL like
+/// `/assets/styles.css`.
+///
+/// The contract: `format!("{prefix}{stable_url}")` must produce a
+/// well-formed URL where:
+///
+/// - the joined URL has exactly one `/` between the prefix and the
+///   `/assets/...` portion (no doubled slashes, no missing slash).
+/// - omitted / empty / `"/"` bases yield an empty prefix, so the
+///   pre-`base` build path is byte-identical.
+///
+/// Accepted authoring shapes (all mapped to a canonical prefix):
+///
+/// | author wrote          | prefix returned        |
+/// |-----------------------|------------------------|
+/// | `None` / `""` / `"/"` | `""`                   |
+/// | `"/pj/zudo-doc/"`     | `"/pj/zudo-doc"`       |
+/// | `"/pj/zudo-doc"`      | `"/pj/zudo-doc"`       |
+/// | `"https://cdn.example.com/"` | `"https://cdn.example.com"` |
+/// | `"https://cdn.example.com"`  | `"https://cdn.example.com"` |
+///
+/// We trim trailing slashes (any number of them) so concatenating
+/// `prefix + "/assets/..."` always produces a single delimiter. The
+/// caller is responsible for ensuring the stable URL it concatenates
+/// onto already starts with `/` — the asset-URL constants in
+/// `zfb_types::asset_urls` satisfy this by construction.
+pub fn asset_url_base_prefix(base: Option<&str>) -> String {
+    let Some(raw) = base else {
+        return String::new();
+    };
+    let trimmed = raw.trim_end_matches('/');
+    if trimmed.is_empty() {
+        // Either `""` or `"/"` (or `"//"`, …) — none of these mount the
+        // site under a sub-path.
+        return String::new();
+    }
+    trimmed.to_string()
 }
 
 // --- defaults --------------------------------------------------------------
@@ -954,6 +1022,113 @@ mod tests {
         // `stripMdExt` is opt-in; absent / default = disabled. Mirrors
         // the Sub 1 outcome byte-for-byte (zfb#127 / #129).
         assert!(!cfg.strip_md_ext);
+        // `base` is opt-in; absent => no asset-URL prefix.
+        assert_eq!(cfg.base, None);
+    }
+
+    // --- base / asset_url_base_prefix tests ----------------------------------
+
+    #[test]
+    fn asset_url_base_prefix_none_returns_empty() {
+        assert_eq!(asset_url_base_prefix(None), "");
+    }
+
+    #[test]
+    fn asset_url_base_prefix_empty_string_returns_empty() {
+        assert_eq!(asset_url_base_prefix(Some("")), "");
+    }
+
+    #[test]
+    fn asset_url_base_prefix_root_slash_returns_empty() {
+        // `"/"` is the documented shape for "site mounted at the
+        // domain root" — the build behaviour must be byte-identical
+        // to the no-`base` case.
+        assert_eq!(asset_url_base_prefix(Some("/")), "");
+    }
+
+    #[test]
+    fn asset_url_base_prefix_subpath_strips_trailing_slash() {
+        // The PR #1361 acceptance case: `/pj/zudo-doc/` ⇒
+        // `/pj/zudo-doc` so concatenation with `/assets/...` produces
+        // a single delimiter.
+        assert_eq!(
+            asset_url_base_prefix(Some("/pj/zudo-doc/")),
+            "/pj/zudo-doc"
+        );
+    }
+
+    #[test]
+    fn asset_url_base_prefix_subpath_without_trailing_slash_is_idempotent() {
+        // Authors who omit the trailing slash get the same prefix as
+        // those who include it.
+        assert_eq!(
+            asset_url_base_prefix(Some("/pj/zudo-doc")),
+            "/pj/zudo-doc"
+        );
+    }
+
+    #[test]
+    fn asset_url_base_prefix_absolute_url_strips_trailing_slash() {
+        // CDN-hosted assets: an absolute URL is mounted onto the
+        // asset path. Trailing slash is normalised away so the join
+        // is `https://cdn.example.com` + `/assets/...` ⇒ one
+        // delimiter, not two.
+        assert_eq!(
+            asset_url_base_prefix(Some("https://cdn.example.com/")),
+            "https://cdn.example.com"
+        );
+        assert_eq!(
+            asset_url_base_prefix(Some("https://cdn.example.com")),
+            "https://cdn.example.com"
+        );
+    }
+
+    #[test]
+    fn asset_url_base_prefix_join_produces_well_formed_assets_url() {
+        // End-to-end check: the prefix + the authoritative stable URL
+        // constant should produce exactly one `/` between them.
+        let prefix = asset_url_base_prefix(Some("/pj/zudo-doc/"));
+        let joined = format!("{prefix}/assets/styles.css");
+        assert_eq!(joined, "/pj/zudo-doc/assets/styles.css");
+
+        let prefix = asset_url_base_prefix(None);
+        let joined = format!("{prefix}/assets/styles.css");
+        assert_eq!(joined, "/assets/styles.css");
+
+        let prefix = asset_url_base_prefix(Some("/"));
+        let joined = format!("{prefix}/assets/styles.css");
+        assert_eq!(joined, "/assets/styles.css");
+
+        let prefix = asset_url_base_prefix(Some("https://cdn.example.com/"));
+        let joined = format!("{prefix}/assets/styles.css");
+        assert_eq!(joined, "https://cdn.example.com/assets/styles.css");
+    }
+
+    #[tokio::test]
+    async fn loads_base_from_camelcase_json() {
+        // The JSON / TS form spells the field `base` (already camel)
+        // — confirm round-trip into `Config::base`.
+        let tmp = TempDir::new().unwrap();
+        tokio::fs::write(
+            tmp.path().join("zfb.config.json"),
+            r#"{ "base": "/pj/zudo-doc/" }"#,
+        )
+        .await
+        .unwrap();
+        let cfg = load_from_dir(tmp.path()).await.expect("load ok");
+        assert_eq!(cfg.base.as_deref(), Some("/pj/zudo-doc/"));
+    }
+
+    #[tokio::test]
+    async fn base_defaults_to_none_when_absent() {
+        // Acceptance criterion: with `base` absent the build must
+        // behave byte-for-byte the same as the pre-`base` engine.
+        let tmp = TempDir::new().unwrap();
+        tokio::fs::write(tmp.path().join("zfb.config.json"), "{}")
+            .await
+            .unwrap();
+        let cfg = load_from_dir(tmp.path()).await.expect("load ok");
+        assert_eq!(cfg.base, None);
     }
 
     #[tokio::test]

--- a/packages/zfb/src/config.ts
+++ b/packages/zfb/src/config.ts
@@ -98,6 +98,36 @@ export type ZfbConfig = {
    * Mirrors `Config::strip_md_ext` in crates/zfb/src/config.rs.
    */
   stripMdExt?: boolean;
+
+  /**
+   * Public URL prefix mounted in front of every absolute HTML asset
+   * URL the build emits — `<link rel="stylesheet">`, `<script type="module">`,
+   * and any other `/assets/...`-prefixed reference rewritten by the
+   * production asset pipeline.
+   *
+   * Use this when the site is deployed under a sub-path (e.g.
+   * `https://example.com/pj/zudo-doc/`) instead of the domain root.
+   * With `base: "/pj/zudo-doc/"` the dist HTML emits
+   * `<link rel="stylesheet" href="/pj/zudo-doc/assets/styles-<hash>.css">`
+   * instead of the unprefixed `/assets/styles-<hash>.css`.
+   *
+   * Accepted shapes (all normalised to a single canonical form
+   * internally):
+   *
+   * - omitted / `undefined` / `""` / `"/"` — no prefix; behaviour is
+   *   byte-identical to the pre-`base` build (root-mounted site).
+   * - leading-and-trailing-slash path like `"/pj/zudo-doc/"` — prefix
+   *   that path onto every asset URL.
+   * - absolute URL like `"https://cdn.example.com/"` — emit absolute
+   *   URLs (CDN-hosted assets).
+   *
+   * Inputs missing a leading or trailing `/` are normalised at config-
+   * load time (paths) or asset-emit time (URL prefixes); callers do
+   * not have to pre-trim.
+   *
+   * Mirrors `Config::base` in crates/zfb/src/config.rs.
+   */
+  base?: string;
 };
 
 /**


### PR DESCRIPTION
## Summary

Plumbs a config-supplied `base` through HTML asset URL emission so that
`<link rel="stylesheet">` and `<script type="module">` tags in built HTML
respect the configured site base.

With `base = "/pj/zudo-doc/"` the dist HTML now emits
`href="/pj/zudo-doc/assets/styles-<hash>.css"` instead of the unprefixed
`/assets/styles-<hash>.css`. With `base` absent / `""` / `"/"`, the build
is byte-identical to today.

## Why

Closes the blocker for zudolab/zudo-doc#1361 (sub-issue of zudolab/zudo-doc#1360):
PR #669 preview at https://pr-669.zudo-doc.pages.dev/pj/zudo-doc/ shows
`<link rel="stylesheet" href="/assets/styles-...css">` 404'ing because
the assets live at `/pj/zudo-doc/assets/...`. With CSS/JS not loading,
every other audit sub-task can only verify against local builds, not the
deployed preview.

## What changed

- `packages/zfb/src/config.ts` — new `base?: string` field on `ZfbConfig`.
- `crates/zfb/src/config.rs` — new `base: Option<String>` on `Config` with
  serde camelCase round-trip; new public helper `asset_url_base_prefix(...)`
  that canonicalises `None` / `""` / `"/"` to `""` (no prefix) and strips
  trailing slashes from any other shape so `{prefix}{stable_url}` joins
  with exactly one `/`.
- `crates/zfb/src/commands/build.rs` — new `apply_asset_url_base(...)`
  mutates each emitter slot's `stable_url` in place before
  `derive_prod_head_assets` runs. Both halves of the prod rewrite — the
  URL spliced into `<head>` and the `boundary_replace` rewrite key — read
  off the same mutated payload, so the renderer-emitted reference and
  the rewrite mapping never drift apart.

## Acceptance shape (per #1361)

- [x] `base = None` / `"/"` ⇒ output is byte-identical to today.
- [x] `base = "/pj/zudo-doc/"` ⇒ dist HTML emits the prefixed hashed URL,
      and the `boundary_replace` rewrite still pairs end-to-end (the
      unprefixed stable URL does not leak through).
- [x] Rust unit tests cover `None`, `""`, `"/"`, `"/pj/zudo-doc/"`,
      `"/pj/zudo-doc"`, and `"https://cdn.example.com/"`.

## Test plan

- [x] `cargo test -p zfb --lib config::tests` (all 44 pass; 1 ignored is
      the pre-existing `ts_real_subprocess_loads_basic_blog_ts` requiring
      a staged esbuild binary).
- [x] `cargo test -p zfb --lib commands::build` — new
      `apply_asset_url_base_prefixes_populated_slots` and
      `run_build_with_base_emits_prefixed_hashed_css_url_in_html` pass
      alongside the existing 15.
- [x] Full `cargo test` — all crates green.
- [x] `pnpm --filter @takazudo/zfb test` and `pnpm --filter @takazudo/zfb typecheck`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)