### PR TITLE
fix(config): JSON plugin loader + embedded binary extraction (sub-211, sub-212)

### DIFF
--- a/crates/zfb-css/src/engine.rs
+++ b/crates/zfb-css/src/engine.rs
@@ -15,6 +15,7 @@ use std::collections::HashMap;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
 
@@ -118,11 +119,31 @@ pub struct TailwindSubprocessConfig {
 
     /// Output to return when `mock_subprocess` is true.
     pub mock_output: String,
+
+    /// Sub #212 — keep the [`tempfile::TempDir`] backing an
+    /// embedded-binary extraction alive for the lifetime of the engine.
+    ///
+    /// Populated by [`Self::with_embedded_binary`]. Wrapped in [`Arc`] so
+    /// that the surrounding `Clone` impl on `TailwindSubprocessConfig`
+    /// keeps working — `tempfile::TempDir` is itself not `Clone`. The
+    /// field is non-public; callers don't see it, they just receive a
+    /// `binary_path` that points inside the live tempdir.
+    _embedded_handle: Option<Arc<tempfile::TempDir>>,
 }
 
 impl Default for TailwindSubprocessConfig {
     fn default() -> Self {
-        // Resolve binary path: env override → default workspace-relative path.
+        // Resolve binary path with the precedence:
+        //   1. `ZFB_TAILWIND_BIN` env override (full bypass for ops).
+        //   2. embedded extraction (sub #212) — wired in by the caller
+        //      via [`Self::with_embedded_binary`]. We keep `default()`
+        //      infallible by not touching the embedded snapshot here;
+        //      the binary lives inside the `zfb` crate's
+        //      `EMBEDDED_VENDOR` and `zfb-css` would otherwise need a
+        //      reverse dependency to reach it. The `zfb` crate is the
+        //      sole caller that constructs this config and is the
+        //      natural place to do the (potentially fallible) extract.
+        //   3. workspace-relative fallback for in-workspace dev.
         let env_override = std::env::var_os("ZFB_TAILWIND_BIN");
         let binary_path = match env_override {
             Some(p) => PathBuf::from(p),
@@ -139,6 +160,7 @@ impl Default for TailwindSubprocessConfig {
             theme_block: None,
             mock_subprocess: false,
             mock_output: String::new(),
+            _embedded_handle: None,
         }
     }
 }
@@ -193,6 +215,42 @@ impl TailwindSubprocessConfig {
     /// Set an inline `@theme { ... }` block (chainable).
     pub fn with_theme_block(mut self, block: impl Into<String>) -> Self {
         self.theme_block = Some(block.into());
+        self
+    }
+
+    /// Sub #212 — install an embedded-binary extraction as the resolved
+    /// [`Self::binary_path`] and keep the backing [`tempfile::TempDir`]
+    /// alive for the lifetime of `self`.
+    ///
+    /// This is the wiring point for the precedence step "embedded
+    /// extraction" between the env override and the workspace-relative
+    /// fallback. The caller is the zfb crate (which has access to the
+    /// `EMBEDDED_VENDOR` snapshot via
+    /// `crates/zfb/src/render_pipeline.rs::embedded_binary`); zfb-css
+    /// itself stays free of any reverse dependency on the embedded
+    /// vendor tree.
+    ///
+    /// Precedence is preserved: if `ZFB_TAILWIND_BIN` is set in the
+    /// process environment, this method is a no-op so the env override
+    /// keeps winning. Otherwise the embedded `path` replaces the
+    /// workspace-relative fallback that [`Self::default`] selected.
+    ///
+    /// `handle` is wrapped in [`Arc`] so the surrounding
+    /// `#[derive(Clone)]` keeps working — `tempfile::TempDir` is not
+    /// itself `Clone`.
+    pub fn with_embedded_binary(
+        mut self,
+        handle: tempfile::TempDir,
+        path: PathBuf,
+    ) -> Self {
+        if std::env::var_os("ZFB_TAILWIND_BIN").is_some() {
+            // Env tier already won — drop the handle on the floor and
+            // leave `binary_path` pointing at the env value.
+            drop(handle);
+            return self;
+        }
+        self.binary_path = path;
+        self._embedded_handle = Some(Arc::new(handle));
         self
     }
 }
@@ -475,4 +533,111 @@ pub fn engine_provenance(name: &str, version: Option<&str>) -> HashMap<String, S
         m.insert("version".to_string(), v.to_string());
     }
     m
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Sub #212 — `with_embedded_binary` installs the path returned by
+    /// the caller's embedded extraction (a tempdir + binary stem) AND
+    /// keeps the [`tempfile::TempDir`] alive on the config so the path
+    /// stays valid for every subprocess invocation.
+    ///
+    /// Bundles BOTH behavioural assertions — the embedded-tier install AND
+    /// the env-override no-op — into a single test so that `cargo test`'s
+    /// parallel runner can never race the two cases on the shared
+    /// `ZFB_TAILWIND_BIN` env var. Splitting them caused the env-set test
+    /// to leak the var into the embedded-tier test on parallel scheduling.
+    ///
+    /// We don't shell out to the real binary here — that's gated by the
+    /// `#[ignore]` integration tests in zfb-build. This unit test just
+    /// proves the wiring: the path is updated, the file is still present
+    /// after we drop the original `TempDir` handle (which we surrender to
+    /// the config), and the env override always wins.
+    #[test]
+    fn with_embedded_binary_installs_path_unless_env_override_is_set() {
+        // Tiny scope guard so a panic doesn't leak the env var.
+        struct EnvGuard {
+            key: &'static str,
+            prev: Option<std::ffi::OsString>,
+        }
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                match &self.prev {
+                    Some(v) => std::env::set_var(self.key, v),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+
+        // ----- Phase 1: env unset -> embedded path wins ----------------
+        let prev = std::env::var_os("ZFB_TAILWIND_BIN");
+        std::env::remove_var("ZFB_TAILWIND_BIN");
+        let _guard = EnvGuard {
+            key: "ZFB_TAILWIND_BIN",
+            prev,
+        };
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let bin_path = dir.path().join("tailwindcss-v4");
+        std::fs::write(&bin_path, b"#!/bin/sh\necho ok\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&bin_path, std::fs::Permissions::from_mode(0o755))
+                .unwrap();
+        }
+
+        let cfg = TailwindSubprocessConfig::default()
+            .with_embedded_binary(dir, bin_path.clone());
+        assert_eq!(
+            cfg.binary_path, bin_path,
+            "no env override → embedded path should win over the workspace fallback"
+        );
+        assert!(
+            cfg.binary_path.exists(),
+            "embedded binary path should exist via the captured TempDir handle"
+        );
+
+        // Cloning the config preserves the embedded path and keeps the
+        // handle alive (Arc<TempDir>). Drop the original — the clone's
+        // path must still resolve.
+        let cloned = cfg.clone();
+        drop(cfg);
+        assert!(
+            cloned.binary_path.exists(),
+            "Clone should keep the TempDir alive so binary_path stays valid"
+        );
+        drop(cloned);
+
+        // ----- Phase 2: env set -> env value wins, embedded is no-op --
+        std::env::set_var("ZFB_TAILWIND_BIN", "/tmp/zfb-test-tailwind-env-override");
+
+        let dir2 = tempfile::tempdir().expect("tempdir");
+        let bin_path2 = dir2.path().join("tailwindcss-v4");
+        std::fs::write(&bin_path2, b"x").unwrap();
+
+        // Default reads the env override.
+        let cfg = TailwindSubprocessConfig::default();
+        assert_eq!(
+            cfg.binary_path,
+            PathBuf::from("/tmp/zfb-test-tailwind-env-override"),
+            "default() should honour ZFB_TAILWIND_BIN"
+        );
+
+        // with_embedded_binary must not displace the env-override value.
+        let cfg = cfg.with_embedded_binary(dir2, bin_path2);
+        assert_eq!(
+            cfg.binary_path,
+            PathBuf::from("/tmp/zfb-test-tailwind-env-override"),
+            "env-override path must win over with_embedded_binary"
+        );
+
+        // _guard drops here, restoring the previous ZFB_TAILWIND_BIN value.
+    }
 }

