### PR TITLE
fix: make examples/basic-blog build end-to-end (6 bugs fixed)

### DIFF
--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -569,6 +569,57 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
         )
     })?;
 
+    // 2a-extra. Materialise any *other* directories at the project root
+    // that the bundler does not own (e.g. `styles/`, `lib/`, `utils/`).
+    // Layout and component files often import relative paths like
+    // `"../styles/global.css"` — those paths need to resolve to something
+    // in the shadow tree even though the bundler treats CSS as empty
+    // (`--loader:.css=empty`). esbuild's resolution step runs before the
+    // loader, so a missing file causes a hard error regardless of the loader.
+    //
+    // Directories already materialised above (pages, content, components,
+    // layouts) and infrastructure directories (node_modules, dist, .git,
+    // hidden dirs, zfb output dirs) are skipped.
+    {
+        let known: &[&str] = &["pages", "content", "components", "layouts", "node_modules",
+                                "dist", ".git", "target", ".turbo", ".next", ".vercel"];
+        if let Ok(rd) = fs::read_dir(&input.project_root) {
+            for entry in rd.flatten() {
+                let ft = match entry.file_type() {
+                    Ok(ft) => ft,
+                    Err(_) => continue,
+                };
+                if !ft.is_dir() {
+                    continue;
+                }
+                let name = entry.file_name();
+                let name_str = name.to_string_lossy();
+                // Skip hidden dirs and known/infrastructure dirs.
+                if name_str.starts_with('.') {
+                    continue;
+                }
+                if known.iter().any(|k| name_str == *k) {
+                    continue;
+                }
+                let src_dir = input.project_root.join(&name);
+                let dst_dir = shadow.join(&name);
+                materialise_shadow(
+                    &src_dir,
+                    &dst_dir,
+                    &mut Vec::new(),
+                    &input.project_root,
+                    input.strip_md_ext,
+                )
+                .with_context(|| {
+                    format!(
+                        "bundler: failed materialising extra dir {} into shadow",
+                        src_dir.display()
+                    )
+                })?;
+            }
+        }
+    }
+
     // 2b. Optional node_modules symlink into the shadow tree.
     //     When `BundlerInput::node_modules_dir` is set, create a
     //     symlink `<shadow>/node_modules → <path>` so esbuild can

--- a/crates/zfb-build/src/renderer.rs
+++ b/crates/zfb-build/src/renderer.rs
@@ -367,6 +367,12 @@ pub fn render_all(input: RendererInput) -> Result<RendererOutput, RendererError>
     drop(guard);
 
     if let Some(err) = last_err {
+        // Surface miniflare stderr so the operator can see what workerd
+        // printed before the 500. Without this, the logs are discarded
+        // and the user sees only "Internal Server Error" with no context.
+        if !logs.trim().is_empty() {
+            eprintln!("[zfb] miniflare logs at render failure:\n{logs}");
+        }
         return Err(err);
     }
 

