### PR TITLE
[Embed] Stage framework packages (preact, preact-render-to-string, hono) in zfb binary

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -51,6 +51,24 @@ There are two supported ways to provide it:
 
 See [`crates/zfb-css/README.md`](./crates/zfb-css/README.md) ("Getting the binary") for the full contract and the [`crates/zfb/binaries/README.md`](./crates/zfb/binaries/README.md) for the runtime resolution layout.
 
+## Embedded npm packages
+
+`crates/zfb/build.rs` snapshots a small set of npm packages into `$OUT_DIR/vendor/` at compile time, then `crates/zfb/src/render_pipeline.rs` embeds the snapshot into the binary via `include_dir!`. At `zfb build` / `zfb dev` time, when the consumer has no `node_modules/`, the snapshot is extracted to a tempdir and esbuild resolves bare imports against it. Two groups of packages live in the snapshot:
+
+| Group | Packages | Source | Pin location |
+| --- | --- | --- | --- |
+| `@takazudo/*` (sub #198) | `@takazudo/zfb`, `@takazudo/zfb-runtime` | `packages/<name>/src/` (TypeScript source) | the workspace itself — versions follow `packages/<name>/package.json` |
+| Framework runtimes (sub #209) | `preact`, `preact-render-to-string`, `hono` | `node_modules/.pnpm/<name>@<ver>*/node_modules/<name>/` (published trees) | `pnpm-lock.yaml`; mirrored as `*_VERSION` constants in `crates/zfb/build.rs` |
+
+To bump a framework-runtime version:
+
+1. Update the dependency in the relevant `package.json` (e.g. `packages/zfb-runtime/package.json` for `hono`, `examples/basic-blog/package.json` for `preact`/`preact-render-to-string`).
+2. Run `pnpm install` so `pnpm-lock.yaml` re-resolves.
+3. Update the corresponding `*_VERSION` constant in `crates/zfb/build.rs` to match the new lockfile entry.
+4. Rebuild — the build script re-snapshots the new tree.
+
+`pnpm install --frozen-lockfile` is a hard prerequisite for `cargo build` because the build script reads `node_modules/.pnpm/`. The smoke test `embedded_node_modules_extracts_runtime_layout` (in `crates/zfb/src/render_pipeline.rs`) and the integration test `framework_packages_no_pnpm` (in `crates/zfb/tests/`) both fail with an actionable error if the embedded snapshot drifts away from the pinned versions.
+
 ## Running tests
 
 ```sh

--- a/crates/zfb/binaries/README.md
+++ b/crates/zfb/binaries/README.md
@@ -25,6 +25,28 @@ See `crates/zfb-islands/README.md` for the pinned esbuild version and rationale,
 and `crates/zfb/binaries/esbuild/README.md` for the slot-shape rationale
 (the esbuild slot uses a subdirectory rather than a single file path).
 
+## Embedded npm packages (no on-disk slot)
+
+In addition to the binaries above, `crates/zfb/build.rs` snapshots three
+groups of npm packages directly **into the compiled `zfb` binary** via
+`include_dir!`. They have no `binaries/` slot — they ride inside the
+executable bytes themselves and are extracted to a tempdir at `zfb build`
+/ `zfb dev` time so esbuild can resolve framework imports without a
+consumer-side `node_modules/`.
+
+| Embedded package(s)                      | Sub  | Source                                                                  |
+| ---------------------------------------- | ---- | ----------------------------------------------------------------------- |
+| `@takazudo/zfb`, `@takazudo/zfb-runtime` | #198 | `packages/<name>/src/` (TypeScript source from this workspace)          |
+| `preact`, `preact-render-to-string`      | #209 | `node_modules/.pnpm/<name>@<ver>*/node_modules/<name>/` (published)     |
+| `hono`                                   | #209 | `node_modules/.pnpm/hono@<ver>/node_modules/hono/` (published)          |
+
+The version pins for the framework runtimes (`preact`,
+`preact-render-to-string`, `hono`) are constants near the top of
+`crates/zfb/build.rs` (`PREACT_VERSION`, `PREACT_RTS_VERSION`,
+`HONO_VERSION`); the source of truth is zfb's own `pnpm-lock.yaml`. See
+the "Embedded npm packages" section in `BUILDING.md` for the bump
+procedure.
+
 ## Why no binaries are committed
 
 Binaries are large, platform-specific, and license-bound. They are **never**

--- a/crates/zfb/build.rs
+++ b/crates/zfb/build.rs
@@ -48,6 +48,34 @@ const ESBUILD_VERSION: &str = "0.25.12";
 const TAILWIND_VERSION: &str = "4.2.0";
 
 // ---------------------------------------------------------------------------
+// Framework package version pins (sub #209 — embed framework runtimes)
+//
+// `preact`, `preact-render-to-string`, and `hono` are the runtime framework
+// packages a `zfb`-built app imports at bundle time. They are NOT
+// downloaded by `build.rs`; instead, zfb's own `pnpm install` resolves the
+// versions in `pnpm-lock.yaml`, and `embed_framework_packages()` copies the
+// resolved trees from `node_modules/.pnpm/<name>@<ver>*/node_modules/<name>`
+// into `$OUT_DIR/vendor/<name>/`. The constants below are the contract
+// between zfb and its consumers — bump these whenever you bump the
+// corresponding entry in zfb's `pnpm-lock.yaml`.
+//
+// Source of truth: zfb's own `pnpm-lock.yaml`. To verify alignment, run:
+//
+//   pnpm list preact preact-render-to-string hono --depth 0 -r
+//
+// from the workspace root and confirm the output matches the constants below.
+// ---------------------------------------------------------------------------
+
+/// Pinned `preact` version. Mirror of the `preact` entry in `pnpm-lock.yaml`.
+const PREACT_VERSION: &str = "10.29.1";
+
+/// Pinned `preact-render-to-string` version.
+const PREACT_RTS_VERSION: &str = "6.6.7";
+
+/// Pinned `hono` version (transitive dep of `@takazudo/zfb-runtime`).
+const HONO_VERSION: &str = "4.12.15";
+
+// ---------------------------------------------------------------------------
 // SHA-256 constants — esbuild 0.25.12 (from the npm package binary)
 //
 // These are SHA-256 digests of the *extracted* esbuild binary inside each
@@ -169,16 +197,13 @@ fn fetch_bytes(url: &str) -> Result<Vec<u8>, String> {
         .build()
         .map_err(|e| format!("failed to build HTTP client: {e}"))?;
 
-    let response = client
-        .get(url)
-        .send()
-        .map_err(|e| {
-            format!(
-                "network error fetching `{url}`: {e}\n\
+    let response = client.get(url).send().map_err(|e| {
+        format!(
+            "network error fetching `{url}`: {e}\n\
                  Hint: if no network is available, set ZFB_ESBUILD_BIN and \
                  ZFB_TAILWIND_BIN to paths of manually-downloaded binaries."
-            )
-        })?;
+        )
+    })?;
 
     if !response.status().is_success() {
         return Err(format!(
@@ -248,9 +273,7 @@ fn esbuild_tarball_url(npm_pkg: &str, version: &str) -> String {
     // npm_pkg is "@esbuild/linux-x64"; the basename after the "/" is the
     // scoped package name used in the tarball URL segment.
     let basename = npm_pkg.split('/').last().unwrap_or(npm_pkg);
-    format!(
-        "https://registry.npmjs.org/{npm_pkg}/-/{basename}-{version}.tgz"
-    )
+    format!("https://registry.npmjs.org/{npm_pkg}/-/{basename}-{version}.tgz")
 }
 
 /// Extract a single file from a gzipped tar archive (held in memory).
@@ -310,9 +333,7 @@ fn download_esbuild(platform: Platform, slot_path: &Path) -> Result<(), String> 
     }
 
     let url = esbuild_tarball_url(meta.npm_pkg, ESBUILD_VERSION);
-    println!(
-        "cargo:warning=Downloading esbuild {ESBUILD_VERSION} from {url} ..."
-    );
+    println!("cargo:warning=Downloading esbuild {ESBUILD_VERSION} from {url} ...");
 
     let tgz_bytes = fetch_bytes(&url)?;
     let binary_bytes = extract_from_tgz(&tgz_bytes, meta.tarball_binary_path)?;
@@ -330,8 +351,12 @@ fn download_esbuild(platform: Platform, slot_path: &Path) -> Result<(), String> 
         ));
     }
 
-    stage_binary(slot_path, &binary_bytes)
-        .map_err(|e| format!("failed to stage esbuild binary at {}: {e}", slot_path.display()))?;
+    stage_binary(slot_path, &binary_bytes).map_err(|e| {
+        format!(
+            "failed to stage esbuild binary at {}: {e}",
+            slot_path.display()
+        )
+    })?;
 
     println!(
         "cargo:warning=✓ esbuild {ESBUILD_VERSION} installed at {} (sha256 {actual_sha})",
@@ -381,9 +406,7 @@ fn download_tailwindcss(platform: Platform, slot_path: &Path) -> Result<(), Stri
         "https://github.com/tailwindlabs/tailwindcss/releases/download/v{TAILWIND_VERSION}"
     );
     let url = format!("{release_base}/{asset_name}");
-    println!(
-        "cargo:warning=Downloading tailwindcss {TAILWIND_VERSION} from {url} ..."
-    );
+    println!("cargo:warning=Downloading tailwindcss {TAILWIND_VERSION} from {url} ...");
 
     let binary_bytes = fetch_bytes(&url)?;
 
@@ -399,8 +422,12 @@ fn download_tailwindcss(platform: Platform, slot_path: &Path) -> Result<(), Stri
         ));
     }
 
-    stage_binary(slot_path, &binary_bytes)
-        .map_err(|e| format!("failed to stage tailwindcss binary at {}: {e}", slot_path.display()))?;
+    stage_binary(slot_path, &binary_bytes).map_err(|e| {
+        format!(
+            "failed to stage tailwindcss binary at {}: {e}",
+            slot_path.display()
+        )
+    })?;
 
     println!(
         "cargo:warning=✓ tailwindcss {TAILWIND_VERSION} installed at {} (sha256 {actual_sha})",
@@ -453,9 +480,8 @@ fn stage_binary(dest: &Path, bytes: &[u8]) -> io::Result<()> {
 fn find_workspace_root() -> PathBuf {
     // CARGO_MANIFEST_DIR is set by Cargo to the directory of this crate's
     // Cargo.toml (i.e. crates/zfb/).
-    let manifest_dir = PathBuf::from(
-        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set"),
-    );
+    let manifest_dir =
+        PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set"));
 
     let mut dir = manifest_dir.clone();
     loop {
@@ -513,14 +539,8 @@ fn download_binaries() -> Result<(), String> {
     println!("cargo:rerun-if-changed=crates/zfb-islands/src/esbuild.rs");
     println!("cargo:rerun-if-changed=scripts/fetch-tailwind.mjs");
     // Also rerun when either binary slot file changes.
-    println!(
-        "cargo:rerun-if-changed={}",
-        esbuild_slot.display()
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        tailwind_slot.display()
-    );
+    println!("cargo:rerun-if-changed={}", esbuild_slot.display());
+    println!("cargo:rerun-if-changed={}", tailwind_slot.display());
 
     let platform = detect_platform()?;
 
@@ -534,6 +554,11 @@ fn main() {
     // Sub 198 — embed @takazudo/zfb + zfb-runtime TypeScript source so the
     // installed binary works on a consumer with no node_modules.
     embed_runtime();
+
+    // Sub 209 — embed the framework runtime packages (preact,
+    // preact-render-to-string, hono) so a consumer with no node_modules can
+    // still bundle a page that imports them.
+    embed_framework_packages();
 
     // Sub 197 — download pinned esbuild + tailwindcss standalone binaries.
     if let Err(e) = download_binaries() {
@@ -637,5 +662,150 @@ fn copy_ts_src(src: &Path, dst: &Path) {
                 });
             }
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sub 209 — embed framework runtime packages (preact, preact-render-to-string,
+// hono) so esbuild can resolve them from the embedded extraction with no
+// consumer-side node_modules.
+// ---------------------------------------------------------------------------
+
+/// Copy the published trees of `preact`, `preact-render-to-string`, and `hono`
+/// from zfb's pnpm-installed `node_modules/.pnpm/` store into
+/// `$OUT_DIR/vendor/<pkg>/` so they ride along inside `EMBEDDED_VENDOR` (the
+/// `include_dir!` snapshot in `crates/zfb/src/render_pipeline.rs`). The
+/// extraction at runtime then produces `node_modules/<pkg>/` siblings beside
+/// `node_modules/@takazudo/`, giving esbuild a complete tree to resolve from.
+///
+/// pnpm's content-addressable layout puts each direct dep at
+/// `node_modules/.pnpm/<name>@<version>/node_modules/<name>/`. When a package
+/// has injected peer deps (e.g. `preact-render-to-string`), pnpm appends a
+/// `_<peer>@<peerver>` suffix to the directory name, so we match on the
+/// `<name>@<version>` prefix and accept the first match.
+///
+/// Only files needed at bundle time are copied — `node_modules/` (no nested
+/// deps), `__tests__/`, hidden dirs, and source-map files are filtered out to
+/// keep the embedded snapshot lean. The three packages currently have
+/// no nested deps that need following:
+///
+/// - `preact`: zero runtime deps.
+/// - `preact-render-to-string`: peer-only on `preact` (resolved via the
+///   embedded `node_modules/preact` sibling at runtime).
+/// - `hono`: zero runtime deps.
+///
+/// Source of truth for versions: `pnpm-lock.yaml` (mirrored by the
+/// `*_VERSION` constants near the top of this file).
+fn embed_framework_packages() {
+    let manifest_dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    let workspace_root = manifest_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("could not resolve workspace root from CARGO_MANIFEST_DIR");
+
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let vendor_dir = out_dir.join("vendor");
+    std::fs::create_dir_all(&vendor_dir).expect("failed to create vendor dir");
+
+    let pnpm_store = workspace_root.join("node_modules").join(".pnpm");
+
+    let packages: [(&str, &str); 3] = [
+        ("preact", PREACT_VERSION),
+        ("preact-render-to-string", PREACT_RTS_VERSION),
+        ("hono", HONO_VERSION),
+    ];
+
+    for (name, version) in &packages {
+        let src_pkg = locate_pnpm_pkg(&pnpm_store, name, version).unwrap_or_else(|| {
+            panic!(
+                "framework package `{name}@{version}` not found under {}.\n\
+                 Run `pnpm install --frozen-lockfile` from the workspace root, \
+                 then re-run cargo build.\n\
+                 If the package has been bumped in pnpm-lock.yaml, also update \
+                 the *_VERSION constant in crates/zfb/build.rs.",
+                pnpm_store.display()
+            )
+        });
+
+        let dst_pkg = vendor_dir.join(name);
+        copy_pkg_published(&src_pkg, &dst_pkg);
+
+        // Re-run if the source package contents change (e.g. a `pnpm install`
+        // bump or a deliberate edit during local hacking).
+        println!("cargo:rerun-if-changed={}", src_pkg.display());
+    }
+
+    // The cargo:rustc-env=ZFB_VENDOR_DIR=... line is emitted by
+    // `embed_runtime()` and points at the same `$OUT_DIR/vendor` dir, so the
+    // framework packages we just staged are picked up by the existing
+    // `include_dir!("$ZFB_VENDOR_DIR")` macro in `render_pipeline.rs`.
+}
+
+/// Find the pnpm-store directory for `<name>@<version>` under
+/// `node_modules/.pnpm/`. Accepts either the bare directory name
+/// `<name>@<version>` or any peer-suffixed variant `<name>@<version>_*`.
+fn locate_pnpm_pkg(pnpm_store: &Path, name: &str, version: &str) -> Option<PathBuf> {
+    let exact_prefix = format!("{name}@{version}");
+    let entries = std::fs::read_dir(pnpm_store).ok()?;
+    for entry in entries.flatten() {
+        let entry_name = entry.file_name();
+        let entry_str = entry_name.to_string_lossy();
+        // Accept exact match or `<name>@<version>_<peer-suffix>` variants.
+        let matches = entry_str == exact_prefix
+            || entry_str
+                .strip_prefix(&exact_prefix)
+                .is_some_and(|rest| rest.starts_with('_'));
+        if !matches {
+            continue;
+        }
+        let pkg_dir = entry.path().join("node_modules").join(name);
+        if pkg_dir.is_dir() {
+            return Some(pkg_dir);
+        }
+    }
+    None
+}
+
+/// Recursively copy `src` to `dst`, skipping directories and files that are
+/// dev-only or recursive (so we do not pull a vendored package's own
+/// `node_modules/` into the binary). The filter is intentionally conservative:
+/// we keep `package.json`, every `dist/`, `src/`, and any sibling published
+/// JS / TS / d.ts entry files; we drop nested `node_modules/`, `__tests__/`,
+/// hidden dirs, and `*.map` source maps.
+fn copy_pkg_published(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).expect("failed to create vendor pkg dir");
+    let rd = std::fs::read_dir(src)
+        .unwrap_or_else(|e| panic!("failed to read framework pkg dir {}: {e}", src.display()));
+    for entry in rd.flatten() {
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        // Skip nested node_modules (recursive copy hazard) and hidden files.
+        if name_str == "node_modules" || name_str.starts_with('.') {
+            continue;
+        }
+        // Skip test directories.
+        if name_str == "__tests__" || name_str == "test" || name_str == "tests" {
+            continue;
+        }
+        let ft = match entry.file_type() {
+            Ok(ft) => ft,
+            Err(_) => continue,
+        };
+        if ft.is_dir() {
+            copy_pkg_published(&entry.path(), &dst.join(&name));
+        } else if ft.is_file() {
+            // Drop source maps to keep the embedded snapshot lean. The bundle
+            // does not need them at consumer build time.
+            if name_str.ends_with(".map") {
+                continue;
+            }
+            let dst_file = dst.join(&name);
+            std::fs::copy(entry.path(), &dst_file).unwrap_or_else(|e| {
+                panic!("failed to copy {}: {e}", entry.path().display());
+            });
+        }
+        // Symlinks and other non-regular entries are skipped — the pnpm store
+        // never uses symlinks for the actual published files (only for the
+        // top-level `node_modules/<name>` aliasing, which we don't touch).
     }
 }

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -71,7 +71,7 @@ use crate::config::Config;
 use crate::output;
 use crate::render_pipeline::{
     build_prerender_map, build_route_universe, cfg_framework_to_render, check_runtime_installed,
-    embedded_takazudo_node_modules, eval_deferred_paths_via_worker, expand_dynamic_routes,
+    embedded_node_modules, eval_deferred_paths_via_worker, expand_dynamic_routes,
     DeferredDynamicRoute, RouteUniversePlan, WorkerDispatch,
 };
 
@@ -195,10 +195,7 @@ trait BuildRunner {
     /// + `sourcemap_path`. We return them through
     ///   [`zfb_build::bundler::BundlerOutput`] so production retains the
     ///   full manifest for the renderer's diagnostics path.
-    fn bundle(
-        &self,
-        input: BundlerInput,
-    ) -> Result<BundlerOutput>;
+    fn bundle(&self, input: BundlerInput) -> Result<BundlerOutput>;
 
     /// Evaluate deferred dynamic routes whose `paths()` couldn't be
     /// statically extracted. The production runner starts the embedded V8
@@ -221,7 +218,11 @@ trait BuildRunner {
         deferred: &[DeferredDynamicRoute],
         bundle_out: &BundlerOutput,
         cache: &mut PathsCache,
-    ) -> Result<(crate::render_pipeline::DynamicExpansion, Backend, WorkerHandle)>;
+    ) -> Result<(
+        crate::render_pipeline::DynamicExpansion,
+        Backend,
+        WorkerHandle,
+    )>;
 
     /// Run the renderer. Errors surface verbatim — the CLI relies on
     /// the renderer's
@@ -275,10 +276,7 @@ impl Drop for WorkerHandle {
 /// renderer APIs.
 struct DefaultRunner;
 impl BuildRunner for DefaultRunner {
-    fn bundle(
-        &self,
-        input: BundlerInput,
-    ) -> Result<BundlerOutput> {
+    fn bundle(&self, input: BundlerInput) -> Result<BundlerOutput> {
         bundle(input)
     }
 
@@ -287,14 +285,20 @@ impl BuildRunner for DefaultRunner {
         deferred: &[DeferredDynamicRoute],
         bundle_out: &BundlerOutput,
         cache: &mut PathsCache,
-    ) -> Result<(crate::render_pipeline::DynamicExpansion, Backend, WorkerHandle)> {
+    ) -> Result<(
+        crate::render_pipeline::DynamicExpansion,
+        Backend,
+        WorkerHandle,
+    )> {
         let factory = crate::v8_host_adapter::make_v8_host_factory();
         if deferred.is_empty() {
             // No deferred routes: skip host construction entirely. Return the
             // factory so `render_all` can still boot the host for SSG.
             return Ok((
                 crate::render_pipeline::DynamicExpansion::default(),
-                Backend::EmbeddedV8 { host_factory: factory },
+                Backend::EmbeddedV8 {
+                    host_factory: factory,
+                },
                 WorkerHandle(None),
             ));
         }
@@ -304,7 +308,9 @@ impl BuildRunner for DefaultRunner {
         let mut state = zfb_build::renderer::start(zfb_build::renderer::RendererStartInput {
             bundle_path: bundle_out.bundle_path.clone(),
             sourcemap_path: bundle_out.sourcemap_path.clone(),
-            backend: Backend::EmbeddedV8 { host_factory: factory.clone() },
+            backend: Backend::EmbeddedV8 {
+                host_factory: factory.clone(),
+            },
             request_timeout: None,
         })
         .context("could not start embedded V8 host for runtime paths() evaluation")?;
@@ -329,7 +335,9 @@ impl BuildRunner for DefaultRunner {
         // after render_all.
         Ok((
             expansion,
-            Backend::EmbeddedV8 { host_factory: factory },
+            Backend::EmbeddedV8 {
+                host_factory: factory,
+            },
             WorkerHandle(Some(state)),
         ))
     }
@@ -385,11 +393,7 @@ fn build_default_css_payload(
     // Honour the user's opt-out switch before doing any source
     // discovery work — keeps the default runner free of subprocess
     // cost when the project explicitly does not want Tailwind.
-    let tailwind_enabled = config
-        .tailwind
-        .as_ref()
-        .map(|t| t.enabled)
-        .unwrap_or(true);
+    let tailwind_enabled = config.tailwind.as_ref().map(|t| t.enabled).unwrap_or(true);
     if !tailwind_enabled {
         return Ok(None);
     }
@@ -486,10 +490,7 @@ fn build_default_css_payload(
 /// `<root>/styles/global.css` wins so existing projects on the
 /// original convention see no behaviour change.
 fn resolve_input_global_css(project_root: &Path) -> Option<PathBuf> {
-    const CANDIDATES: &[&[&str]] = &[
-        &["styles", "global.css"],
-        &["src", "styles", "global.css"],
-    ];
+    const CANDIDATES: &[&[&str]] = &[&["styles", "global.css"], &["src", "styles", "global.css"]];
     for parts in CANDIDATES {
         let mut candidate = project_root.to_path_buf();
         for seg in *parts {
@@ -634,9 +635,7 @@ fn build_default_islands_payload(
 
 /// Drive the build for a fully-resolved input set. Returns the number
 /// of pages written.
-fn run_build<R: BuildRunner, A: AdapterRunner>(
-    args: BuildArgsResolved<'_, R, A>,
-) -> Result<usize> {
+fn run_build<R: BuildRunner, A: AdapterRunner>(args: BuildArgsResolved<'_, R, A>) -> Result<usize> {
     let BuildArgsResolved {
         project_root,
         outdir,
@@ -691,12 +690,7 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
         let collections: Vec<zfb_content::CollectionConfig> = config
             .collections
             .iter()
-            .map(|c| {
-                zfb_content::CollectionConfig::new(
-                    c.name.clone(),
-                    project_root.join(&c.path),
-                )
-            })
+            .map(|c| zfb_content::CollectionConfig::new(c.name.clone(), project_root.join(&c.path)))
             .collect();
         // Mirror the bundler's pipeline shape (theme, strip-md-ext,
         // resolve-links). Every plugin the bundler appends to its
@@ -706,10 +700,7 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
         // dumping the rendered output into a
         // `<pre data-zfb-content-fallback>` block. See zfb#188.
         let snapshot_config = zfb_content::SnapshotPipelineConfig {
-            code_highlight_theme: config
-                .code_highlight
-                .as_ref()
-                .and_then(|c| c.theme.clone()),
+            code_highlight_theme: config.code_highlight.as_ref().and_then(|c| c.theme.clone()),
             strip_md_ext: config.strip_md_ext,
             resolve_source_map: build_resolve_source_map_for_snapshot(project_root, config),
         };
@@ -756,12 +747,7 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
     // renderer boot) with a pointer at the offending route.
     let ssr_route_refs: Vec<SsrRouteRef<'_>> = static_routes
         .iter()
-        .filter(|entry| {
-            !prerender_map
-                .get(&entry.route_key)
-                .copied()
-                .unwrap_or(true)
-        })
+        .filter(|entry| !prerender_map.get(&entry.route_key).copied().unwrap_or(true))
         .map(|entry| SsrRouteRef {
             route_key: entry.route_key.as_str(),
             url_path: entry.url_path.as_str(),
@@ -814,7 +800,7 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
         bundler_input.node_modules_dir = Some(nm);
         _embedded_nm_handle = None;
     } else {
-        match embedded_takazudo_node_modules() {
+        match embedded_node_modules() {
             Ok((handle, nm_path)) => {
                 bundler_input.node_modules_dir = Some(nm_path);
                 // esbuild must follow symlinks into the tempdir so that
@@ -854,10 +840,8 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
     // Thread the optional `codeHighlight.theme` from `zfb.config.ts`
     // so the hoisted MDX pre-compile pipeline uses the configured
     // syntect theme instead of the default `base16-ocean.dark`.
-    bundler_input.code_highlight_theme = config
-        .code_highlight
-        .as_ref()
-        .and_then(|c| c.theme.clone());
+    bundler_input.code_highlight_theme =
+        config.code_highlight.as_ref().and_then(|c| c.theme.clone());
     let bundler_out = runner
         .bundle(bundler_input)
         .context("bundler step failed")?;
@@ -881,9 +865,7 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
     warn_deferred_dynamic(&runtime_expansion.deferred);
 
     if static_routes.is_empty() {
-        output::warn(
-            "no routes to render after runtime paths() evaluation; dist will be empty",
-        );
+        output::warn("no routes to render after runtime paths() evaluation; dist will be empty");
         return Ok(0);
     }
 
@@ -1000,8 +982,13 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
     // <out_dir>/<base-segment>/... so URLs emitted via withBase()
     // resolve under the sub-path mount. Missing public/ is silently
     // ignored — not every project has one.
-    copy_public_dir(project_root, outdir, &config.public_dir, config.base.as_deref())
-        .context("public dir copy step failed")?;
+    copy_public_dir(
+        project_root,
+        outdir,
+        &config.public_dir,
+        config.base.as_deref(),
+    )
+    .context("public dir copy step failed")?;
 
     Ok(render_out.ssg_files_written.len())
 }
@@ -1262,9 +1249,7 @@ fn strip_jsonc(input: &str) -> String {
         // Block comment.
         if c == '/' && i + 1 < bytes.len() && bytes[i + 1] as char == '*' {
             i += 2;
-            while i + 1 < bytes.len()
-                && !(bytes[i] as char == '*' && bytes[i + 1] as char == '/')
-            {
+            while i + 1 < bytes.len() && !(bytes[i] as char == '*' && bytes[i + 1] as char == '/') {
                 i += 1;
             }
             i = (i + 2).min(bytes.len());
@@ -1382,10 +1367,7 @@ fn copy_public_dir(
 
     // Strip leading/trailing slashes from the base to get the segment,
     // e.g. "/pj/test/" → "pj/test", "/" → "", None → "".
-    let base_segment = base
-        .map(|b| b.trim_matches('/'))
-        .unwrap_or("")
-        .to_string();
+    let base_segment = base.map(|b| b.trim_matches('/')).unwrap_or("").to_string();
 
     let dest_root = if base_segment.is_empty() {
         outdir.to_path_buf()
@@ -1393,7 +1375,10 @@ fn copy_public_dir(
         outdir.join(&base_segment)
     };
 
-    for entry in walkdir::WalkDir::new(&src).into_iter().filter_map(|r| r.ok()) {
+    for entry in walkdir::WalkDir::new(&src)
+        .into_iter()
+        .filter_map(|r| r.ok())
+    {
         let rel = entry
             .path()
             .strip_prefix(&src)
@@ -1494,7 +1479,11 @@ mod tests {
             deferred: &[DeferredDynamicRoute],
             _bundle_out: &BundlerOutput,
             _cache: &mut PathsCache,
-        ) -> Result<(crate::render_pipeline::DynamicExpansion, Backend, WorkerHandle)> {
+        ) -> Result<(
+            crate::render_pipeline::DynamicExpansion,
+            Backend,
+            WorkerHandle,
+        )> {
             // The fake runner doesn't start a real host; return all deferred
             // routes unchanged (still deferred), and a no-op Stub backend
             // (the fake render_all ignores the backend).
@@ -1524,14 +1513,10 @@ mod tests {
                 Some(assets) => {
                     let mut s = String::new();
                     if let Some(href) = assets.css_url.as_deref() {
-                        s.push_str(&format!(
-                            "<link rel=\"stylesheet\" href=\"{href}\">"
-                        ));
+                        s.push_str(&format!("<link rel=\"stylesheet\" href=\"{href}\">"));
                     }
                     for src in &assets.island_module_urls {
-                        s.push_str(&format!(
-                            "<script type=\"module\" src=\"{src}\"></script>"
-                        ));
+                        s.push_str(&format!("<script type=\"module\" src=\"{src}\"></script>"));
                     }
                     s
                 }
@@ -1628,11 +1613,7 @@ mod tests {
         }
     }
     impl AdapterRunner for FakeAdapterRunner {
-        fn run(
-            &self,
-            package: &str,
-            input: &AdapterBundleInput,
-        ) -> Result<AdapterBundleOutput> {
+        fn run(&self, package: &str, input: &AdapterBundleInput) -> Result<AdapterBundleOutput> {
             self.calls
                 .borrow_mut()
                 .push((package.to_string(), input.clone()));
@@ -1842,7 +1823,11 @@ mod tests {
                 deferred: &[DeferredDynamicRoute],
                 _bundle_out: &BundlerOutput,
                 _cache: &mut PathsCache,
-            ) -> Result<(crate::render_pipeline::DynamicExpansion, Backend, WorkerHandle)> {
+            ) -> Result<(
+                crate::render_pipeline::DynamicExpansion,
+                Backend,
+                WorkerHandle,
+            )> {
                 Ok((
                     crate::render_pipeline::DynamicExpansion {
                         resolved: Vec::new(),
@@ -1957,10 +1942,7 @@ mod tests {
 
         let routes = vec![Route {
             source_path: PathBuf::from("pages/api/foo.tsx"),
-            segments: vec![
-                Segment::Static("api".into()),
-                Segment::Static("foo".into()),
-            ],
+            segments: vec![Segment::Static("api".into()), Segment::Static("foo".into())],
             kind: RouteKind::Static,
             specificity: 0,
             output_extension: None,
@@ -2015,10 +1997,7 @@ mod tests {
             static_route(vec![], "pages/index.tsx"),
             Route {
                 source_path: PathBuf::from("pages/api/foo.tsx"),
-                segments: vec![
-                    Segment::Static("api".into()),
-                    Segment::Static("foo".into()),
-                ],
+                segments: vec![Segment::Static("api".into()), Segment::Static("foo".into())],
                 kind: RouteKind::Static,
                 specificity: 0,
                 output_extension: None,
@@ -2089,15 +2068,16 @@ mod tests {
             static_route(vec![], "pages/index.tsx"),
             static_route(vec!["about"], "pages/about.tsx"),
         ];
-        let runner = FakeRunner::new(outdir.join(".zfb-build/bundle.mjs"))
-            .with_prod_asset_inputs(ProdAssetEmitterInputs {
+        let runner = FakeRunner::new(outdir.join(".zfb-build/bundle.mjs")).with_prod_asset_inputs(
+            ProdAssetEmitterInputs {
                 css: Some(zfb_build::pipeline::AssetEmitterPayload {
                     bytes: b".btn{color:red}".to_vec(),
                     relative_path: PathBuf::from("assets/styles.css"),
                     stable_url: "/assets/styles.css".to_string(),
                 }),
                 islands: None,
-            });
+            },
+        );
         let cfg = Config::default();
         let fake_adapter = FakeAdapterRunner::new();
         run_build(BuildArgsResolved {
@@ -2184,20 +2164,38 @@ mod tests {
         // None ⇒ no mutation.
         let mut inputs = fixture();
         apply_asset_url_base(&mut inputs, None);
-        assert_eq!(inputs.css.as_ref().unwrap().stable_url, "/assets/styles.css");
-        assert_eq!(inputs.islands.as_ref().unwrap().stable_url, "/assets/islands.js");
+        assert_eq!(
+            inputs.css.as_ref().unwrap().stable_url,
+            "/assets/styles.css"
+        );
+        assert_eq!(
+            inputs.islands.as_ref().unwrap().stable_url,
+            "/assets/islands.js"
+        );
 
         // "" ⇒ no mutation.
         let mut inputs = fixture();
         apply_asset_url_base(&mut inputs, Some(""));
-        assert_eq!(inputs.css.as_ref().unwrap().stable_url, "/assets/styles.css");
-        assert_eq!(inputs.islands.as_ref().unwrap().stable_url, "/assets/islands.js");
+        assert_eq!(
+            inputs.css.as_ref().unwrap().stable_url,
+            "/assets/styles.css"
+        );
+        assert_eq!(
+            inputs.islands.as_ref().unwrap().stable_url,
+            "/assets/islands.js"
+        );
 
         // "/" ⇒ no mutation (root-mounted site).
         let mut inputs = fixture();
         apply_asset_url_base(&mut inputs, Some("/"));
-        assert_eq!(inputs.css.as_ref().unwrap().stable_url, "/assets/styles.css");
-        assert_eq!(inputs.islands.as_ref().unwrap().stable_url, "/assets/islands.js");
+        assert_eq!(
+            inputs.css.as_ref().unwrap().stable_url,
+            "/assets/styles.css"
+        );
+        assert_eq!(
+            inputs.islands.as_ref().unwrap().stable_url,
+            "/assets/islands.js"
+        );
 
         // "/pj/zudo-doc/" ⇒ subpath prefix.
         let mut inputs = fixture();
@@ -2258,8 +2256,8 @@ mod tests {
         let outdir = project_root.join("dist");
         make_runtime(project_root);
         let routes = vec![static_route(vec![], "pages/index.tsx")];
-        let runner = FakeRunner::new(outdir.join(".zfb-build/bundle.mjs"))
-            .with_prod_asset_inputs(ProdAssetEmitterInputs {
+        let runner = FakeRunner::new(outdir.join(".zfb-build/bundle.mjs")).with_prod_asset_inputs(
+            ProdAssetEmitterInputs {
                 css: Some(zfb_build::pipeline::AssetEmitterPayload {
                     bytes: b".btn{color:red}".to_vec(),
                     relative_path: PathBuf::from("assets/styles.css"),
@@ -2270,7 +2268,8 @@ mod tests {
                     stable_url: "/assets/styles.css".to_string(),
                 }),
                 islands: None,
-            });
+            },
+        );
         let mut cfg = Config::default();
         cfg.base = Some("/pj/zudo-doc/".to_string());
         let fake_adapter = FakeAdapterRunner::new();
@@ -2351,8 +2350,8 @@ mod tests {
         let outdir = project_root.join("dist");
         make_runtime(project_root);
         let routes = vec![static_route(vec![], "pages/index.tsx")];
-        let runner = FakeRunner::new(outdir.join(".zfb-build/bundle.mjs"))
-            .with_prod_asset_inputs(ProdAssetEmitterInputs {
+        let runner = FakeRunner::new(outdir.join(".zfb-build/bundle.mjs")).with_prod_asset_inputs(
+            ProdAssetEmitterInputs {
                 css: Some(zfb_build::pipeline::AssetEmitterPayload {
                     bytes: b".btn{color:red}".to_vec(),
                     relative_path: PathBuf::from("assets/styles.css"),
@@ -2363,7 +2362,8 @@ mod tests {
                     relative_path: PathBuf::from("assets/islands.js"),
                     stable_url: "/assets/islands.js".to_string(),
                 }),
-            });
+            },
+        );
         let mut cfg = Config::default();
         cfg.base = Some("/pj/zudo-doc/".to_string());
         let fake_adapter = FakeAdapterRunner::new();
@@ -2383,7 +2383,11 @@ mod tests {
             .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
             .collect();
         assets_entries.sort();
-        assert_eq!(assets_entries.len(), 2, "expected both hashed assets; got {assets_entries:?}");
+        assert_eq!(
+            assets_entries.len(),
+            2,
+            "expected both hashed assets; got {assets_entries:?}"
+        );
         let css_name = assets_entries
             .iter()
             .find(|n| n.starts_with("styles-") && n.ends_with(".css"))
@@ -2716,7 +2720,10 @@ mod tests {
             .expect("missing public/ must not error");
         // dist/ contains nothing (no phantom files).
         let entries: Vec<_> = std::fs::read_dir(&outdir).unwrap().collect();
-        assert!(entries.is_empty(), "dist/ must stay empty when public/ is absent");
+        assert!(
+            entries.is_empty(),
+            "dist/ must stay empty when public/ is absent"
+        );
     }
 
     /// Without base, files copy directly under out_dir.
@@ -2726,15 +2733,14 @@ mod tests {
         let project_root = tmp.path();
         let outdir = project_root.join("dist");
         std::fs::create_dir_all(project_root.join("public/img")).unwrap();
-        std::fs::write(
-            project_root.join("public/img/logo.svg"),
-            b"<svg/>",
-        )
-        .unwrap();
+        std::fs::write(project_root.join("public/img/logo.svg"), b"<svg/>").unwrap();
         copy_public_dir(project_root, &outdir, std::path::Path::new("public"), None)
             .expect("copy must succeed");
         let dest = outdir.join("img/logo.svg");
-        assert!(dest.is_file(), "public/img/logo.svg must land at dist/img/logo.svg");
+        assert!(
+            dest.is_file(),
+            "public/img/logo.svg must land at dist/img/logo.svg"
+        );
         assert_eq!(std::fs::read(&dest).unwrap(), b"<svg/>");
     }
 
@@ -2746,11 +2752,7 @@ mod tests {
         let outdir = project_root.join("dist");
         std::fs::create_dir_all(project_root.join("public/img")).unwrap();
         let logo_content = b"<svg id=\"logo\"/>";
-        std::fs::write(
-            project_root.join("public/img/logo.svg"),
-            logo_content,
-        )
-        .unwrap();
+        std::fs::write(project_root.join("public/img/logo.svg"), logo_content).unwrap();
         copy_public_dir(
             project_root,
             &outdir,
@@ -2805,7 +2807,10 @@ mod tests {
             Some("/"),
         )
         .expect("copy must succeed");
-        assert!(outdir.join("favicon.ico").is_file(), "base='/' must copy under root, not under '/'");
+        assert!(
+            outdir.join("favicon.ico").is_file(),
+            "base='/' must copy under root, not under '/'"
+        );
     }
 
     /// Full run_build integration: public/img/logo.svg + base = "/pj/test/"

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -83,8 +83,7 @@ use crate::commands::resolve::{resolve_port, resolve_under_root};
 use crate::config;
 use crate::output;
 use crate::render_pipeline::{
-    build_route_universe, cfg_framework_to_render, check_runtime_installed,
-    embedded_takazudo_node_modules,
+    build_route_universe, cfg_framework_to_render, check_runtime_installed, embedded_node_modules,
 };
 
 /// Default source directories the watcher follows.
@@ -492,7 +491,7 @@ fn boot_dev_renderer(
         bundler_input.node_modules_dir = Some(nm);
         _embedded_nm_handle = None;
     } else {
-        match embedded_takazudo_node_modules() {
+        match embedded_node_modules() {
             Ok((handle, nm_path)) => {
                 bundler_input.node_modules_dir = Some(nm_path);
                 _embedded_nm_handle = Some(handle);
@@ -524,10 +523,7 @@ fn boot_dev_renderer(
     // Thread the optional `codeHighlight.theme` from `zfb.config.ts`
     // so the hoisted MDX pre-compile pipeline uses the configured
     // syntect theme. Mirrors the `commands/build.rs` wiring.
-    bundler_input.code_highlight_theme = cfg
-        .code_highlight
-        .as_ref()
-        .and_then(|c| c.theme.clone());
+    bundler_input.code_highlight_theme = cfg.code_highlight.as_ref().and_then(|c| c.theme.clone());
     let bundler_out: BundlerOutput = bundle(bundler_input).context("bundler step failed")?;
 
     let state = start(RendererStartInput {

--- a/crates/zfb/src/render_pipeline.rs
+++ b/crates/zfb/src/render_pipeline.rs
@@ -61,36 +61,52 @@ use include_dir::{include_dir, Dir};
 use zfb_build::renderer::RouteUniverseEntry;
 use zfb_build::EmbeddedV8Host;
 use zfb_content::extract_tsx_frontmatter;
-use zfb_render::paths::{
-    resolve_paths, PathsCache, PathsError, Segment as PathsSegment,
-};
+use zfb_render::paths::{resolve_paths, PathsCache, PathsError, Segment as PathsSegment};
 use zfb_render::paths_extract::{extract_paths, PathsExtractError, PathsExtraction};
 use zfb_router::{Route, RouteKind, Segment};
 
 // ---------------------------------------------------------------------------
-// Embedded @takazudo/zfb + @takazudo/zfb-runtime packages
+// Embedded @takazudo/* + framework runtime packages
 // ---------------------------------------------------------------------------
 //
-// The `build.rs` script copies `packages/zfb/src` and `packages/zfb-runtime/src`
-// (plus each package.json) into `$OUT_DIR/vendor/@takazudo/` and emits the env
-// var `ZFB_VENDOR_DIR` pointing at `$OUT_DIR/vendor`. The `include_dir!` macro
-// then embeds that tree in the binary at compile time.
+// The `build.rs` script populates `$OUT_DIR/vendor/` with two groups of
+// packages:
 //
-// At runtime, `embedded_takazudo_node_modules()` extracts this tree into a
-// freshly allocated tempdir shaped as a proper `node_modules/@takazudo/` layout,
-// ready for esbuild resolution. The tempdir is kept alive for the duration of
-// the build by returning the `TempDir` handle alongside the path.
+// 1. `@takazudo/zfb` and `@takazudo/zfb-runtime` (sub #198): TypeScript source
+//    of the runtime packages, copied from the `packages/` workspace dirs.
+// 2. `preact`, `preact-render-to-string`, `hono` (sub #209): published trees
+//    copied from zfb's pnpm-installed `node_modules/.pnpm/<name>@<ver>*/` so
+//    consumers without their own node_modules can still resolve framework
+//    imports.
+//
+// Both groups land as siblings under `$OUT_DIR/vendor/`:
+//
+//   $OUT_DIR/vendor/
+//     @takazudo/zfb/             (TS source + package.json)
+//     @takazudo/zfb-runtime/     (TS source + package.json)
+//     preact/                    (published dist/ + package.json + ...)
+//     preact-render-to-string/   (published dist/ + package.json + ...)
+//     hono/                      (published dist/ + package.json)
+//
+// `build.rs` emits `cargo:rustc-env=ZFB_VENDOR_DIR=<this dir>` so the
+// `include_dir!` macro below embeds the whole tree at compile time.
+//
+// At runtime, [`embedded_node_modules`] extracts the tree into a freshly
+// allocated tempdir shaped as a proper `node_modules/<pkg>/` layout, ready
+// for esbuild resolution. The tempdir is kept alive for the duration of the
+// build by returning the `TempDir` handle alongside the path.
 
-/// Compile-time embedding of `$OUT_DIR/vendor/@takazudo` (= `@takazudo/zfb` +
-/// `@takazudo/zfb-runtime` source, staged by `build.rs`).
+/// Compile-time embedding of `$OUT_DIR/vendor/` (`@takazudo/*` + framework
+/// runtime packages, staged by `build.rs`).
 ///
 /// `include_dir!` expands `$VAR` using the env var set via `cargo:rustc-env`.
 /// `build.rs` emits `cargo:rustc-env=ZFB_VENDOR_DIR=<path>` pointing at
 /// `$OUT_DIR/vendor` so this path resolves at macro-expansion time.
 static EMBEDDED_VENDOR: Dir<'_> = include_dir!("$ZFB_VENDOR_DIR");
 
-/// Extract the embedded `@takazudo` packages into a temporary directory
-/// structured as a `node_modules/@takazudo/` layout esbuild can resolve.
+/// Extract the embedded `@takazudo/*` packages and framework runtime packages
+/// into a temporary directory structured as a `node_modules/` layout esbuild
+/// can resolve.
 ///
 /// Returns a `(TempDir, PathBuf)` pair where:
 /// - `TempDir` must be kept alive for as long as esbuild runs (dropping it
@@ -102,11 +118,11 @@ static EMBEDDED_VENDOR: Dir<'_> = include_dir!("$ZFB_VENDOR_DIR");
 ///
 /// Returns an error if the temp directory cannot be created or if extracting
 /// any embedded file fails.
-pub fn embedded_takazudo_node_modules() -> Result<(tempfile::TempDir, PathBuf)> {
+pub fn embedded_node_modules() -> Result<(tempfile::TempDir, PathBuf)> {
     let dir = tempfile::tempdir().context("failed to create tempdir for embedded packages")?;
     let node_modules = dir.path().join("node_modules");
     extract_dir_with_prefix(&EMBEDDED_VENDOR, &node_modules, Path::new(""))
-        .context("failed to extract embedded @takazudo packages")?;
+        .context("failed to extract embedded packages")?;
     let nm_path = node_modules;
     Ok((dir, nm_path))
 }
@@ -125,9 +141,8 @@ fn extract_dir_with_prefix(embedded: &Dir<'_>, dest: &Path, prefix: &Path) -> Re
             DirEntry::Dir(sub) => {
                 let rel = sub.path().strip_prefix(prefix).unwrap_or(sub.path());
                 let target = dest.join(rel);
-                std::fs::create_dir_all(&target).with_context(|| {
-                    format!("failed to create dir {}", target.display())
-                })?;
+                std::fs::create_dir_all(&target)
+                    .with_context(|| format!("failed to create dir {}", target.display()))?;
                 extract_dir_with_prefix(sub, dest, prefix)?;
             }
             DirEntry::File(file) => {
@@ -348,19 +363,13 @@ fn try_expand_one(
             ));
         }
     };
-    let segs: Vec<PathsSegment> = route
-        .segments
-        .iter()
-        .cloned()
-        .collect();
+    let segs: Vec<PathsSegment> = route.segments.iter().cloned().collect();
     let resolved = resolve_paths(cache, &route.template, &segs, &json)
         .map_err(|e| format!("{}: {}", abs.display(), format_paths_error(&e)))?;
     let mut out = Vec::with_capacity(resolved.len());
     for r in resolved {
-        let output_path = build_output_path_for_resolved_url(
-            &r.url,
-            route.output_extension.as_deref(),
-        );
+        let output_path =
+            build_output_path_for_resolved_url(&r.url, route.output_extension.as_deref());
         out.push(RouteUniverseEntry {
             url_path: r.url,
             output_path,
@@ -429,7 +438,12 @@ fn format_paths_error(e: &PathsError) -> String {
         PathsError::InvalidParamType { name, reason, .. } => {
             format!("paths() entry has invalid param `{name}`: {reason}")
         }
-        PathsError::InvalidPathsExport { field, reason, expected, .. } => {
+        PathsError::InvalidPathsExport {
+            field,
+            reason,
+            expected,
+            ..
+        } => {
             let field_note = match field {
                 Some(f) => format!(" at `{f}`"),
                 None => String::new(),
@@ -516,9 +530,7 @@ pub fn eval_deferred_paths_via_worker(
         WorkerDispatch::Http { base_url } => {
             eval_deferred_paths_http(deferred, base_url, cache, timeout)
         }
-        WorkerDispatch::EmbeddedV8 { host } => {
-            eval_deferred_paths_embedded(deferred, *host, cache)
-        }
+        WorkerDispatch::EmbeddedV8 { host } => eval_deferred_paths_embedded(deferred, *host, cache),
     }
 }
 
@@ -641,9 +653,12 @@ fn eval_one_deferred_path_http(
         ));
     }
 
-    let json: serde_json::Value = resp
-        .json()
-        .map_err(|e| format!("could not parse JSON from /__paths__/{}: {}", route.template, e))?;
+    let json: serde_json::Value = resp.json().map_err(|e| {
+        format!(
+            "could not parse JSON from /__paths__/{}: {}",
+            route.template, e
+        )
+    })?;
 
     resolve_json_paths(json, route, cache)
 }
@@ -658,9 +673,12 @@ fn eval_one_deferred_path_embedded(
     let encoded = encode_route_key(&route.template);
     let url_path = format!("/__paths__/{encoded}");
 
-    let resp = host
-        .dispatch_fetch(&url_path)
-        .map_err(|e| format!("embedded V8 dispatch for /__paths__/{} failed: {e}", route.template))?;
+    let resp = host.dispatch_fetch(&url_path).map_err(|e| {
+        format!(
+            "embedded V8 dispatch for /__paths__/{} failed: {e}",
+            route.template
+        )
+    })?;
 
     if !(200..300).contains(&resp.status) {
         let body = String::from_utf8_lossy(&resp.body).into_owned();
@@ -672,8 +690,12 @@ fn eval_one_deferred_path_embedded(
         ));
     }
 
-    let json: serde_json::Value = serde_json::from_slice(&resp.body)
-        .map_err(|e| format!("could not parse JSON from /__paths__/{}: {}", route.template, e))?;
+    let json: serde_json::Value = serde_json::from_slice(&resp.body).map_err(|e| {
+        format!(
+            "could not parse JSON from /__paths__/{}: {}",
+            route.template, e
+        )
+    })?;
 
     resolve_json_paths(json, route, cache)
 }
@@ -684,18 +706,15 @@ fn resolve_json_paths(
     route: &DeferredDynamicRoute,
     cache: &mut PathsCache,
 ) -> Result<Vec<RouteUniverseEntry>, String> {
-    let segs: Vec<PathsSegment> = route
-        .segments
-        .iter()
-        .cloned()
-        .collect();
+    let segs: Vec<PathsSegment> = route.segments.iter().cloned().collect();
 
     let resolved = resolve_paths(cache, &route.template, &segs, &json)
         .map_err(|e| format!("{}: {}", route.template, format_paths_error(&e)))?;
 
     let mut entries = Vec::with_capacity(resolved.len());
     for r in resolved {
-        let output_path = build_output_path_for_resolved_url(&r.url, route.output_extension.as_deref());
+        let output_path =
+            build_output_path_for_resolved_url(&r.url, route.output_extension.as_deref());
         entries.push(RouteUniverseEntry {
             url_path: r.url,
             output_path,
@@ -831,9 +850,9 @@ pub fn build_prerender_map(
 /// Returns `Err` with an actionable hint when neither resolves.
 pub fn check_runtime_installed(project_root: &Path) -> Result<()> {
     // 1. Binary-adjacent path (cargo-installed binary scenario).
-    let exe_dir = std::env::current_exe().ok().and_then(|p| {
-        p.parent().map(|d| d.to_path_buf())
-    });
+    let exe_dir = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.parent().map(|d| d.to_path_buf()));
     check_runtime_installed_with_exe_dir(project_root, exe_dir.as_deref())
 }
 
@@ -859,8 +878,7 @@ pub(crate) fn check_runtime_installed_with_exe_dir(
     // 2. Ancestor node_modules walk (dev / local-checkout scenario).
     let mut cur: Option<&Path> = Some(project_root);
     while let Some(p) = cur {
-        if p
-            .join("node_modules")
+        if p.join("node_modules")
             .join("@takazudo")
             .join("zfb-runtime")
             .exists()
@@ -958,7 +976,10 @@ mod tests {
         let plan = build_route_universe(&routes);
         assert_eq!(plan.static_routes.len(), 2);
         assert_eq!(plan.static_routes[0].url_path, "/");
-        assert_eq!(plan.static_routes[0].output_path, PathBuf::from("index.html"));
+        assert_eq!(
+            plan.static_routes[0].output_path,
+            PathBuf::from("index.html")
+        );
         assert_eq!(plan.static_routes[0].route_key, "/");
         assert_eq!(plan.static_routes[1].url_path, "/about");
         assert_eq!(
@@ -1030,7 +1051,10 @@ mod tests {
         let routes = vec![static_route(vec!["post"], "pages/post.mdx")];
         let mut warnings: Vec<String> = Vec::new();
         let map = build_prerender_map(&routes, dir.path(), |msg| warnings.push(msg.into()));
-        assert!(map.is_empty(), "MDX should be left to the default-true path");
+        assert!(
+            map.is_empty(),
+            "MDX should be left to the default-true path"
+        );
         // Non-TSX files are skipped silently (no warning).
         assert!(warnings.is_empty(), "warnings: {warnings:?}");
     }
@@ -1092,16 +1116,17 @@ mod tests {
         assert!(msg.contains("cargo install"), "{msg}");
     }
 
-    /// Smoke-test that `embedded_takazudo_node_modules` extracts a proper
-    /// `node_modules/@takazudo/zfb/package.json` and
-    /// `node_modules/@takazudo/zfb-runtime/package.json` layout that
-    /// `check_runtime_installed_with_exe_dir` (and esbuild) can resolve.
+    /// Smoke-test that [`embedded_node_modules`] extracts a proper
+    /// `node_modules/@takazudo/zfb/package.json`,
+    /// `node_modules/@takazudo/zfb-runtime/package.json`, and the framework
+    /// runtime packages (`preact`, `preact-render-to-string`, `hono`) layout
+    /// that `check_runtime_installed_with_exe_dir` (and esbuild) can resolve.
     #[test]
-    fn embedded_takazudo_node_modules_extracts_runtime_layout() {
-        let (handle, nm_path) = embedded_takazudo_node_modules()
-            .expect("embedded_takazudo_node_modules should not fail");
+    fn embedded_node_modules_extracts_runtime_layout() {
+        let (handle, nm_path) =
+            embedded_node_modules().expect("embedded_node_modules should not fail");
 
-        // Package root markers must exist.
+        // @takazudo/* package root markers must exist.
         assert!(
             nm_path.join("@takazudo/zfb/package.json").exists(),
             "missing @takazudo/zfb/package.json in extracted layout"
@@ -1111,7 +1136,7 @@ mod tests {
             "missing @takazudo/zfb-runtime/package.json in extracted layout"
         );
 
-        // Entry-point source files must be present.
+        // @takazudo/* entry-point source files must be present.
         assert!(
             nm_path.join("@takazudo/zfb/src/index.ts").exists(),
             "missing @takazudo/zfb/src/index.ts"
@@ -1120,6 +1145,16 @@ mod tests {
             nm_path.join("@takazudo/zfb-runtime/src/index.ts").exists(),
             "missing @takazudo/zfb-runtime/src/index.ts"
         );
+
+        // Sub #209 — framework runtime package roots must exist alongside.
+        for pkg in ["preact", "preact-render-to-string", "hono"] {
+            let pkg_json = nm_path.join(pkg).join("package.json");
+            assert!(
+                pkg_json.exists(),
+                "missing {pkg}/package.json in extracted layout: {}",
+                pkg_json.display()
+            );
+        }
 
         // Verify check_runtime_installed sees the embedded runtime via the
         // exe-dir path (the nm_path is the node_modules dir; its parent is
@@ -1342,7 +1377,9 @@ mod tests {
         assert_eq!(out.resolved.len(), 0);
         assert_eq!(out.deferred.len(), 1);
         assert!(
-            out.deferred[0].reason.contains("missing required param `slug`"),
+            out.deferred[0]
+                .reason
+                .contains("missing required param `slug`"),
             "reason: {}",
             out.deferred[0].reason,
         );
@@ -1430,8 +1467,7 @@ mod tests {
         assert_eq!(plan.deferred_dynamic.len(), 1);
 
         let mut cache = PathsCache::new();
-        let expansion =
-            expand_dynamic_routes(&plan.deferred_dynamic, dir.path(), &mut cache);
+        let expansion = expand_dynamic_routes(&plan.deferred_dynamic, dir.path(), &mut cache);
         assert_eq!(expansion.deferred.len(), 0, "{:?}", expansion.deferred);
         assert_eq!(expansion.resolved.len(), 2);
 

--- a/crates/zfb/tests/framework_packages_no_pnpm.rs
+++ b/crates/zfb/tests/framework_packages_no_pnpm.rs
@@ -1,0 +1,205 @@
+//! Sub #209 — Framework-packages no-pnpm integration test.
+//!
+//! Verifies that a consumer with NO `node_modules/` directory and NO `pnpm
+//! install` can still bundle a page that imports `preact`,
+//! `preact-render-to-string`, and `hono` — because the embedded extraction
+//! produced by [`zfb::render_pipeline::embedded_node_modules`] supplies all
+//! three.
+//!
+//! ## Why this lives in `crates/zfb/tests/`
+//!
+//! [`embedded_node_modules`] is a function on the `zfb` crate (it owns the
+//! `include_dir!` snapshot of `$OUT_DIR/vendor`). The bundler test crates
+//! (`crates/zfb-build/tests/`) do not depend on `zfb`, so they cannot reach
+//! the embedded snapshot. Driving the test from here lets us exercise the
+//! exact same code path that `zfb build` and `zfb dev` use at runtime when no
+//! consumer-side `node_modules` is present.
+//!
+//! ## What the assertion proves
+//!
+//! 1. The build script (`crates/zfb/build.rs::embed_framework_packages`)
+//!    successfully copied the three framework packages into the embedded
+//!    vendor tree.
+//! 2. The runtime extraction (`embedded_node_modules`) lays the packages out
+//!    as proper `node_modules/<pkg>/package.json` siblings esbuild can
+//!    resolve.
+//! 3. esbuild's bundler can resolve and bundle imports of `preact`,
+//!    `preact-render-to-string`, and `hono` against the extracted tree —
+//!    nothing is marked external, and there is no consumer `node_modules/`
+//!    on disk.
+//!
+//! ## Skipping
+//!
+//! The test gates on the same esbuild discovery path as the rest of the
+//! bundler tests. When no esbuild binary is available it prints a skip note
+//! and returns early.
+
+use std::collections::{BTreeMap, HashMap};
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+use zfb::render_pipeline::embedded_node_modules;
+use zfb_build::{bundle, BundleMode, BundlerInput};
+use zfb_render::adapters::Framework;
+
+fn locate_esbuild() -> Option<PathBuf> {
+    if let Some(p) = std::env::var_os("ZFB_ESBUILD_BIN") {
+        let p = PathBuf::from(p);
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    let here = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    if let Some(workspace) = here.parent().and_then(|p| p.parent()) {
+        let slot = workspace.join("crates/zfb/binaries/esbuild/esbuild");
+        if slot.exists() {
+            return Some(slot);
+        }
+    }
+    if let Ok(out) = Command::new("which").arg("esbuild").output() {
+        if out.status.success() {
+            let p = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim());
+            if p.exists() {
+                return Some(p);
+            }
+        }
+    }
+    None
+}
+
+#[test]
+fn embedded_extraction_resolves_framework_imports_with_no_consumer_node_modules() {
+    let Some(esbuild) = locate_esbuild() else {
+        eprintln!(
+            "[framework_packages_no_pnpm] no esbuild binary available; \
+             set ZFB_ESBUILD_BIN, place the binary at \
+             crates/zfb/binaries/esbuild/esbuild, or install esbuild on PATH \
+             to enable this test. Skipping."
+        );
+        return;
+    };
+
+    // Step 1 — synthesize a minimal consumer project on disk with NO
+    // node_modules/ tree at all. The page imports `preact`,
+    // `preact-render-to-string`, and `hono` directly so esbuild MUST resolve
+    // them somewhere — and the only "somewhere" available is the embedded
+    // extraction we wire in below.
+    let project = tempfile::tempdir().expect("tempdir for project root");
+    let root = project.path().to_path_buf();
+    for d in ["pages", "components", "layouts"] {
+        fs::create_dir_all(root.join(d)).unwrap();
+    }
+    fs::write(
+        root.join("layouts/default.tsx"),
+        "export default function DefaultLayout({ children }) { return children; }\n",
+    )
+    .unwrap();
+
+    fs::write(
+        root.join("pages/index.tsx"),
+        // Touch every package the embedded extraction provides so the test
+        // fails if any one of them goes missing from the vendor tree.
+        // - `preact` (top-level): the `h` JSX runtime entry.
+        // - `preact-render-to-string` (top-level): the `renderToString` SSR
+        //   entry — the page reaches into it directly so esbuild has to
+        //   resolve `preact-render-to-string`'s `dist/` against the embedded
+        //   extraction.
+        // - `hono`: the consumer rarely imports hono directly, but pulling
+        //   it in here forces esbuild to resolve it from the same extraction
+        //   tree (it is a transitive dep of `@takazudo/zfb-runtime` in
+        //   the real consumer flow; importing it directly removes any
+        //   indirection from the test).
+        r#"
+            import { h } from "preact";
+            import { renderToString } from "preact-render-to-string";
+            import { Hono } from "hono";
+
+            const app = new Hono();
+            app.get("/", (c) => c.text("hello"));
+
+            export default function Home() {
+              const tree = h("div", null, "hello world");
+              return renderToString(tree) + " / app=" + (typeof app);
+            }
+        "#,
+    )
+    .unwrap();
+
+    // Step 2 — extract the embedded vendor tree into a fresh tempdir and
+    // confirm every framework package's `package.json` is present at the
+    // expected path. (The `embedded_node_modules` smoke test in the unit
+    // tests covers this too; we re-assert here so a failure points the
+    // operator at this file's exact import set rather than at a generic
+    // unit-test layout assertion.)
+    let (nm_handle, nm_path) = embedded_node_modules().expect("embedded_node_modules must succeed");
+    for pkg in ["preact", "preact-render-to-string", "hono"] {
+        let pkg_json = nm_path.join(pkg).join("package.json");
+        assert!(
+            pkg_json.exists(),
+            "embedded extraction is missing {pkg}/package.json at {} — \
+             check crates/zfb/build.rs::embed_framework_packages and the \
+             *_VERSION constants",
+            pkg_json.display()
+        );
+    }
+
+    // Step 3 — run the bundler with `external: vec![]` (NOTHING marked
+    // external — every framework import must resolve from the extraction)
+    // and `node_modules_dir = Some(nm_path)` pointing at the extraction.
+    let input = BundlerInput {
+        project_root: root.clone(),
+        pages_dir: PathBuf::from("pages"),
+        content_dir: PathBuf::from("content"),
+        components_dir: PathBuf::from("components"),
+        layouts_dir: PathBuf::from("layouts"),
+        framework: Framework::Preact,
+        define_vars: HashMap::new(),
+        tsconfig_paths: BTreeMap::new(),
+        external: vec![],
+        outdir: root.join("dist"),
+        mode: BundleMode::Production,
+        minify: false,
+        esbuild_binary: Some(esbuild.clone()),
+        mock_subprocess_output: None,
+        content_snapshot_json: None,
+        node_modules_dir: Some(nm_path.clone()),
+        node_modules_preserve_symlinks: false,
+        content_collections: Vec::new(),
+        strip_md_ext: false,
+        code_highlight_theme: None,
+        resolve_markdown_links: None,
+    };
+
+    let out = bundle(input).expect(
+        "bundle must succeed against the embedded framework-packages extraction \
+         with no consumer-side node_modules — \
+         if it fails, check crates/zfb/build.rs::embed_framework_packages and \
+         the embedded extraction in render_pipeline.rs",
+    );
+
+    // The bundle file must exist and must contain at least a hint of every
+    // framework module's runtime code, proving that esbuild really did
+    // pull each module in from the embedded extraction (rather than, say,
+    // tree-shaking everything away). We check for a couple of distinctive
+    // identifiers from each module instead of insisting on exact strings —
+    // the published bundles minify-rename a lot of internals, but the
+    // exported entry-point names survive.
+    assert!(out.bundle_path.exists(), "bundle output must exist");
+    let body = fs::read_to_string(&out.bundle_path).expect("bundle output must be readable utf-8");
+
+    assert!(
+        body.contains("renderToString") || body.contains("render_to_string"),
+        "bundle should contain preact-render-to-string entry; \
+         excerpt: {}",
+        &body[..body.len().min(800)]
+    );
+    assert!(
+        body.contains("Hono"),
+        "bundle should contain hono's `Hono` class; \
+         excerpt: {}",
+        &body[..body.len().min(800)]
+    );
+
+    drop(nm_handle); // explicit: tempdir is removed here
+}


### PR DESCRIPTION
## Summary

Closes #209. Extends the `@takazudo/*` embedding mechanism (sub #198) to also stage the three framework runtime packages — `preact`, `preact-render-to-string`, `hono` — into the zfb binary, so a consumer with no Node, no pnpm, and no `node_modules/` can run `zfb build` successfully.

This is the last residual upstream gap from the no-node spike: sub #197 (esbuild + tailwind binaries) and sub #198 (`@takazudo/*` packages) had landed; this PR closes the loop.

## What changed

- **`crates/zfb/build.rs`**:
  - New `FRAMEWORK_PKG_VERSIONS` constants table (`PREACT_VERSION`, `PREACT_RTS_VERSION`, `HONO_VERSION`) with a comment pointing at `pnpm-lock.yaml` as the source of truth.
  - New `embed_framework_packages()` function that locates `node_modules/.pnpm/<name>@<version>*/node_modules/<name>/` (handling pnpm's peer-suffixed dirnames) and copies the published trees into `$OUT_DIR/vendor/<name>/`, filtering out nested `node_modules/`, `__tests__/`, hidden dirs, and `.map` source maps.
  - Called from `main()` alongside `embed_runtime()`.
- **`crates/zfb/src/render_pipeline.rs`**:
  - Renamed `embedded_takazudo_node_modules()` -> `embedded_node_modules()` (the function now produces a tree with both `@takazudo/*` and framework packages).
  - Updated module doc + smoke test.
- **`crates/zfb/src/commands/{build,dev}.rs`**: updated callers for the rename.
- **`crates/zfb/tests/framework_packages_no_pnpm.rs`**: new integration test that synthesizes a consumer project with NO `node_modules/`, points the bundler at the embedded extraction, marks NOTHING external, and asserts `bundle()` succeeds and the bundle output references `renderToString` and `Hono`.
- **`BUILDING.md`** + **`crates/zfb/binaries/README.md`**: new sections describing the embedded-packages layer and the bump procedure.

## Test plan

- [x] `cargo test --workspace` — all 172 zfb-lib tests + 134 zfb-build tests + 277 zfb-content tests + every other workspace crate pass.
- [x] `cargo test -p zfb --test framework_packages_no_pnpm` — new no-pnpm bundle test passes.
- [x] `cargo test -p zfb --lib embedded_node_modules_extracts_runtime_layout` — extended smoke test (now asserts framework packages too) passes.
- [x] `cargo fmt -p zfb -- --check` — clean.
- [x] Manual: verified `target/debug/build/zfb-*/out/vendor/` contains `@takazudo/`, `preact/`, `preact-render-to-string/`, `hono/` siblings after `cargo check -p zfb`.

## Acceptance criteria check

- [x] `embed_runtime()` extended (via new `embed_framework_packages()` companion) to stage `preact`, `preact-render-to-string`, `hono`.
- [x] `embedded_takazudo_node_modules()` renamed to `embedded_node_modules()` and produces a node_modules tree with both `@takazudo/*` and the three framework packages.
- [x] Pinned versions recorded as constants in `build.rs` with a source-of-truth comment.
- [x] No-pnpm integration test asserts framework imports resolve from the embedded extraction.
- [x] `BUILDING.md` and `crates/zfb/binaries/README.md` updated.
