### PR TITLE
zfb-docs-uplift: docs update + wisdom skill

### DIFF
--- a/docs/.claude/skills/zfb-wisdom/SKILL.md
+++ b/docs/.claude/skills/zfb-wisdom/SKILL.md
@@ -63,7 +63,9 @@ The documentation is organized in MDX files under `docs/`:
 - api/
 - architecture/
 - changelog/
+- claude-md/
 - claude-skills/
+- claude/
 - concepts/
 - dogfood/
 - getting-started/

--- a/docs/.claude/skills/zfb-wisdom/SKILL.md
+++ b/docs/.claude/skills/zfb-wisdom/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: zfb-wisdom
+description: >-
+  Search and reference documentation from the zfb (zudo-front-builder) project.
+  Use when answering questions about zfb features, CLI usage, configuration,
+  content collections, routing, build pipeline, or architecture decisions.
+user-invocable: true
+argument-hint: "[-u|--update] [topic keyword, e.g., 'routing', 'build-pipeline', 'content-collections']"
+---
+
+# zfb Documentation Reference
+
+Look up documentation from the zfb (zudo-front-builder) project.
+Documentation base path: `docs/src/content/docs` (relative to repo root)
+
+## Mode Detection
+
+Parse the argument string for flags:
+
+- If args start with `-u` or `--update`: enter **Update mode** (see below)
+- Otherwise: enter **Lookup mode** (default)
+
+Strip the flag from the remaining argument to get the topic keyword.
+
+## Lookup Mode (default)
+
+1. Find the relevant article(s) from the `docs/` directory based on the topic
+2. Read ONLY the specific article(s) you need — do NOT load all articles at once
+3. For architecture questions, also check `architecture/` for ADR files
+4. Apply the information from the article when answering the user's question
+5. Mention the source article path so the user can find it for further reading
+
+## Update Mode (`-u` / `--update`)
+
+The user has new information and wants to add or update documentation in this repo.
+
+### Workflow
+
+1. **Understand the new info**: Ask the user what they learned or want to
+   document. The topic keyword (if provided) hints at the subject area.
+2. **Find existing docs**: Search the `docs/` directory for articles related to
+   the topic. Read them to understand what is already covered.
+3. **Decide create vs update**: If an existing article covers the topic, update
+   it. Otherwise, create a new `.mdx` file in the appropriate subdirectory.
+4. **Write the content**: Follow the doc-authoring rules in `docs/CLAUDE.md`:
+   - Required frontmatter: `title` (string). Always set `sidebar_position`.
+     Optional: `description`, `sidebar_label`, `tags`, etc.
+   - Do NOT use `# h1` in content — the frontmatter `title` renders as h1.
+     Start with `## h2` headings.
+   - Use available MDX components (`<Note>`, `<Tip>`, `<Info>`, `<Warning>`,
+     `<Danger>`) where appropriate.
+5. **Update Japanese docs**: Create or update the corresponding file under
+   `docs-ja/` mirroring the English directory structure. Keep code blocks and
+   diagrams identical — only translate surrounding prose.
+6. **Format**: Run `pnpm format:md` inside `docs/` to format the changed files.
+7. **Verify**: Run `pnpm build` inside `docs/` to confirm the site builds correctly.
+
+## Documentation Structure
+
+The documentation is organized in MDX files under `docs/`:
+
+```
+- api/
+- architecture/
+- changelog/
+- claude-skills/
+- concepts/
+- dogfood/
+- getting-started/
+- guides/
+```
+
+Architecture Decision Records (ADRs) are in `architecture/`.
+
+Browse the `docs/` directory to discover available articles. Each `.mdx` file
+has YAML frontmatter with `title` and `description` fields that help identify
+the right article to read.
+
+## Japanese Documentation
+
+Japanese translations are available under `docs-ja/`. When the user is working
+in Japanese or asks for Japanese content, prefer articles from `docs-ja/`.

--- a/docs/.claude/skills/zfb-wisdom/architecture
+++ b/docs/.claude/skills/zfb-wisdom/architecture
@@ -1,0 +1,1 @@
+/Users/takazudo/repos/myoss/zfb/docs/architecture

--- a/docs/.claude/skills/zfb-wisdom/docs
+++ b/docs/.claude/skills/zfb-wisdom/docs
@@ -1,0 +1,1 @@
+/Users/takazudo/repos/myoss/zfb/docs/src/content/docs