--- a/crates/zfb/src/config.rs
+++ b/crates/zfb/src/config.rs
@@ -434,10 +434,10 @@ fn default_true() -> bool {
 /// don't have to ship a sidecar file at runtime.
 const CONFIG_LOADER_MJS: &str = include_str!("../js/config-loader.mjs");
 
-/// Stub for the `zfb/config` import that user TS configs reach for. We
-/// alias `zfb/config` → this stub at esbuild time so the user's project
-/// does not need the `zfb` npm package installed locally just to be
-/// parsed.
+/// Stub for the `zfb/config` (and `@takazudo/zfb/config`) import that user
+/// TS configs reach for. We alias both the unscoped bare form (`zfb/config`)
+/// and the full npm-package form (`@takazudo/zfb/config`) to this stub at
+/// esbuild time so either spelling works without installing the npm package.
 const CONFIG_STUB_MJS: &str = include_str!("../js/zfb-config-stub.mjs");
 
 /// Default location of the staged esbuild CLI, mirroring
@@ -650,7 +650,14 @@ async fn load_ts_via_subprocess(
     // 1. Bundle the user's TS file. Run with `dir` as cwd so any
     //    relative imports the user wrote (e.g. `./constants`) resolve
     //    against the project root.
+    //
+    // Alias both the bare `zfb/config` form (the documented convention in
+    // the zfb docs) and the full npm-package form `@takazudo/zfb/config`
+    // (what users naturally write when they know the package is published
+    // as `@takazudo/zfb`). Both spellings must work because the canonical
+    // example (examples/basic-blog/zfb.config.ts) uses the scoped form.
     let alias_arg = format!("--alias:zfb/config={}", stub_path.display());
+    let alias_scoped_arg = format!("--alias:@takazudo/zfb/config={}", stub_path.display());
     let outfile_arg = format!("--outfile={}", bundle_path.display());
     let mut cmd = Command::new(&esbuild);
     cmd.current_dir(dir);
@@ -660,6 +667,7 @@ async fn load_ts_via_subprocess(
     cmd.arg("--target=esnext");
     cmd.arg("--log-level=warning");
     cmd.arg(&alias_arg);
+    cmd.arg(&alias_scoped_arg);
     cmd.arg(&outfile_arg);
     cmd.arg(ts_path);
 

--- a/examples/basic-blog/package.json
+++ b/examples/basic-blog/package.json
@@ -10,7 +10,10 @@
     "preview": "zfb preview"
   },
   "dependencies": {
-    "preact": "^10.22.0"
+    "@takazudo/zfb": "workspace:*",
+    "@takazudo/zfb-runtime": "workspace:*",
+    "preact": "^10.22.0",
+    "preact-render-to-string": "^6.5.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/zfb-runtime/src/__tests__/router.test.ts
+++ b/packages/zfb-runtime/src/__tests__/router.test.ts
@@ -283,10 +283,11 @@ describe("createPageRouter", () => {
     expect(items[0]?.data).toEqual({});
   });
 
-  it("passes { params, props } to the default component when paths() finds a match", async () => {
+  it("spreads paths() props to top-level when paths() finds a match", async () => {
     // Capture whatever the router invokes default() with so the
     // assertion can verify the input shape matches the
-    // ADR-002 / Astro paths() contract.
+    // ADR-002 / Astro paths() contract: props are spread at top level
+    // alongside `params`, not nested under a `props` key.
     let received: unknown = null;
     const dynamicPage: PageModule & { paths: () => unknown[] } = {
       default: (input) => {
@@ -308,11 +309,14 @@ describe("createPageRouter", () => {
     expect(res.status).toBe(200);
     expect(received).toEqual({
       params: { slug: "hello" },
-      props: { title: "Hello" },
+      title: "Hello",
     });
   });
 
-  it("passes an empty props object when paths() finds a match without props", async () => {
+  it("passes only params when paths() finds a match without props", async () => {
+    // When paths() returns an entry with no `props`, the component receives
+    // only `{ params }` — no `props` key — because spreading an empty/absent
+    // props object adds nothing. Components destructure params directly.
     let received: unknown = null;
     const dynamicPage: PageModule & { paths: () => unknown[] } = {
       default: (input) => {
@@ -331,7 +335,6 @@ describe("createPageRouter", () => {
     expect(res.status).toBe(200);
     expect(received).toEqual({
       params: { slug: "hello" },
-      props: {},
     });
   });
 

--- a/packages/zfb-runtime/src/router.ts
+++ b/packages/zfb-runtime/src/router.ts
@@ -60,9 +60,10 @@ export interface PageHeading {
 /**
  * The shape every page module must export.
  *
- * - `default`: the JSX page component. Called with no props (today —
- *   wave 2 will extend this for `paths()` dynamic routes). The return
- *   value is fed straight to the framework adapter's `renderToString`.
+ * - `default`: the JSX page component. Called with the props returned by
+ *   `getStaticProps` (if exported) or the `props` from the matching
+ *   `paths()` entry (for dynamic routes). The return value is fed straight
+ *   to the framework adapter's `renderToString`.
  * - `prerender`: literal `false` opts a route OUT of build-time SSG (T5
  *   contract). The page router still serves it under miniflare so dev
  *   mode behaves identically; SSG callers filter the route list before
@@ -76,6 +77,10 @@ export interface PageHeading {
  *   for this route template. May be async. Returns an array of
  *   `{ params, props? }` objects identical in shape to the Astro/zfb
  *   `paths()` contract.
+ * - `getStaticProps`: optional async function for static routes that need
+ *   to fetch data at build/render time. Called once per request (before
+ *   `default`). Must return `{ props: Record<string, unknown> }`. The
+ *   returned `props` are spread into the `default` component's props.
  */
 export interface PageModule {
   readonly default: (props: Record<string, unknown>) => unknown;
@@ -83,6 +88,7 @@ export interface PageModule {
   readonly contentType?: string;
   readonly headings?: readonly PageHeading[];
   readonly paths?: () => unknown[] | Promise<unknown[]>;
+  readonly getStaticProps?: () => Promise<{ props: Record<string, unknown> }>;
 }
 
 /**
@@ -332,10 +338,41 @@ export function createPageRouter(opts: CreatePageRouterOptions): PageRouter {
           return c.notFound();
         }
 
+        // Pass the paths() entry's props directly as component props
+        // (spread to top level, matching the Astro/zfb convention).
+        // Also include `params` so components can access URL params if
+        // needed, but individual prop keys from `props` win on collision.
         componentInput = {
           params: match.params,
-          props: match.props ?? {},
+          ...(match.props ?? {}),
         };
+      } else if (!hasDynamicParams && typeof mod.getStaticProps === "function") {
+        // Static route with `getStaticProps`: call it to fetch build-time
+        // data and pass the returned props to the default component. This
+        // supports the `export async function getStaticProps()` pattern
+        // used by static pages that need to query content collections (e.g.
+        // a homepage listing all blog posts via `getCollection("blog")`).
+        let staticPropsResult: unknown;
+        try {
+          staticPropsResult = await mod.getStaticProps();
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          return c.body(`[zfb-runtime] getStaticProps() threw for "${page.route}": ${msg}`, 500, {
+            "Content-Type": "text/plain; charset=utf-8",
+          });
+        }
+        if (
+          typeof staticPropsResult !== "object" ||
+          staticPropsResult === null ||
+          !("props" in staticPropsResult)
+        ) {
+          return c.body(
+            `[zfb-runtime] getStaticProps() for "${page.route}" must return { props: {...} }`,
+            500,
+            { "Content-Type": "text/plain; charset=utf-8" },
+          );
+        }
+        componentInput = (staticPropsResult as { props: Record<string, unknown> }).props;
       }
 
       // `await` so async page modules (e.g. API routes typed as

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,28 @@ importers:
         specifier: ^5.9.0
         version: 5.9.3
 
+  examples/basic-blog:
+    dependencies:
+      '@takazudo/zfb':
+        specifier: workspace:*
+        version: link:../../packages/zfb
+      '@takazudo/zfb-runtime':
+        specifier: workspace:*
+        version: link:../../packages/zfb-runtime
+      preact:
+        specifier: ^10.22.0
+        version: 10.29.1
+      preact-render-to-string:
+        specifier: ^6.5.0
+        version: 6.6.7(preact@10.29.1)
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+
   packages/zfb:
     devDependencies:
       '@types/node':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,7 @@ packages:
   # also publishes a tiny npm package for JS-side helpers). None exist today; the
   # glob is reserved so adding one later requires no workspace-config change.
   - "crates/*/npm"
+  # examples/* — dogfood / smoke-test sites. Added so workspace-local packages
+  # (@takazudo/zfb-runtime, @takazudo/zfb, etc.) resolve for `cargo run -p zfb -- build`
+  # without requiring a published npm release.
+  - "examples/*"


### PR DESCRIPTION
## Summary

Six upstream bugs prevented `zfb build` from completing on `examples/basic-blog`. All fixed in this PR, verified by a successful build producing 14 pages.

### Fixes

- **config.rs**: add `--alias:@takazudo/zfb/config=<stub>` in addition to the existing `zfb/config` alias, so scoped package import forms in `zfb.config.ts` resolve during bundling
- **pnpm-workspace.yaml + basic-blog/package.json**: add `examples/*` to the pnpm workspace and declare `workspace:*` deps so local packages resolve without a published npm release
- **bundler.rs**: materialise any extra project-root directories (e.g. `styles/`, `lib/`) into the shadow tree so esbuild can resolve CSS imports like `../styles/global.css` from within `layouts/`
- **renderer.rs**: surface miniflare logs on render failure to aid diagnosis (previously the 500 body swallowed the actual JS error message)
- **router.ts**: add `getStaticProps` support — call the export before invoking the default component so static pages that query content collections receive data (fixes homepage crash)
- **router.ts**: spread `match.props` at top level (`{ params, ...props }`) instead of nesting under a `props` key, matching the Astro convention that page components destructure props directly (fixes paginated index crash)

### Test plan

- [ ] `pnpm --filter @takazudo/zfb-runtime test` — 48 tests pass (updated 2 assertions to match the corrected spread shape)
- [ ] `cargo test --workspace` — all non-ignored tests pass (1 pre-existing flaky watcher test unrelated to this PR)
- [ ] `ZFB_ESBUILD_BIN=<path> ZFB_TAILWIND_BIN=<path> pnpm exec zfb build` in `examples/basic-blog` — produces 14 pages in ~2s

🤖 Generated with [Claude Code](https://claude.com/claude-code)