### PR TITLE
feat: bring wave13 (data-props + Tailwind input-path probe) onto main

### DIFF
--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -38,7 +38,7 @@
 //! handling, `✓ N pages built in X.XXs` summary) is unchanged.
 
 use std::env;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use anyhow::{anyhow, Context, Result};
@@ -403,9 +403,20 @@ fn build_default_css_payload(
     // location. Tailwind v4's entry CSS prepends our `@source`
     // directives to whatever the user wrote there, so the user's
     // `@theme`, `@import` of vendor CSS, etc. continue to work.
-    let global_css = project_root.join("styles").join("global.css");
-    if global_css.is_file() {
-        tw_cfg = tw_cfg.with_input_css(global_css);
+    //
+    // Probe two layouts in order, first match wins:
+    //   1. `<root>/styles/global.css`     — zfb's original convention
+    //   2. `<root>/src/styles/global.css` — Vite/Astro/Next-style src/ layout
+    //
+    // The two-path probe matters because real-world consumers
+    // (e.g. zudo-doc, see zudolab/zudo-doc#1355 wave 13) keep their
+    // authored `@theme` tokens under `src/styles/` to share the src
+    // tree with components and TS sources. Without this fallback the
+    // Tailwind run misses the host's `@theme` block entirely and
+    // utility classes like `bg-zd-bg` plus host-defined custom
+    // properties go unstyled.
+    if let Some(path) = resolve_input_global_css(project_root) {
+        tw_cfg = tw_cfg.with_input_css(path);
     }
 
     let engine = TailwindSubprocessEngine::new(tw_cfg);
@@ -433,6 +444,43 @@ fn build_default_css_payload(
         relative_path: css_relative_path(),
         stable_url: emitter_out.stable_url,
     }))
+}
+
+/// Locate the project's authored global Tailwind input CSS file.
+///
+/// Probes the two conventional layouts in order and returns the first
+/// match. Returns `None` when neither file exists, in which case the
+/// CSS pipeline emits Tailwind preflight + scanned utilities only
+/// (no `@theme` tokens, no user `@import` of vendor CSS).
+///
+/// Probe order:
+///
+/// 1. `<root>/styles/global.css`     — zfb's original convention.
+/// 2. `<root>/src/styles/global.css` — Vite/Astro/Next-style `src/`
+///    layout used by real-world consumers (e.g. zudo-doc; see
+///    zudolab/zudo-doc#1355 wave 13). The `src/styles` fallback
+///    closes the upstream gap that previously dropped the host's
+///    authored `@theme` block on the floor whenever the project
+///    organised its sources under `src/`.
+///
+/// Order is deterministic. If both files exist the legacy
+/// `<root>/styles/global.css` wins so existing projects on the
+/// original convention see no behaviour change.
+fn resolve_input_global_css(project_root: &Path) -> Option<PathBuf> {
+    const CANDIDATES: &[&[&str]] = &[
+        &["styles", "global.css"],
+        &["src", "styles", "global.css"],
+    ];
+    for parts in CANDIDATES {
+        let mut candidate = project_root.to_path_buf();
+        for seg in *parts {
+            candidate.push(seg);
+        }
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
 }
 
 /// Walk the conventional CSS-content roots (`pages/`, `components/`,
@@ -2252,6 +2300,72 @@ mod tests {
             !html.contains("<script type=\"module\""),
             "no islands script should appear without emitter bytes: {html}",
         );
+    }
+
+    /// `resolve_input_global_css` honours the legacy
+    /// `<root>/styles/global.css` location.
+    #[test]
+    fn resolve_input_global_css_legacy_root_styles() {
+        let tmp = tempdir().unwrap();
+        let project_root = tmp.path();
+        std::fs::create_dir_all(project_root.join("styles")).unwrap();
+        let target = project_root.join("styles/global.css");
+        std::fs::write(&target, ":root{}\n").unwrap();
+        assert_eq!(
+            resolve_input_global_css(project_root),
+            Some(target),
+            "legacy <root>/styles/global.css should resolve",
+        );
+    }
+
+    /// `resolve_input_global_css` falls back to
+    /// `<root>/src/styles/global.css` when the legacy location is
+    /// absent. This is the conventional `src/`-rooted layout used by
+    /// real-world consumers (e.g. zudo-doc; zudolab/zudo-doc#1355
+    /// wave 13). Pre-fix the upstream probe missed this file
+    /// entirely and dropped the host's `@theme` block on the floor.
+    #[test]
+    fn resolve_input_global_css_src_styles_fallback() {
+        let tmp = tempdir().unwrap();
+        let project_root = tmp.path();
+        std::fs::create_dir_all(project_root.join("src/styles")).unwrap();
+        let target = project_root.join("src/styles/global.css");
+        std::fs::write(&target, ":root{}\n").unwrap();
+        assert_eq!(
+            resolve_input_global_css(project_root),
+            Some(target),
+            "src/styles/global.css fallback should resolve when legacy is absent",
+        );
+    }
+
+    /// Legacy `<root>/styles/global.css` wins when both layouts are
+    /// present, so existing projects on the original convention see
+    /// no behaviour change.
+    #[test]
+    fn resolve_input_global_css_prefers_legacy_when_both_exist() {
+        let tmp = tempdir().unwrap();
+        let project_root = tmp.path();
+        std::fs::create_dir_all(project_root.join("styles")).unwrap();
+        std::fs::create_dir_all(project_root.join("src/styles")).unwrap();
+        let legacy = project_root.join("styles/global.css");
+        let src = project_root.join("src/styles/global.css");
+        std::fs::write(&legacy, ":root{ /* legacy */ }\n").unwrap();
+        std::fs::write(&src, ":root{ /* src */ }\n").unwrap();
+        assert_eq!(
+            resolve_input_global_css(project_root),
+            Some(legacy),
+            "legacy convention should win when both files exist",
+        );
+    }
+
+    /// Neither file present => `None`. The CSS emitter still runs
+    /// (preflight + scanned utilities) but the user's `@theme` is
+    /// simply not contributed.
+    #[test]
+    fn resolve_input_global_css_none_when_neither_exists() {
+        let tmp = tempdir().unwrap();
+        let project_root = tmp.path();
+        assert_eq!(resolve_input_global_css(project_root), None);
     }
 
     /// Tailwind disabled in config => CSS emitter slot is `None`.