--- a/crates/zfb/Cargo.toml
+++ b/crates/zfb/Cargo.toml
@@ -31,6 +31,10 @@ serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal", "fs", "process", "sync"] }
 tracing = "0.1"
+# Sub 211: convert relative/absolute plugin paths in zfb.config.json
+# into file:// URLs that match the resolved_module shape produced by
+# the TS-config path (config-loader.mjs returns Node-style file URLs).
+url = "2"
 # Source-file discovery for the production asset emit path: the CSS
 # pipeline takes a `Vec<PathBuf>` of project sources to feed into
 # Tailwind's content scanner, and the islands scanner takes the same

--- a/crates/zfb/build.rs
+++ b/crates/zfb/build.rs
@@ -547,6 +547,86 @@ fn download_binaries() -> Result<(), String> {
     download_esbuild(platform, &esbuild_slot)?;
     download_tailwindcss(platform, &tailwind_slot)?;
 
+    // Sub #212 — also stage the binaries into `$OUT_DIR/vendor/bin/` so the
+    // existing `include_dir!("$ZFB_VENDOR_DIR")` snapshot embeds them next to
+    // `@takazudo/*` and the framework packages. Consumers without a
+    // workspace-relative `crates/zfb/binaries/` dir can then extract them at
+    // runtime via `embedded_binary()` in `crates/zfb/src/render_pipeline.rs`.
+    stage_binaries_into_vendor(&esbuild_slot, &tailwind_slot)?;
+
+    Ok(())
+}
+
+/// Copy the staged esbuild and tailwindcss binaries from
+/// `crates/zfb/binaries/` into `$OUT_DIR/vendor/bin/` so they ride along
+/// inside `EMBEDDED_VENDOR` (the `include_dir!` snapshot in
+/// `crates/zfb/src/render_pipeline.rs`). The `embedded_binary()` helper
+/// then extracts whichever name a caller asks for at runtime.
+///
+/// Windows binaries ship with a `.exe` suffix; the destination filename
+/// preserves that suffix. The executable bit is set on Unix so the
+/// extracted file is invocable without an extra chmod.
+fn stage_binaries_into_vendor(esbuild_slot: &Path, tailwind_slot: &Path) -> Result<(), String> {
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    let bin_dir = out_dir.join("vendor").join("bin");
+    fs::create_dir_all(&bin_dir).map_err(|e| {
+        format!("failed to create vendor bin dir {}: {e}", bin_dir.display())
+    })?;
+
+    // Re-emit rerun triggers so a manual re-fetch of either binary refreshes
+    // the embedded snapshot on the next cargo build.
+    println!("cargo:rerun-if-changed={}", esbuild_slot.display());
+    println!("cargo:rerun-if-changed={}", tailwind_slot.display());
+
+    // Esbuild → vendor/bin/esbuild (or .exe on Windows).
+    let esbuild_dst_name = if cfg!(target_os = "windows") {
+        "esbuild.exe"
+    } else {
+        "esbuild"
+    };
+    let esbuild_dst = bin_dir.join(esbuild_dst_name);
+    copy_executable(esbuild_slot, &esbuild_dst)?;
+
+    // Tailwind → vendor/bin/tailwindcss-v4 (or .exe on Windows).
+    let tailwind_dst_name = if cfg!(target_os = "windows") {
+        "tailwindcss-v4.exe"
+    } else {
+        "tailwindcss-v4"
+    };
+    let tailwind_dst = bin_dir.join(tailwind_dst_name);
+    copy_executable(tailwind_slot, &tailwind_dst)?;
+
+    Ok(())
+}
+
+/// Copy `src` to `dst` and (on Unix) preserve / re-apply the 0o755
+/// executable bit so the extracted binary is invocable without an extra
+/// chmod.
+fn copy_executable(src: &Path, dst: &Path) -> Result<(), String> {
+    if !src.exists() {
+        return Err(format!(
+            "expected staged binary at {} to exist before vendor staging — \
+             download_binaries() should have produced it",
+            src.display()
+        ));
+    }
+    fs::copy(src, dst).map_err(|e| {
+        format!(
+            "failed to copy {} → {}: {e}",
+            src.display(),
+            dst.display()
+        )
+    })?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(dst, fs::Permissions::from_mode(0o755)).map_err(|e| {
+            format!(
+                "failed to set executable bit on {}: {e}",
+                dst.display()
+            )
+        })?;
+    }
     Ok(())
 }
 

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -71,7 +71,7 @@ use crate::config::Config;
 use crate::output;
 use crate::render_pipeline::{
     build_prerender_map, build_route_universe, cfg_framework_to_render, check_runtime_installed,
-    embedded_node_modules, eval_deferred_paths_via_worker, expand_dynamic_routes,
+    embedded_binary, embedded_node_modules, eval_deferred_paths_via_worker, expand_dynamic_routes,
     DeferredDynamicRoute, RouteUniversePlan, WorkerDispatch,
 };
 