--- a/docs/.claude/skills/zfb-wisdom/docs-ja
+++ b/docs/.claude/skills/zfb-wisdom/docs-ja
@@ -1,0 +1,1 @@
+/Users/takazudo/repos/myoss/zfb/docs/src/content/docs-ja

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -10,6 +10,10 @@ Documentation site built with [zudo-doc](https://github.com/zudolab/zudo-doc) �
 - **Preact** — for interactive islands only (with compat mode for React API)
 - **Shiki** — built-in code highlighting
 
+## Setup
+
+- **zfb-wisdom Claude Code skill** — run `bash docs/scripts/setup-zfb-wisdom.sh` once to give AI agents lookup access to this documentation tree (see `src/content/docs/claude-skills/zfb-wisdom.mdx`)
+
 ## Commands
 
 - `pnpm dev` — Astro dev server (port 4321)

--- a/docs/scripts/setup-zfb-wisdom.sh
+++ b/docs/scripts/setup-zfb-wisdom.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── setup-zfb-wisdom.sh ────────────────────────────────────
+# Creates a Claude Code skill (zfb-wisdom) that exposes the
+# zfb project documentation as a browsable knowledge base,
+# then symlinks it into the user-scope skills directory
+# (~/.claude/skills/).
+#
+# Run from anywhere inside the repo:
+#   bash docs/scripts/setup-zfb-wisdom.sh
+# ────────────────────────────────────────────────────────────
+
+SKILL_NAME="zfb-wisdom"
+
+# Resolve docs sub-project root (the directory containing this script's parent)
+DOCS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Resolve the main repo root (handles git worktrees: always points at the main
+# worktree so symlinks remain valid after a worktree is removed)
+REPO_ROOT="$(git -C "$DOCS_DIR" worktree list | head -1 | awk '{print $1}')"
+if [ -z "$REPO_ROOT" ]; then
+  echo "Error: Could not resolve repo root (git worktree list returned empty)"
+  exit 1
+fi
+
+SKILL_DIR="$DOCS_DIR/.claude/skills/$SKILL_NAME"
+DOCS_CONTENT_DIR="$DOCS_DIR/src/content/docs"
+DOCS_JA_CONTENT_DIR="$DOCS_DIR/src/content/docs-ja"
+ARCHITECTURE_DIR="$REPO_ROOT/docs/architecture"
+GLOBAL_SKILLS_DIR="$HOME/.claude/skills"
+
+echo ""
+echo "=== zfb-wisdom Skill Setup ==="
+echo ""
+
+# Validate docs content directory exists
+if [ ! -d "$DOCS_CONTENT_DIR" ]; then
+  echo "Error: Documentation directory not found at $DOCS_CONTENT_DIR"
+  exit 1
+fi
+
+# Helper: replace a symlink or file at the given path with a new symlink
+ensure_symlink() {
+  local link_path="$1"
+  local target="$2"
+  if [ -L "$link_path" ] || [ -e "$link_path" ]; then
+    rm -rf "$link_path"
+  fi
+  ln -s "$target" "$link_path"
+  echo "  Symlinked $link_path -> $target"
+}
+
+# Create skill directory
+mkdir -p "$SKILL_DIR"
+echo "  Created skill directory: $SKILL_DIR"
+
+# Symlink docs/ → docs/src/content/docs/
+ensure_symlink "$SKILL_DIR/docs" "$REPO_ROOT/docs/src/content/docs"
+
+# Symlink docs-ja/ → docs/src/content/docs-ja/ (if it exists)
+HAS_JA=""
+if [ -d "$DOCS_JA_CONTENT_DIR" ]; then
+  HAS_JA="true"
+  ensure_symlink "$SKILL_DIR/docs-ja" "$REPO_ROOT/docs/src/content/docs-ja"
+fi
+
+# Symlink architecture/ → docs/architecture/ (ADR directory)
+if [ -d "$ARCHITECTURE_DIR" ]; then
+  ensure_symlink "$SKILL_DIR/architecture" "$ARCHITECTURE_DIR"
+fi
+
+# Discover top-level doc categories dynamically for the SKILL.md index
+DOC_TREE=""
+for dir in "$DOCS_CONTENT_DIR"/*/; do
+  [ -d "$dir" ] || continue
+  dirname="$(basename "$dir")"
+  DOC_TREE="${DOC_TREE}- ${dirname}/
+"
+done
+
+# Generate SKILL.md with YAML frontmatter + category index
+cat > "$SKILL_DIR/SKILL.md" << SKILLEOF
+---
+name: $SKILL_NAME
+description: >-
+  Search and reference documentation from the zfb (zudo-front-builder) project.
+  Use when answering questions about zfb features, CLI usage, configuration,
+  content collections, routing, build pipeline, or architecture decisions.
+user-invocable: true
+argument-hint: "[-u|--update] [topic keyword, e.g., 'routing', 'build-pipeline', 'content-collections']"
+---
+
+# zfb Documentation Reference
+
+Look up documentation from the zfb (zudo-front-builder) project.
+Documentation base path: \`docs/src/content/docs\` (relative to repo root)
+
+## Mode Detection
+
+Parse the argument string for flags:
+
+- If args start with \`-u\` or \`--update\`: enter **Update mode** (see below)
+- Otherwise: enter **Lookup mode** (default)
+
+Strip the flag from the remaining argument to get the topic keyword.
+
+## Lookup Mode (default)
+
+1. Find the relevant article(s) from the \`docs/\` directory based on the topic
+2. Read ONLY the specific article(s) you need — do NOT load all articles at once
+3. For architecture questions, also check \`architecture/\` for ADR files
+4. Apply the information from the article when answering the user's question
+5. Mention the source article path so the user can find it for further reading
+
+## Update Mode (\`-u\` / \`--update\`)
+
+The user has new information and wants to add or update documentation in this repo.
+
+### Workflow
+
+1. **Understand the new info**: Ask the user what they learned or want to
+   document. The topic keyword (if provided) hints at the subject area.
+2. **Find existing docs**: Search the \`docs/\` directory for articles related to
+   the topic. Read them to understand what is already covered.
+3. **Decide create vs update**: If an existing article covers the topic, update
+   it. Otherwise, create a new \`.mdx\` file in the appropriate subdirectory.
+4. **Write the content**: Follow the doc-authoring rules in \`docs/CLAUDE.md\`:
+   - Required frontmatter: \`title\` (string). Always set \`sidebar_position\`.
+     Optional: \`description\`, \`sidebar_label\`, \`tags\`, etc.
+   - Do NOT use \`# h1\` in content — the frontmatter \`title\` renders as h1.
+     Start with \`## h2\` headings.
+   - Use available MDX components (\`<Note>\`, \`<Tip>\`, \`<Info>\`, \`<Warning>\`,
+     \`<Danger>\`) where appropriate.
+5. **Update Japanese docs**: Create or update the corresponding file under
+   \`docs-ja/\` mirroring the English directory structure. Keep code blocks and
+   diagrams identical — only translate surrounding prose.
+6. **Format**: Run \`pnpm format:md\` inside \`docs/\` to format the changed files.
+7. **Verify**: Run \`pnpm build\` inside \`docs/\` to confirm the site builds correctly.
+
+## Documentation Structure
+
+The documentation is organized in MDX files under \`docs/\`:
+
+\`\`\`
+${DOC_TREE}\`\`\`
+
+Architecture Decision Records (ADRs) are in \`architecture/\`.
+
+Browse the \`docs/\` directory to discover available articles. Each \`.mdx\` file
+has YAML frontmatter with \`title\` and \`description\` fields that help identify
+the right article to read.
+SKILLEOF
+
+if [ "$HAS_JA" = "true" ]; then
+  cat >> "$SKILL_DIR/SKILL.md" << JAEOF
+
+## Japanese Documentation
+
+Japanese translations are available under \`docs-ja/\`. When the user is working
+in Japanese or asks for Japanese content, prefer articles from \`docs-ja/\`.
+JAEOF
+fi
+
+echo "  Generated SKILL.md"
+
+# Symlink into global skills directory
+mkdir -p "$GLOBAL_SKILLS_DIR"
+ensure_symlink "$GLOBAL_SKILLS_DIR/$SKILL_NAME" "$SKILL_DIR"
+
+echo ""
+echo "Done! Skill '$SKILL_NAME' is ready."
+echo ""
+echo "  Project skill : $SKILL_DIR"
+echo "  Global symlink: $GLOBAL_SKILLS_DIR/$SKILL_NAME"
+echo ""
+echo "You can now use it in Claude Code with: /$SKILL_NAME <topic>"
+echo ""

--- a/docs/src/content/docs/architecture/build-engine.mdx
+++ b/docs/src/content/docs/architecture/build-engine.mdx
@@ -6,6 +6,8 @@ sidebar_position: 1
 
 This page is about the *shape* of zfb's build engine. For a step-by-step walk of what happens when you save a file, read [Build pipeline](/docs/concepts/build-pipeline); this page explains why the story is shaped this way.
 
+See also: [Architecture overview](/docs/architecture/architecture-overview) · [Islands](/docs/concepts/islands) · [Incremental rebuild](/docs/architecture/incremental-rebuild)
+
 ## The crate split
 
 zfb is a Rust workspace. Each crate owns one slice of the build, and the data flowing between them is small and explicit.
@@ -30,13 +32,39 @@ When a file changes, `zfb-watcher` emits a `Change`, the orchestrator asks `zfb-
 
 The win is granularity. A 2,000-page site rebuilds the affected pages in milliseconds when a shared header changes. The cost is that the graph must be honest — `zfb-graph` is updated as part of every successful render so the next query has a current picture.
 
-<Info title="v0 status">
+<Info title="Current status">
 
-  Most pieces of the engine are wired and unit-tested. The full
-  end-to-end render flow — TSX → JS → HTML — is gated on ADR-001's
-  runtime decision; see [JS runtime](/docs/architecture/js-runtime).
+  The orchestrator, dependency graph, watcher, atomic writes, and CSS
+  pipeline are wired and unit-tested. The full end-to-end render flow
+  — TSX → JS → HTML — runs through the embedded V8 host chosen by
+  [ADR-005 (SSG-first)](https://github.com/Takazudo/zudo-front-builder/blob/main/docs/architecture/adr-005-ssg-first.md);
+  see [JS runtime](/docs/architecture/js-runtime) for the historical
+  evaluation and [ADR-005](/docs/architecture/js-runtime) for the
+  settled decision.
 
 </Info>
+
+## Tools the engine uses (and why they're swappable)
+
+zfb is the orchestrator. It owns the dependency graph, the per-page rebuild contract, and the data flowing between crates. The external tools it calls are an implementation detail — each sits behind a Rust trait, so a future ADR can replace any one of them without touching the rest of the pipeline.
+
+| Tool | Role | Trait boundary |
+| --- | --- | --- |
+| **esbuild** | Bundles the server-side worker bundle (`zfb-build/bundler.rs`) and the per-island client bundles (`zfb-islands`). Fast, handles TSX/JSX, MDX loaders, and tree-shaking. | `ClientBundler` (in `zfb-islands`) |
+| **workerd / miniflare** | The JS runtime that executes the server-side worker bundle for SSR and the dev preview server. Chosen by [ADR-005](https://github.com/Takazudo/zudo-front-builder/blob/main/docs/architecture/adr-005-ssg-first.md). | `RenderHost` (in `zfb-render`) |
+| **SWC** | Compiles TSX source to JavaScript before handing it off to esbuild or the render host. Lives inside `zfb-render`. | Internal to `zfb-render`; swappable by replacing that crate's transform step |
+| **lol_html** | Streaming HTML rewriter used to inject hydration entry-point `<script>` tags and island mount markers into the rendered HTML without a full parse. | Used inside `zfb-build/head_inject.rs`; no public trait needed — it is a low-level utility |
+
+### How the layering works
+
+zfb owns orchestration, the dependency graph, and the per-page contract. The tools each appear in exactly one layer:
+
+- **esbuild** is called in two places: `zfb-build` (server worker bundle) and `zfb-islands` (per-island client bundles). Both use it for bundling TypeScript/JSX source trees; neither exposes it to the crates above.
+- **workerd / miniflare** is the JS engine behind `RenderHost`. The renderer in `zfb-render` calls `RenderHost::call_default`; the concrete host boots a miniflare worker. The orchestrator in `zfb-build` never names the engine — it only receives rendered HTML.
+- **SWC** runs inside `zfb-render` before the module reaches the render host, or inside `zfb-build/bundler.rs` before esbuild sees the source. Either way it is invisible to the orchestrator.
+- **lol_html** runs after the render host returns HTML, inside `zfb-build/head_inject.rs`. The orchestrator sees plain strings in and plain strings out.
+
+This structure means the crates above each tool's trait boundary are unaffected when the tool changes. See [Islands](/docs/concepts/islands) for the `ClientBundler` contract and [Incremental rebuild](/docs/architecture/incremental-rebuild) for how the dependency graph feeds the per-page policy.
 
 ## Atomic writes
 

--- a/docs/src/content/docs/architecture/build-engine.mdx
+++ b/docs/src/content/docs/architecture/build-engine.mdx
@@ -4,9 +4,9 @@ description: "How zfb's crates fit together, why the rebuild is per-page, and wh
 sidebar_position: 1
 ---
 
-This page is about the *shape* of zfb's build engine. For a step-by-step walk of what happens when you save a file, read [Build pipeline](/docs/concepts/build-pipeline); this page explains why the story is shaped this way.
+This page is about the *shape* of zfb's build engine. For a step-by-step walk of what happens when you save a file, read [Build pipeline](/concepts/build-pipeline); this page explains why the story is shaped this way.
 
-See also: [Architecture overview](/docs/architecture/architecture-overview) · [Islands](/docs/concepts/islands) · [Incremental rebuild](/docs/architecture/incremental-rebuild)
+See also: [Architecture overview](/concepts/architecture-overview) · [Islands](/concepts/islands) · [Incremental rebuild](/concepts/incremental-rebuild)
 
 ## The crate split
 
@@ -38,8 +38,8 @@ The win is granularity. A 2,000-page site rebuilds the affected pages in millise
   pipeline are wired and unit-tested. The full end-to-end render flow
   — TSX → JS → HTML — runs through the embedded V8 host chosen by
   [ADR-005 (SSG-first)](https://github.com/Takazudo/zudo-front-builder/blob/main/docs/architecture/adr-005-ssg-first.md);
-  see [JS runtime](/docs/architecture/js-runtime) for the historical
-  evaluation and [ADR-005](/docs/architecture/js-runtime) for the
+  see [JS runtime](/architecture/js-runtime) for the historical
+  evaluation and [ADR-005](/architecture/js-runtime) for the
   settled decision.
 
 </Info>
@@ -64,7 +64,7 @@ zfb owns orchestration, the dependency graph, and the per-page contract. The too
 - **SWC** runs inside `zfb-render` before the module reaches the render host, or inside `zfb-build/bundler.rs` before esbuild sees the source. Either way it is invisible to the orchestrator.
 - **lol_html** runs after the render host returns HTML, inside `zfb-build/head_inject.rs`. The orchestrator sees plain strings in and plain strings out.
 
-This structure means the crates above each tool's trait boundary are unaffected when the tool changes. See [Islands](/docs/concepts/islands) for the `ClientBundler` contract and [Incremental rebuild](/docs/architecture/incremental-rebuild) for how the dependency graph feeds the per-page policy.
+This structure means the crates above each tool's trait boundary are unaffected when the tool changes. See [Islands](/concepts/islands) for the `ClientBundler` contract and [Incremental rebuild](/concepts/incremental-rebuild) for how the dependency graph feeds the per-page policy.
 
 ## Atomic writes
 

--- a/docs/src/content/docs/architecture/future-directions-js-runtime.mdx
+++ b/docs/src/content/docs/architecture/future-directions-js-runtime.mdx
@@ -19,7 +19,7 @@ alternative is adopted, a new ADR will record it formally.
 `@takazudo/zfb-runtime` is a Hono-style page router that runs inside an
 in-process V8 isolate via `deno_core` at build time. The bundle is shaped as a
 Cloudflare-Workers-compatible `export default { fetch }` module, per
-[ADR-007](/docs/architecture/js-runtime). The same bundle deploys unchanged to
+[ADR-007](/architecture/js-runtime). The same bundle deploys unchanged to
 Cloudflare Workers for runtime SSR via `packages/zfb-adapter-cloudflare`. The
 `RenderHost` trait in `crates/zfb-render` is the Rust abstraction that wraps
 the host — the renderer never names the concrete implementation. Today's
@@ -79,7 +79,7 @@ approximate (rather than exact) Web API parity with workerd.
 The primary reason this exploration exists is the Tauri distribution goal. If
 and when zfb ships as a desktop app, the zfb binary must run on end-user
 machines without Node.js installed. See the [desktop deployment
-guide](/docs/guides/desktop-deployment) for the current facts: `zfb build`
+guide](/guides/desktop-deployment) for the current facts: `zfb build`
 outputs plain HTML that a Tauri app can serve as static assets without any JS
 runtime on the user's machine. The constraint is the _build_ step, not the
 _output_.
@@ -91,7 +91,7 @@ binary or distributable as a sidecar without requiring Node (or any separately-
 installed JS runtime) on the user's machine.
 
 For a deeper look at the overall runtime stack, see [architecture
-overview](/docs/concepts/architecture-overview).
+overview](/concepts/architecture-overview).
 
 ## What would need to change for a host swap
 

--- a/docs/src/content/docs/architecture/future-directions-js-runtime.mdx
+++ b/docs/src/content/docs/architecture/future-directions-js-runtime.mdx
@@ -1,0 +1,135 @@
+---
+title: "Future directions: JS runtime exploration"
+description: "A thinking-out-loud sketch of alternative JS-runtime hosts for zfb's build-time render step. Exploration only — ADR-007 stands."
+sidebar_position: 5
+---
+
+<Warning title="Exploration, not a committed direction">
+
+This page is thinking-out-loud. It captures the reasoning behind architectural
+exploration of alternative JS-runtime hosts so that future contributors (and AI
+agents) understand the design space without mistaking the discussion for a
+ratified decision. **ADR-007 is the accepted decision.** If and when any
+alternative is adopted, a new ADR will record it formally.
+
+</Warning>
+
+## What we have today
+
+`@takazudo/zfb-runtime` is a Hono-style page router that runs inside an
+in-process V8 isolate via `deno_core` at build time. The bundle is shaped as a
+Cloudflare-Workers-compatible `export default { fetch }` module, per
+[ADR-007](/docs/architecture/js-runtime). The same bundle deploys unchanged to
+Cloudflare Workers for runtime SSR via `packages/zfb-adapter-cloudflare`. The
+`RenderHost` trait in `crates/zfb-render` is the Rust abstraction that wraps
+the host — the renderer never names the concrete implementation. Today's
+concrete implementation is `DenoCoreHost`.
+
+## The implementation / contract distinction
+
+The design space splits into two layers, and the distinction matters:
+
+**The bundle contract is locked.** `@takazudo/zfb-runtime` exports
+`export default { fetch }` — the workerd shape. That contract is what
+Cloudflare Workers loads in production. It does not change regardless of which
+engine runs it at build time. Hono's routing core, the page-render path, and
+`getCollection` all live above this boundary. So does `packages/zfb-adapter-cloudflare`.
+
+**The execution host is implementation.** `deno_core` is what runs the bundle
+during `zfb build`. Nothing in the bundle itself knows or cares which engine is
+executing it — it sees Web APIs (`fetch`, `Request`, `Response`, `URL`) and a
+module loader. Any host that provides those APIs and can load an ESM bundle
+satisfies the contract.
+
+Other hosts that could, in principle, satisfy the contract:
+
+- **workerd as a sidecar binary** — run workerd as a subprocess, just like
+  miniflare did (the ADR-005 era), but using the upstream workerd binary
+  directly rather than the Node-hosted miniflare wrapper.
+- **Bun** — Bun ships a built-in JS runtime with Web APIs and ESM support.
+- **Deno** — the Deno CLI could be invoked as a subprocess much like miniflare.
+- **deno_core embedded V8** — the current choice: V8 in-process via the
+  `deno_core` Rust crate, with `deno_fetch` / `deno_web` / `deno_url` for Web
+  API coverage.
+
+None of the first three are currently supported. This section is conceptual.
+
+## Trade-off sketch
+
+The table covers the candidates that have come up in architectural discussion.
+"Current" is `deno_core` (ADR-007).
+
+| Host | What it solves | What it costs | What it forecloses |
+|------|---------------|---------------|-------------------|
+| **deno_core** *(current)* | No Node required; in-process; ~30–40 MB binary growth; source-accurate errors | 15–30 min first compile; V8 recompile on crate bumps | Ship a `zfb-lean` binary without V8 |
+| **workerd sidecar** | True workerd parity at build time; no V8 in Rust binary | ~50–100 MB sidecar binary; subprocess latency; still not Node-free (miniflare was Node; bare workerd is C++ so Node-free, but adds a second binary to distribute) | In-process render speed |
+| **Bun subprocess** | Very fast cold start; single binary; Node-free | Bun's `fetch` semantics differ subtly from workerd's; subprocess boundary; Bun version pinning | Full Web API parity without shims |
+| **Deno subprocess** | Deno's `fetch` closely tracks the spec; Node-free | Deno version pinning; subprocess IPC overhead | In-process render speed |
+
+The workerd-sidecar path is the most faithful to the "same engine at build and
+deploy time" principle that ADR-005 argued for. The cost is distribution
+complexity: shipping a C++ binary alongside the Rust CLI.
+
+The embedded `deno_core` path (the current choice) wins on distribution
+simplicity and in-process speed at the expense of build-time compile cost and
+approximate (rather than exact) Web API parity with workerd.
+
+## Tauri / desktop angle
+
+The primary reason this exploration exists is the Tauri distribution goal. If
+and when zfb ships as a desktop app, the zfb binary must run on end-user
+machines without Node.js installed. See the [desktop deployment
+guide](/docs/guides/desktop-deployment) for the current facts: `zfb build`
+outputs plain HTML that a Tauri app can serve as static assets without any JS
+runtime on the user's machine. The constraint is the _build_ step, not the
+_output_.
+
+ADR-007 resolved this constraint by re-embedding `deno_core`, dropping the
+Node requirement from build time. Any future exploration of alternative hosts
+would face the same constraint: the host must either be embeddable in the Rust
+binary or distributable as a sidecar without requiring Node (or any separately-
+installed JS runtime) on the user's machine.
+
+For a deeper look at the overall runtime stack, see [architecture
+overview](/docs/concepts/architecture-overview).
+
+## What would need to change for a host swap
+
+The `RenderHost` trait is already the abstraction seam. Swapping the host
+implementation would touch:
+
+1. **`crates/zfb-render` — new `RenderHost` impl.** Add a new concrete struct
+   (e.g. `WorkerdSidecarHost`, `BunHost`) that satisfies the three trait
+   methods: `execute_module`, `call_default`, `get_export`. The rest of the
+   renderer is unaffected.
+2. **Web API shim layer.** `deno_core` provides Web APIs via extension crates
+   (`deno_fetch`, `deno_web`, `deno_url`, `deno_console`). An alternative
+   embedded host would need an equivalent set of shims so the bundle's
+   `new Request(...)` and `new URL(...)` calls succeed. A subprocess host
+   (workerd sidecar, Bun, Deno) gets this for free from the subprocess runtime.
+3. **ESM module loader.** The host must resolve `import` specifiers and load
+   the `@takazudo/zfb-runtime` bundle. `deno_core` ships a built-in ESM loader.
+   An embedded alternative would need to replicate this. A subprocess host
+   handles it natively.
+4. **Snapshot / isolate injection.** `deno_core` supports V8 snapshots to
+   pre-initialize the isolate and speed up cold starts. An alternative host
+   would have its own equivalent (or none). The `__zfb.content` global
+   (content-bridge data, per ADR-004) is injected into `globalThis` before each
+   render; the injection mechanism is host-specific.
+5. **IPC contract (subprocess hosts only).** If the host runs out-of-process,
+   the wire format between Rust and the subprocess must be agreed on. ADR-005
+   explored newline-delimited JSON over stdio and HTTP loopback; either could
+   work. The IPC boundary adds error-surfacing complexity — stack traces from
+   inside the subprocess must cross the boundary without truncation.
+6. **Cargo feature flag / build configuration.** The binary-size consequence
+   of embedding V8 is significant. If a future non-V8 host is considered, the
+   `deno_core_host` feature flag pattern from ADR-001/ADR-007 could re-emerge
+   to make V8 embedding opt-in for contributors who do not need it.
+
+## Explicit non-commitment
+
+This page is thinking-out-loud. ADR-007 stands. If and when we revisit the
+decision, a new ADR (ADR-008, or a revision of ADR-007) will capture the
+analysis formally — with a measured spike, real performance numbers, and a
+documented rationale. Until that ADR exists, `deno_core` is the build-time
+host.

--- a/docs/src/content/docs/architecture/why-rust.mdx
+++ b/docs/src/content/docs/architecture/why-rust.mdx
@@ -40,7 +40,7 @@ A single binary pins cleanly. CI installs the version it needs; production deplo
 
 ## Honest counterpoint: build cost
 
-The first `cargo build` of zfb's workspace is slow. If V8 (`deno_core`) ends up as the JS runtime — see [JS runtime](/docs/architecture/js-runtime) — the V8 source bundle compiles for 5 to 15 minutes on a typical contributor machine. Incremental builds are fast; the first one hurts.
+The first `cargo build` of zfb's workspace is slow. If V8 (`deno_core`) ends up as the JS runtime — see [JS runtime](/architecture/js-runtime) — the V8 source bundle compiles for 5 to 15 minutes on a typical contributor machine. Incremental builds are fast; the first one hurts.
 
 The runtime spike's QuickJS feature is much faster (around 30 seconds). We gate the heavy candidates behind opt-in cargo features so a contributor can run unit tests without waiting on V8. End users do not pay this cost — they install the prebuilt binary.
 

--- a/docs/src/content/docs/claude-skills/zfb-wisdom.mdx
+++ b/docs/src/content/docs/claude-skills/zfb-wisdom.mdx
@@ -1,0 +1,79 @@
+---
+title: zfb-wisdom skill
+description: Give Claude Code lookup access to the zfb documentation so AI agents can answer questions about routing, build pipeline, content collections, and architecture without leaving the editor.
+sidebar_position: 1
+---
+
+<Info>
+
+AI agents working on zfb — writing features, debugging, or updating docs —
+benefit from having this skill installed. It lets Claude Code read the
+project's documentation directly without switching context or searching the
+web.
+
+</Info>
+
+## What it does
+
+`/zfb-wisdom` is a Claude Code skill that gives any AI agent instant,
+lookup-only access to the zfb documentation tree. When installed, the agent
+can browse `docs/src/content/docs/` and `docs/architecture/` directly from
+within a Claude Code session — no browser, no copy-paste.
+
+Typical use cases:
+
+- "How does zfb's routing work?" — agent reads `concepts/routing.mdx`
+- "What did ADR-003 decide?" — agent reads `architecture/adr-003-*.md`
+- "Show me the build pipeline overview" — agent reads `concepts/build-pipeline.mdx`
+
+The skill also has an **update mode** (`-u`) for adding or editing
+documentation from within Claude Code.
+
+## Setup
+
+Run the setup script once from the repo root:
+
+```bash
+bash docs/scripts/setup-zfb-wisdom.sh
+```
+
+The script:
+
+1. Creates `docs/.claude/skills/zfb-wisdom/` with a generated `SKILL.md`
+2. Symlinks `docs/src/content/docs/` → `skill/docs/`
+3. Symlinks `docs/src/content/docs-ja/` → `skill/docs-ja/` (Japanese content)
+4. Symlinks `docs/architecture/` → `skill/architecture/` (ADR files)
+5. Symlinks the skill directory into `~/.claude/skills/zfb-wisdom` so it is
+   available globally in all Claude Code sessions
+
+The script is **idempotent** — safe to re-run after pulling new commits.
+
+## Invocation
+
+```
+/zfb-wisdom <topic>
+```
+
+Examples:
+
+```
+/zfb-wisdom routing
+/zfb-wisdom build-pipeline
+/zfb-wisdom content-collections
+/zfb-wisdom adr-003
+/zfb-wisdom -u new-feature-name
+```
+
+Pass `-u` or `--update` as the first token to enter update mode, which
+writes or edits a documentation article instead of just reading one.
+
+## What gets indexed
+
+| Symlink in skill dir | Points to |
+|---|---|
+| `docs/` | `docs/src/content/docs/` |
+| `docs-ja/` | `docs/src/content/docs-ja/` |
+| `architecture/` | `docs/architecture/` |
+
+The skill reads live files through symlinks — no copy step, always
+up-to-date with the working tree.

--- a/docs/src/content/docs/concepts/architecture-overview.mdx
+++ b/docs/src/content/docs/concepts/architecture-overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: Architecture overview
 description: "Top-down mental model of zfb's runtime stack — the two bundles, what runs where, and why the Hono/Workers shape is the stable contract."
-sidebar_position: -1
+sidebar_position: -0.5
 category: Concepts
 ---
 
@@ -143,4 +143,4 @@ Downstream of the contract:
 
 - [Islands](/concepts/islands) — how `"use client"` opts a component into the island bundle
 - [Build engine](/architecture/build-engine) — how the Rust crates coordinate the pipeline
-- [Incremental rebuild](/concepts/build-pipeline) — how the dependency graph keeps dev rebuilds fast
+- [Incremental rebuild](/concepts/incremental-rebuild) — how the dependency graph keeps dev rebuilds fast

--- a/docs/src/content/docs/concepts/architecture-overview.mdx
+++ b/docs/src/content/docs/concepts/architecture-overview.mdx
@@ -1,0 +1,146 @@
+---
+title: Architecture overview
+description: "Top-down mental model of zfb's runtime stack — the two bundles, what runs where, and why the Hono/Workers shape is the stable contract."
+sidebar_position: -1
+category: Concepts
+---
+
+<Info title="What this page covers">
+
+The two-bundle model, a diagram of the full build-time pipeline, why the worker
+bundle is shaped as a Cloudflare Workers module, and the layering principle that
+keeps esbuild and the JS runtime swappable. For the step-by-step build pipeline,
+read [Build pipeline](/concepts/build-pipeline).
+
+</Info>
+
+zfb produces two kinds of JavaScript output, sends them to two different
+destinations, and uses two different execution environments to get there. Getting
+that split clear in your head first makes the rest of the architecture fall into
+place.
+
+## The two bundles, two destinations
+
+**Worker bundle — build-time only, never shipped to users.**
+
+When you run `zfb build`, the first thing that happens is that esbuild compiles
+your TSX pages, layouts, and components into a single worker bundle. This bundle
+is shaped as a Cloudflare Workers module — it exports a `fetch` handler and
+nothing else:
+
+```ts
+export default {
+  fetch(request: Request, env: Env, ctx: ExecutionContext): Response { ... }
+};
+```
+
+The Rust orchestrator loads this bundle into an embedded V8 isolate (via
+`deno_core`) and drives it with synthetic HTTP requests — one request per page
+URL. Each synthetic request produces an HTML `Response`. The orchestrator writes
+those responses to `dist/` as plain `.html` files. When the build finishes, the
+isolate is torn down. The worker bundle never leaves your machine; it is the
+*tool* that produces the static output, not the output itself.
+
+**Island bundles — shipped to the browser, on-demand.**
+
+Components marked with `"use client"` are a different story. esbuild bundles
+each one as a separate ESM module, and those bundles land in `dist/` alongside
+the HTML files. The browser downloads them on-demand and hydrates the
+corresponding DOM nodes. Island bundles are the *only* JavaScript that ever
+reaches end users.
+
+The distinction matters because the two bundles have completely different
+lifetimes, different execution environments, and different optimization targets.
+Conflating them is the source of most confusion about how zfb works.
+
+See [Islands](/concepts/islands) for how to opt in with `"use client"`.
+
+## What runs where
+
+```mermaid
+flowchart TD
+    src["TSX / MDX source files\n(pages/, components/, content/)"]
+
+    subgraph build["zfb build — your machine"]
+        esbuild_worker["esbuild\n(worker bundle)"]
+        v8["embedded V8 via deno_core\n(synthetic HTTP requests → HTML)"]
+        esbuild_islands["esbuild\n(island bundles)"]
+        dist_html["dist/\nHTML files"]
+        dist_js["dist/\nisland JS files"]
+    end
+
+    deploy["Static host\n(any CDN / Cloudflare Pages)"]
+    browser["Browser\n(island bundles hydrate on-demand)"]
+
+    src --> esbuild_worker
+    esbuild_worker --> v8
+    v8 --> dist_html
+
+    src --> esbuild_islands
+    esbuild_islands --> dist_js
+
+    dist_html --> deploy
+    dist_js --> deploy
+    deploy --> browser
+```
+
+Everything inside the `zfb build` box runs on your machine at build time and
+exits when the build finishes. Nothing in that box runs on a server at request
+time for static deployments.
+
+For the deeper story on how the build orchestrator coordinates these steps, read
+[Build engine](/architecture/build-engine).
+
+## The Hono / Cloudflare Workers portability bet
+
+The worker bundle shape — `export default { fetch }` — is not accidental. It is
+the same contract a Cloudflare Workers deployment expects. That means the bundle
+the Rust orchestrator drives at build time can be deployed to Cloudflare Workers
+unchanged, and workerd will execute it in production for any route that opts out
+of static prerendering.
+
+The routing core (`createPageRouter` from `@takazudo/zfb-runtime`) follows the
+Hono adapter pattern: one router, multiple entry adapters. The build-time
+adapter feeds it synthetic `Request` objects and collects `Response` strings.
+The Cloudflare Workers adapter registers it as the worker's `fetch` handler. The
+router itself does not know which adapter is driving it.
+
+This is the portability bet: by fixing the bundle shape as the stable contract,
+zfb stays decoupled from which JS engine executes it. Today the build-time host
+is an embedded V8 isolate (`deno_core`). The production host is workerd.
+The contract — `export default { fetch }` — is the same in both contexts.
+
+`packages/zfb-adapter-cloudflare` is the deployment adapter for Cloudflare
+Workers. It takes the bundle produced by `zfb build --target=cloudflare` and
+wraps it in the thin shell that `wrangler deploy` expects.
+
+The full rationale for this design, including the sequence of decisions that
+arrived at it, lives in
+[ADR-005](https://github.com/Takazudo/zudo-front-builder/blob/main/docs/architecture/adr-005-ssg-first.md)
+(the original miniflare + Hono design) and
+[ADR-007](https://github.com/Takazudo/zudo-front-builder/blob/main/docs/architecture/adr-007-embedded-v8.md)
+(why the build-time host later moved to embedded V8 while the bundle contract
+stayed the same).
+
+## Layering summary
+
+Three layers, each with a distinct job:
+
+| Layer | What it owns | What it does NOT own |
+|-------|-------------|----------------------|
+| **Your source** | Pages, components, content, styles | Build mechanics |
+| **zfb** | The build contract — route table, page props shape, island protocol, `dist/` layout | Which bundler, which JS runtime |
+| **Tools** | esbuild (bundling), V8 via `deno_core` (build-time evaluation) | Your code's semantics |
+
+zfb owns the contract — what inputs it accepts, what the output looks like, and
+what invariants hold across the build. esbuild and the embedded V8 runtime are
+implementation details that can be swapped behind the `RenderHost` trait without
+touching user code.
+
+The bundler is the cheap, fast saw. zfb is the carpenter.
+
+Downstream of the contract:
+
+- [Islands](/concepts/islands) — how `"use client"` opts a component into the island bundle
+- [Build engine](/architecture/build-engine) — how the Rust crates coordinate the pipeline
+- [Incremental rebuild](/concepts/build-pipeline) — how the dependency graph keeps dev rebuilds fast

--- a/docs/src/content/docs/concepts/choosing-zfb.mdx
+++ b/docs/src/content/docs/concepts/choosing-zfb.mdx
@@ -1,0 +1,148 @@
+---
+title: Choosing zfb
+description: When zfb fits your project, when it does not, and where the scaling sweet spot is.
+sidebar_position: -1
+category: Concepts
+---
+
+<Info title="What this page covers">
+
+Whether zfb is the right tool for your project — including an honest
+look at what it is not good at. Cross-linked to the
+[architecture overview](/architecture/build-engine), the
+[getting-started guide](/getting-started), and the scaling note in the
+[README](https://github.com/Takazudo/zudo-front-builder#limits).
+
+</Info>
+
+zfb is a focused tool. It solves a specific problem well, and it
+deliberately leaves other problems to other tools. This page maps that
+out so you can make the call before you invest time.
+
+## When zfb fits well
+
+zfb is a strong match if most of the following describe your project:
+
+**Content-heavy, statically generated site.** Your source of truth is
+Markdown or MDX files in a repository. You want a build step that turns
+those files into static HTML, and you want that build to be fast and
+deterministic. zfb's entire architecture is shaped around this case.
+
+**Per-page dependency graph.** You have hundreds of pages and you do
+not want a full rebuild on every edit. zfb tracks which source files
+each page depends on and rebuilds only the affected pages when
+something changes. The dependency graph (`crates/zfb-graph`) is a
+first-class part of the engine, not a bolt-on.
+
+**Workerd-shaped output bundle.** Your target is Cloudflare Workers or
+Pages. zfb's build-time JS host is V8-based (via embedded V8), the
+same engine family as workerd. The content snapshot and island bundles
+are sized for that environment. If you deploy to Workers, you get a
+bundle shape that actually fits.
+
+**Cloudflare Pages–friendly deployment.** Static output from
+`zfb build` drops directly into a Pages deployment. There is no server
+runtime to manage, no serverless function to configure, and no adapter
+layer. The built `dist/` is the deployment artifact.
+
+**Light interactive islands.** Your pages are mostly static documents
+with a small number of interactive components — a search box, a
+counter, a modal trigger. zfb's islands model (`"use client"`) ships
+exactly the JS for the islands each page uses and nothing else. A page
+with no islands ships zero bytes of client JS.
+
+## Comparison
+
+| | **zfb** | **Astro** | **Next.js** |
+|---|---|---|---|
+| CLI language | Rust | Node.js | Node.js |
+| TSX compile | SWC (embedded) | Vite/Rollup | SWC/Webpack |
+| Bundler | esbuild (islands) | Vite | Webpack/Turbopack |
+| Build-time JS host | Embedded V8 | Node.js | Node.js |
+| Client framework | Any TSX (`"use client"`) | Any (adapters) | React |
+
+The most meaningful difference is the **build-time JS host**. zfb uses
+embedded V8 directly — the same engine family as Cloudflare's workerd.
+Astro and Next.js both build in a full Node.js process. For
+Workers-targeted deployments, zfb's host is closer to the target
+runtime, which means fewer surprises around global availability and
+module resolution.
+
+## When to pick something else
+
+zfb is the wrong choice in several cases — be honest with yourself
+before committing.
+
+**Your site is primarily server-rendered or driven by dynamic data.**
+zfb is an SSG engine. Every page is computed at build time and written
+to `dist/` as static HTML. There is no per-request rendering, no API
+routes, and no database-query layer. If your pages change per-user or
+on every request, you need a full SSR framework.
+
+**You need broad multi-framework support.** Astro's adapter ecosystem
+lets you swap between React, Vue, Svelte, Solid, and others inside the
+same site. zfb's client side is TSX (React or Preact). If your team
+owns components in multiple frameworks and you want them all in one
+site, zfb is not the right host.
+
+**You have 100 000+ pages.** zfb builds an in-memory content snapshot
+and embeds it into the V8 host for the duration of the render pass.
+For hundreds or low thousands of MDX files this fits comfortably in
+default workerd memory. For very large corpora — tens of thousands of
+entries, or entries with multi-megabyte bodies — V8 RSS grows linearly
+with snapshot size. At that scale the snapshot design needs rethinking
+(see the [Scaling sweet spot](#scaling-sweet-spot) section below), and
+zfb does not solve that problem today.
+
+**You want a stable, production-hardened tool right now.** zfb is in
+v0. The core primitives work, but the rendering pipeline, islands
+wiring, and CSS extraction are still being connected. If you need a
+proven, documented, community-backed SSG today,
+[Astro](https://astro.build) is the right answer. Come back to zfb
+when it hits v1.
+
+## Scaling sweet spot
+
+The engine is designed for **hundreds to low thousands of MDX pages**.
+That covers:
+
+- A typical documentation site (50–500 pages)
+- A developer blog with a years-long archive (100–2000 posts)
+- A `zudo-doc`-scale content set
+
+At those sizes the content snapshot is small, cold-start build time
+is measured in seconds, and the dependency graph keeps incremental
+rebuilds fast regardless of total page count.
+
+**Beyond roughly 10 000 pages**, the snapshot-in-memory approach
+becomes the bottleneck. The right answer at that scale is not to build
+a larger monolith — it is to shard the content into multiple zfb
+projects (one per section, one per locale, one per content type) and
+compose them at the CDN layer. That composition story is on the roadmap
+but is not implemented today.
+
+To inspect the actual snapshot footprint of your build:
+
+```sh
+ZFB_DEBUG_SNAPSHOT=1 pnpm exec zfb build
+```
+
+This prints a single line to stderr:
+
+```
+content snapshot: 187 entries / 412 KB
+```
+
+`KB` here is the byte size of the deterministic JSON serialization —
+a reliable proxy for V8 heap cost. Watch this number as your content
+grows. If it climbs past a few hundred megabytes, you are approaching
+the edge of the sweet spot. The full explanation of the memory model
+lives in the [README scaling note](https://github.com/Takazudo/zudo-front-builder#limits).
+
+## Where to go next
+
+- [Getting started](/getting-started) — scaffold your first site.
+- [Architecture: Build engine](/architecture/build-engine) — how the
+  Rust crates, the JS host, and the snapshot fit together.
+- [Engine vs Framework](/concepts/engine-vs-framework) — the six
+  primitives zfb commits to, and what lives outside the engine.

--- a/docs/src/content/docs/concepts/incremental-rebuild.mdx
+++ b/docs/src/content/docs/concepts/incremental-rebuild.mdx
@@ -74,7 +74,7 @@ The orchestrator (`crates/zfb-build`) receives the `DirtySet` and feeds it into 
 
 The combined effect: a content edit that touches two pages produces two HTML writes, one live-reload event, and no island bundling. A header component edit produces writes for every page that imports the header, but still only those pages.
 
-For a deeper look at the orchestrator design, see [Build engine](/docs/architecture/build-engine).
+For a deeper look at the orchestrator design, see [Build engine](/architecture/build-engine).
 
 ## Comparison to Astro's dev model
 
@@ -87,7 +87,7 @@ zfb's model differs in granularity level:
 
 For a content-heavy site the distinction matters: editing one MDX file in Astro can trigger a Content Layer reload that re-parses every collection entry before the page re-renders. zfb routes the change through the graph, finds the two pages that consume that entry, and renders only those without touching the snapshot for other entries.
 
-For the broader architecture picture, see [Architecture overview](/docs/concepts/engine-vs-framework).
+For the broader architecture picture, see [Architecture overview](/concepts/architecture-overview).
 
 ## Honest current bottlenecks
 

--- a/docs/src/content/docs/concepts/incremental-rebuild.mdx
+++ b/docs/src/content/docs/concepts/incremental-rebuild.mdx
@@ -1,0 +1,135 @@
+---
+title: Incremental rebuild
+description: "How zfb's dependency graph limits each rebuild to the pages actually affected by a file change."
+sidebar_position: 7
+category: Concepts
+---
+
+Edit one file, rebuild only the pages that depend on it. This page explains how that guarantee works, what the graph tracks, where the wins are real, and where the current costs live.
+
+## The promise
+
+When you save `content/blog/post-3.md` during `zfb dev`, zfb does not rebuild every page on your site. It asks the dependency graph which pages imported that file, and re-renders only those — typically one or two pages in a content-heavy blog.
+
+A concrete example: a 500-page site with a blog index (`pages/blog/index.tsx`) and per-post pages (`pages/blog/[slug].tsx`) consuming a `blog` collection. Saving `content/blog/post-3.md` dirties `pages/blog/index.tsx` (lists all posts) and the single post page that renders that slug — two pages, not five hundred.
+
+The graph makes this precise. It is not a heuristic or a cache invalidation timeout — each page is rebuilt if and only if a recorded dependency changed.
+
+## What zfb-graph tracks
+
+`crates/zfb-graph` maintains two layers of dependency information.
+
+**Source-level deps (per-page):**
+
+Each page is assigned a `PageId` (its source `.tsx` path). The graph records every file that page depends on, tagged with a `DepKind`:
+
+| Kind | Examples |
+|---|---|
+| `Module` | TSX/TS layouts, components, lib files |
+| `Content` | Markdown/MDX entries via content collections |
+| `Style` | CSS sources, CSS modules |
+| `Data` | JSON/TOML/YAML data modules |
+| `Asset` | Static files under `public/` |
+
+The reverse index maps every dependency path back to the set of pages that consume it. This is the index that `dirty_pages()` queries.
+
+**Asset-level deps (per-page):**
+
+Alongside the source graph, each page also carries an `AssetDeps` record:
+
+- `islands` — the stable component identifiers of every `"use client"` island the page hydrates.
+- `css_modules` — the CSS-Modules source paths the page imports.
+
+This second layer answers a different question: not "which pages re-render?" but "which asset bundles re-emit?" A change to a `"use client"` component tells the graph which page-scoped islands bundles to invalidate without re-rendering every page that ships JS.
+
+The graph updates both layers after every successful render, so the next query always has a current picture.
+
+## DirtySet
+
+When a file changes, the build orchestrator calls `DependencyGraph::dirty_pages(path)` (or the batch variant `dirty_pages_batch` for bursts of changes). The return type is `DirtySet`:
+
+```rust
+pub enum DirtySet {
+    /// Rebuild every page. Triggered by global files like zfb.config.ts.
+    All,
+    /// Rebuild exactly this set of pages. May be empty.
+    Specific(BTreeSet<PageId>),
+}
+```
+
+**`DirtySet::Specific`** is the common case. The graph performs a reverse-index lookup in O(consumers) time and returns only the pages that imported the changed path.
+
+**`DirtySet::All`** is the nuclear option. Files registered via `DependencyGraph::mark_global()` always return `All` regardless of recorded edges. `zfb.config.ts` is globally registered by default. Other candidates include top-level `_app.tsx` or `_document.tsx` — anything whose change semantically affects every page.
+
+Unknown paths (a file the graph has never seen as a dependency) return an empty `DirtySet::Specific`. Nothing to rebuild, nothing happens.
+
+## What the dev pipeline does with the dirty set
+
+The orchestrator (`crates/zfb-build`) receives the `DirtySet` and feeds it into the dev pipeline (`DevAssetPipeline`):
+
+1. **Re-render dirty pages only.** The pipeline calls the renderer for the pages in `DirtySet::Specific`. Pages not in the set are untouched.
+2. **Skip writes when HTML is byte-identical.** After rendering, each page's new HTML is compared to the last-known bytes. If the bytes match, the file is not written and the page is not included in the reload signal. A pure refactor that produces no semantic HTML change produces no browser reload.
+3. **Re-bundle islands only when consuming pages changed.** The islands sub-pipeline runs only when the plan's `rerun_islands` flag is set — which the orchestrator sets only when a changed file is inside an islands root (e.g. `components/`). A content-only change does not trigger an islands re-bundle.
+4. **Keep filenames stable.** Dev-mode output files use stable names (no content hashes). The browser cache contract does not change between watcher ticks. Content hashing is the production pipeline's job.
+
+The combined effect: a content edit that touches two pages produces two HTML writes, one live-reload event, and no island bundling. A header component edit produces writes for every page that imports the header, but still only those pages.
+
+For a deeper look at the orchestrator design, see [Build engine](/docs/architecture/build-engine).
+
+## Comparison to Astro's dev model
+
+Astro uses Vite under the hood. Vite's hot module replacement (HMR) invalidates modules, walks the module import graph to find affected ESM boundaries, and pushes updates to the browser over a WebSocket. The centralized Content Layer caches parsed content in a SQLite store and reloads on collection changes.
+
+zfb's model differs in granularity level:
+
+- **Astro's unit of invalidation is an ES module.** A change invalidates the module and the bundler decides which chunks to re-emit based on the module graph.
+- **zfb's unit of invalidation is a page.** The dependency graph is keyed on rendered output, not on modules, so a shared component change dirties exactly the pages that produce HTML — not the full import closure.
+
+For a content-heavy site the distinction matters: editing one MDX file in Astro can trigger a Content Layer reload that re-parses every collection entry before the page re-renders. zfb routes the change through the graph, finds the two pages that consume that entry, and renders only those without touching the snapshot for other entries.
+
+For the broader architecture picture, see [Architecture overview](/docs/concepts/engine-vs-framework).
+
+## Honest current bottlenecks
+
+The dependency graph is not the bottleneck. Even with a perfect dirty set (one page to rebuild), two costs are paid on every dev-mode rebuild:
+
+**1. Per-rebuild engine boot.**
+
+zfb renders pages by loading a worker bundle into an embedded V8 host (Node + miniflare + workerd). Each rebuild reloads the renderer — that means a cold Node process start, miniflare initialisation, and workerd spin-up. This overhead is constant regardless of how many pages are dirty. The graph saves you from rendering 500 pages, but it cannot save you from the ~N ms of engine boot that happens before any page renders.
+
+This is not a graph problem. It is a separate optimization axis — keeping the worker hot between ticks, or switching to a persistent renderer host — that is not in scope today.
+
+**2. Worker bundle rebuild on content changes.**
+
+The `ContentSnapshot` (all content collection entries, serialized to JSON) is embedded directly into the worker bundle that the V8 host loads. A content change today triggers a full bundle rebuild, even if only one entry changed. Bundle rebuild time is O(snapshot size), not O(changed entries).
+
+For the project sizes zfb targets — hundreds of MDX files, typical documentation sites — this fits comfortably. Very large content sets will push rebuild time up linearly. The planned mitigations (snapshot patching so only the changed entry is re-serialized, per-collection sharding so each bundle covers one collection) are tracked as future roadmap but are not implemented today.
+
+To measure the snapshot footprint of a build, set `ZFB_DEBUG_SNAPSHOT=1`:
+
+```sh
+ZFB_DEBUG_SNAPSHOT=1 pnpm exec zfb build
+```
+
+This prints a line to stderr like:
+
+```
+content snapshot: 187 entries / 412 KB
+```
+
+See the [README's snapshot section](https://github.com/Takazudo/zudo-front-builder#limits) for the full measurement guide and the planned sharding work.
+
+## Scaling sweet spot
+
+The table below gives a rough feel for where the current architecture is comfortable and where it hurts. Numbers are order-of-magnitude estimates — actual times depend on hardware, content entry sizes, and component depth.
+
+| Site size | Cold-start boot | Graph lookup | Pages re-rendered | Overall feel |
+|---|---|---|---|---|
+| ~100 pages, ~100 content entries | Fast | Instant | 1–3 | Instant save-to-reload |
+| ~1 000 pages, ~1 000 entries | Fast | Instant | 1–5 | Snappy; snapshot size still small |
+| ~10 000 pages, ~5 000 entries | Fast | Instant | 1–10 | Noticeable; snapshot rebuild is the cost |
+| ~100 000+ pages | Fast | Instant | 1–many | Linear pain; consider split builds or per-collection sharding |
+
+The graph lookup and page-render columns do not change much with site size — that is the win. The snapshot rebuild column grows with content set size and is the current ceiling. Engine boot is constant overhead that matters most when the dirty set is tiny (one page to render, but still paying the same boot cost).
+
+For sites above the ~10 k line, the advice today is: monitor snapshot size with `ZFB_DEBUG_SNAPSHOT`, keep content entries short, and plan for per-collection sharding when the roadmap delivers it.

--- a/docs/src/content/docs/concepts/islands.mdx
+++ b/docs/src/content/docs/concepts/islands.mdx
@@ -128,7 +128,7 @@ This is a **project-wide setting** — one framework per project. The bundler (`
 
 zfb does not support Vue, Svelte, or Solid. The `FrameworkKind` enum is intentionally a two-variant enum, not a plugin point. If you need a different framework, the escape hatches below cover the common cases.
 
-For a deeper look at how the two adapters work, see [Framework adapters](/docs/architecture/framework-adapters).
+For a deeper look at how the two adapters work, see [Framework adapters](/architecture/framework-adapters).
 
 ## Escape hatches for non-island client JS
 
@@ -189,4 +189,4 @@ CSS-only approaches (`:target`, `:checked` + `<label>`, `@starting-style`) handl
 
 If the honest answer is "I just want a class toggled on click", reach for CSS or a tiny inline script first. Islands for "stateful UI you'd build twice" is the right heuristic.
 
-For more on the pipeline shape, see [Build pipeline](/docs/concepts/build-pipeline) and [Build engine](/docs/architecture/build-engine).
+For more on the pipeline shape, see [Build pipeline](/concepts/build-pipeline) and [Build engine](/architecture/build-engine).

--- a/docs/src/content/docs/concepts/islands.mdx
+++ b/docs/src/content/docs/concepts/islands.mdx
@@ -5,24 +5,18 @@ sidebar_position: 5
 category: Concepts
 ---
 
-<Warning title="v0 status">
-
-The `"use client"` detection and the island bundler are sketched in `crates/zfb-islands` but are not wired into the build output yet. The blocker is the same as the renderer (ADR-001 — the JS runtime decision). See /architecture/js-runtime for the deeper discussion.
-
-</Warning>
-
 zfb pages render to static HTML by default. **Islands** are the escape hatch — small components that ship JavaScript to the browser and hydrate on the client, while the rest of the page stays as plain HTML.
 
-The mental model is straightforward: most of your page is a static document. A few interactive bits — a counter, a search box, a modal trigger — are islands embedded inside that document, each loaded and hydrated independently.
+The mental model is straightforward: most of your page is a static document. A few interactive bits — a counter, a search box, a theme toggle — are islands embedded inside that document, each loaded and hydrated independently.
 
-## Marking a component as an island
+## What an island is
 
 Add the `"use client"` directive at the top of a `.tsx` file:
 
 ```tsx
 "use client";
 
-import { useState } from "react";
+import { useState } from "preact/hooks";
 
 export default function Counter() {
   const [count, setCount] = useState(0);
@@ -36,38 +30,163 @@ export default function Counter() {
 
 That single directive is the whole opt-in. Files without it are pure server components — they render once at build time and never reach the browser.
 
-The default template's `components/counter.tsx` is the canonical example to look at when you start.
-
-## Using an island in a page
-
-Import the island and use it like any other component:
+The `examples/basic-blog/components/theme-toggle.tsx` component is the canonical real-world example: it reads `localStorage` and `matchMedia`, manages its own state, and mirrors the active theme to `document.documentElement.dataset.theme`. The key pattern is that it renders a deterministic SSR-safe default on first paint, then syncs to the user preference inside `useEffect`:
 
 ```tsx
-import Counter from "../components/counter";
+"use client";
 
-export default function Home() {
+import { useEffect, useState } from "preact/hooks";
+
+type Theme = "light" | "dark";
+
+export default function ThemeToggle() {
+  // Deterministic SSR-safe default. Real preference is applied in useEffect.
+  const [theme, setTheme] = useState<Theme>("light");
+
+  useEffect(() => {
+    const saved = window.localStorage.getItem("theme");
+    if (saved === "light" || saved === "dark") setTheme(saved);
+  }, []);
+
+  const next: Theme = theme === "dark" ? "light" : "dark";
   return (
-    <main>
-      <h1>Welcome</h1>
-      <p>This paragraph is static HTML.</p>
-      <Counter />
-    </main>
+    <button
+      type="button"
+      aria-pressed={theme === "dark"}
+      onClick={() => setTheme(next)}
+    >
+      {theme === "dark" ? "Light mode" : "Dark mode"}
+    </button>
   );
 }
 ```
 
-The page renders to HTML at build time. The `<Counter />` portion gets a marker in the output that the client bootstrap uses to find and hydrate the island.
+## What esbuild produces for N islands
 
-## How it will work end-to-end
+For a project with three islands (`Counter`, `ThemeToggle`, `SearchBox`), the islands build step emits **four files**:
 
-When the renderer is live, the pipeline for islands looks like this:
+```
+dist/islands/Counter.js
+dist/islands/ThemeToggle.js
+dist/islands/SearchBox.js
+dist/islands/islands-runtime.js
+```
 
-1. **Detection.** During page render, the renderer notes every `"use client"` import as an island reference.
-2. **Bundling.** The build pipeline (`crates/zfb-islands`) compiles each island as a separate ESM bundle via esbuild — one file per island, so a page that uses three islands ships three small bundles instead of one large one.
-3. **Hydration.** The page HTML includes a small inline bootstrap that imports each island bundle and hydrates it when its DOM marker enters view (or immediately, if you opt in with `client:load`).
+Three per-island bundles — one per component — plus a single shared runtime bundle that drives hydration. Each per-island file is a self-contained ESM module: it imports the component and the framework-specific hydration glue (e.g. Preact's `hydrate`) and exports nothing. Sharing between islands happens at the esbuild level within each bundle; the runtime itself is a separate bundle.
 
-The result is that each page only ships the JavaScript for the islands it actually uses, and only when those islands are needed. A page with no islands ships zero bytes of JS.
+**Filenames are stable** — no content hash in the name. The `ProductionAssetPipeline` is the single source of truth for hashing and handles URL rewrites in the emitted HTML; the bundler writes predictable paths so nothing downstream has to guess.
 
-## Today vs. soon
+## How islands are loaded
 
-The `"use client"` convention is real and the bundler is sketched out, but the wiring from page render → island detection → bundle output is part of the ADR-001 work. You can author islands now and they will start hydrating once the runtime lands.
+After render, each island's server-rendered HTML is wrapped in a `<div>` that carries metadata:
+
+```html
+<div data-zfb-island="ThemeToggle"
+     data-props="{}"
+     data-when="load">
+  <!-- server-rendered island HTML -->
+  <button type="button" aria-pressed="false">Dark mode</button>
+</div>
+```
+
+On pages that have at least one island, **one `<script>` tag** is injected into `<head>`:
+
+```html
+<script type="module" src="/islands/islands-runtime.js"></script>
+```
+
+The runtime (`islands-runtime.js`) walks all `[data-zfb-island]` elements on the page. For each element it finds, it `dynamic-import()`s the matching per-island bundle — `/islands/ThemeToggle.js` for `data-zfb-island="ThemeToggle"` — reads the serialised `data-props`, and calls `hydrate()` on the existing server-rendered DOM.
+
+## Consequences of the dynamic-import design
+
+Because the runtime resolves islands lazily via `import()`:
+
+- **Only the islands a page actually uses are fetched.** A page that uses `ThemeToggle` never downloads `Counter.js` or `SearchBox.js`.
+- **Pages with no islands get no runtime.** If a page's render tree contains no `"use client"` components, the build pipeline skips the `<script>` injection entirely. Zero bytes of JavaScript land on a fully static page.
+- **Adding a new island to one page does not affect other pages.** Because each page's HTML is independent and islands are fetched by name, adding `SearchBox` to the home page leaves every other page's HTML and network traffic unchanged.
+
+The stable filenames reinforce this: a CI deploy adds `SearchBox.js` to the `dist/islands/` directory; all existing `*.js` files stay byte-identical and remain cache-valid in the browser.
+
+## Framework choices
+
+zfb supports two frameworks for islands:
+
+| Config value | Runtime |
+|---|---|
+| `"preact"` (default) | Preact + `preact/jsx-runtime` |
+| `"react"` | React 18 + `react-dom/client` |
+
+Set it once in `zfb.config.ts`:
+
+```ts
+export default {
+  framework: "preact", // or "react"
+};
+```
+
+This is a **project-wide setting** — one framework per project. The bundler (`FrameworkKind` enum in `crates/zfb-islands`) threads the choice through JSX transform options (`--jsx-import-source`) and the hydration glue that wraps each per-island entry. You cannot mix Preact islands and React islands in the same project.
+
+zfb does not support Vue, Svelte, or Solid. The `FrameworkKind` enum is intentionally a two-variant enum, not a plugin point. If you need a different framework, the escape hatches below cover the common cases.
+
+For a deeper look at how the two adapters work, see [Framework adapters](/docs/architecture/framework-adapters).
+
+## Escape hatches for non-island client JS
+
+Islands cover stateful UI components. For other client-side JavaScript needs, use the standard HTML mechanisms directly.
+
+**Inline scripts** — write a `<script>` tag directly in your page TSX or layout:
+
+```tsx
+export default function Layout({ children }) {
+  return (
+    <html>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `document.documentElement.dataset.theme = localStorage.getItem('theme') ?? 'light';`,
+          }}
+        />
+      </head>
+      <body>{children}</body>
+    </html>
+  );
+}
+```
+
+This is the right tool for synchronous pre-hydration work that must run before the stylesheet parses (FOUC prevention, theme init, analytics setup).
+
+**External scripts** — reference any `.js` file from `public/` or a CDN:
+
+```tsx
+<script src="/scripts/analytics.js" defer />
+<script src="https://cdn.example.com/lib.js" defer />
+```
+
+**Custom build steps** — if you need to bundle additional TypeScript modules, add a separate esbuild or Rollup step to your build pipeline and reference the output from a `<script src>`. zfb does not auto-bundle arbitrary non-`"use client"` modules — only the islands pipeline runs automatically.
+
+What you **cannot** do: import a regular (non-`"use client"`) `.ts` or `.tsx` module from a page and expect its browser-side code to reach the client. Modules without the directive are server-only — SWC compiles and evaluates them at build time, and none of their bytes are included in the output.
+
+## When not to use islands
+
+Islands ship JavaScript. That has a cost. Before adding one, ask whether you can solve the problem without it.
+
+**DOM class-swap toggles** — accordions, disclosure menus, show/hide panels — are often solved with a few lines of plain CSS or a small inline `<script>`. The native `<details>` / `<summary>` element handles accordion behaviour with no JavaScript at all:
+
+```html
+<details>
+  <summary>Frequently asked question</summary>
+  <p>The answer goes here.</p>
+</details>
+```
+
+CSS-only approaches (`:target`, `:checked` + `<label>`, `@starting-style`) handle many interactive patterns that previously required JavaScript.
+
+**Islands are the right tool when:**
+
+- The component has state that must survive beyond a single interaction (e.g., a cart, a user session, a multi-step form).
+- The component relies on browser APIs not available at build time (`canvas`, `WebGL`, `getUserMedia`, real-time data).
+- You would otherwise write the component twice — once for the server render, once for the client — and keep them in sync manually.
+
+If the honest answer is "I just want a class toggled on click", reach for CSS or a tiny inline script first. Islands for "stateful UI you'd build twice" is the right heuristic.
+
+For more on the pipeline shape, see [Build pipeline](/docs/concepts/build-pipeline) and [Build engine](/docs/architecture/build-engine).

--- a/docs/src/content/docs/getting-started/index.mdx
+++ b/docs/src/content/docs/getting-started/index.mdx
@@ -3,10 +3,45 @@ title: Welcome
 sidebar_position: 1
 ---
 
-# Welcome to Docs
+zfb (zudo-front-builder) is a static-site framework where you write pages in TSX and the build produces plain HTML — no Node.js or server required at runtime.
 
-This documentation site was created with [zudo-doc](https://github.com/zudolab/zudo-doc).
+## What zfb is
 
-## Getting Started
+zfb is a **build-time engine**. You write pages and components in TSX; zfb compiles them with SWC, renders them through a V8-based runtime during the build, and writes the output to `dist/` as static HTML. Once built, the site is a folder of files — no application server, no runtime dependency.
 
-Edit the files in `src/content/docs/` to add your documentation.
+The engine is written in Rust. Rust handles orchestration, file-watching, content parsing, routing, and atomic writes. Node.js (via a miniflare/workerd worker) is the render runtime during `zfb dev` and `zfb build` — it evaluates your compiled TSX and returns HTML strings. When you deploy the built output, nothing from that toolchain is needed on the host.
+
+## What you write
+
+Your project has a `pages/` directory. Each file in it is a route. A page is a `.tsx` file that exports a React component as its default export, plus an optional `meta` export for `<head>` data:
+
+```tsx
+// pages/index.tsx
+export const meta = { title: "Home" };
+
+export default function Home() {
+  return <h1>Hello from zfb</h1>;
+}
+```
+
+Components, layouts, and content collections live alongside `pages/` in their own directories. The entire authoring surface is TypeScript and JSX — no framework-specific template syntax or custom file formats to learn.
+
+## What the build produces
+
+`zfb build` produces static HTML in `dist/`. Each route becomes an `.html` file. Interactive fragments — [Islands](/concepts/islands) — ship their own small JS bundles and hydrate in the browser. Pages with no interactive components ship zero bytes of JavaScript.
+
+The engine rebuilds only the pages affected by each file change, not the whole site, so dev-loop latency stays in the tens of milliseconds even for large sites. See [Build engine](/architecture/build-engine) for the full picture of how the crates fit together.
+
+## What problems it solves
+
+**Build speed.** zfb's orchestration is a tight Rust loop over a dependency graph. A shared header change in a 2,000-page site touches only the pages that import it.
+
+**Distribution.** The framework ships as a single binary. No `node_modules` for zfb itself, no transitive package tree to audit. Your project's own dependencies are still managed via pnpm — zfb just isn't one of them.
+
+**Authoring simplicity.** TSX is the only authoring surface. Content collections work the same whether a file is `.md`, `.mdx`, or `.tsx`. There is no framework-specific config layer or plugin API to learn before you can ship a page.
+
+**Clear scope.** zfb is an [engine, not a framework](/concepts/engine-vs-framework). It commits to six primitives — frontmatter, content collections, dynamic routes, MDX components, non-HTML pages, and the content-query bridge — and stops there. Sidebars, search, theming, and i18n are your project's responsibility, which means they're under your control.
+
+## What to read next
+
+Start with [Installation](/getting-started/installation) to build and install the CLI. Then work through [Your first site](/getting-started/your-first-site) to scaffold a project and see an end-to-end build. For a deeper understanding of the system, read [Engine vs Framework](/concepts/engine-vs-framework) to understand zfb's scope, [Build engine](/architecture/build-engine) for how the Rust crates fit together, and [Islands](/concepts/islands) for how interactive components work. If you are moving an existing site, [Migrating from Astro](/guides/migrating-from-astro) maps concepts side by side.

--- a/docs/src/content/docs/guides/desktop-deployment.mdx
+++ b/docs/src/content/docs/guides/desktop-deployment.mdx
@@ -1,0 +1,125 @@
+---
+title: Desktop Deployment
+description: How to ship a zfb-built site inside a Tauri, Electron, or similar desktop application.
+sidebar_position: 6
+---
+
+This guide covers what is realistic today when you want to embed a zfb site
+inside a desktop app. The short answer is: **the `dist/` output requires no
+Node.js at runtime**, so shipping a pre-built site is straightforward. Enabling
+live content edits inside the app is a different, harder problem.
+
+## The simple case: ship the static output
+
+`zfb build` produces a fully static site in `dist/` — HTML, CSS, and JavaScript
+files with no server-side dependency at runtime. A desktop app can serve that
+directory directly using the framework's built-in asset server.
+
+For **Tauri**, the relevant `tauri.conf.json` keys are:
+
+```json
+{
+  "build": {
+    "distDir": "../dist",
+    "devPath": "http://localhost:4321"
+  }
+}
+```
+
+Point `distDir` at your `dist/` folder (adjust the relative path to match your
+project layout). Tauri's built-in static file server handles the rest. There is
+no Node.js process, no miniflare worker, and no HTTP server required in the
+packaged app — just files on disk.
+
+This is the **recommended approach** for documentation apps, help systems, and
+any desktop app where the content is authored at build time and bundled with the
+release:
+
+1. Run `zfb build` on the developer machine (or in CI).
+2. Include the resulting `dist/` in your Tauri app bundle.
+3. Ship it. Done.
+
+See the [Tauri `tauri.conf.json` reference](https://tauri.app/v1/api/config/) for
+the full set of asset-serving options, including custom protocols and security
+policies.
+
+## The harder case: rebuild content inside the app
+
+Some desktop apps want to let users edit Markdown files locally and see a live
+preview inside the app — essentially running `zfb dev` from within a packaged
+Tauri or Electron window.
+
+This is where the current constraint surfaces: **zfb's build and dev tooling
+requires Node.js**. The dev server spins up a miniflare worker to evaluate your
+TSX page modules. Miniflare is a Node.js process; it cannot run without one.
+
+If you need in-app rebuilds today, the realistic options are:
+
+**Bundle Node.js with the app.** Tauri does not officially support shipping a
+Node.js sidecar, but Electron does — the entire framework runs on Node.js, so
+`zfb dev` runs naturally inside an Electron process. The cost is a significant
+binary size increase and a more complex packaging story.
+
+**Ship `workerd` as a Tauri sidecar.** `workerd` (Cloudflare's open-source
+Workers runtime, the engine behind miniflare) is a standalone C++ binary with no
+Node dependency. Tauri's sidecar mechanism can launch and manage it. This is
+architecturally cleaner than bundling Node.js, but it requires writing a custom
+bridge between `workerd` and zfb's build pipeline — that integration does not
+exist out of the box today.
+
+**Pre-build on the developer machine; embed the result.** Rather than rebuilding
+inside the app, keep the rebuild workflow on developer machines and ship only
+the `dist/` artifacts. The packaged app delivers a snapshot; users who need
+updated content get a new app release. This is the most conservative option and
+the easiest to reason about.
+
+The core invariant to keep in mind:
+
+> **Build time = Node.js required. Runtime = no Node.js, ever.**
+
+zfb's static output is deliberately runtime-agnostic. The build tooling is not.
+Plan your architecture around that boundary rather than against it.
+
+## What about Electron, Wails, or other desktop frameworks?
+
+The story is the same regardless of which desktop framework you use.
+
+- **Electron** — `dist/` works as a static asset directory (use
+  `loadFile()` or a `file://` protocol handler). Running `zfb dev` inside the
+  main process is possible because Electron embeds Node.js, but it means
+  shipping the full zfb build toolchain with your app.
+- **Wails** — embeds a WebView and serves assets from an embedded Go server.
+  Point it at the `dist/` directory. The build-time Node.js requirement is the
+  same as above.
+- **Neutralino, Tauri, or any other framework** with a built-in static file
+  server — ship `dist/`, no runtime dependency on Node.
+
+The `dist/` output is just files. Any framework that can serve files from disk
+works.
+
+## Tauri-specific tips
+
+A few practical notes for Tauri integrations:
+
+**`dist/` as the asset source.** Set `distDir` to point at the `dist/`
+directory zfb produces. During development, set `devPath` to
+`http://localhost:4321` (the default `zfb dev` port) so Tauri loads from the
+live dev server rather than a stale snapshot.
+
+**Content Security Policy.** Tauri's default CSP may block inline scripts. zfb's
+island hydration uses inline `<script type="module">` tags. Relax or extend the
+CSP policy in `tauri.conf.json` if you use islands in your app.
+
+**File paths.** `zfb build` generates absolute-root-relative paths by default
+(`/assets/main.css`). Tauri's custom protocol rewrites these correctly when you
+use the `tauri://` protocol. If you use `file://` directly, you may need to set
+`base` in `zfb.config.ts` to a relative path.
+
+## See also
+
+- [Build pipeline](/concepts/build-pipeline) — how `zfb build` produces `dist/`
+  and what each crate contributes to the output.
+- [Architecture: build engine](/architecture/build-engine) — the crate split and
+  why `dist/` writes are atomic.
+- [Installation](/getting-started/installation) — the Node.js requirement for
+  build and dev tooling is documented here.


### PR DESCRIPTION
## Summary

Docs uplift: 9 documentation updates capturing architectural insights + zfb-wisdom skill for Claude Code.

**Completed topics:**
1. #172 — Rewrite getting-started/index.mdx as landing page
2. #173 — New "Choosing zfb" positioning page
3. #174 — New architecture overview (two-bundle mental model)
4. #175 — Rewrite islands.mdx (deep-dive on bundle layout, hydration, escapes)
5. #176 — Refresh build-engine.mdx (ADR-005, tools/swappability)
6. #177 — New incremental-rebuild concept page (dep-graph, DirtySet, bottlenecks)
7. #178 — New Tauri/desktop deployment guide (honest about build-time Node requirement)
8. #179 — zfb-wisdom skill setup script + docs page + CLAUDE.md mention
9. #180 — New future-directions JS-runtime exploration page (workerd-sidecar, deno_core) 
10. #181 — Confirm pass: cross-links fixed, sidebar order verified, wisdom skill smoke-test passed, currency sweep clean

## Statistics

- **Files changed:** 16
- **Insertions:** 1,256
- **Deletions:** 39
- **New docs pages:** 5 (choosing-zfb, architecture-overview, incremental-rebuild, desktop-deployment, future-directions)
- **Rewritten pages:** 4 (getting-started, islands, build-engine, CLAUDE.md added to docs/)
- **New skill:** zfb-wisdom (setup script + docs page)

## Quality Assurance

✓ Cross-link audit: 10+ broken links fixed in Subs 1–7
✓ Sidebar order: positioned correctly in concept flow
✓ Wisdom-skill: smoke test passed, idempotent script verified
✓ Currency sweep: ADR-001→ADR-005 refs updated, v0 warnings reviewed, deno_core context preserved
✓ Tone consistency: confident, concrete, no marketing fluff across all pages
✓ CI: in progress (will verify before merge)

## Audience Coverage

1. **User developers** (what is zfb, how to use, when to choose): Subs 1, 2, 4, 7, cross-links from 3
2. **Architecture-curious developers + AI agents** (how zfb is built): Subs 3, 5, 6, 10 + zfb-wisdom skill

## Out of Scope (as planned)

- Japanese translations (docs-ja) — tracked separately
- ADR superseding ADR-005 — deno_core framing as exploratory in Sub 10, not committed

---

Ready for review and merge.