--- a/packages/zfb/src/__tests__/island.test.ts
+++ b/packages/zfb/src/__tests__/island.test.ts
@@ -4,8 +4,10 @@ import {
   ANONYMOUS_COMPONENT_NAME,
   HYDRATE_MARKER_ATTR,
   Island,
+  PROPS_DATA_ATTR,
   SKIP_SSR_MARKER_ATTR,
   captureComponentName,
+  captureSerializableProps,
   resolveWhen,
 } from "../island.js";
 import { DEFAULT_WHEN, isWhen, WHEN_VALUES } from "../types.js";
@@ -155,6 +157,127 @@ describe("captureComponentName", () => {
     const anon = (() => null) as (...args: unknown[]) => unknown;
     Object.defineProperty(anon, "name", { value: "" });
     expect(captureComponentName(vnode(anon))).toBe(ANONYMOUS_COMPONENT_NAME);
+  });
+});
+
+describe("captureSerializableProps", () => {
+  it("returns undefined for non-element values", () => {
+    expect(captureSerializableProps(undefined)).toBeUndefined();
+    expect(captureSerializableProps(null)).toBeUndefined();
+    expect(captureSerializableProps(0)).toBeUndefined();
+    expect(captureSerializableProps("text")).toBeUndefined();
+    expect(captureSerializableProps(true)).toBeUndefined();
+  });
+
+  it("returns undefined when child has no own props", () => {
+    expect(captureSerializableProps(vnode(NamedFn))).toBeUndefined();
+  });
+
+  it("returns undefined when child only has `children` (the hydration target)", () => {
+    expect(captureSerializableProps(vnode(NamedFn, { children: vnode("p") }))).toBeUndefined();
+  });
+
+  it("serialises a primitive prop bag to JSON", () => {
+    expect(captureSerializableProps(vnode(NamedFn, { count: 3, label: "hi" }))).toBe(
+      '{"count":3,"label":"hi"}',
+    );
+  });
+
+  it("serialises nested arrays/objects (e.g. heading lists)", () => {
+    const headings = [
+      { text: "Intro", slug: "intro", depth: 2 },
+      { text: "Setup", slug: "setup", depth: 2 },
+    ];
+    const json = captureSerializableProps(vnode(NamedFn, { headings, title: "On this page" }));
+    expect(json).toBeDefined();
+    const parsed = JSON.parse(json as string) as Record<string, unknown>;
+    expect(parsed["headings"]).toEqual(headings);
+    expect(parsed["title"]).toBe("On this page");
+  });
+
+  it("strips `children` from the serialised payload (DOM is the source of truth at hydrate time)", () => {
+    const json = captureSerializableProps(
+      vnode(NamedFn, { count: 3, children: vnode("p", { children: "ignore me" }) }),
+    );
+    expect(json).toBeDefined();
+    expect(json).not.toContain("children");
+    expect(json).not.toContain("ignore me");
+    expect(JSON.parse(json as string)).toEqual({ count: 3 });
+  });
+
+  it("silently drops function-valued props (JSON.stringify behaviour)", () => {
+    const json = captureSerializableProps(vnode(NamedFn, { count: 3, onClick: () => {} }));
+    expect(json).toBe('{"count":3}');
+  });
+
+  it("returns undefined when every own prop is non-serialisable", () => {
+    expect(
+      captureSerializableProps(vnode(NamedFn, { onClick: () => {}, sym: Symbol("x") })),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for circular structures rather than throwing", () => {
+    const circular: Record<string, unknown> = { a: 1 };
+    circular["self"] = circular;
+    expect(captureSerializableProps(vnode(NamedFn, circular))).toBeUndefined();
+  });
+
+  it("returns undefined when props itself is an array (malformed input)", () => {
+    const malformed: VNodeObject = {
+      type: NamedFn,
+      props: [] as unknown as Record<string, unknown>,
+      key: null,
+    };
+    expect(captureSerializableProps(malformed)).toBeUndefined();
+  });
+
+  it("uses the first child whose props serialise when given an array", () => {
+    const childA = vnode(NamedFn); // no props → undefined
+    const childB = vnode(NamedFn, { count: 7 }); // serialisable
+    expect(captureSerializableProps([childA, childB])).toBe('{"count":7}');
+  });
+});
+
+describe("Island JSX wrapper — data-props serialisation", () => {
+  it("emits data-props when the wrapped child has own props (default mode)", () => {
+    const child = vnode(NamedFn, { count: 3, label: "hi" });
+    const node = Island({ children: child });
+    expect(node.props[PROPS_DATA_ATTR]).toBe('{"count":3,"label":"hi"}');
+    // The hydrate marker stays present alongside data-props.
+    expect(node.props[HYDRATE_MARKER_ATTR]).toBe("NamedFn");
+    expect(node.props["data-when"]).toBe("load");
+  });
+
+  it("omits data-props when the wrapped child has no own props (default mode)", () => {
+    const node = Island({ children: vnode(NamedFn) });
+    expect(node.props[PROPS_DATA_ATTR]).toBeUndefined();
+    expect(node.props[HYDRATE_MARKER_ATTR]).toBe("NamedFn");
+  });
+
+  it("emits data-props in SSR-skip mode reading from `children` (not ssrFallback)", () => {
+    // `ssrFallback` is just placeholder markup — the hydrated component is
+    // still `children`, so its props are what mount() needs at hydrate.
+    const heavy = vnode(NamedFn, { open: true });
+    const fallback = vnode("div", { children: "Loading…" });
+    const node = Island({ ssrFallback: fallback, children: heavy });
+    expect(node.props[PROPS_DATA_ATTR]).toBe('{"open":true}');
+    expect(node.props[SKIP_SSR_MARKER_ATTR]).toBe("NamedFn");
+    // The rendered children must still be the fallback, not the heavy.
+    expect(node.props.children).toBe(fallback);
+  });
+
+  it("omits data-props in SSR-skip mode when the heavy child has no own props", () => {
+    const fallback = vnode("div", { children: "Loading…" });
+    const node = Island({ ssrFallback: fallback, children: vnode(NamedFn) });
+    expect(node.props[PROPS_DATA_ATTR]).toBeUndefined();
+    expect(node.props[SKIP_SSR_MARKER_ATTR]).toBe("NamedFn");
+  });
+
+  it("preserves children verbatim alongside data-props (default mode)", () => {
+    const child = vnode(NamedFn, { count: 3 });
+    const node = Island({ when: "idle", children: child });
+    expect(node.props.children).toBe(child);
+    expect(node.props[PROPS_DATA_ATTR]).toBe('{"count":3}');
   });
 });
 

--- a/packages/zfb/src/island.ts
+++ b/packages/zfb/src/island.ts
@@ -68,6 +68,19 @@ export const SKIP_SSR_MARKER_ATTR = "data-zfb-island-skip-ssr";
 /** Fallback name surfaced when child identity cannot be determined. */
 export const ANONYMOUS_COMPONENT_NAME = "Anonymous";
 
+/**
+ * Attribute the SSR wrapper writes to ferry the wrapped component's props
+ * across the SSR → hydrate boundary. The hydration runtime parses this
+ * with `JSON.parse` and forwards the result to the per-island `mount()`
+ * call so the hydrated component sees the same props the SSR pass did.
+ *
+ * Omitted entirely when the wrapped child has no own data props (other
+ * than `children`) — `readProps` already falls back to `{}` when the
+ * attribute is missing, and emitting `data-props=""` would just bloat
+ * the SSR markup.
+ */
+export const PROPS_DATA_ATTR = "data-props";
+
 /** Props for `<Island>`. */
 export interface IslandProps {
   /** Hydration scheduling strategy. Defaults to `"load"`. */
@@ -126,26 +139,35 @@ export function Island(props: IslandProps): IslandElement {
   const when = resolveWhen(props.when);
   const componentName = captureComponentName(props.children);
   const isSkipSsr = props.ssrFallback !== undefined;
+  // Always source props from `props.children` (the heavy component VNode),
+  // never from `ssrFallback` — the fallback is just SSR placeholder markup;
+  // the hydrated component is the child, so its props are what `mount()`
+  // needs at hydrate time. (Same rationale as `captureComponentName`.)
+  const dataProps = captureSerializableProps(props.children);
 
   if (isSkipSsr) {
+    const skipSsrProps: Record<string, unknown> = {
+      [SKIP_SSR_MARKER_ATTR]: componentName,
+      "data-when": when,
+      children: props.ssrFallback ?? null,
+    };
+    if (dataProps !== undefined) skipSsrProps[PROPS_DATA_ATTR] = dataProps;
     return makeVNode({
       type: "div",
-      props: {
-        [SKIP_SSR_MARKER_ATTR]: componentName,
-        "data-when": when,
-        children: props.ssrFallback ?? null,
-      },
+      props: skipSsrProps,
       key: null,
     });
   }
 
+  const hydrateProps: Record<string, unknown> = {
+    [HYDRATE_MARKER_ATTR]: componentName,
+    "data-when": when,
+    children: props.children,
+  };
+  if (dataProps !== undefined) hydrateProps[PROPS_DATA_ATTR] = dataProps;
   return makeVNode({
     type: "div",
-    props: {
-      [HYDRATE_MARKER_ATTR]: componentName,
-      "data-when": when,
-      children: props.children,
-    },
+    props: hydrateProps,
     key: null,
   });
 }
@@ -213,4 +235,80 @@ function nameFromSingle(child: unknown): string {
   }
   if (typeof t === "string" && t) return t;
   return "";
+}
+
+/**
+ * Serialize the wrapped child's data props as a JSON string the runtime
+ * can parse out of the `data-props` attribute on the Island marker div.
+ *
+ * Mirrors [`captureComponentName`]'s array handling: when `children` is
+ * an array (multiple JSX siblings), the first child whose own props
+ * yield a non-empty serialization wins. This keeps the "first
+ * identifiable child" contract consistent across both attributes —
+ * whatever the marker name points at is what the data-props payload
+ * describes.
+ *
+ * Returns `undefined` (not `"{}"` and not `""`) when no usable props
+ * exist. The runtime's `readProps` already maps a missing attribute to
+ * `{}`, so omitting the attribute keeps the SSR markup smaller and
+ * preserves the invariant that the attribute, when present, always
+ * parses to a non-empty record.
+ *
+ * Exported for tests; not re-exported from `index.ts`.
+ */
+export function captureSerializableProps(children: unknown): string | undefined {
+  if (Array.isArray(children)) {
+    for (const child of children) {
+      const json = propsFromSingle(child);
+      if (json !== undefined) return json;
+    }
+    return undefined;
+  }
+  return propsFromSingle(children);
+}
+
+function propsFromSingle(child: unknown): string | undefined {
+  if (!child || typeof child !== "object") return undefined;
+  const c = child as { props?: unknown };
+  const raw = c.props;
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return undefined;
+
+  // Exclude `children` from the serialized payload: the SSR pass already
+  // emitted the rendered children into the DOM (the hydration target),
+  // and JSX child nodes are typically VNode trees with non-serializable
+  // shapes (functions, circular refs) that would either bloat the
+  // payload or throw inside JSON.stringify. The hydration runtime
+  // re-renders into the existing DOM, so it does not need the JSX
+  // children replayed through props.
+  //
+  // Note: JSON.stringify already silently drops function / symbol /
+  // undefined values from the output, so those don't need explicit
+  // pre-filtering here.
+  const propsRecord = raw as Record<string, unknown>;
+  let hasOwn = false;
+  const filtered: Record<string, unknown> = {};
+  for (const key of Object.keys(propsRecord)) {
+    if (key === "children") continue;
+    filtered[key] = propsRecord[key];
+    hasOwn = true;
+  }
+  if (!hasOwn) return undefined;
+
+  let json: string | undefined;
+  try {
+    json = JSON.stringify(filtered);
+  } catch {
+    // Circular references, BigInt, or any other non-serializable input
+    // — silently fall through (no `data-props`) rather than ship a
+    // partial payload. The runtime already handles the missing-attribute
+    // case by returning `{}` from `readProps`.
+    return undefined;
+  }
+
+  // JSON.stringify can also return `undefined` (when the top-level value
+  // serializes to nothing) or `"{}"` (when every key was a function /
+  // symbol / undefined and got dropped). Treat both as "nothing useful
+  // to ship" so the marker stays clean.
+  if (json === undefined || json === "{}") return undefined;
+  return json;
 }


### PR DESCRIPTION
## Summary

Brings two commits from `wave13-css-path-probe` onto `main`. Both commits were authored before PR #154/#155 but never PR'd or merged. Without them on main, downstream pinning to main loses both:

- **Data-props SSR machinery** (`a8f79dd` → rebased as `f23b633`) — `<Island>` wrapper writes the wrapped child's props onto `data-props` so the runtime hydration path can `JSON.parse` them back. Without this, every hydrated island sees `{}` and any iteration over expected props crashes.
- **Tailwind input-CSS path probe** (`c2cff95` → rebased as `11fdeb3`) — `build_default_css_payload` now probes `<root>/src/styles/global.css` as a fallback. Real-world consumers (zudo-doc, Vite/Astro/Next-style layouts) keep their authored `@theme` block under `src/`; without the probe, design tokens never reach the Tailwind run.

## Background

Discovered while bumping `zudolab/zudo-doc`'s ZFB_PINNED_SHA from `c2cff95` (HEAD of wave13-css-path-probe) up to `0f6f8c4` (post-PR-#154/#155 main). 73 of 145 e2e tests started failing at the new pin; bisect surfaced these two unmerged wave13 commits as the cause.

## Composition with PR #154 / #155

Wave13 commits touch `packages/zfb/src/island.ts`, `packages/zfb/src/config.ts`, and `packages/zfb/src/__tests__/island.test.ts`. PR #154/#155 touch `crates/zfb/src/commands/build.rs` and the renderer Rust side. The rebase was textually clean — concerns are orthogonal (asset-URL prefixing vs SSR data ferrying vs Tailwind input path).

## Test plan

- [ ] Upstream zfb test suite green (cargo test + JS-side tests on the package — wave13's data-props commit included +123 lines of `island.test.ts` coverage)
- [ ] Downstream zudo-doc e2e suite goes from 73-fail / 72-pass to all-green at the post-merge SHA (will be re-verified during sub-issue zudolab/zudo-doc#1388 rerun)

🤖 Generated with [Claude Code](https://claude.com/claude-code)