### PR TITLE
fix: align snapshot pipeline with bundler to eliminate content-fallback dump (epic zudolab/zudo-doc#1431)

### DIFF
--- a/crates/zfb-content/src/collection.rs
+++ b/crates/zfb-content/src/collection.rs
@@ -206,8 +206,32 @@ where
     let mut errors: Vec<CollectionError> = Vec::new();
 
     for path in files {
+        // Reset per-document pipeline state (e.g. HeadingLinksPlugin's
+        // slug-dedupe counter) before each new entry so cross-document
+        // state cannot leak from one file to the next. This mirrors
+        // the bundler's `materialise_collection` / `materialise_shadow`
+        // walk loops in `crates/zfb-build/src/bundler.rs`. Without
+        // this, the snapshot produced by `build_snapshot` and the
+        // bundler's bridge map disagree on the JSX `content_hash` for
+        // any file processed after a slug-colliding heading earlier in
+        // the same walk — `bridge.get(spec)` then misses and the page
+        // silently falls back to `<pre data-zfb-content-fallback>`.
         // Re-borrow the pipeline for each entry so the loop can use the
         // mutable reference across iterations without consuming it.
+        if let Some(p) = pipeline.as_deref_mut() {
+            p.reset_per_entry();
+            // Per-file source_dir for ResolveLinksPlugin (no-op when
+            // the plugin isn't wired). The bundler does the same in
+            // `crates/zfb-build/src/bundler.rs`'s materialise_*
+            // helpers — without this, relative `[link](./other.mdx)`
+            // references in collection content are emitted as raw
+            // markdown links instead of resolved URLs, which changes
+            // the compiled JSX byte-for-byte and diverges the
+            // snapshot's content_hash from the bundler's.
+            if let Some(parent) = path.parent() {
+                p.set_resolve_links_source_dir(parent.to_path_buf());
+            }
+        }
         match parse_entry::<T>(dir, &path, cache, pipeline.as_deref_mut()) {
             Ok(entry) => entries.push(entry),
             Err(e) => errors.push(e),

--- a/crates/zfb-content/src/content_bridge.rs
+++ b/crates/zfb-content/src/content_bridge.rs
@@ -119,22 +119,102 @@ pub enum BridgeError {
     },
 }
 
+/// Pipeline-shape configuration for [`build_snapshot_with_config`].
+///
+/// The fields here mirror the knobs the bundler passes to
+/// `Pipeline::with_defaults_and_theme` + `add_strip_md_ext` +
+/// `add_resolve_links` in `crates/zfb-build/src/bundler.rs`. The
+/// snapshot walker MUST construct its pipelines with the same shape so
+/// the JSX `content_hash` it bakes into each `EntrySnapshot::module_specifier`
+/// matches the bundler's bridge-map key byte-for-byte. Any divergence
+/// here makes `bridge.get(specifier)` miss and dumps the page into a
+/// `<pre data-zfb-content-fallback>` block.
+///
+/// `Default` reproduces the pre-config-API behaviour (no theme override,
+/// no strip-md-ext, no resolve-links) so existing call sites that don't
+/// need any of these knobs can keep using [`build_snapshot`].
+#[derive(Debug, Clone, Default)]
+pub struct SnapshotPipelineConfig {
+    /// Optional syntect theme name. Forwarded to
+    /// [`Pipeline::with_defaults_and_theme`]. `None` keeps the built-in
+    /// default theme.
+    pub code_highlight_theme: Option<String>,
+    /// When true, append [`Pipeline::add_strip_md_ext`] to every
+    /// per-collection pipeline. Match the bundler's `strip_md_ext`
+    /// flag exactly.
+    pub strip_md_ext: bool,
+    /// When `Some`, wire [`Pipeline::add_resolve_links`] with this
+    /// `(absolute path → URL)` map and call
+    /// [`Pipeline::set_resolve_links_source_dir`] per file so internal
+    /// `[link](./other.mdx)` references resolve to URLs. `None` skips
+    /// the plugin entirely.
+    pub resolve_source_map:
+        Option<std::collections::HashMap<std::path::PathBuf, String>>,
+}
+
+impl SnapshotPipelineConfig {
+    /// Construct a pipeline shaped by this config. Used by
+    /// [`build_snapshot_with_config`] once per collection.
+    fn build_pipeline(&self) -> Pipeline {
+        let mut p = Pipeline::with_defaults_and_theme(self.code_highlight_theme.as_deref());
+        if self.strip_md_ext {
+            p.add_strip_md_ext();
+        }
+        if let Some(map) = self.resolve_source_map.as_ref() {
+            p.add_resolve_links(map.clone());
+        }
+        p
+    }
+}
+
 /// Build a deterministic [`ContentSnapshot`] from the configured
-/// collections.
+/// collections, using the **default** pipeline shape (no theme override,
+/// no strip-md-ext, no resolve-links).
+///
+/// **Most callers should prefer [`build_snapshot_with_config`]**, which
+/// accepts a [`SnapshotPipelineConfig`] mirroring the bundler's
+/// pipeline knobs. This zero-arg form exists for unit tests and
+/// fixture-based call sites that don't enable any of the optional
+/// pipeline plugins; it produces snapshot hashes that only match the
+/// bundler when the bundler is also using the default pipeline shape.
+///
+/// See [`build_snapshot_with_config`] for full semantics.
+///
+/// # Errors
+///
+/// Returns [`BridgeError::Walk`] if any underlying walker call fails.
+pub fn build_snapshot(collections: &[CollectionConfig]) -> Result<ContentSnapshot, BridgeError> {
+    build_snapshot_with_config(collections, &SnapshotPipelineConfig::default())
+}
+
+/// Build a deterministic [`ContentSnapshot`] from the configured
+/// collections, using a pipeline whose shape matches the bundler's.
 ///
 /// Walks each collection in `collections` via [`walk_collection`],
-/// driving the walker through a fresh-per-collection
-/// [`Pipeline::with_defaults()`] so the resulting JSX (and the
-/// [`module_specifier`](EntrySnapshot::module_specifier) hash baked from
-/// it) is **byte-identical** to what the bundler emits in
-/// `crates/zfb-build/src/bundler.rs`. Snapshot specifiers must agree
-/// with the bundler's bridge map keys byte-for-byte; otherwise every
-/// `globalThis.__zfb.content.get(specifier)` lookup misses and the page
-/// renders the raw-markdown `<pre data-zfb-content-fallback>` fallback.
-/// Driving both code paths through the same default pipeline shape —
-/// one pipeline per collection, reused across files within that
-/// collection — is what keeps the two hashes in lock-step
-/// (zfb #131 / #132).
+/// driving the walker through a fresh-per-collection [`Pipeline`] built
+/// from `pipeline_config` so the resulting JSX (and the
+/// [`module_specifier`](EntrySnapshot::module_specifier) hash baked
+/// from it) is **byte-identical** to what the bundler emits in
+/// `crates/zfb-build/src/bundler.rs`. Snapshot specifiers MUST agree
+/// with the bundler's bridge-map keys byte-for-byte; otherwise every
+/// `globalThis.__zfb.content.get(specifier)` lookup misses and the
+/// page renders the raw-markdown `<pre data-zfb-content-fallback>`
+/// fallback.
+///
+/// The pipeline shape covered by [`SnapshotPipelineConfig`] must mirror
+/// the bundler's three knobs (theme, strip-md-ext, resolve-links). When
+/// any of them is enabled in the bundler but disabled here, the JSX
+/// content hash diverges and the bridge lookup misses (zfb#188).
+///
+/// Per-collection instantiation matters because some default plugins
+/// (notably `HeadingLinksPlugin`) carry per-document state (the
+/// slug-dedupe `seen` map). Reusing one pipeline across collections
+/// would mean a heading like "Intro" in collection B would slugify to
+/// `intro-1` if collection A already used `intro`, leaking unrelated
+/// collections' headings into B's compiled JSX (and into the hash that
+/// drives `module_specifier`). The bundler's
+/// `materialise_*` helpers also instantiate one pipeline per
+/// collection; this walker matches that shape.
 ///
 /// Each entry is converted into an [`EntrySnapshot`] and the resulting
 /// `Vec` is inserted into a [`BTreeMap`] keyed by collection name.
@@ -158,34 +238,25 @@ pub enum BridgeError {
 /// Returns [`BridgeError::Walk`] if any underlying walker call fails
 /// (typically a malformed frontmatter, schema validation failure, or
 /// MDX compile error inside one of the configured roots).
-pub fn build_snapshot(collections: &[CollectionConfig]) -> Result<ContentSnapshot, BridgeError> {
+pub fn build_snapshot_with_config(
+    collections: &[CollectionConfig],
+    pipeline_config: &SnapshotPipelineConfig,
+) -> Result<ContentSnapshot, BridgeError> {
     let mut out: BTreeMap<String, Vec<EntrySnapshot>> = BTreeMap::new();
 
     for cfg in collections {
-        // Construct a fresh `Pipeline::with_defaults()` per collection,
-        // mirroring the bundler's two call sites at
-        // `crates/zfb-build/src/bundler.rs:734` and `:964` — each
-        // `materialise_*` call hoists its own pipeline outside the
-        // walk loop, so within one collection a single pipeline serves
-        // every entry sequentially while no state leaks across
-        // collection boundaries. Per-collection instantiation matters
-        // because some default plugins (notably `HeadingLinksPlugin`)
-        // carry per-document state (the slug-dedupe `seen` map):
-        // reusing one pipeline across collections would mean a heading
-        // like "Intro" in collection B would slugify to `intro-1` if
-        // collection A already used `intro`, leaking unrelated
-        // collections' headings into B's compiled JSX (and into the
-        // hash that drives `module_specifier`). The snapshot must
-        // agree byte-for-byte with the bundler's bridge map keys (see
-        // the doc comment on `build_snapshot`); the fastest way to
-        // hold that contract is to drive `walk_collection` with the
-        // same pipeline shape the bundler uses.
-        let mut pipeline = Pipeline::with_defaults();
+        let mut pipeline = pipeline_config.build_pipeline();
 
         // The bridge ships frontmatter as raw JSON, so we walk with the
         // no-op `UntypedFrontmatter` schema. See module-level docs for
         // why the parallel walker is implemented as a `T` substitution
         // rather than a duplicate FS traversal.
+        //
+        // `walk_collection_with_cache` resets the pipeline's per-entry
+        // state before each file (zfb#188-followup), so any stateful
+        // plugin in the chain — `HeadingLinksPlugin`'s slug counter
+        // included — starts fresh per document, matching the bundler's
+        // `materialise_*` walk loop.
         let entries: Vec<Entry<UntypedFrontmatter>> =
             walk_collection(&cfg.root, Some(&mut pipeline)).map_err(|source| {
                 BridgeError::Walk {

--- a/crates/zfb-content/src/lib.rs
+++ b/crates/zfb-content/src/lib.rs
@@ -12,8 +12,8 @@ pub mod syntect_highlight;
 pub mod tsx_frontmatter;
 
 pub use content_bridge::{
-    build_snapshot, debug_snapshot_enabled, BridgeError, CollectionConfig, ContentSnapshot,
-    EntrySnapshot,
+    build_snapshot, build_snapshot_with_config, debug_snapshot_enabled, BridgeError,
+    CollectionConfig, ContentSnapshot, EntrySnapshot, SnapshotPipelineConfig,
 };
 
 pub use frontmatter::{FrontmatterError, UnifiedFrontmatter};

--- a/crates/zfb-content/tests/walk_order_determinism.rs
+++ b/crates/zfb-content/tests/walk_order_determinism.rs
@@ -112,6 +112,76 @@ fn with_reset_per_entry_same_heading_always_gets_base_slug() {
     }
 }
 
+/// Verify that `build_snapshot` (the snapshot-side walker) and an
+/// independent compile-with-reset call agree on the JSX content hash
+/// for every entry. Before zfb#188-followup, `walk_collection_with_cache`
+/// did NOT call `Pipeline::reset_per_entry()` between files, so any
+/// stateful plugin (notably `HeadingLinksPlugin`) leaked state from one
+/// entry to the next. The bundler's bridge-map walk DID reset, so the
+/// snapshot's `module_specifier` hash diverged from the bridge-map's
+/// hash and `bridge.get(specifier)` missed, dumping the page into a
+/// `<pre data-zfb-content-fallback>` block.
+///
+/// This test pins the contract end-to-end: build a corpus where many
+/// files share an identical heading slug (`## Setup`), let
+/// `build_snapshot` walk it, then independently compile each file with
+/// a fresh-per-file pipeline and confirm every snapshot specifier hash
+/// matches what the bundler-style compile produces.
+#[test]
+fn build_snapshot_resets_pipeline_per_entry_so_hashes_match_bundler() {
+    use zfb_content::{build_snapshot, CollectionConfig};
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().join("docs");
+    std::fs::create_dir_all(&root).unwrap();
+
+    // Five files with the same `## Setup` heading. Without
+    // `reset_per_entry()`, files 2..5 would receive `setup-1`,
+    // `setup-2`, `setup-3`, `setup-4` slugs — yielding distinct JSX
+    // and distinct content hashes from a fresh-pipeline compile.
+    let bodies = [
+        ("a.mdx", "---\ntitle: A\n---\n\n## Setup\n\nFirst.\n"),
+        ("b.mdx", "---\ntitle: B\n---\n\n## Setup\n\nSecond.\n"),
+        ("c.mdx", "---\ntitle: C\n---\n\n## Setup\n\nThird.\n"),
+        ("d.mdx", "---\ntitle: D\n---\n\n## Setup\n\nFourth.\n"),
+        ("e.mdx", "---\ntitle: E\n---\n\n## Setup\n\nFifth.\n"),
+    ];
+    for (name, body) in &bodies {
+        std::fs::write(root.join(name), body).unwrap();
+    }
+
+    let snap =
+        build_snapshot(&[CollectionConfig::new("docs", &root)]).expect("snapshot ok");
+    let entries = snap.collections.get("docs").expect("docs collection");
+    assert_eq!(entries.len(), 5);
+
+    // Now compile each body the same way the bundler does — with a
+    // `reset_per_entry()` call before each file — and assert the
+    // hashes line up byte-for-byte.
+    let mut bundler_pipeline = Pipeline::with_defaults();
+    for (i, (name, body)) in bodies.iter().enumerate() {
+        bundler_pipeline.reset_per_entry();
+        // Strip frontmatter the same way build_snapshot does.
+        let stripped = body.split_once("---\n").and_then(|(_, rest)| rest.split_once("---\n")).map(|(_, b)| b).unwrap_or(body);
+        let path = root.join(name);
+        let compiled = compile_mdx_to_jsx_module_cached(stripped, &path, None, Some(&mut bundler_pipeline))
+            .expect("compile ok");
+        let snap_entry = &entries[i];
+        let snap_hash = snap_entry
+            .module_specifier
+            .rsplit_once('#')
+            .map(|(_, h)| h)
+            .expect("specifier has hash");
+        assert_eq!(
+            snap_hash, compiled.content_hash,
+            "snapshot hash for {name} ({snap_specifier}) must match bundler-style fresh-pipeline compile ({compiled_hash}). \
+             A divergence here means `bridge.get(specifier)` will miss and the page will fall back to <pre data-zfb-content-fallback>.",
+            snap_specifier = snap_entry.module_specifier,
+            compiled_hash = compiled.content_hash,
+        );
+    }
+}
+
 /// Verify that processing documents in two different orders (simulating
 /// the old unsorted walk vs the sorted walk) produces byte-identical
 /// output when `reset_per_entry()` is called between documents.

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -698,7 +698,22 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
                 )
             })
             .collect();
-        match zfb_content::build_snapshot(&collections) {
+        // Mirror the bundler's pipeline shape (theme, strip-md-ext,
+        // resolve-links). Every plugin the bundler appends to its
+        // `Pipeline::with_defaults_and_theme(...)` MUST also be
+        // appended here, otherwise the JSX content_hash diverges and
+        // `bridge.get(specifier)` misses on every collection page —
+        // dumping the rendered output into a
+        // `<pre data-zfb-content-fallback>` block. See zfb#188.
+        let snapshot_config = zfb_content::SnapshotPipelineConfig {
+            code_highlight_theme: config
+                .code_highlight
+                .as_ref()
+                .and_then(|c| c.theme.clone()),
+            strip_md_ext: config.strip_md_ext,
+            resolve_source_map: build_resolve_source_map_for_snapshot(project_root, config),
+        };
+        match zfb_content::build_snapshot_with_config(&collections, &snapshot_config) {
             Ok(snap) => match serde_json::to_string(&snap) {
                 Ok(json) => Some(json),
                 Err(e) => {
@@ -1279,6 +1294,37 @@ fn strip_jsonc(input: &str) -> String {
         j += 1;
     }
     stripped
+}
+
+/// Build the `(absolute path → URL)` source map the bundler hands to
+/// `ResolveLinksPlugin`, so `build_snapshot_with_config` can drive the
+/// snapshot-side pipeline through the same plugin shape. Returns `None`
+/// when the project doesn't enable `resolveMarkdownLinks`. See zfb#188.
+fn build_resolve_source_map_for_snapshot(
+    project_root: &Path,
+    config: &Config,
+) -> Option<std::collections::HashMap<std::path::PathBuf, String>> {
+    use zfb_content::plugins::util::source_map::{
+        build_docs_source_map, CollectionRoute, DocsSourceMapOptions,
+    };
+    let spec = config.resolve_markdown_links.as_ref()?;
+    if !spec.enabled {
+        return None;
+    }
+    let docs_dir = project_root.join(&spec.docs_dir);
+    let map = build_docs_source_map(DocsSourceMapOptions {
+        collections: vec![CollectionRoute {
+            name: "docs".to_string(),
+            dir: docs_dir,
+            // Match the bundler's hard-coded `/docs/` prefix in
+            // `crates/zfb-build/src/bundler.rs` (`build_docs_source_map`
+            // call). Both paths must produce the same URL strings or
+            // `[link](./other.mdx)` rewrites diverge byte-for-byte and
+            // the snapshot's content_hash drifts from the bundler's.
+            route_prefix: "/docs/".to_string(),
+        }],
+    });
+    Some(map)
 }
 
 /// When `ZFB_DEBUG_SNAPSHOT` is truthy, build the content snapshot from


### PR DESCRIPTION
## Summary

Closes the post-#190 fallback-render regression in downstream
zudo-doc (zudolab/zudo-doc#1431). ~104 doc pages were rendering as
`<pre data-zfb-content-fallback>` blocks because
`globalThis.__zfb.content.get(specifier)` missed for every page that
hit pipeline-shape divergence between the snapshot walker
(`build_snapshot`) and the bundler walker (`materialise_*`).

## Root cause (three contributing factors)

1. `walk_collection_with_cache` (snapshot side) did not call
   `Pipeline::reset_per_entry()` between files. Stateful plugins —
   notably `HeadingLinksPlugin` — accumulated their slug-dedupe
   counter across files, so the second occurrence of `## Setup` got
   `id="setup-1"` instead of `id="setup"`. The bundler resets per
   file (#190); the snapshot did not. Different JSX -> different
   SHA-8 hash -> bridge miss.

2. `build_snapshot` constructed `Pipeline::with_defaults()`
   unconditionally, ignoring the project's `code_highlight_theme`,
   `strip_md_ext`, and `resolveMarkdownLinks` config — while the
   bundler honoured all three via `with_defaults_and_theme` +
   `add_strip_md_ext` + `add_resolve_links`. The dominant divergence
   in zudo-doc2 was `strip_md_ext: true` (the bundler stripped
   `./other.mdx` -> `/path/other/` in `<a>` hrefs; the snapshot left
   them as `./other.mdx`).

3. `zfb`'s build command did not pass any pipeline config to
   `build_snapshot`, so even with the API extension the production
   path would still construct an unconfigured pipeline.

## Fix

Three coordinated changes:

- `crates/zfb-content/src/collection.rs::walk_collection_with_cache`:
  call `pipeline.reset_per_entry()` and
  `pipeline.set_resolve_links_source_dir(parent)` before each file,
  mirroring the bundler's `materialise_*` loops.

- `crates/zfb-content/src/content_bridge.rs`: add
  `SnapshotPipelineConfig` (theme, strip_md_ext, resolve_source_map)
  and `build_snapshot_with_config(collections, config)`. Keep the
  zero-arg `build_snapshot(collections)` as a thin delegating wrapper
  for backward compatibility / unit-test call sites.

- `crates/zfb/src/commands/build.rs`: switch the production-path
  call to `build_snapshot_with_config(...)` and populate the config
  from the project's `code_highlight.theme`, `strip_md_ext`, and
  `resolve_markdown_links` config — exactly the same axes the
  bundler already uses.

## Regression test

`tests/walk_order_determinism.rs::build_snapshot_resets_pipeline_per_entry_so_hashes_match_bundler`
builds a 5-file corpus where every file shares a `## Setup` heading,
walks via `build_snapshot`, and asserts each snapshot specifier hash
matches an independent fresh-pipeline compile. Passes with the fix;
fails without (panics at file 2 with an explicit "snapshot hash
diverged from bundler-style fresh-pipeline compile" message).

## Test plan

- [x] `cargo test --workspace --release` -> 0 new failures (the
      single pre-existing failure in
      `emit_types_dts_with_schemas_matches_golden` is on `f68a9ba`
      WITHOUT this PR's changes; flagged for separate triage).
- [x] Build downstream zudo-doc with the fixed `zfb` binary.
      Before fix: 80+ pages rendered an actual `<pre data-zfb-content-fallback>`
      element. After fix: zero `<pre data-zfb-content-fallback>`
      elements anywhere under `dist/docs` or `dist/ja/docs`.
- [ ] Manager review.

## Followup (out of scope, flagged)

`resolve_markdown_links` config field exists in `crates/zfb/src/config.rs`
but the bundler-input `resolve_markdown_links` field is never set in
`zfb/src/commands/{build,dev}.rs`. My snapshot-side wiring is correct
in shape but currently a no-op until the bundler-side wiring catches
up. Worth a separate issue.

Refs: zfb#187 (walk-order — already fixed in #190 for the bundler
half), zfb#188 (Syntect theme + pipeline-shape exposure for the
snapshot half — closed by this commit).