@@ -421,6 +421,20 @@ fn build_default_css_payload(
     let mut tw_cfg = TailwindSubprocessConfig::default()
         .with_working_dir(project_root.to_path_buf())
         .with_content_globs(content_globs);
+
+    // Sub #212 — wire in the embedded-binary extraction tier so consumers
+    // running `zfb build` from a project that doesn't ship the
+    // `crates/zfb/binaries/` workspace dir still resolve a working tailwind
+    // CLI. The TempDir handle rides on the config (and hence the engine)
+    // so the extracted file outlives every `produce_utility_css` call.
+    // Skip when `ZFB_TAILWIND_BIN` is set — `with_embedded_binary` is also
+    // a no-op in that case, but skipping the extract avoids the disk + tar
+    // work entirely.
+    if std::env::var_os("ZFB_TAILWIND_BIN").is_none() {
+        if let Ok((handle, path)) = embedded_binary("tailwindcss-v4") {
+            tw_cfg = tw_cfg.with_embedded_binary(handle, path);
+        }
+    }
 
     // Honour an authored global stylesheet at the conventional
     // location. Tailwind v4's entry CSS prepends our `@source`

--- a/crates/zfb/src/config.rs
+++ b/crates/zfb/src/config.rs
@@ -587,7 +587,7 @@ pub async fn load_from_dir_with_options(
         let text = tokio::fs::read_to_string(&json_path)
             .await
             .with_context(|| format!("reading {}", json_path.display()))?;
-        let cfg: Config = serde_json::from_str(&text).map_err(|e| {
+        let mut cfg: Config = serde_json::from_str(&text).map_err(|e| {
             anyhow!(
                 "{}: invalid config JSON at line {}, column {}: {}",
                 json_path.display(),
@@ -596,6 +596,16 @@ pub async fn load_from_dir_with_options(
                 e
             )
         })?;
+        // Issue #211: the JSON config path used to leave every
+        // `PluginConfig.resolved_module` at `None`, which made the
+        // downstream plugin-host filter silently drop ALL plugins
+        // (see `commands::plugins::build_plugin_specs`). Mirror the
+        // shape the TS-load path produces (a `file://` URL) for plugin
+        // entries that name a path on disk; bare specifiers can't be
+        // resolved without a node subprocess and stay `None` with a
+        // user-facing warning so the surprise is visible.
+        resolve_json_plugin_modules(&mut cfg, dir)
+            .with_context(|| format!("resolving plugin paths for {}", json_path.display()))?;
         validate(&cfg, dir).with_context(|| format!("validating {}", json_path.display()))?;
         return Ok(cfg);
     }
@@ -609,6 +619,70 @@ pub async fn load_from_dir_with_options(
     // down on what is a benign discovery step.
     validate(&cfg, dir).context("Config::default() must validate cleanly")?;
     Ok(cfg)
+}
+
+/// Resolve `Config.plugins[].resolved_module` for the JSON-load path.
+///
+/// Issue #211: `zfb.config.json` is parsed via `serde_json` and skips the
+/// node subprocess that the TS path uses, so without this helper every
+/// plugin entry would have `resolved_module = None` and the plugin-host
+/// filter (`commands::plugins::build_plugin_specs`) would drop them all
+/// silently — both `preBuild` and `postBuild` hooks would never fire.
+///
+/// Behaviour mirrors the TS path (`config-loader.mjs`) for the cases we
+/// can handle without a JS runtime:
+///
+/// - Plugin entries naming a relative path (`./` or `../` prefix) or an
+///   absolute path are canonicalised against `dir` and converted to a
+///   `file://` URL via [`url::Url::from_file_path`]. A missing file is a
+///   hard error pointing at the path the user wrote so the failure is
+///   self-explanatory.
+/// - Bare specifiers (`@scope/pkg`, `pkg-name`) cannot be resolved here
+///   without running node; they stay `None` and we emit a user-visible
+///   warning so the silent-drop behaviour is at least announced. The
+///   user's recovery path is to switch to `zfb.config.ts`.
+fn resolve_json_plugin_modules(cfg: &mut Config, dir: &Path) -> Result<()> {
+    for entry in cfg.plugins.iter_mut() {
+        let name = entry.name.as_str();
+        let is_relative = name.starts_with("./") || name.starts_with("../");
+        let is_absolute = name.starts_with('/');
+        if is_relative || is_absolute {
+            let raw_path = if is_relative {
+                dir.join(name)
+            } else {
+                PathBuf::from(name)
+            };
+            let canonical = raw_path.canonicalize().with_context(|| {
+                format!(
+                    "plugin {:?}: cannot resolve plugin file at {} \
+                     (does the file exist?)",
+                    name,
+                    raw_path.display()
+                )
+            })?;
+            let url = url::Url::from_file_path(&canonical).map_err(|()| {
+                anyhow!(
+                    "plugin {:?}: failed to convert {} to a file:// URL",
+                    name,
+                    canonical.display()
+                )
+            })?;
+            entry.resolved_module = Some(url.into());
+        } else {
+            // Bare specifier — no way to resolve without node. Warn so
+            // the surprising "all plugins ignored" behaviour from #211
+            // is at least announced. resolved_module stays None and the
+            // plugin-host filter will drop this entry the same way it
+            // does for synthetic test configs.
+            crate::output::warn(format!(
+                "plugin {:?}: bare specifiers cannot be resolved by zfb.config.json; \
+                 use a relative path (e.g. \"./node_modules/{name}/index.mjs\") or \
+                 switch to zfb.config.ts so node can resolve it",
+                name
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Load a single `zfb.config.ts` file: bundle it with esbuild, evaluate
@@ -1608,6 +1682,166 @@ mod tests {
         .unwrap();
         let cfg = load_from_dir(tmp.path()).await.expect("json load ok");
         assert_eq!(cfg.port, Some(5500));
+    }
+
+    // --- JSON plugin module resolution (issue #211) ---------------------------
+    //
+    // The JSON-load path used to leave every plugin's `resolved_module` at
+    // `None`, which the plugin-host filter (commands::plugins::build_plugin_specs)
+    // silently dropped — so neither preBuild nor postBuild ever fired for
+    // JSON-config projects. These tests pin the new behaviour: relative and
+    // absolute path entries get resolved into file:// URLs, missing files
+    // become hard errors, and bare specifiers stay None (with a warning) so
+    // the user at least sees the surprise.
+
+    #[tokio::test]
+    async fn json_plugin_relative_path_resolves_to_file_url() {
+        let tmp = TempDir::new().unwrap();
+        let plugin_dir = tmp.path().join("plugins");
+        tokio::fs::create_dir_all(&plugin_dir).await.unwrap();
+        let plugin_path = plugin_dir.join("foo.mjs");
+        tokio::fs::write(&plugin_path, "export default {};\n")
+            .await
+            .unwrap();
+
+        tokio::fs::write(
+            tmp.path().join("zfb.config.json"),
+            r#"{
+                "plugins": [
+                    { "name": "./plugins/foo.mjs", "options": { "k": 1 } }
+                ]
+            }"#,
+        )
+        .await
+        .unwrap();
+
+        let cfg = load_from_dir(tmp.path()).await.expect("json load ok");
+        assert_eq!(cfg.plugins.len(), 1);
+
+        let resolved = cfg.plugins[0]
+            .resolved_module
+            .as_deref()
+            .expect("relative-path plugin should populate resolved_module");
+        assert!(
+            resolved.starts_with("file://"),
+            "expected file:// URL, got {resolved:?}"
+        );
+        // Round-trip the URL back to a path and check it matches the
+        // file we created — the canonicalise step normalises symlinks
+        // (e.g. /tmp → /private/tmp on macOS) so compare against the
+        // canonicalised source path, not the raw `plugin_path`.
+        let parsed = url::Url::parse(resolved).expect("valid url");
+        let parsed_path = parsed
+            .to_file_path()
+            .expect("file:// URL should round-trip to a path");
+        let canonical_plugin = plugin_path.canonicalize().unwrap();
+        assert_eq!(parsed_path, canonical_plugin);
+    }
+
+    #[tokio::test]
+    async fn json_plugin_missing_file_errors_clearly() {
+        let tmp = TempDir::new().unwrap();
+        tokio::fs::write(
+            tmp.path().join("zfb.config.json"),
+            r#"{
+                "plugins": [
+                    { "name": "./plugins/does-not-exist.mjs" }
+                ]
+            }"#,
+        )
+        .await
+        .unwrap();
+
+        let err = load_from_dir(tmp.path())
+            .await
+            .expect_err("missing plugin file should error");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("./plugins/does-not-exist.mjs"),
+            "error should name the offending plugin entry: {msg}"
+        );
+        assert!(
+            msg.contains("plugin"),
+            "error should mention plugin context: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn json_plugin_bare_specifier_stays_unresolved_no_error() {
+        let tmp = TempDir::new().unwrap();
+        tokio::fs::write(
+            tmp.path().join("zfb.config.json"),
+            r#"{
+                "plugins": [
+                    { "name": "@takazudo/zfb-shell-rename" },
+                    { "name": "some-bare-pkg" }
+                ]
+            }"#,
+        )
+        .await
+        .unwrap();
+
+        // Bare specifiers cannot be resolved without node; they must
+        // not raise an error here (warning is emitted instead, but we
+        // do not assert on stderr text — that's a UX detail).
+        let cfg = load_from_dir(tmp.path())
+            .await
+            .expect("bare specifier in JSON config must not error");
+        assert_eq!(cfg.plugins.len(), 2);
+        assert!(
+            cfg.plugins[0].resolved_module.is_none(),
+            "bare specifier must stay None (got {:?})",
+            cfg.plugins[0].resolved_module
+        );
+        assert!(
+            cfg.plugins[1].resolved_module.is_none(),
+            "bare specifier must stay None (got {:?})",
+            cfg.plugins[1].resolved_module
+        );
+    }
+
+    #[tokio::test]
+    async fn json_plugin_absolute_path_resolves_to_file_url() {
+        // The plugin file lives at an absolute path that's outside the
+        // project dir — mirror what a user might do when pointing at a
+        // shared monorepo helper. Using TempDir keeps it portable
+        // across CI runners that don't have a stable /opt/... layout.
+        let plugin_root = TempDir::new().unwrap();
+        let plugin_path = plugin_root.path().join("abs-plugin.mjs");
+        tokio::fs::write(&plugin_path, "export default {};\n")
+            .await
+            .unwrap();
+
+        let project = TempDir::new().unwrap();
+        let plugin_path_str = plugin_path.canonicalize().unwrap();
+        let plugin_path_str = plugin_path_str.to_str().unwrap();
+        // The path must be absolute for this branch — assert that
+        // before serialising it into JSON.
+        assert!(
+            plugin_path_str.starts_with('/'),
+            "test setup expects POSIX-absolute path, got {plugin_path_str}"
+        );
+        let json = format!(
+            r#"{{ "plugins": [ {{ "name": "{}" }} ] }}"#,
+            plugin_path_str
+        );
+        tokio::fs::write(project.path().join("zfb.config.json"), json)
+            .await
+            .unwrap();
+
+        let cfg = load_from_dir(project.path())
+            .await
+            .expect("absolute-path plugin should load");
+        let resolved = cfg.plugins[0]
+            .resolved_module
+            .as_deref()
+            .expect("absolute-path plugin should populate resolved_module");
+        let parsed = url::Url::parse(resolved).expect("valid url");
+        assert_eq!(parsed.scheme(), "file");
+        let parsed_path = parsed
+            .to_file_path()
+            .expect("file:// URL should round-trip");
+        assert_eq!(parsed_path, plugin_path.canonicalize().unwrap());
     }
 
     #[tokio::test]

--- a/crates/zfb/src/config.rs
+++ b/crates/zfb/src/config.rs
@@ -681,9 +681,37 @@ fn parse_loader_envelope(json: &str, ts_path: &Path) -> Result<Config> {
 }
 
 /// Resolve the esbuild binary path using the same precedence the
-/// build-time bundler uses: explicit override > `ZFB_ESBUILD_BIN` env >
-/// the staged slot under `crates/zfb/binaries/esbuild/`.
+/// build-time bundler uses:
+/// 1. explicit `LoadOptions::esbuild_binary` override
+/// 2. `ZFB_ESBUILD_BIN` env
+/// 3. embedded extraction from the `EMBEDDED_VENDOR` snapshot (sub #212 —
+///    the consumer-friendly path: works on a machine that has no
+///    `crates/zfb/binaries/` workspace dir)
+/// 4. the staged slot under `crates/zfb/binaries/esbuild/` (in-workspace
+///    dev fallback)
+///
+/// Returns the resolved path. Most callers should use
+/// [`resolve_esbuild_binary_with_handle`] instead — the embedded tier
+/// returns a [`tempfile::TempDir`] that must be kept alive for the
+/// lifetime of the spawned subprocess. This thin wrapper drops the
+/// handle eagerly and is therefore only safe when the caller is sure the
+/// path it gets back will not be the embedded one (e.g. in tests where
+/// `ZFB_ESBUILD_BIN` is set, or when `crates/zfb/binaries/esbuild/esbuild`
+/// is known to exist).
+#[allow(dead_code)]
 fn resolve_esbuild_binary(opts: &LoadOptions) -> Result<PathBuf> {
+    let (_handle, path) = resolve_esbuild_binary_with_handle(opts)?;
+    Ok(path)
+}
+
+/// Variant of [`resolve_esbuild_binary`] that also returns the
+/// [`tempfile::TempDir`] handle backing the embedded extraction tier.
+/// The caller MUST hold the handle alive for as long as the returned
+/// `PathBuf` is referenced by a running subprocess — dropping the handle
+/// removes the tempdir and the binary along with it.
+fn resolve_esbuild_binary_with_handle(
+    opts: &LoadOptions,
+) -> Result<(Option<tempfile::TempDir>, PathBuf)> {
     if let Some(p) = opts.esbuild_binary.as_deref() {
         if !p.exists() {
             bail!(
@@ -691,7 +719,7 @@ fn resolve_esbuild_binary(opts: &LoadOptions) -> Result<PathBuf> {
                 p.display()
             );
         }
-        return Ok(p.to_path_buf());
+        return Ok((None, p.to_path_buf()));
     }
     if let Some(env) = std::env::var_os("ZFB_ESBUILD_BIN") {
         let p = PathBuf::from(env);
@@ -701,7 +729,21 @@ fn resolve_esbuild_binary(opts: &LoadOptions) -> Result<PathBuf> {
                 p.display()
             );
         }
-        return Ok(p);
+        return Ok((None, p));
+    }
+    // Embedded extraction tier (sub #212). We try this BEFORE the
+    // workspace-relative slot so consumers running `zfb build` from a
+    // project that doesn't ship `crates/zfb/binaries/` still resolve a
+    // working binary. The TempDir is propagated to the caller so the
+    // extracted file outlives the subprocess invocation.
+    match crate::render_pipeline::embedded_binary("esbuild") {
+        Ok((handle, path)) => return Ok((Some(handle), path)),
+        Err(_embed_err) => {
+            // Fall through to the workspace-relative slot. The embedded
+            // path is the expected production resolution for cargo-installed
+            // binaries; failure here is normal during in-workspace dev (and
+            // the slot fallback below covers that).
+        }
     }
     let slot = PathBuf::from(DEFAULT_ESBUILD_SLOT);
     if !slot.exists() {
@@ -712,7 +754,7 @@ fn resolve_esbuild_binary(opts: &LoadOptions) -> Result<PathBuf> {
             slot.display()
         ));
     }
-    Ok(slot)
+    Ok((None, slot))
 }
 
 /// Run esbuild + node to compile `ts_path` to ESM and pull the default
@@ -722,7 +764,10 @@ async fn load_ts_via_subprocess(
     dir: &Path,
     opts: &LoadOptions,
 ) -> Result<String> {
-    let esbuild = resolve_esbuild_binary(opts)?;
+    // The TempDir handle (when the embedded extraction tier is taken) must
+    // outlive every subprocess spawn below — esbuild and node both reference
+    // the extracted binary path. Drop only happens at function return.
+    let (_esbuild_embed_guard, esbuild) = resolve_esbuild_binary_with_handle(opts)?;
 
     // Stage the embedded helper scripts and esbuild output into a
     // tempdir that vanishes at the end of this function.
@@ -1647,6 +1692,45 @@ mod tests {
         assert!(
             msg.contains("Node.js"),
             "msg should mention Node.js: {msg}"
+        );
+    }
+
+    /// Sub #212 — when neither `LoadOptions::esbuild_binary` nor the
+    /// `ZFB_ESBUILD_BIN` env var is set, the resolver falls through to the
+    /// embedded extraction tier (the binary staged inside the zfb crate at
+    /// build time). The returned path must exist and the function must
+    /// hand back a TempDir handle so the caller can keep the extracted
+    /// binary alive for the lifetime of the spawned subprocess.
+    #[test]
+    fn resolve_esbuild_binary_picks_embedded_path_without_env_or_explicit() {
+        // Defensive: if a parent process has set ZFB_ESBUILD_BIN, this
+        // test would short-circuit on the env tier instead of testing the
+        // embedded tier we care about. Skip cleanly in that case.
+        // SAFETY: tests run sequentially within this thread and we do not
+        // touch ZFB_ESBUILD_BIN ourselves. Other tests must not depend on
+        // a leaked override.
+        if std::env::var_os("ZFB_ESBUILD_BIN").is_some() {
+            eprintln!(
+                "skipping resolve_esbuild_binary_picks_embedded_path_without_env_or_explicit \
+                 because ZFB_ESBUILD_BIN is set in the surrounding env"
+            );
+            return;
+        }
+        let opts = LoadOptions::default();
+        let (handle, path) = resolve_esbuild_binary_with_handle(&opts)
+            .expect("embedded extraction should succeed for esbuild");
+        assert!(
+            path.exists(),
+            "resolved esbuild path should exist: {}",
+            path.display()
+        );
+        // The embedded tier always returns a Some(TempDir). The
+        // workspace-relative dev fallback would return None, but we expect
+        // the embedded tier to win because the include_dir! snapshot
+        // always carries the binary in a release build.
+        assert!(
+            handle.is_some(),
+            "expected the embedded extraction tier to be selected"
         );
     }
 

--- a/crates/zfb/src/render_pipeline.rs
+++ b/crates/zfb/src/render_pipeline.rs
@@ -121,10 +121,83 @@ static EMBEDDED_VENDOR: Dir<'_> = include_dir!("$ZFB_VENDOR_DIR");
 pub fn embedded_node_modules() -> Result<(tempfile::TempDir, PathBuf)> {
     let dir = tempfile::tempdir().context("failed to create tempdir for embedded packages")?;
     let node_modules = dir.path().join("node_modules");
-    extract_dir_with_prefix(&EMBEDDED_VENDOR, &node_modules, Path::new(""))
-        .context("failed to extract embedded packages")?;
+    // Skip the top-level `bin/` entry — those are helper binaries (esbuild,
+    // tailwindcss-v4) staged by `stage_binaries_into_vendor` for
+    // `embedded_binary()` to extract on demand. They have no business inside
+    // a node_modules tree, and not extracting them avoids ~100 MB of wasted
+    // copies on every esbuild bundler invocation.
+    extract_dir_with_prefix_filtered(&EMBEDDED_VENDOR, &node_modules, Path::new(""), &|p| {
+        p.iter().next().map(|s| s == "bin").unwrap_or(false)
+    })
+    .context("failed to extract embedded packages")?;
     let nm_path = node_modules;
     Ok((dir, nm_path))
+}
+
+/// Extract a single embedded helper binary (esbuild, tailwindcss-v4, …) from
+/// the `bin/` subtree of [`EMBEDDED_VENDOR`] into a fresh tempdir so the TS
+/// config loader and the CSS engine can shell out to it without a
+/// workspace-relative `crates/zfb/binaries/` slot.
+///
+/// `name` is the binary's stem (e.g. `"esbuild"`, `"tailwindcss-v4"`). On
+/// Windows this function additionally probes for `<name>.exe` so a caller
+/// passing `"esbuild"` resolves the Windows variant transparently.
+///
+/// Returns a `(TempDir, PathBuf)` pair where:
+/// - `TempDir` must be kept alive for as long as the subprocess runs
+///   (dropping it removes the temp directory and the extracted binary).
+/// - `PathBuf` is the path to the extracted binary on disk; on Unix the
+///   executable bit is set at write time.
+///
+/// # Errors
+///
+/// Returns an error pointing the operator at the build-script staging step
+/// (`stage_binaries_into_vendor` in `crates/zfb/build.rs`) when the binary is
+/// not present in [`EMBEDDED_VENDOR`].
+pub fn embedded_binary(name: &str) -> Result<(tempfile::TempDir, PathBuf)> {
+    // Probe `bin/<name>` first; on Windows fall back to `bin/<name>.exe` so
+    // callers can pass the stem without worrying about target_os.
+    let primary = format!("bin/{name}");
+    let file = EMBEDDED_VENDOR.get_file(&primary).or_else(|| {
+        if cfg!(target_os = "windows") {
+            EMBEDDED_VENDOR.get_file(format!("bin/{name}.exe"))
+        } else {
+            None
+        }
+    });
+    let file = file.ok_or_else(|| {
+        anyhow::anyhow!(
+            "embedded binary `{name}` not found under bin/ inside the embedded vendor snapshot. \
+             Make sure `crates/zfb/build.rs::stage_binaries_into_vendor` ran during the last \
+             build (it copies crates/zfb/binaries/{{esbuild,tailwindcss-v4}} into \
+             $OUT_DIR/vendor/bin/ so include_dir! picks them up)."
+        )
+    })?;
+
+    let dir = tempfile::tempdir()
+        .with_context(|| format!("failed to create tempdir for embedded binary `{name}`"))?;
+
+    // Preserve any `.exe` suffix from the matched embedded path so callers
+    // don't need to know the host platform.
+    let dst_name = file
+        .path()
+        .file_name()
+        .map(|s| s.to_os_string())
+        .unwrap_or_else(|| std::ffi::OsString::from(name));
+    let dst = dir.path().join(&dst_name);
+    std::fs::write(&dst, file.contents()).with_context(|| {
+        format!("failed to write embedded binary `{name}` to {}", dst.display())
+    })?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&dst, std::fs::Permissions::from_mode(0o755)).with_context(
+            || format!("failed to set executable bit on {}", dst.display()),
+        )?;
+    }
+
+    Ok((dir, dst))
 }
 
 /// Recursively extract all entries from `embedded` into `dest`, stripping
@@ -134,19 +207,35 @@ pub fn embedded_node_modules() -> Result<(tempfile::TempDir, PathBuf)> {
 /// For example, if the embedded root is `$OUT_DIR/vendor` and `prefix` is
 /// `""` (empty), the entry `@takazudo/zfb/src/index.ts` is written to
 /// `dest/@takazudo/zfb/src/index.ts`.
-fn extract_dir_with_prefix(embedded: &Dir<'_>, dest: &Path, prefix: &Path) -> Result<()> {
+/// Recursively extract entries from `embedded` into `dest`, stripping
+/// `prefix` from each entry's embedded path. Skips any entry whose
+/// `prefix`-stripped path satisfies `skip`. Used by [`embedded_node_modules`]
+/// to filter out the `bin/` subtree that's only relevant to
+/// [`embedded_binary`].
+fn extract_dir_with_prefix_filtered(
+    embedded: &Dir<'_>,
+    dest: &Path,
+    prefix: &Path,
+    skip: &dyn Fn(&Path) -> bool,
+) -> Result<()> {
     use include_dir::DirEntry;
     for entry in embedded.entries() {
         match entry {
             DirEntry::Dir(sub) => {
                 let rel = sub.path().strip_prefix(prefix).unwrap_or(sub.path());
+                if skip(rel) {
+                    continue;
+                }
                 let target = dest.join(rel);
                 std::fs::create_dir_all(&target)
                     .with_context(|| format!("failed to create dir {}", target.display()))?;
-                extract_dir_with_prefix(sub, dest, prefix)?;
+                extract_dir_with_prefix_filtered(sub, dest, prefix, skip)?;
             }
             DirEntry::File(file) => {
                 let rel = file.path().strip_prefix(prefix).unwrap_or(file.path());
+                if skip(rel) {
+                    continue;
+                }
                 let target = dest.join(rel);
                 if let Some(parent) = target.parent() {
                     std::fs::create_dir_all(parent).with_context(|| {
@@ -1165,6 +1254,59 @@ mod tests {
             .expect("runtime should resolve via embedded nm_path");
 
         drop(handle); // explicit: tempdir is removed here
+    }
+
+    /// Smoke-test [`embedded_binary`] for the `esbuild` slot:
+    ///
+    /// 1. The path returned exists on disk.
+    /// 2. On Unix the executable bit is set so a subprocess can spawn it.
+    /// 3. The file is non-empty (we don't shell out — that's the
+    ///    `#[ignore]`-gated integration test's job).
+    ///
+    /// Mirrors `embedded_node_modules_extracts_runtime_layout` for the
+    /// `bin/` half of the embedded vendor tree (sub #212).
+    #[test]
+    fn embedded_binary_extracts_executable_esbuild_path() {
+        let (handle, path) =
+            embedded_binary("esbuild").expect("embedded_binary(\"esbuild\") should succeed");
+        assert!(
+            path.exists(),
+            "extracted esbuild path should exist: {}",
+            path.display()
+        );
+        let meta = std::fs::metadata(&path).expect("metadata should be readable");
+        assert!(
+            meta.len() > 0,
+            "extracted esbuild binary should not be empty: {}",
+            path.display()
+        );
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = meta.permissions().mode();
+            assert!(
+                mode & 0o111 != 0,
+                "extracted esbuild binary should be executable: mode = {mode:o}"
+            );
+        }
+        drop(handle);
+    }
+
+    /// `embedded_binary` returns a clear error when the requested name is
+    /// not present in `EMBEDDED_VENDOR/bin/`. The error message must point
+    /// the operator at the build-script staging step.
+    #[test]
+    fn embedded_binary_errors_with_actionable_hint_when_missing() {
+        let err = embedded_binary("does-not-exist-xyz").unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("does-not-exist-xyz"),
+            "msg should name the requested binary: {msg}"
+        );
+        assert!(
+            msg.contains("stage_binaries_into_vendor"),
+            "msg should point at the build-script staging step: {msg}"
+        );
     }
 
     // ---- expand_dynamic_routes -------------------------------------------


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/213 (tracking)
    - https://github.com/Takazudo/zudo-front-builder/issues/211
    - https://github.com/Takazudo/zudo-front-builder/issues/212

---

## Summary

Two parallel bug fixes for zfb's path-resolution gaps when consumers run `zfb` from a project outside the zfb workspace.

### sub-211 — JSON config plugin loader (`crates/zfb/src/config.rs`)

When projects use `zfb.config.json` instead of `zfb.config.ts`, plugins were silently ignored because `PluginConfig.resolved_module` was never populated for the JSON load path. `build_plugin_specs` (in `commands/plugins.rs`) drops any entry with `resolved_module: None`, so neither `preBuild` nor `postBuild` hooks fired.

`load_from_dir_with_options` now:

- Resolves relative paths (`./` or `../`) and absolute paths in `plugins[i].name` to canonical `file://` URLs via `url::Url::from_file_path`.
- Returns a clear error if a relative-path plugin file is missing.
- Emits a warning and leaves `resolved_module: None` for bare specifiers (npm package names) — those still need the TS-config path which runs node for resolution.

Adds `url` v2 as a direct dependency of crate `zfb` (was already present transitively).

Tests cover relative, absolute, missing-file, and bare-specifier cases (4 new tests in `config.rs`).

### sub-212 — Embedded binary extraction for TS config loader and CSS engine

Companion of #210 (which embedded the framework runtime packages). The embedded snapshot now also carries the staged `esbuild` and `tailwindcss-v4` binaries so the TS config loader and the CSS engine resolve them correctly when zfb is invoked from a project that lives outside the zfb workspace.

- `crates/zfb/build.rs` stages the binaries into `$OUT_DIR/vendor/bin/` (preserving the executable bit on Unix), so they ride inside the existing `include_dir!(env!("ZFB_VENDOR_DIR"))` snapshot — no separate `include_dir!` macro needed.
- `crates/zfb/src/render_pipeline.rs` exposes a new `embedded_binary(name)` helper that extracts a single named binary into a fresh tempdir, returning the `(TempDir, PathBuf)` pair so callers hold the tempdir alive across subprocess invocations.
- `crates/zfb/src/config.rs::resolve_esbuild_binary` was split into a `_with_handle` variant returning `(Option<TempDir>, PathBuf)`. Precedence is now: explicit override → `ZFB_ESBUILD_BIN` env → embedded extraction → workspace-relative slot. `load_ts_via_subprocess` binds the optional tempdir as a guard.
- `crates/zfb-css/src/engine.rs` `TailwindSubprocessConfig` grew an `Arc<TempDir>` field and a `with_embedded_binary` chainable method (Arc because the config is `Clone` and `TempDir` is not). Wired in from `commands::build` so the embedded path is selected when no env override exists.

Tests cover embedded-extraction smoke (binary present + executable bit), config.rs precedence with no env / no slot, and the engine's tempdir lifetime (3 new tests across the three crates).

### Out of scope / follow-ups

- Windows-specific path canonicalization tests (gcoc-review noted as a coverage wish).
- Symlinked plugin path tests for monorepos.
- Both can be added once cross-platform CI runs the test suite on Windows.

Closes #211
Closes #212
Closes #213

## Topic PRs

Topic branches were merged into base locally and have already been deleted.
