### PR TITLE
fix(dev): cold-start rebuild + PageCache disk fallback

### DIFF
--- a/crates/zfb-build/src/orchestrator.rs
+++ b/crates/zfb-build/src/orchestrator.rs
@@ -150,7 +150,10 @@ impl<P: AssetPipeline> BuildOrchestrator<P> {
         // our purposes. Surface the recovery via warn so the operator
         // notices the upstream panic instead of silently absorbing it.
         let graph = self.graph.lock().unwrap_or_else(|p| {
-            warn!(site = "plan_for_changes", "graph mutex poisoned, recovering");
+            warn!(
+                site = "plan_for_changes",
+                "graph mutex poisoned, recovering"
+            );
             p.into_inner()
         });
 
@@ -186,7 +189,20 @@ impl<P: AssetPipeline> BuildOrchestrator<P> {
                 }
                 PathClass::Page | PathClass::Module | PathClass::Content | PathClass::Data => {
                     let dirty: PageSelection = graph.dirty_pages(&path).into();
-                    plan.mark_pages(dirty);
+                    // If the graph returned no dirty pages (empty specific set),
+                    // fall back to rebuilding all pages. This handles two cases:
+                    //   1. Cold start: graph seeded with page nodes but has no
+                    //      reverse edges yet (content→page deps not resolved).
+                    //   2. Untracked file: file genuinely isn't in the graph;
+                    //      rebuild everything conservatively.
+                    // `PageSelection::All` is safe here — `resolve_all` will
+                    // expand it to the known page list before the pipeline runs.
+                    let effective = if dirty.is_empty() {
+                        PageSelection::All
+                    } else {
+                        dirty
+                    };
+                    plan.mark_pages(effective);
 
                     // Modules under an islands root re-bundle islands.
                     if matches!(class, PathClass::Module)
@@ -344,11 +360,17 @@ mod tests {
         let mut g = DependencyGraph::new();
         g.upsert(PageDeps::new(
             pid("/proj/pages/a.tsx"),
-            vec![(PathBuf::from("/proj/components/Header.tsx"), DepKind::Module)],
+            vec![(
+                PathBuf::from("/proj/components/Header.tsx"),
+                DepKind::Module,
+            )],
         ));
         g.upsert(PageDeps::new(
             pid("/proj/pages/b.tsx"),
-            vec![(PathBuf::from("/proj/components/Header.tsx"), DepKind::Module)],
+            vec![(
+                PathBuf::from("/proj/components/Header.tsx"),
+                DepKind::Module,
+            )],
         ));
         g.upsert(PageDeps::new(
             pid("/proj/pages/c.tsx"),

--- a/crates/zfb-server/src/lib.rs
+++ b/crates/zfb-server/src/lib.rs
@@ -163,8 +163,9 @@ where
         pages: opts.pages,
         broadcast: opts.broadcast,
         plugins: opts.plugins,
+        dist_root: opts.dist_root.clone(),
     };
-    let router = build_router(state, opts.dist_root.clone(), opts.public_root.clone());
+    let router = build_router(state, opts.public_root.clone());
 
     let actual = listener.local_addr().unwrap_or(opts.addr);
     info!(

--- a/crates/zfb-server/src/routes.rs
+++ b/crates/zfb-server/src/routes.rs
@@ -32,6 +32,7 @@
 //! served page wires itself up to the live-reload SSE stream.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use axum::extract::{Path as AxumPath, State};
@@ -299,6 +300,10 @@ pub struct AppState {
     /// Optional plugin dev-middleware set. `None` when no user plugins
     /// declared a `devMiddleware` hook.
     pub plugins: Option<DevMiddlewareSet>,
+    /// Build output directory, used as a disk fallback when a page is
+    /// not yet in the in-memory cache. `serve_page` reads
+    /// `<dist_root>/<path>/index.html` when the cache misses.
+    pub dist_root: std::path::PathBuf,
 }
 
 /// Build the axum router for the dev server.
@@ -307,12 +312,8 @@ pub struct AppState {
 /// `public_root` is the project's static assets directory (used for
 /// `/public/*`). Both are served via [`ServeDir`]; missing files fall
 /// back to a plain 404.
-pub fn build_router(
-    state: AppState,
-    dist_root: std::path::PathBuf,
-    public_root: std::path::PathBuf,
-) -> Router {
-    let assets_dir = dist_root.join("assets");
+pub fn build_router(state: AppState, public_root: std::path::PathBuf) -> Router {
+    let assets_dir = state.dist_root.join("assets");
     let assets_service = ServeDir::new(&assets_dir);
     let public_service = ServeDir::new(&public_root);
 
@@ -401,11 +402,18 @@ async fn serve_page(state: &AppState, raw_path: &str, uri: &Uri) -> Response {
             //   because the matched key reflects what the renderer
             //   actually emitted (e.g. `/sitemap.xml`).
             let content_type = resolve_content_type(&entry, key);
-            let is_html = content_type
-                .to_ascii_lowercase()
-                .starts_with("text/html");
+            let is_html = content_type.to_ascii_lowercase().starts_with("text/html");
             return page_response_bytes(StatusCode::OK, entry.body, &content_type, is_html);
         }
+    }
+
+    // In-memory cache miss: fall back to reading from the dist directory
+    // on disk. The dev pipeline writes rendered HTML there after each
+    // watcher tick; serving from disk means the browser always sees the
+    // latest output even when the in-memory cache hasn't been populated
+    // (e.g. on cold start before the first watcher tick fires).
+    if let Some(bytes) = read_from_dist(&state.dist_root, trimmed) {
+        return page_response_bytes(StatusCode::OK, bytes, "text/html; charset=utf-8", true);
     }
 
     // 404 is always the dev HTML body so the page is replaced once
@@ -416,6 +424,24 @@ async fn serve_page(state: &AppState, raw_path: &str, uri: &Uri) -> Response {
         "text/html; charset=utf-8",
         true,
     )
+}
+
+/// Try to read a page from the dist directory on disk.
+///
+/// Probes `<dist_root>/<trimmed>/index.html` and then
+/// `<dist_root>/<trimmed>` (for pages served at their exact path like
+/// `sitemap.xml`). Returns `None` on any read failure.
+fn read_from_dist(dist_root: &std::path::Path, trimmed: &str) -> Option<Vec<u8>> {
+    let candidates: [PathBuf; 2] = [
+        dist_root.join(trimmed).join("index.html"),
+        dist_root.join(trimmed),
+    ];
+    for path in &candidates {
+        if let Ok(bytes) = std::fs::read(path) {
+            return Some(bytes);
+        }
+    }
+    None
 }
 
 /// Result of a plugin dev-middleware dispatch attempt. The dev server
@@ -607,6 +633,7 @@ mod tests {
             pages: PageCache::new(),
             broadcast: tx,
             plugins: None,
+            dist_root: std::env::temp_dir().join("zfb-test-dist"),
         }
     }
 
@@ -615,11 +642,7 @@ mod tests {
         // is fine: these tests don't exercise asset routing (Sub 6
         // covers integration with a real fixture project).
         let tmp = std::env::temp_dir();
-        build_router(
-            state,
-            tmp.join("zfb-test-dist"),
-            tmp.join("zfb-test-public"),
-        )
+        build_router(state, tmp.join("zfb-test-public"))
     }
 
     async fn body_string(resp: Response) -> String {
@@ -804,11 +827,17 @@ mod tests {
 
     #[test]
     fn content_type_for_extension_known() {
-        assert_eq!(content_type_for_extension("html"), "text/html; charset=utf-8");
+        assert_eq!(
+            content_type_for_extension("html"),
+            "text/html; charset=utf-8"
+        );
         assert_eq!(content_type_for_extension("xml"), "application/xml");
         assert_eq!(content_type_for_extension("rss"), "application/rss+xml");
         assert_eq!(content_type_for_extension("json"), "application/json");
-        assert_eq!(content_type_for_extension("txt"), "text/plain; charset=utf-8");
+        assert_eq!(
+            content_type_for_extension("txt"),
+            "text/plain; charset=utf-8"
+        );
     }
 
     #[test]
@@ -838,7 +867,10 @@ mod tests {
         };
         // URL says `.xml`, but the override (`application/rss+xml`)
         // wins per the precedence rule.
-        assert_eq!(resolve_content_type(&entry, "/feed.xml"), "application/rss+xml");
+        assert_eq!(
+            resolve_content_type(&entry, "/feed.xml"),
+            "application/rss+xml"
+        );
     }
 
     #[test]
@@ -847,8 +879,14 @@ mod tests {
             body: b"<urlset/>".to_vec(),
             content_type: None,
         };
-        assert_eq!(resolve_content_type(&entry, "/sitemap.xml"), "application/xml");
-        assert_eq!(resolve_content_type(&entry, "/llms.txt"), "text/plain; charset=utf-8");
+        assert_eq!(
+            resolve_content_type(&entry, "/sitemap.xml"),
+            "application/xml"
+        );
+        assert_eq!(
+            resolve_content_type(&entry, "/llms.txt"),
+            "text/plain; charset=utf-8"
+        );
     }
 
     #[test]
@@ -858,8 +896,14 @@ mod tests {
             content_type: None,
         };
         // No extension on the URL → HTML default.
-        assert_eq!(resolve_content_type(&entry, "/about"), "text/html; charset=utf-8");
-        assert_eq!(resolve_content_type(&entry, "/"), "text/html; charset=utf-8");
+        assert_eq!(
+            resolve_content_type(&entry, "/about"),
+            "text/html; charset=utf-8"
+        );
+        assert_eq!(
+            resolve_content_type(&entry, "/"),
+            "text/html; charset=utf-8"
+        );
     }
 
     #[tokio::test]
@@ -936,7 +980,10 @@ mod tests {
     #[tokio::test]
     async fn html_pages_still_get_livereload_injected() {
         let state = test_state();
-        state.pages.insert("/about", "<html><body>x</body></html>").await;
+        state
+            .pages
+            .insert("/about", "<html><body>x</body></html>")
+            .await;
         let router = test_router(state);
 
         let resp = router

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -75,7 +75,7 @@ use zfb_build::{
     PageRenderer, RelDistPath, RenderedPage,
 };
 use zfb_graph::persist::{load_from_disk, save_to_disk, ManifestDigest};
-use zfb_graph::{DependencyGraph, PageId};
+use zfb_graph::{DependencyGraph, PageDeps, PageId};
 use zfb_server::{outcome_to_events, serve, PageCache, ReloadEvent, ServeOpts};
 
 use crate::cli::DevArgs;
@@ -184,7 +184,23 @@ pub async fn run(args: &DevArgs) -> Result<()> {
     // cache miss we construct a known-empty graph. Default was removed
     // from DependencyGraph to prevent silent empty-graph construction
     // elsewhere.
-    let graph = Arc::new(Mutex::new(initial_graph.unwrap_or_else(DependencyGraph::new)));
+    let graph = Arc::new(Mutex::new(
+        initial_graph.unwrap_or_else(DependencyGraph::new),
+    ));
+
+    // Seed the graph with all page source paths from the router scan so
+    // `plan_for_changes` can resolve `PageSelection::All` to a concrete
+    // page list even before the first file-change tick. Without this
+    // seeding the graph is empty, `resolve_all` produces an empty page
+    // set, and every watcher tick is a no-op (zfb#N / cold-start bug).
+    if let Some(ref session) = dev_session {
+        if let Ok(mut g) = graph.lock() {
+            for page_id in session.page_ids() {
+                g.upsert(PageDeps::new(page_id, vec![]));
+            }
+        }
+    }
+
     let graph_for_save = Arc::clone(&graph);
     let pipeline = DevAssetPipeline::new();
     let orch_config = OrchestratorConfig::new(&project_root, watch_roots.clone());
@@ -285,10 +301,7 @@ pub async fn run(args: &DevArgs) -> Result<()> {
 /// denied while walking sources). On `None` the caller should bypass
 /// the persistence layer entirely — never falsely reuse a stale
 /// graph.
-fn compute_manifest_digest(
-    project_root: &Path,
-    watch_roots: &[PathBuf],
-) -> Option<ManifestDigest> {
+fn compute_manifest_digest(project_root: &Path, watch_roots: &[PathBuf]) -> Option<ManifestDigest> {
     // Config files that, when changed, must invalidate the graph
     // even though they live next to (not under) the watched roots.
     // Both JSON and TS are listed; missing ones are silently
@@ -385,6 +398,17 @@ impl DevRenderSession {
             html,
             content_type: None,
         }))
+    }
+
+    /// Return all known page IDs (source paths) from the router scan.
+    /// Used to seed the dependency graph so incremental rebuilds have a
+    /// non-empty page set to resolve against.
+    fn page_ids(&self) -> Vec<PageId> {
+        self.inner
+            .routes_by_source
+            .keys()
+            .map(|p| PageId::new(p.clone()))
+            .collect()
     }
 
     /// Tear down the underlying [`RendererState`] cleanly. Safe to call


### PR DESCRIPTION
## Problem

Two independent bugs prevented `zfb dev` from being usable after a clean start:

### Bug 1 — Empty DependencyGraph on startup → no rebuilds ever trigger

`BuildOrchestrator::plan_for_changes()` routes all `Page / Module / Content / Data` path classes through `graph.dirty_pages(path)`. On a fresh dev session the graph has **no nodes at all**, so `dirty_pages` always returns `DirtySet::Specific(∅)`. The orchestrator treats that as "nothing changed" and produces a no-op tick for every file event.

### Bug 2 — PageCache never populated → every HTTP request 404s

The dev pipeline (`DevAssetPipeline`) writes rendered HTML to disk via `atomic_write()` into `dist/`. The `zfb-server` HTTP handler (`serve_page`) only checked the in-memory `PageCache` — which nothing ever writes to in dev mode — so every page request returned `DEV_404_BODY`.

## Fix

**`crates/zfb/src/commands/dev.rs`** — After the router is built at startup, seed the graph with one zero-dep `PageDeps` node per page. This registers the page IDs so `resolve_all()` can later expand `PageSelection::All` to a concrete list.

**`crates/zfb-build/src/orchestrator.rs`** — In `plan_for_changes()`, when `dirty_pages()` returns an empty specific set (cold-start: graph has page nodes but no reverse edges yet), escalate to `PageSelection::All`. This is safe because `resolve_all()` caps the set to the registered page list.

**`crates/zfb-server/src/routes.rs`** — Add `dist_root: PathBuf` to `AppState`. In `serve_page()`, after a PageCache miss, fall back to reading `<dist_root>/<trimmed>/index.html` (or `<dist_root>/<trimmed>`) from disk. This bridges the architectural gap between the pipeline (writes disk) and the server (reads cache).

**`crates/zfb-server/src/lib.rs`** — Wire the new `dist_root` field through `ServeOpts → AppState`.

## Testing

- `cargo build --workspace` — clean
- `cargo test --workspace` — 266 passed; 1 pre-existing failure in `zfb-content` (`emit_types_dts_with_schemas_matches_golden` golden-file mismatch already present on `main`)
- `cargo fmt --check` — pre-existing unformatted files only (not in this diff)
- `cargo clippy --workspace` — pre-existing errors only (not in this diff)

Manual smoke against `examples/basic-blog`:
- `zfb build` → 14 pages in `dist/`, assets present ✓
- `zfb dev` → server starts, curl `http://127.0.0.1:3000/` returns HTML after first-tick build ✓
- Edit `content/blog/hello-zfb.mdx` → watcher fires, page rebuilds, curl returns updated HTML ✓

## Scope

4 files, 127 net lines. No public API surface changes (the `dist_root` field in `AppState` is additive; `build_router` signature unchanged for external callers that already pass state). Follows existing patterns (`DependencyGraph`, `PageDeps`, `atomic_write`).