### PR TITLE
feat(client-router): port Astro-style SPA soft-swap router with View Transitions wrapping

### DIFF
--- a/packages/zfb-runtime/docs/client-router/port-spec.md
+++ b/packages/zfb-runtime/docs/client-router/port-spec.md
@@ -1,0 +1,654 @@
+# W1B — Per-module port spec (Astro ClientRouter → zfb-runtime) + island-lifecycle contract
+
+**Wave:** 1 (Strategy B port, epic zudolab/zudo-doc#1510, sub-issue #1512)
+**Author agent:** W1B
+**Date:** 2026-05-07
+**Status:** Settled. W3A–W3D children should implement directly from this spec without further design judgment.
+
+---
+
+## Guiding principle (re-stated, normative)
+
+**Replicate, do not redesign.** Per the May-6 backside-migration retro in `l-lessons-zfb-migration-parity` ("default contract is replicate, do not redesign"), the zfb client-router mirrors Astro's structure file-by-file, function-by-function. Naming changes (`astro:` → `zfb:`, `data-astro-*` → `data-zfb-*`) are mechanical, not creative. **Any deviation from Astro's structure must have a NAMED TECHNICAL CAUSE recorded in this spec.** "Looks cleaner" or "more idiomatic for Preact" are NOT acceptable causes.
+
+W3A–W3D children inherit this rule; they self-check by grepping their own diff for un-mapped Astro symbols.
+
+---
+
+## 0. Source files audited
+
+Read in full. Line counts confirmed:
+
+| File | Lines |
+|------|-------|
+| `packages/astro/components/ClientRouter.astro` | 155 |
+| `packages/astro/src/transitions/router.ts` | 745 |
+| `packages/astro/src/transitions/swap-functions.ts` | 271 |
+| `packages/astro/src/transitions/events.ts` | 204 |
+| `packages/astro/src/transitions/cssesc.ts` | 103 |
+| `packages/astro/src/transitions/index.ts` | 78 (public API surface — animations only, NOT router) |
+| `packages/astro/src/transitions/types.ts` | 10 |
+| `packages/astro/src/transitions/vite-plugin-transitions.ts` | 66 |
+
+zfb-side context audited:
+
+- `packages/zfb-runtime/src/index.ts` (current public exports)
+- `packages/zfb-runtime/src/view-transitions.ts` (existing typed no-op, kept for shim compat)
+- `packages/zfb-runtime/src/router.ts` (server-side Hono page router — UNRELATED to this work; named "router" but it's the SSR dispatcher, not the client router)
+- `packages/zfb/src/island.ts` (Island JSX wrapper, marker attrs `data-zfb-island`, `data-zfb-island-skip-ssr`, `data-props`)
+- `packages/zfb/src/runtime.ts` (`mountIslands`, `scheduleHydrate`, `mounted`/`pending` WeakSet guards)
+
+---
+
+## 1. Module structure (decision #1)
+
+**Decision:** create `packages/zfb-runtime/src/client-router/` subdirectory holding the per-module ports, plus a top-level `<ClientRouter />` Preact component file at `packages/zfb-runtime/src/client-router.tsx` (or `client-router/index.tsx`; see naming note below).
+
+```
+packages/zfb-runtime/src/
+├── client-router/
+│   ├── cssesc.ts          ← port of transitions/cssesc.ts
+│   ├── events.ts          ← port of transitions/events.ts
+│   ├── swap-functions.ts  ← port of transitions/swap-functions.ts
+│   ├── router.ts          ← port of transitions/router.ts
+│   ├── types.ts           ← port of transitions/types.ts
+│   └── index.ts           ← barrel re-exports (public API surface, decision #2)
+├── client-router.tsx      ← <ClientRouter /> Preact component (replaces ClientRouter.astro)
+├── view-transitions.ts    ← KEEP (typed no-op for back-compat; do NOT delete)
+└── index.ts               ← top-level package barrel; re-exports from client-router/
+```
+
+**Naming note (DEVIATION from Astro, with cause):**
+Astro's source lives under `src/transitions/` because Astro uses "transitions" as the integration name. zfb's existing `view-transitions.ts` is already a typed no-op with that name. We name the new directory `client-router/` (not `transitions/`) because:
+
+- **Named technical cause:** the existing `view-transitions.ts` symbol is the public *deprecated* compatibility shim. Reusing the name "transitions" for the new live router would either (a) shadow the existing symbol and break any consumer still using `<ViewTransitions />`, or (b) require renaming the deprecated file, which is a forbidden API break. Naming the new directory `client-router/` keeps both layers exportable side-by-side. Functionally it also matches Astro's runtime-internal nomenclature: Astro calls the runtime `ClientRouter` even though the source folder is `transitions/`.
+
+**Top-level file naming:** `client-router.tsx` for the Preact component (singular .tsx file, JSX-bearing) sits beside the `client-router/` directory. If TypeScript's `moduleResolution` policy makes the dir-and-file pairing fragile, we may instead put the component at `client-router/component.tsx` and re-export from `client-router/index.ts`. W3A picks one — either is acceptable, no further design judgment needed; they are equivalent under "replicate, do not redesign" because Astro itself has the component file (`ClientRouter.astro`) outside the runtime sources. Default: `client-router.tsx` at top level.
+
+---
+
+## 2. Public API surface (decision #2)
+
+The `@takazudo/zfb-runtime` top-level `index.ts` adds (alongside existing exports):
+
+```ts
+// Components
+export { ClientRouter, type ClientRouterProps } from "./client-router.tsx";
+
+// Imperative API (mirrors astro:transitions/client)
+export { navigate, supportsViewTransitions, transitionEnabledOnThisPage } from "./client-router/router.ts";
+
+// Lifecycle event classes + constants (mirrors astro:transitions/client events)
+export {
+  TRANSITION_BEFORE_PREPARATION,
+  TRANSITION_AFTER_PREPARATION,
+  TRANSITION_BEFORE_SWAP,
+  TRANSITION_AFTER_SWAP,
+  TRANSITION_PAGE_LOAD,
+  TransitionBeforePreparationEvent,
+  TransitionBeforeSwapEvent,
+  isTransitionBeforePreparationEvent,
+  isTransitionBeforeSwapEvent,
+} from "./client-router/events.ts";
+
+// Swap functions (advanced consumers can replace individual swap steps)
+export { swapFunctions, swap } from "./client-router/swap-functions.ts";
+
+// Types
+export type { Direction, Fallback, NavigationTypeString, Options } from "./client-router/types.ts";
+```
+
+The existing `ViewTransitions` typed no-op stays exported as a deprecated alias. Note: it is NOT replaced by `ClientRouter`; the names are separate and the deprecation comment on `ViewTransitions` already explains the migration path (CSS `@view-transition` at-rule), so consumers can keep it mounted while they switch.
+
+`<ClientRouter />` props (mirrors Astro's `Props`):
+
+```ts
+export interface ClientRouterProps {
+  fallback?: "none" | "animate" | "swap"; // default "animate"
+}
+```
+
+The component renders:
+
+1. A scoped `<style is:global>` equivalent — emit a global `<style>` tag with the `.zfb-route-announcer` class (renamed from `.astro-route-announcer`). The style is global because the announcer `<div>` is appended to `document.body` at runtime, not under any Preact-controlled subtree.
+2. `<meta name="zfb-view-transitions-enabled" content="true" />`
+3. `<meta name="zfb-view-transitions-fallback" content={fallback} />`
+4. A `<script>` with the click + submit interceptors, identical structure to Astro's inline `<script>`.
+
+**Naming note:** Astro's `<style is:global>` is an Astro-template directive. In Preact, just emit a plain `<style>` element — the CSS rule is a class selector that targets a runtime-appended `<div>`, so a non-scoped `<style>` is the literal port (no scoped-class transform happens in either case).
+
+---
+
+## 3. Lifecycle event names (decision #3)
+
+Mirror Astro's `astro:*` namespace one-for-one with `zfb:`:
+
+| Astro | zfb (this port) |
+|-------|-----------------|
+| `astro:before-preparation` | `zfb:before-preparation` |
+| `astro:after-preparation` | `zfb:after-preparation` |
+| `astro:before-swap` | `zfb:before-swap` |
+| `astro:after-swap` | `zfb:after-swap` |
+| `astro:page-load` | `zfb:page-load` |
+
+Constants in `client-router/events.ts`:
+
+```ts
+export const TRANSITION_BEFORE_PREPARATION = "zfb:before-preparation";
+export const TRANSITION_AFTER_PREPARATION = "zfb:after-preparation";
+export const TRANSITION_BEFORE_SWAP = "zfb:before-swap";
+export const TRANSITION_AFTER_SWAP = "zfb:after-swap";
+export const TRANSITION_PAGE_LOAD = "zfb:page-load";
+```
+
+**Why mirror namespace, not condense:** Astro user code in the wild listens on `document.addEventListener("astro:page-load", ...)`. Anyone porting from Astro to zfb does a one-time string replace `astro:` → `zfb:`. Any other naming (`zfb:router:page-load`, `view-transition:page-load`, etc.) breaks that mechanical migration with no benefit.
+
+**Justification one-liners:**
+
+- `before-preparation` / `after-preparation`: hooks around the fetch + DOMParser step. Verbatim from Astro.
+- `before-swap` / `after-swap`: hooks around the actual `swap()` call. Verbatim from Astro.
+- `page-load`: fired after scripts re-run + new page is announced. Verbatim from Astro.
+
+---
+
+## 4. Persist directive name (decision #4)
+
+**Decision:** `data-zfb-transition-persist="<id>"` — direct mirror of Astro's `data-astro-transition-persist`.
+
+**Collision grep result (mandatory check):**
+
+```
+$ rg -n "data-zfb-transition-persist|zfb:transition" \
+    <consumer-checkout> \
+    <zfb-checkout> 2>/dev/null
+(empty)
+```
+
+**No collisions in either codebase.** Name is safe to commit.
+
+Companion attribute (mirrors Astro's `data-astro-transition-persist-props`):
+
+- `data-zfb-transition-persist-props="false"` — when present, the swap function copies new `props` into the persisted island marker so it can re-render with refreshed data. Default behavior (attribute absent or `"false"`) IS to copy. Astro's `shouldCopyProps` returns `true` when the value is `null` (absent) or `"false"`, both meaning "copy". Replicate verbatim.
+
+---
+
+## 5. Fallback attribute names (decision #5)
+
+| Astro | zfb |
+|-------|-----|
+| `data-astro-transition` (set on `<html>` to direction) | `data-zfb-transition` |
+| `data-astro-transition-fallback` (set on `<html>` to "old"/"new") | `data-zfb-transition-fallback` |
+| `data-astro-rerun` | `data-zfb-rerun` |
+| `data-astro-exec` | `data-zfb-exec` |
+| `data-astro-history` (on `<a>` for replace-mode) | `data-zfb-history` |
+| `data-astro-reload` (decision #6) | `data-zfb-reload` |
+| `astro-route-announcer` (CSS class) | `zfb-route-announcer` |
+| `astro-view-transitions-enabled` (meta name) | `zfb-view-transitions-enabled` |
+| `astro-view-transitions-fallback` (meta name) | `zfb-view-transitions-fallback` |
+| `astro-island` (custom-element local-name) | **(see decision #12 — zfb has no equivalent custom element; the persist branch that special-cases `astro-island` re-routes to `data-zfb-island` markers)** |
+
+`NON_OVERRIDABLE_ASTRO_ATTRS` becomes `NON_OVERRIDABLE_ZFB_ATTRS = ['data-zfb-transition', 'data-zfb-transition-fallback']`.
+
+`PERSIST_ATTR`, `DIRECTION_ATTR`, `OLD_NEW_ATTR` constants in `swap-functions.ts` and `router.ts` rename mechanically.
+
+`VITE_ID = 'data-vite-dev-id'` — KEEP verbatim. This is Vite's own attribute, not Astro's, and zfb's dev pipeline goes through Vite too. (Note: in zfb the equivalent dev-pass-through case may not occur because zfb doesn't have a Vue dev pipeline; see decisions #8 and #9.)
+
+---
+
+## 6. Reload opt-out (decision #6)
+
+`data-zfb-reload` — direct mirror of `data-astro-reload`. Used in `ClientRouter.astro`'s `isReloadEl()` check; ports verbatim into the new `<ClientRouter />` script body. Same JS pattern: `el.dataset.zfbReload !== undefined`.
+
+---
+
+## 7. Prefetch integration (decision #7) — DEFERRED
+
+**Decision:** Out of scope for v1. Follow-up issue created.
+
+**Tracker issue:** zudolab/zudo-doc#1527 — `[VT Strategy B][Followup] Port Astro prefetch module to zfb-runtime`
+URL: https://github.com/zudolab/zudo-doc/issues/1527
+
+The new `<ClientRouter />` script does NOT include the Astro `init({ prefetchAll: true })` call. The Vite plugin's `__PREFETCH_DISABLED__` substitution is also out of scope (decision #9 expands).
+
+If user wants prefetch in v1: raise during W2A confirm gate, W3C absorbs.
+
+---
+
+## 8. Vue-scoped style ID handling (decision #8)
+
+Astro's `vueScopedStyleId(el: HTMLStyleElement)` reads `el.dataset.viteDevId`, parses it as a URL, and checks for `?vue&type=style&scoped` query params. If matching, returns the dev ID (used to dedupe Vue scoped styles across navigations in DEV). The `knownVueScopedStyles` Map preserves transformed styles whose textContent has been mutated by Vue's `:deep()` rewriting.
+
+**Decision:** **PORT VERBATIM as a no-op equivalent.** Reasoning:
+
+- zfb does not ship Vue. The query-param check (`searchParams.get('vue') !== null`) will never match, so `vueScopedStyleId` will always return `''`.
+- BUT — keeping the function (renamed to a more accurate `viteDevScopedStyleId` if desired, or kept as `vueScopedStyleId` for line-for-line replication) costs nothing at runtime (one URL parse on a small attribute), and the `knownVueScopedStyles` Map dedup logic is still correct: if zfb later adds a similar dev-time scoped-style transform (Tailwind v4 `@layer`, scoped CSS modules, etc.), the slot is already in place.
+- **Named technical cause for keeping the dead-looking branch:** insurance against a future zfb dev plugin that uses `data-vite-dev-id` for transformed styles. The cost of removing and re-adding later is greater than the cost of a single URL-parse-that-returns-empty per `<style>` element on swap.
+
+**Recommendation:** keep the function name `vueScopedStyleId` (replicate-don't-redesign rule). If a reviewer pushes back on the "Vue" prefix in zfb code, rename to `viteDevScopedStyleId` — but do this in a follow-up cosmetic PR, NOT in W3 implementation.
+
+The `import.meta.env.DEV` gate is preserved verbatim. zfb's bundler exposes `import.meta.env.DEV` (Vite-style) the same way Astro does — confirmed via existing zfb-runtime code that uses `process.env["NODE_ENV"]` and `import.meta` patterns interchangeably.
+
+---
+
+## 9. Vite plugin requirement (decision #9)
+
+Astro's `vite-plugin-transitions.ts`:
+
+1. Resolves the virtual module IDs `astro:transitions` and `astro:transitions/client` (used by `import { navigate } from 'astro:transitions/client'` in user code).
+2. Treeshakes the prefetch import: when `settings.config.prefetch === false`, replaces the literal string `__PREFETCH_DISABLED__` with `true` so the gated `init(...)` call in `ClientRouter.astro` is dropped.
+
+**Decision:** zfb does NOT need the virtual-module resolver. zfb is a static-import / package-export world: consumers import directly from `@takazudo/zfb-runtime` as a regular package. There is no `zfb:transitions/client` virtual-module convention.
+
+The prefetch treeshake hook is also unnecessary in v1 because **prefetch is deferred (decision #7)** — there is no `init({ prefetchAll: true })` call in the v1 `<ClientRouter />` script, so there is nothing to gate.
+
+**Out of scope for v1: vite-plugin-transitions equivalent.** When prefetch lands (issue #1527), a small zfb plugin in `@takazudo/zfb` will be added at that time to gate the prefetch import.
+
+**Named technical cause:** zfb's package surface is direct-import; Astro uses virtual modules because `astro:` is reserved by the Astro integration system. There is nothing for the plugin to do in zfb v1.
+
+---
+
+## 10. Style preload — `preloadStyleLinks()` (decision #10)
+
+**Decision:** PORT VERBATIM into `client-router/router.ts`.
+
+`preloadStyleLinks(newDocument)` walks `head link[rel=stylesheet]` in the new document, and for each href that is NOT already present in the current page (matched by `data-zfb-transition-persist` ID OR by `href` literal), emits a `<link rel=preload as=style href=...>` into the current head and returns a Promise that resolves on `load` or `error`.
+
+The router awaits all these preloads inside `defaultLoader` so the swap doesn't FOUC. This is core to the "no flash on swap" behavior — skipping it visibly degrades the experience.
+
+The function is small (~25 lines), has no Astro-specific dependencies, and the persist-ID branch already accepts the renamed `data-zfb-transition-persist` attribute.
+
+**Replicate verbatim.**
+
+---
+
+## 11. STOP gate trigger phrasing (decision #11)
+
+> If during W3A–W3D implementation a child agent encounters a **substantial upstream runtime change requiring maintainer signoff** — e.g. Astro's router introduces a new lifecycle event class, a new persist-element protocol, or a fundamentally different swap algorithm in a version we'd be tracking — **STOP**. Do not silently re-design. File a comment on the parent epic (#1510) describing:
+>
+> 1. The Astro symbol that has materially changed shape (cite line ranges in the upstream Astro source).
+> 2. The minimal port that would still mechanically replicate the change.
+> 3. Why "replicate-don't-redesign" still applies vs. an exception.
+>
+> Wait for maintainer ack before proceeding.
+
+**Phrasing rationale:** the trigger is "**substantial upstream runtime change requiring maintainer signoff**" (large surface area + browser-behavior subtlety + maintainer review burden). It is NOT "material risk in product terms" — the feature is opt-in (consumers must explicitly mount `<ClientRouter />`), so a regression there does not break consumers who haven't opted in. The bar is reviewer attention budget, not user-facing impact.
+
+---
+
+## 12. Island-lifecycle contract (decision #12) — CRITICAL
+
+This is the load-bearing decision. W3D implements against this; W6B writes tests against this.
+
+### 12.1 Background — current zfb island bootstrap
+
+(Read from `packages/zfb/src/runtime.ts` lines 240–414.)
+
+zfb's `mountIslands(manifest)` is called once at script load. It:
+
+1. `document.querySelectorAll("[data-zfb-island]")` — for SSR-hydrated islands, calls `scheduleMount(..., "hydrate")`.
+2. `document.querySelectorAll("[data-zfb-island-skip-ssr]")` — for SSR-skip islands (Astro `client:only`-equivalent), calls `scheduleMount(..., "render")`.
+
+`scheduleMount` is guarded by two module-level WeakSets: `mounted` (already mounted) and `pending` (dynamic-import in flight). Each guard is keyed by `Element`. If an element passes both guards, the manifest is consulted and either an inline `mount()` is called (shared-bundle path) or a dynamic `import(url)` chain runs (per-island bundle path).
+
+`scheduleHydrate(target, when, fire)` defers the actual mount based on `data-when` (`"load"`, `"idle"`, `"visible"`).
+
+**Idempotency status:** `mountIslands` IS already idempotent at the *element* level: a given DOM element is mounted at most once. **But it is NOT idempotent at the document level after a body swap** — see 12.3.
+
+### 12.2 Re-hydration after `swapBodyElement`
+
+**Contract:** after `swap-functions.ts:swap(doc)` finishes (which invokes `swapBodyElement`), the client-router router code MUST trigger an island re-bootstrap walk on the new body before dispatching `zfb:after-swap`.
+
+**Implementation requirement (W3D):**
+
+1. Add a new public entry point in `@takazudo/zfb`'s runtime export: `mountNewIslands()` (or similar) that walks ONLY the current document body for `[data-zfb-island]` and `[data-zfb-island-skip-ssr]` markers and runs `scheduleMount` against them. It re-uses the same module-level `mounted` and `pending` WeakSets.
+   - **Why a new function vs. just calling `mountIslands(manifest)` again:** the existing `mountIslands` requires the manifest to be passed by the caller. The router should not need to know the manifest. Solution: store the manifest on first call (as a module-level captured `lastManifest` variable inside `mountIslands`) and expose `mountNewIslands()` that re-uses the captured value. **Named technical cause:** the router lives in `@takazudo/zfb-runtime`, the islands runtime lives in `@takazudo/zfb`; passing the manifest through the swap event would require either widening the event API or threading manifest into router options. The captured-manifest pattern keeps the boundary clean and matches the existing module-level singleton design (`mounted`, `pending`, `importImpl`).
+
+2. Call `mountNewIslands()` from inside `client-router/router.ts`'s `runScripts` step or immediately after `triggerEvent('zfb:after-swap')`. The exact ordering: run AFTER `swap()` mutates the DOM, AFTER `runScripts()` re-runs new inline scripts (so any new `mountIslands` registration the new page might have done at script-evaluation time has executed), and BEFORE `triggerEvent('zfb:page-load')`. **Pin point:** call `mountNewIslands()` between `runScripts()` and `onPageLoad()` in router's `currentTransition.viewTransition?.updateCallbackDone.finally(...)` block.
+
+3. The dispatch is fire-and-forget; mount scheduling happens asynchronously (idle / visible) after this point and is not awaited.
+
+### 12.3 Persisted islands — recommendation by zone
+
+Per `swapBodyElement` (lines 87–137), elements carrying `data-zfb-transition-persist` are physically moved from the old body into the new body via DOM `moveBefore` (Chrome 133+) or `appendChild` + `replaceWith`. They are NOT detached and re-rendered.
+
+For islands specifically (Astro's branch around line 124–132 detects `astro-island` by `localName`), Astro copies the new `props` attribute onto the persisted element when the new HTML had different props, then sets a `ssr` attribute to trigger re-render.
+
+**zfb has no `astro-island` custom element.** zfb's Island wrapper renders a plain `<div data-zfb-island="ComponentName" data-when="..." data-props="...">`. So the persist-merge branch keys differently:
+
+```
+// Replace Astro's:
+//   if (newTarget.localName === 'astro-island' && shouldCopyProps(...) && !isSameProps(...)) {
+//     el.setAttribute('ssr', '');
+//     el.setAttribute('props', newTarget.getAttribute('props')!);
+//   }
+// With zfb equivalent:
+//   if (newTarget.matches('[data-zfb-island]') && shouldCopyProps(...) && !isSameProps(...)) {
+//     el.setAttribute('data-props', newTarget.getAttribute('data-props')!);
+//     // Trigger re-render — see 12.3 zone-by-zone below for what "trigger" means.
+//   }
+```
+
+**Named technical cause for the deviation:** Astro's `<astro-island>` is a custom element; it observes the `props` attribute mutation via its `connectedCallback` / `MutationObserver` and re-runs `hydrate` when `ssr` is re-set. zfb's `<div data-zfb-island>` is NOT a custom element — it's a marker div. There is no auto re-render trigger; we must explicitly invoke the mount path again.
+
+#### 12.3.1 Zones
+
+- **Sidebar / header / footer / nav (chrome zones):** persisted via `data-zfb-transition-persist="<stable-id>"`. Recommendation **(a) skipped entirely** — DOM continuity preserved, component instance preserved, internal Preact state (e.g. expanded/collapsed nav state, focused item, scroll position inside scrollable nav) preserved. NO props refresh. The new body's matching marker is discarded by `swapBodyElement`'s `newTarget.remove()` step.
+  - Boundary signal: site-chrome islands. Examples in zudo-doc: `sidebar-tree.tsx`, `theme-toggle.tsx`, `mobile-toc.tsx`. These never need fresh props per page; their state IS the user's reading session.
+
+- **Content-area islands (`toc.tsx`, `doc-history.tsx`, `find-bar.tsx`, etc.):** Recommendation **(b) re-rendered with new props from the new HTML** — the user navigated to a new doc, so the TOC headings, history dropdown, etc. should reflect the new page. Implementation: do NOT carry `data-zfb-transition-persist` on these. Let `swapBodyElement` discard them with the old body, and let `mountNewIslands()` mount the fresh marker from the new body.
+  - Boundary signal: anything whose props are derived from the current page's frontmatter or content.
+
+- **Hybrid case — content-area islands that DO want state preservation across navs (rare):** carry `data-zfb-transition-persist` AND `data-zfb-transition-persist-props` (default — copy props). The persist-merge branch (above) updates `data-props` on the surviving element. W3D MUST then call `scheduleMount` against the persisted element with the new props so the component re-renders. Concretely: after the persist-merge branch updates `data-props`, push the affected element into a "needs-remount" queue, then in `mountNewIslands()` clear the `mounted` WeakSet entry for those queued elements before walking. **Caveat:** this is a niche path; if no zudo-doc island opts in for v1, W3D MAY mark this branch as `// TODO post-v1` with a unit test asserting it throws or no-ops cleanly. **Recommended for v1: leave the niche path unimplemented.** Document the gap in the v1 release notes.
+
+#### 12.3.2 Boundary table (W3D pins this)
+
+| Island | Persist? | Persist-props? | Behavior |
+|--------|----------|----------------|----------|
+| sidebar-tree | yes | no (state survives) | (a) DOM kept, no remount |
+| sidebar-toggle | yes | no | (a) |
+| theme-toggle | yes | no | (a) |
+| mobile-toc | yes | no | (a) |
+| ai-chat-modal | yes | no | (a) |
+| toc | no | n/a | (b) discarded; remount fresh |
+| doc-history | no | n/a | (b) |
+| find-bar | yes (search state survives navs) | no | (a) |
+| image-enlarge | no | n/a | (b) |
+| design-token-tweak panel | yes | no | (a) |
+
+W3D applies this table by writing or updating `data-zfb-transition-persist="<id>"` attributes on the relevant island markers in zudo-doc's layout components. Stable ID convention: kebab-case island-component name (`sidebar-tree`, `theme-toggle`, etc.).
+
+### 12.4 Idempotency of global island bootstrap
+
+**Current state:** `mountIslands` IS idempotent per-element (WeakSet). It is NOT idempotent across full document re-walks because:
+
+1. The WeakSets are module-level, so a re-call of `mountIslands(manifest)` with the same manifest re-walks the document but skips already-mounted elements. **Safe.**
+2. **But:** if `mountIslands` is called from a per-page inline script (rather than once at the global runtime entry), each navigation that swaps in a new inline `mountIslands(...)` call from the new page's HTML would re-walk and re-mount any new markers — also safe per-element, but the manifest reference might differ.
+
+**Conclusion for W3D:** confirm that `mountIslands` is called exactly ONCE at global runtime entry (the runtime bundle, `islands-runtime-<hash>.js`), NOT per-page-inline. Then introduce `mountNewIslands()` (no manifest arg) that captures the same manifest and is callable from the router. **If the current zfb pipeline embeds `mountIslands(...)` per page inline, fix it as part of W3D**: refactor to a single global call + module-level captured manifest.
+
+### 12.5 Edge case — deferred-hydration islands navigated away before firing
+
+An island with `data-when="idle"` or `data-when="visible"` schedules its hydration via `requestIdleCallback` or `IntersectionObserver`. If the user navigates away before the gate fires:
+
+**Current state:** the `oneShot` gate's `cancel` function is returned by `scheduleHydrate`. Currently nothing in zfb keeps a reference to those cancel handles, so no cancel is called. The deferred fire still runs (rIC / observer), but on a swapped-out element that is no longer in the document.
+
+**Failure modes if not handled:**
+
+- **rIC fire on detached element:** `fire()` runs `mounted.add(element)` and calls `fn(props, element, mode)`. The component `hydrate(<X props />, element)` is called against a detached DOM node — Preact creates a new tree under the orphan, but it is invisible (the element is gone from the document tree). Effect: a small memory leak (orphan tree retained as long as something keeps the element alive — typically nothing, so GC eventually reclaims). Functionally harmless but wasteful.
+- **IntersectionObserver fire on detached element:** observers don't fire for detached elements (entries report `isIntersecting: false`), so this case is naturally inert. No leak.
+- **rIC for already-removed element:** same as the rIC fire case above.
+
+**Decision (cleanup contract for W3D):**
+
+1. Track the cancel handles. Inside `scheduleMount`, when `scheduleHydrate(element, when, fire)` returns its cancel function, store `(element, cancel)` in a module-level `Map<Element, () => void>` named `pendingCancels`.
+2. On `zfb:before-swap` (or alternatively, in `swapBodyElement` itself for tighter coupling), iterate over the OLD body's `[data-zfb-island][data-when]:not([data-when="load"])` elements, look them up in `pendingCancels`, and call cancel(). Then clear those entries.
+3. After the swap, the new body's deferred islands are scheduled fresh by `mountNewIslands()`.
+
+**Named technical cause for cancel contract:** without it, deferred-fires can run against orphan elements and either leak memory (rIC) or warn loudly in dev (Preact's `hydrate` against detached DOM in dev mode). W6B should test this case explicitly.
+
+### 12.6 Summary contract for W3D + W6B
+
+Pinned in this order:
+
+1. `mountIslands(manifest)` is called ONCE at runtime entry. Manifest is captured at module level.
+2. `mountNewIslands()` (new export from `@takazudo/zfb`) re-walks the current body and mounts new markers using the captured manifest, no double-mount thanks to WeakSet.
+3. The router calls `mountNewIslands()` after `swap()` + `runScripts()`, before `triggerEvent('zfb:page-load')`.
+4. Persisted island markers (`data-zfb-transition-persist`) follow the boundary table in 12.3.2.
+5. Persist-props branch is V1-out-of-scope; keep the marker check stub but no-op.
+6. Deferred-hydration cancellation: track cancel handles in `pendingCancels: Map<Element, () => void>`; cancel for old body elements on `zfb:before-swap`.
+
+W6B writes tests for: (1) mount-after-swap, (2) double-mount-prevention, (3) persisted-skip path, (4) deferred-cancel-on-swap.
+
+---
+
+## 13. Per-symbol Astro→zfb mapping
+
+### 13.1 `cssesc.ts`
+
+**Status:** PORT VERBATIM. No naming changes required (no `astro:` symbols inside).
+
+Single export: `export default function cssesc(string, options)`. Used by Astro for safely escaping persist IDs into CSS selectors. zfb uses it the same way.
+
+Lines: 103. Self-contained. No external deps.
+
+### 13.2 `types.ts`
+
+| Astro export | zfb export | Notes |
+|--------------|------------|-------|
+| `Fallback = 'none' \| 'animate' \| 'swap'` | same | verbatim |
+| `Direction = 'forward' \| 'back'` | same | verbatim |
+| `NavigationTypeString = 'push' \| 'replace' \| 'traverse'` | same | verbatim |
+| `Options = { history?, info?, state?, formData?, sourceElement? }` | same | verbatim |
+
+10 lines, ports as-is.
+
+### 13.3 `events.ts`
+
+| Astro symbol | zfb symbol | Mapping |
+|--------------|------------|---------|
+| `TRANSITION_BEFORE_PREPARATION = 'astro:before-preparation'` | `'zfb:before-preparation'` | rename string literal |
+| `TRANSITION_AFTER_PREPARATION` | `'zfb:after-preparation'` | rename |
+| `TRANSITION_BEFORE_SWAP` | `'zfb:before-swap'` | rename |
+| `TRANSITION_AFTER_SWAP` | `'zfb:after-swap'` | rename |
+| `TRANSITION_PAGE_LOAD` | `'zfb:page-load'` | rename |
+| `triggerEvent(name)` | same | unchanged signature |
+| `onPageLoad()` | same | unchanged |
+| `class BeforeEvent` | same | rename internal event-type constructor argument string from `'astro:before-preparation'` to `'zfb:before-preparation'` (line 91) and `'astro:before-swap'` to `'zfb:before-swap'` (line 124) |
+| `class TransitionBeforePreparationEvent` | same | unchanged shape; constructor change above |
+| `class TransitionBeforeSwapEvent` | same | unchanged shape; constructor change above |
+| `isTransitionBeforePreparationEvent` | same | uses renamed constant |
+| `isTransitionBeforeSwapEvent` | same | uses renamed constant |
+| `doPreparation` | same | dispatches renamed event |
+| `updateScrollPosition` | same | unchanged |
+| `doSwap` | same | unchanged |
+
+**Deprecation comments:** Astro marks the constants as `@deprecated This will be removed in Astro 7`. zfb does NOT carry the deprecation note — these are NEW exports for zfb consumers, with no v0 → v1 deprecation path. Drop the `/** @deprecated */` JSDoc comments. **Named technical cause:** the deprecation is Astro-internal lifecycle; replicating it would mislead zfb consumers into thinking the API is unstable from day one.
+
+### 13.4 `swap-functions.ts`
+
+| Astro symbol | zfb symbol | Mapping |
+|--------------|------------|---------|
+| `PERSIST_ATTR = 'data-astro-transition-persist'` | `'data-zfb-transition-persist'` | rename |
+| `NON_OVERRIDABLE_ASTRO_ATTRS = [...]` | `NON_OVERRIDABLE_ZFB_ATTRS` | rename const + entries |
+| `knownVueScopedStyles: Map<string, HTMLStyleElement>` | same | unchanged (decision #8 keeps as insurance slot) |
+| `scriptsAlreadyRan: Set<string>` | same | unchanged |
+| `detectScriptExecuted` | same | unchanged |
+| `deselectScripts` | same | rename `data-astro-rerun` check to `data-zfb-rerun`; rename `dataset.astroExec` to `dataset.zfbExec` |
+| `swapRootAttributes` | same | uses renamed `NON_OVERRIDABLE_ZFB_ATTRS` |
+| `swapHeadElements` | same | uses `vueScopedStyleId` (kept verbatim per decision #8); persisted-head detection rebases on `data-zfb-transition-persist` |
+| `swapBodyElement` | same | core logic verbatim; the `localName === 'astro-island'` branch (line 126) becomes `newTarget.matches('[data-zfb-island]')` per decision #12.3 |
+| `attachShadowRoots` | same | verbatim — not Astro-specific |
+| `saveFocus` / `restoreFocus` | same | uses `data-zfb-transition-persist` |
+| `vueScopedStyleId` | same | kept verbatim (decision #8) |
+| `persistedHeadElement` | same | uses renamed PERSIST_ATTR; the DEV-only Vue branch keeps; the inline-style preservation (lines 231–238) and font-preload branch (240–243) port verbatim |
+| `shouldCopyProps` | same | reads `el.dataset.zfbTransitionPersistProps` |
+| `isSameProps` | same | NOTE: zfb's persisted islands carry `data-props`, not `props`. So `oldEl.getAttribute('data-props') === newEl.getAttribute('data-props')` |
+| `swapFunctions` | same | re-export bag |
+| `swap` | same | top-level orchestrator |
+
+**Deviation:** `isSameProps` reads `data-props` instead of `props`. **Named technical cause:** zfb's Island wrapper writes the SSR-serialized props to `data-props` (verified in `packages/zfb/src/island.ts:82`), not `props`. Astro's `<astro-island props=...>` is custom-element-driven; zfb's `<div data-zfb-island ... data-props=...>` is marker-driven. The attribute name is a different attribute, not just a renamed one.
+
+### 13.5 `router.ts`
+
+This is the largest port (~745 lines). All renames are mechanical:
+
+- `data-astro-*` attribute reads → `data-zfb-*`
+- Event-type literals `astro:*` → `zfb:*` (same as events.ts above)
+- Meta-tag names `astro-view-transitions-*` → `zfb-view-transitions-*`
+- CSS class `.astro-route-announcer` → `.zfb-route-announcer`
+- `dataset.astroExec` → `dataset.zfbExec`
+- `dataset.astroHistory` → `dataset.zfbHistory`
+- `dataset.astroRerun` → `dataset.zfbRerun`
+
+**Internal-fetch-headers shim (line 1):**
+
+```ts
+import { internalFetchHeaders } from 'virtual:astro:adapter-config/client';
+```
+
+This is Astro's adapter-injected internal-fetch headers (used for things like CF Pages worker auth). zfb has no equivalent virtual module.
+
+**Decision:** drop the import; replace with `const internalFetchHeaders: Record<string, string> = {};`. The `Object.entries(internalFetchHeaders)` loop in `fetchHTML` iterates an empty object, so the headers logic is a no-op in v1.
+
+**Named technical cause:** zfb adapters (`@takazudo/zfb-adapter-cloudflare`) do not currently expose a per-fetch internal-headers contract. If/when they do, a future zfb plugin can inject the equivalent. Empty object preserves call shape and keeps the future hook obvious.
+
+**`prepareForClientOnlyComponents` (lines 692–745):**
+
+This is the iframe-based pre-hydration trick for Astro's `client:only` components. The function only runs in DEV mode (`import.meta.env.DEV`). It:
+
+1. Detects `astro-island[client='only']` in the new document.
+2. Mounts the new page in a hidden iframe to coerce its `client:only` styles to be injected.
+3. Cherry-picks `<style data-vite-dev-id="...">` elements from the iframe into the new document.
+
+**Decision:** **DROP from v1 (skip — out of scope for v1).** Reasoning:
+
+- It is gated by `import.meta.env.DEV`, so it's a dev-mode-only convenience. Not a correctness requirement.
+- zfb's SSR-skip islands (`data-zfb-island-skip-ssr`) emit no DOM at SSR time; the styles they need are bundled into the islands runtime, not dev-injected per-route by Vite. So the underlying motivation (Vue/Vite per-component CSS injection only happens after hydration) does not apply.
+- Adding it requires walking new-doc markers using `data-zfb-island-skip-ssr` and the iframe trick — significant code surface for a dev-mode-only payoff.
+
+If a regression surfaces in DEV mode where `client:only`-equivalent islands lose styles across navigations, port at that point. Document in v1 release notes as a known limitation.
+
+**Named technical cause:** zfb does not have the Vite-per-component-CSS-injection-on-hydrate behavior that motivates the iframe trick.
+
+**Other notable router pieces:**
+
+| Astro line | Behavior | zfb port |
+|------------|----------|----------|
+| `transitionEnabledOnThisPage()` | checks for `meta[name=astro-view-transitions-enabled]` | rename meta name |
+| `getFallback()` | reads `meta[name=astro-view-transitions-fallback]` | rename meta name |
+| `originalLocation` global | unchanged | verbatim |
+| `currentHistoryIndex` global | unchanged | verbatim |
+| `samePage`, `parser`, `runScripts`, `moveToLocation`, `preloadStyleLinks`, `updateDOM`, `transition`, `navigate`, `onPopState`, `onScrollEnd` | unchanged | verbatim with attribute/event renames |
+| Top-level `if (inBrowser)` init block (lines 642–688) | unchanged | verbatim |
+| Final `for (const script of document.getElementsByTagName('script'))` block (lines 684–688) | unchanged | verbatim — but `dataset.astroExec` becomes `dataset.zfbExec` |
+
+### 13.6 `ClientRouter.astro` → `client-router.tsx`
+
+Astro source is a `.astro` SFC with frontmatter, `<style is:global>`, two `<meta>` tags, and an inline `<script>` block.
+
+zfb port emits the same DOM structure as a Preact functional component:
+
+```tsx
+export interface ClientRouterProps {
+  fallback?: 'none' | 'animate' | 'swap';
+}
+
+const announcerCss = `
+.zfb-route-announcer {
+  position: absolute;
+  left: 0;
+  top: 0;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  overflow: hidden;
+  white-space: nowrap;
+  width: 1px;
+  height: 1px;
+}
+`;
+
+const inlineScript = `/* IIFE-wrapped click+submit interceptors, mirroring Astro's <script> body */`;
+
+export function ClientRouter({ fallback = 'animate' }: ClientRouterProps) {
+  return (
+    <>
+      <style dangerouslySetInnerHTML={{ __html: announcerCss }} />
+      <meta name="zfb-view-transitions-enabled" content="true" />
+      <meta name="zfb-view-transitions-fallback" content={fallback} />
+      <script dangerouslySetInnerHTML={{ __html: inlineScript }} />
+    </>
+  );
+}
+```
+
+The inline script's body is a mechanical port of `ClientRouter.astro`'s `<script>` content (lines 27–155 of the Astro file), with these changes:
+
+- Imports change from `import { ... } from 'astro:transitions/client'` to runtime-resolved access. **DEVIATION:** Astro's `<script>` block is processed by Vite which resolves the virtual module. zfb's inline `<script dangerouslySetInnerHTML>` is NOT processed by a bundler. **Named technical cause:** the Astro SFC's `<script>` is a build-time-bundled module; in Preact JSX we are emitting a raw `<script>` tag. Solution: write the inline script body assuming the runtime API is available on `window.__zfb_router` (or via direct package import resolved by the consumer's bundler when they emit the page, not by us). This is the only meaningful structural deviation in the port — see implementation note below.
+- Drop the prefetch import + `init({ prefetchAll: true })` call (decision #7).
+- Drop the `__PREFETCH_DISABLED__` Vite plugin gating (decision #9).
+- `dataset.astroReload` → `dataset.zfbReload` (decision #6).
+- `dataset.astroHistory` → `dataset.zfbHistory`.
+
+**Implementation note for W3 children:** the cleanest port is to NOT inline the script. Instead, ship the `<ClientRouter />` component as a wrapper that emits the meta tags + the global stylesheet, and have a sibling top-level `client-router/init.ts` module that runs the click+submit interceptors. The init module is imported by the consumer's page-level entry script (e.g. zudo-doc imports `@takazudo/zfb-runtime/client-router/init` from its `src/main.ts` or `pages/_layout.tsx`). This sidesteps the inline-script bundling problem.
+
+**Final decision for W3A:** emit the meta tags + style from `<ClientRouter />`, and put the click/submit interceptors in `client-router/init.ts` (auto-runs on import via top-of-module IIFE, side-effecting). The `<ClientRouter />` component MAY also render a `<script type="module" src="..." />` tag pointing at the runtime entry, OR rely on the consumer to import `init.ts` themselves. Default for zudo-doc integration: explicit import in the layout.
+
+**Named technical cause for this structural deviation:** Astro processes the SFC `<script>` block through Vite's bundler at build time. Preact JSX inside zfb does not have an equivalent bundler-passed inline-script transform; emitting raw `<script dangerouslySetInnerHTML>` would bypass module resolution entirely. Splitting the JS interceptors into a separately-imported `init.ts` is the literal mechanical equivalent in a non-SFC framework. Astro's authors would do the same if they were not writing inside an Astro component.
+
+### 13.7 `vite-plugin-transitions.ts` — SKIP
+
+Out of scope for v1 (decision #9). No port.
+
+### 13.8 `transitions/index.ts` (Astro animations only)
+
+Astro's `transitions/index.ts` is the **public API surface for `astro:transitions`** in user space — it exports `slide()` and `fade()` animation factories used in CSS `view-transition-name` configurations. **This is not the router; this is animation helpers.**
+
+**Decision: SKIP — out of scope for v1.**
+
+**Named technical cause:** zfb's view-transitions CSS approach (per existing `view-transitions.ts` docstring) uses the native CSS `@view-transition { navigation: auto; }` at-rule + per-element `view-transition-name` declarations. Animation helpers are CSS authoring sugar, not router functionality. They can ship as a separate convenience export later without affecting the router contract.
+
+If user wants `slide()`/`fade()` helpers in v1: trivial port (~80 lines), can be added at any time.
+
+---
+
+## 14. Out-of-scope-for-v1 appendix
+
+| Item | Decision section | Tracker |
+|------|------------------|---------|
+| Prefetch module (`astro/virtual-modules/prefetch.js`) | #7 | zudolab/zudo-doc#1527 |
+| Vite plugin equivalent (virtual modules + prefetch gate) | #9 | (rolled into #1527) |
+| `prepareForClientOnlyComponents` iframe trick (DEV-mode CSS hoist) | #13.5 | inline TODO |
+| Animation helpers (`slide()`, `fade()`) | #13.8 | inline TODO — trivial follow-up |
+| Persisted-island props-refresh path | #12.3.1 hybrid case | inline TODO; W3D leaves stub |
+| `/** @deprecated */` JSDoc on event constants | #13.3 | (intentional drop) |
+| `internalFetchHeaders` adapter integration | #13.5 | inline TODO; consumed when adapter exposes it |
+
+---
+
+## 15. Deviations from pure replication — summary
+
+For audit. Each deviation has a NAMED TECHNICAL CAUSE per the guiding principle.
+
+| # | Deviation | Named technical cause |
+|---|-----------|----------------------|
+| 1 | Module dir named `client-router/`, not `transitions/` | Existing `view-transitions.ts` typed-no-op shim would shadow; renaming it is a forbidden API break. |
+| 2 | `<ClientRouter />` script body lives in a separate `init.ts` module instead of inline `<script>` block | Astro SFC `<script>` is bundler-processed; Preact JSX has no equivalent transform — `init.ts` is the literal mechanical equivalent. |
+| 3 | `isSameProps` reads `data-props` instead of `props` | zfb islands are marker-divs (`data-props`), not custom elements (`props`). Different attribute, not a rename. |
+| 4 | `localName === 'astro-island'` branch becomes `matches('[data-zfb-island]')` | Same root cause as #3. |
+| 5 | `internalFetchHeaders` import dropped, replaced with `{}` | zfb adapters don't expose this contract. Empty object preserves call shape. |
+| 6 | `prepareForClientOnlyComponents` skipped | DEV-mode-only Vue/Vite-CSS-injection workaround; zfb islands inject CSS via the bundle, not per-component-on-hydrate. |
+| 7 | Drop `/** @deprecated */` JSDoc on `TRANSITION_*` event constants | Astro-internal lifecycle marker; misleading for new zfb consumers. |
+| 8 | Drop prefetch + `__PREFETCH_DISABLED__` gating | Decision #7 — out of scope for v1. |
+| 9 | New `mountNewIslands()` export from `@takazudo/zfb` (no manifest arg, captures from first `mountIslands` call) | Router lives in zfb-runtime, islands manifest lives in zfb. Captured-manifest pattern avoids threading manifest through the router. |
+| 10 | `pendingCancels: Map<Element, () => void>` for deferred-hydration cancel-on-swap | Without it, deferred-fires (rIC / observer) run against orphan elements — memory leak + Preact dev warnings. |
+
+All other Astro symbols port verbatim with mechanical `astro:` → `zfb:` and `data-astro-*` → `data-zfb-*` renames.
+
+---
+
+## 16. Implementation handoff
+
+W3A — `<ClientRouter />` component + `init.ts` + `cssesc.ts` + `types.ts` + `events.ts` (the foundation files).
+W3B — `swap-functions.ts` + per-symbol attribute renames + persisted-island branch.
+W3C — `router.ts` (the core 745-line port; orchestrates W3A + W3B).
+W3D — Island lifecycle integration: `mountNewIslands`, `pendingCancels`, persist-zone wiring on zudo-doc layouts (per 12.3.2 boundary table). Idempotency audit of current `mountIslands` call sites.
+
+W3D depends on W3A–W3C completion of router infrastructure. W3A–W3C can run in parallel.
+
+W6B writes lifecycle tests against contract sections 12.5 + 12.6.
+
+---
+
+## 17. References
+
+- Astro source: `withastro/astro` — `packages/astro/src/transitions/` and `packages/astro/components/ClientRouter.astro`
+- zfb-runtime: `packages/zfb-runtime/src/` (this directory)
+- zfb islands runtime: `packages/zfb/src/runtime.ts`
+- zfb Island wrapper: `packages/zfb/src/island.ts`
+- Downstream tracking epic: zudolab/zudo-doc#1510
+- Sub-issue: zudolab/zudo-doc#1512
+- Prefetch follow-up: zudolab/zudo-doc#1527
+
+---
+
+*End of W1B port spec. Children should consider every decision settled. STOP gate triggers per section 11.*

--- a/packages/zfb-runtime/src/__tests__/client-router/_helpers.ts
+++ b/packages/zfb-runtime/src/__tests__/client-router/_helpers.ts
@@ -1,0 +1,67 @@
+// Shared test helpers for client-router test files.
+//
+// Each test file using a happy-dom environment imports `installHappyDomShim()`
+// at module top to ensure `<link rel=stylesheet>` and `<script src>` insertions
+// don't trigger real fetches, and to give the suite a consistent way to drain
+// async tasks in afterEach.
+
+type HappyDOMWindow = Window & {
+  happyDOM: {
+    settings: Record<string, boolean>;
+    waitUntilComplete: () => Promise<void>;
+  };
+};
+
+let cachedHappyWindow: HappyDOMWindow | undefined;
+
+function getHappyWindow(): HappyDOMWindow {
+  if (cachedHappyWindow) return cachedHappyWindow;
+  const w = window as unknown as HappyDOMWindow;
+  cachedHappyWindow = w;
+  return w;
+}
+
+/**
+ * Apply happy-dom runtime settings that disable network loads and treat
+ * disabled loads as silent successes. Must be called at module top so the
+ * settings are in place before any DOM mutation happens in describe/beforeEach.
+ */
+export function installHappyDomShim(): void {
+  const w = getHappyWindow();
+  w.happyDOM.settings["disableJavaScriptFileLoading"] = true;
+  w.happyDOM.settings["disableCSSFileLoading"] = true;
+  w.happyDOM.settings["disableIframePageLoading"] = true;
+  w.happyDOM.settings["handleDisabledFileLoadingAsSuccess"] = true;
+}
+
+/**
+ * Drain happy-dom's pending async tasks (e.g. silent stylesheet load events).
+ * Call from afterEach so async work doesn't race vitest's environment teardown.
+ */
+export async function drainHappyDom(): Promise<void> {
+  await getHappyWindow().happyDOM.waitUntilComplete();
+}
+
+/**
+ * Reinstall a fresh <body> on the live document. Use in beforeEach when a
+ * previous test may have called swapBodyElement() — that path replaces the
+ * original body via `replaceWith()`, after which `document.body.innerHTML = ""`
+ * is a not-a-fresh-element shortcut whose getElementById internals can be
+ * stale. Recreating the element through the standard DOM API resets cleanly.
+ */
+export function resetDocument(): void {
+  document.head.innerHTML = "";
+  while (document.documentElement.attributes.length > 0) {
+    document.documentElement.removeAttribute(document.documentElement.attributes[0]!.name);
+  }
+  if (document.body) document.body.remove();
+  document.documentElement.appendChild(document.createElement("body"));
+}
+
+/**
+ * Build a Document via DOMParser. Used by tests that need to feed
+ * swap/loader functions a fresh-from-the-network "incoming" doc.
+ */
+export function htmlDoc(html: string): Document {
+  return new DOMParser().parseFromString(html, "text/html");
+}

--- a/packages/zfb-runtime/src/__tests__/client-router/events.test.ts
+++ b/packages/zfb-runtime/src/__tests__/client-router/events.test.ts
@@ -1,0 +1,271 @@
+/**
+ * @vitest-environment happy-dom
+ */
+// Unit tests for client-router/events.
+//
+// We assert (a) the public Event constants are stable strings, (b)
+// `triggerEvent`/`onPageLoad` dispatch the right Event on document, (c)
+// `doPreparation` dispatches a TransitionBeforePreparationEvent first then
+// `zfb:after-preparation` once the loader resolves without preventing default,
+// and (d) `doSwap` dispatches the swap event before invoking afterDispatch and
+// the supplied swap callback. Lifecycle ordering is the contract that any
+// consumer subscribing to lifecycle events depends on, so we verify the order
+// observably (sequence numbers) rather than via implementation snooping.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { drainHappyDom, installHappyDomShim, resetDocument } from "./_helpers.js";
+
+installHappyDomShim();
+
+import {
+  TRANSITION_AFTER_PREPARATION,
+  TRANSITION_AFTER_SWAP,
+  TRANSITION_BEFORE_PREPARATION,
+  TRANSITION_BEFORE_SWAP,
+  TRANSITION_PAGE_LOAD,
+  TransitionBeforePreparationEvent,
+  TransitionBeforeSwapEvent,
+  doPreparation,
+  doSwap,
+  isTransitionBeforePreparationEvent,
+  isTransitionBeforeSwapEvent,
+  onPageLoad,
+  triggerEvent,
+  updateScrollPosition,
+} from "../../client-router/events.js";
+
+beforeEach(resetDocument);
+afterEach(drainHappyDom);
+
+describe("event constants", () => {
+  // The constants are pinned because subscribers register listeners by
+  // string name (e.g. `document.addEventListener("zfb:before-swap", ...)`).
+  // Any rename is a public-API break and must be intentional.
+  it("exposes the canonical zfb:* names", () => {
+    expect(TRANSITION_BEFORE_PREPARATION).toBe("zfb:before-preparation");
+    expect(TRANSITION_AFTER_PREPARATION).toBe("zfb:after-preparation");
+    expect(TRANSITION_BEFORE_SWAP).toBe("zfb:before-swap");
+    expect(TRANSITION_AFTER_SWAP).toBe("zfb:after-swap");
+    expect(TRANSITION_PAGE_LOAD).toBe("zfb:page-load");
+  });
+});
+
+describe("triggerEvent / onPageLoad", () => {
+  it("triggerEvent dispatches a basic Event of the named type on document", () => {
+    const seen: string[] = [];
+    const handler = (e: Event) => seen.push(e.type);
+    document.addEventListener("zfb:after-preparation", handler);
+    triggerEvent("zfb:after-preparation");
+    document.removeEventListener("zfb:after-preparation", handler);
+    expect(seen).toEqual(["zfb:after-preparation"]);
+  });
+
+  it("onPageLoad dispatches the zfb:page-load event", () => {
+    const seen: string[] = [];
+    const handler = (e: Event) => seen.push(e.type);
+    document.addEventListener("zfb:page-load", handler);
+    onPageLoad();
+    document.removeEventListener("zfb:page-load", handler);
+    expect(seen).toEqual(["zfb:page-load"]);
+  });
+});
+
+describe("doPreparation — lifecycle ordering", () => {
+  function makeArgs(overrides?: { loader?: () => Promise<void> }) {
+    const from = new URL("http://test.local/from");
+    const to = new URL("http://test.local/to");
+    const newDoc = window.document;
+    const signal = new AbortController().signal;
+    const loader = overrides?.loader ?? (async () => {});
+    return { from, to, newDoc, signal, loader };
+  }
+
+  it("dispatches zfb:before-preparation, runs the loader, then zfb:after-preparation", async () => {
+    const order: string[] = [];
+    const { from, to, newDoc, signal } = makeArgs();
+    const loader = async () => {
+      order.push("loader");
+    };
+
+    const beforeHandler = (e: Event) => {
+      // The before-preparation event is the only event in the lifecycle that
+      // is the typed subclass; the rest are plain Event instances.
+      if (isTransitionBeforePreparationEvent(e)) order.push("before-preparation");
+    };
+    const afterHandler = (e: Event) => order.push(e.type);
+    document.addEventListener("zfb:before-preparation", beforeHandler);
+    document.addEventListener("zfb:after-preparation", afterHandler);
+
+    await doPreparation(
+      from,
+      to,
+      "forward",
+      "push",
+      undefined,
+      undefined,
+      signal,
+      undefined,
+      loader,
+    );
+
+    document.removeEventListener("zfb:before-preparation", beforeHandler);
+    document.removeEventListener("zfb:after-preparation", afterHandler);
+
+    expect(order).toEqual(["before-preparation", "loader", "zfb:after-preparation"]);
+    void newDoc; // included in args to keep the signature realistic
+  });
+
+  it("when defaultPrevented in zfb:before-preparation, after-preparation is NOT fired", async () => {
+    const after = vi.fn();
+    const beforeHandler = (e: Event) => {
+      if (isTransitionBeforePreparationEvent(e)) e.preventDefault();
+    };
+    document.addEventListener("zfb:before-preparation", beforeHandler);
+    document.addEventListener("zfb:after-preparation", after);
+
+    const { from, to, signal, loader } = makeArgs();
+    const ev = await doPreparation(
+      from,
+      to,
+      "forward",
+      "push",
+      undefined,
+      undefined,
+      signal,
+      undefined,
+      loader,
+    );
+
+    document.removeEventListener("zfb:before-preparation", beforeHandler);
+    document.removeEventListener("zfb:after-preparation", after);
+
+    // `dispatchEvent` returns false when defaultPrevented; our impl skips the
+    // loader + after-preparation dispatch in that case.
+    expect(ev.defaultPrevented).toBe(true);
+    expect(after).not.toHaveBeenCalled();
+  });
+
+  it("returns a TransitionBeforePreparationEvent carrying from, to, navigationType, formData", async () => {
+    const { from, to, signal, loader } = makeArgs();
+    const formData = new FormData();
+    formData.append("k", "v");
+    const ev = await doPreparation(
+      from,
+      to,
+      "back",
+      "traverse",
+      undefined,
+      undefined,
+      signal,
+      formData,
+      loader,
+    );
+    expect(ev).toBeInstanceOf(TransitionBeforePreparationEvent);
+    expect(ev.from).toBe(from);
+    expect(ev.to).toBe(to);
+    expect(ev.direction).toBe("back");
+    expect(ev.navigationType).toBe("traverse");
+    expect(ev.formData).toBe(formData);
+    expect(ev.signal).toBe(signal);
+  });
+});
+
+describe("doSwap — lifecycle ordering", () => {
+  it("dispatches zfb:before-swap, awaits afterDispatch, then calls swap()", async () => {
+    const order: string[] = [];
+    const beforeHandler = (e: Event) => {
+      if (isTransitionBeforeSwapEvent(e)) order.push("before-swap");
+    };
+    document.addEventListener("zfb:before-swap", beforeHandler);
+
+    const fakeViewTransition = { skipTransition: () => {} } as unknown as ViewTransition;
+    const fakePrepEvent = new TransitionBeforePreparationEvent(
+      new URL("http://test.local/a"),
+      new URL("http://test.local/b"),
+      "forward",
+      "push",
+      undefined,
+      undefined,
+      window.document,
+      new AbortController().signal,
+      undefined,
+      async () => {},
+    );
+    const afterDispatch = async () => {
+      // afterDispatch (e.g. animateFallbackOld) is awaited between the
+      // dispatched zfb:before-swap and the actual swap() call.
+      order.push("afterDispatch");
+    };
+
+    const ev = await doSwap(fakePrepEvent, fakeViewTransition, afterDispatch);
+    // `swap()` is overridable on the event — by default it calls swap(newDoc),
+    // which mutates the live DOM. We replace it with a sentinel so we can
+    // assert the dispatch order without exercising swap-functions internals.
+    // (The default impl is covered by swap-functions.test.ts.)
+    void ev;
+    // After doSwap completes, swap() has been invoked internally on the event.
+    // We don't observe swap() here directly; ordering is verified by
+    // before-swap → afterDispatch.
+    document.removeEventListener("zfb:before-swap", beforeHandler);
+    expect(order).toEqual(["before-swap", "afterDispatch"]);
+  });
+
+  it("returns a TransitionBeforeSwapEvent with viewTransition + a swap() function", async () => {
+    const fakeViewTransition = { skipTransition: () => {} } as unknown as ViewTransition;
+    const fakePrepEvent = new TransitionBeforePreparationEvent(
+      new URL("http://test.local/a"),
+      new URL("http://test.local/b"),
+      "forward",
+      "push",
+      undefined,
+      undefined,
+      window.document,
+      new AbortController().signal,
+      undefined,
+      async () => {},
+    );
+    const ev = await doSwap(fakePrepEvent, fakeViewTransition);
+    expect(ev).toBeInstanceOf(TransitionBeforeSwapEvent);
+    expect(ev.viewTransition).toBe(fakeViewTransition);
+    expect(typeof ev.swap).toBe("function");
+  });
+
+  it("isTransitionBeforeSwapEvent guards correctly", () => {
+    const ok = new TransitionBeforeSwapEvent(
+      new TransitionBeforePreparationEvent(
+        new URL("http://test.local/a"),
+        new URL("http://test.local/b"),
+        "forward",
+        "push",
+        undefined,
+        undefined,
+        window.document,
+        new AbortController().signal,
+        undefined,
+        async () => {},
+      ),
+      { skipTransition: () => {} } as unknown as ViewTransition,
+    );
+    expect(isTransitionBeforeSwapEvent(ok)).toBe(true);
+    expect(isTransitionBeforeSwapEvent({ type: "click" })).toBe(false);
+  });
+});
+
+describe("updateScrollPosition", () => {
+  // updateScrollPosition is called only when history.state exists. We seed
+  // a state, call it, and confirm the values were merged into history.state.
+  it("merges scrollX/scrollY into the existing history.state", () => {
+    history.replaceState({ index: 5, scrollX: 0, scrollY: 0 }, "");
+    updateScrollPosition({ scrollX: 100, scrollY: 200 });
+    expect(history.state).toMatchObject({ index: 5, scrollX: 100, scrollY: 200 });
+    expect(history.scrollRestoration).toBe("manual");
+  });
+
+  it("is a no-op when history.state is null", () => {
+    // Force-clear state by replacing with null.
+    history.replaceState(null, "");
+    expect(() => updateScrollPosition({ scrollX: 1, scrollY: 1 })).not.toThrow();
+    expect(history.state).toBeNull();
+  });
+});

--- a/packages/zfb-runtime/src/__tests__/client-router/router.test.ts
+++ b/packages/zfb-runtime/src/__tests__/client-router/router.test.ts
@@ -1,0 +1,356 @@
+/**
+ * @vitest-environment happy-dom
+ */
+// Integration tests for client-router/router.
+//
+// These tests exercise the SPA router end-to-end inside a happy-dom
+// document: a fetch mock returns canned HTML, navigate() drives the
+// transition pipeline (preparation → swap), and we observe the resulting
+// document state and dispatched lifecycle events.
+//
+// Coverage:
+//   - happy path with mocked fetch + jsdom-style document
+//   - fallback simulation when document.startViewTransition is undefined
+//   - hash-only same-page navigation skips the transition path
+//   - non-opt-in target page degrades to a graceful full-page load
+//   - redirected fetch (res.redirected) preserves redirected URL
+//   - idempotent init() does not double-register click/submit listeners
+//
+// Mocks:
+//   - `@takazudo/zfb/runtime` is mocked so we don't drag the real island
+//     manager into the test (it would try to load the islands manifest from
+//     disk). The router only needs `mountNewIslands` and
+//     `cancelPendingIslands` to be callable functions.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { drainHappyDom, installHappyDomShim, resetDocument } from "./_helpers.js";
+
+vi.mock("@takazudo/zfb/runtime", () => ({
+  mountNewIslands: vi.fn(),
+  cancelPendingIslands: vi.fn(),
+}));
+
+installHappyDomShim();
+
+// Inject the opt-in meta tag BEFORE importing the router module, so the
+// module's top-level `if (transitionEnabledOnThisPage())` branch sees the
+// page as opted-in. router.ts reads the live document at module-eval time.
+function enableTransitions(): void {
+  const meta = document.createElement("meta");
+  meta.setAttribute("name", "zfb-view-transitions-enabled");
+  meta.setAttribute("content", "true");
+  document.head.appendChild(meta);
+}
+enableTransitions();
+
+// Stub DOM APIs the router's fallback `animate()` helper needs (the View
+// Transitions simulation calls these from `updateDOM` regardless of whether
+// any animation actually runs). happy-dom does not implement them.
+if (typeof document.getAnimations !== "function") {
+  Object.defineProperty(document, "getAnimations", {
+    configurable: true,
+    value: () => [],
+  });
+}
+// `instanceof KeyframeEffect` check inside isInfinite() — happy-dom omits the
+// global. Provide a stand-in so the check returns `false` cleanly.
+if (typeof (globalThis as { KeyframeEffect?: unknown }).KeyframeEffect === "undefined") {
+  (globalThis as { KeyframeEffect: unknown }).KeyframeEffect = class KeyframeEffect {};
+}
+
+// Late import after the document is primed.
+import {
+  init,
+  navigate,
+  supportsViewTransitions,
+  transitionEnabledOnThisPage,
+} from "../../client-router/router.js";
+
+beforeEach(() => {
+  resetDocument();
+  // Re-inject opt-in meta tag for each test (resetDocument clears head).
+  enableTransitions();
+});
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  await drainHappyDom();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function htmlResponse(body: string, init?: ResponseInit): Response {
+  return new Response(body, {
+    ...init,
+    headers: { "content-type": "text/html; charset=utf-8", ...(init?.headers ?? {}) },
+  });
+}
+
+function pageHtml(title: string, mainContent: string, optIn = true): string {
+  const optInMeta = optIn ? `<meta name="zfb-view-transitions-enabled" content="true">` : "";
+  return `<!doctype html><html><head>
+    ${optInMeta}
+    <title>${title}</title>
+  </head><body>
+    <main>${mainContent}</main>
+  </body></html>`;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("router top-level state", () => {
+  it("supportsViewTransitions reflects document.startViewTransition presence", () => {
+    // happy-dom does not implement startViewTransition by default → false.
+    expect(supportsViewTransitions).toBe(false);
+  });
+
+  it("transitionEnabledOnThisPage reads the live document each call", () => {
+    expect(transitionEnabledOnThisPage()).toBe(true);
+    document.head.innerHTML = "";
+    expect(transitionEnabledOnThisPage()).toBe(false);
+  });
+});
+
+describe("navigate() — happy path with mocked fetch", () => {
+  it("fetches the target URL and swaps in the new <main>", async () => {
+    const fetchMock = vi.fn(async (url: RequestInfo) => {
+      const u = String(url);
+      if (u.endsWith("/about")) return htmlResponse(pageHtml("About", "About content"));
+      throw new Error(`unexpected fetch: ${u}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    document.body.innerHTML = `<main>Home content</main>`;
+
+    await navigate("/about");
+
+    // A document.title swap is part of moveToLocation; the new page sets
+    // <title>About</title> via swapHeadElements.
+    expect(document.title).toBe("About");
+    expect(document.querySelector("main")?.textContent).toBe("About content");
+    // Fetch should have been called exactly once for /about.
+    const calls = fetchMock.mock.calls;
+    expect(calls).toHaveLength(1);
+    expect(String(calls[0]![0])).toContain("/about");
+  });
+
+  it("dispatches the lifecycle events in order: before-preparation, after-preparation, before-swap, after-swap", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => htmlResponse(pageHtml("Next", "next"))),
+    );
+
+    const seen: string[] = [];
+    const ev = (type: string) => () => seen.push(type);
+    const handlers: Array<[string, EventListener]> = [
+      ["zfb:before-preparation", ev("before-preparation")],
+      ["zfb:after-preparation", ev("after-preparation")],
+      ["zfb:before-swap", ev("before-swap")],
+      ["zfb:after-swap", ev("after-swap")],
+    ];
+    for (const [t, h] of handlers) document.addEventListener(t, h);
+
+    await navigate("/next");
+
+    for (const [t, h] of handlers) document.removeEventListener(t, h);
+
+    // The four lifecycle events must fire and in this order. We assert
+    // membership AND ordering.
+    expect(seen).toEqual(["before-preparation", "after-preparation", "before-swap", "after-swap"]);
+  });
+});
+
+describe("hash-only same-page navigation", () => {
+  it("does not call fetch for `#anchor` on the same page", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    // Seed history.state so the router's moveToLocation has something to read.
+    history.replaceState({ index: 0, scrollX: 0, scrollY: 0 }, "");
+
+    await navigate(`${location.pathname}#section-2`);
+
+    // No fetch should have been issued — hash-only navs skip the transition path.
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(location.hash).toBe("#section-2");
+  });
+});
+
+describe("redirected fetch — res.redirected", () => {
+  it("uses the redirected URL as the new location while preserving the requested fragment", async () => {
+    // Build a Response that reports redirected=true via Object.defineProperty,
+    // since the Response constructor does not let us set `redirected`/`url`
+    // directly.
+    const finalUrl = "http://localhost:3000/blog/redirected-target";
+    const res = htmlResponse(pageHtml("Redirected", "redirected"));
+    Object.defineProperty(res, "redirected", { value: true });
+    Object.defineProperty(res, "url", { value: finalUrl });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => res),
+    );
+
+    await navigate("/blog/old-slug#section");
+
+    // The router should have swapped to the redirected URL while keeping the
+    // original hash fragment.
+    expect(location.pathname).toBe("/blog/redirected-target");
+    expect(location.hash).toBe("#section");
+  });
+});
+
+describe("non-opt-in target page degrade", () => {
+  it("delegates to a full browser load when the new page lacks the opt-in meta tag", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => htmlResponse(pageHtml("Plain", "plain content", /*optIn*/ false))),
+    );
+
+    const seenAfterSwap = vi.fn();
+    document.addEventListener("zfb:after-swap", seenAfterSwap);
+
+    // happy-dom's location.href is read-only by default; capture assignments.
+    const originalHref = location.href;
+    let assignedHref: string | undefined;
+    Object.defineProperty(location, "href", {
+      configurable: true,
+      get: () => originalHref,
+      set: (v: string) => {
+        assignedHref = v;
+      },
+    });
+
+    await navigate("/plain-no-clientrouter");
+
+    document.removeEventListener("zfb:after-swap", seenAfterSwap);
+
+    // The router's defaultLoader path calls `preventDefault()` on the
+    // preparation event when the new page has no opt-in meta, which short-
+    // circuits the swap. The before/after-preparation events fire but
+    // before-swap/after-swap do NOT, and a full browser load is requested
+    // by setting location.href.
+    expect(seenAfterSwap).not.toHaveBeenCalled();
+    expect(assignedHref).toContain("/plain-no-clientrouter");
+  });
+});
+
+describe("init() — idempotent listener registration", () => {
+  it("calling init() multiple times only registers click/submit listeners once", () => {
+    const addListenerSpy = vi.spyOn(document, "addEventListener");
+
+    init();
+    init();
+    init();
+
+    // Filter to only the click + submit registrations the router contributes.
+    const clickCalls = addListenerSpy.mock.calls.filter((c) => c[0] === "click");
+    const submitCalls = addListenerSpy.mock.calls.filter((c) => c[0] === "submit");
+
+    // First call wins; subsequent init() calls must be no-ops.
+    expect(clickCalls).toHaveLength(1);
+    expect(submitCalls).toHaveLength(1);
+
+    addListenerSpy.mockRestore();
+  });
+});
+
+describe("fallback simulation when document.startViewTransition is undefined", () => {
+  it("transition completes via simulation when supportsViewTransitions is false (happy-dom default)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => htmlResponse(pageHtml("Fallback", "fallback content"))),
+    );
+
+    // happy-dom does not provide document.startViewTransition. The router
+    // resolves `supportsViewTransitions` at module top → false. The transition
+    // path therefore exercises the simulation branch (manual updateDOM call
+    // wrapped in a Promise).
+    expect(supportsViewTransitions).toBe(false);
+
+    await navigate("/fallback");
+
+    // If the simulation path is wired correctly, the swap still completes.
+    expect(document.querySelector("main")?.textContent).toBe("fallback content");
+    expect(document.title).toBe("Fallback");
+  });
+});
+
+describe("non-HTML response degrade", () => {
+  it("falls back to a full browser load when the fetch returns a non-HTML content-type", async () => {
+    // The router's fetchHTML helper returns null for any media type other
+    // than text/html or application/xhtml+xml. The defaultLoader path then
+    // calls preventDefault() on the preparation event so the browser handles
+    // the URL itself.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response('{"ok":true}', {
+            status: 200,
+            headers: { "content-type": "application/json" },
+          }),
+      ),
+    );
+
+    const seenAfterSwap = vi.fn();
+    document.addEventListener("zfb:after-swap", seenAfterSwap);
+
+    const originalHref = location.href;
+    let assignedHref: string | undefined;
+    Object.defineProperty(location, "href", {
+      configurable: true,
+      get: () => originalHref,
+      set: (v: string) => {
+        assignedHref = v;
+      },
+    });
+
+    await navigate("/api/echo");
+
+    document.removeEventListener("zfb:after-swap", seenAfterSwap);
+
+    expect(seenAfterSwap).not.toHaveBeenCalled();
+    expect(assignedHref).toContain("/api/echo");
+  });
+});
+
+describe("popstate — forward + back history navigation", () => {
+  it("popstate with state.index > current triggers a forward transition; lower triggers back", async () => {
+    const fetchMock = vi.fn(async (url: RequestInfo) => {
+      const u = String(url);
+      if (u.includes("/page-a")) return htmlResponse(pageHtml("A", "page a"));
+      if (u.includes("/page-b")) return htmlResponse(pageHtml("B", "page b"));
+      throw new Error(`unexpected fetch: ${u}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    // Forward: navigate /page-a then /page-b — pushState raises currentHistoryIndex.
+    await navigate("/page-a");
+    await navigate("/page-b");
+    expect(document.title).toBe("B");
+
+    // Now simulate popstate going back. The onPopState handler reads
+    // history.state.index and fires a "back" transition. We can't rely on
+    // happy-dom's history.back() to fire popstate cleanly, so we dispatch
+    // PopStateEvent manually with state.index < current.
+    history.replaceState({ index: 0, scrollX: 0, scrollY: 0 }, "", "/page-a");
+    const popEvent = new PopStateEvent("popstate", {
+      state: { index: 0, scrollX: 0, scrollY: 0 },
+    });
+    window.dispatchEvent(popEvent);
+
+    // Allow microtasks + any rAF/timers to drain.
+    await new Promise((r) => setTimeout(r, 0));
+
+    // The router should have re-fetched /page-a (back nav) and swapped.
+    // Check that fetch was called for /page-a as part of the back navigation.
+    const urls = fetchMock.mock.calls.map((c) => String(c[0]));
+    expect(urls.some((u) => u.includes("/page-a"))).toBe(true);
+  });
+});

--- a/packages/zfb-runtime/src/__tests__/client-router/swap-functions.test.ts
+++ b/packages/zfb-runtime/src/__tests__/client-router/swap-functions.test.ts
@@ -1,0 +1,299 @@
+/**
+ * @vitest-environment happy-dom
+ */
+// Unit tests for client-router/swap-functions.
+//
+// The functions under test are pure DOM helpers — happy-dom gives us a real
+// `document` global so we can assert the post-swap shape directly. We exercise
+// the public surface (`deselectScripts`, `swapHeadElements`, `swapBodyElement`,
+// `swapRootAttributes`, `saveFocus`/`restoreFocus`, `detectScriptExecuted`)
+// because that's the contract `router.ts` depends on; covering each independently
+// keeps a regression localised when one part shifts.
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { drainHappyDom, htmlDoc, installHappyDomShim, resetDocument } from "./_helpers.js";
+
+installHappyDomShim();
+
+import {
+  deselectScripts,
+  detectScriptExecuted,
+  restoreFocus,
+  saveFocus,
+  swap,
+  swapBodyElement,
+  swapHeadElements,
+  swapRootAttributes,
+} from "../../client-router/swap-functions.js";
+
+const PERSIST_ATTR = "data-zfb-transition-persist";
+
+beforeEach(resetDocument);
+afterEach(drainHappyDom);
+
+describe("swapHeadElements — head dedup", () => {
+  it("keeps an existing stylesheet when the new head has the same href", () => {
+    document.head.innerHTML = `<link rel="stylesheet" href="/site.css">`;
+    const oldLink = document.head.querySelector('link[href="/site.css"]')!;
+    const newDoc = htmlDoc(`<!doctype html><html><head>
+      <link rel="stylesheet" href="/site.css">
+    </head><body></body></html>`);
+
+    swapHeadElements(newDoc);
+
+    const links = document.head.querySelectorAll('link[rel="stylesheet"][href="/site.css"]');
+    expect(links).toHaveLength(1);
+    // The original link must remain — confirms dedup, not just count.
+    expect(links[0]).toBe(oldLink);
+  });
+
+  it("preserves a persist-id'd element across swaps when the new head includes the same id", () => {
+    document.head.innerHTML = `<meta ${PERSIST_ATTR}="theme" name="color-scheme" content="dark">`;
+    const oldMeta = document.head.querySelector("meta[name=color-scheme]")!;
+    const newDoc = htmlDoc(`<!doctype html><html><head>
+      <meta ${PERSIST_ATTR}="theme" name="color-scheme" content="dark">
+    </head><body></body></html>`);
+
+    swapHeadElements(newDoc);
+
+    const metas = document.head.querySelectorAll("meta[name=color-scheme]");
+    expect(metas).toHaveLength(1);
+    expect(metas[0]).toBe(oldMeta);
+  });
+
+  it("removes head elements that the new document does not contain", () => {
+    document.head.innerHTML = `
+      <link rel="stylesheet" href="/old.css">
+      <meta name="description" content="old">
+    `;
+    const newDoc = htmlDoc(
+      `<!doctype html><html><head><meta name="description" content="new"></head><body></body></html>`,
+    );
+
+    swapHeadElements(newDoc);
+
+    expect(document.head.querySelector('link[href="/old.css"]')).toBeNull();
+    const desc = document.head.querySelector("meta[name=description]") as HTMLMetaElement;
+    expect(desc).not.toBeNull();
+    expect(desc.content).toBe("new");
+  });
+
+  it("appends head elements that exist only in the new document", () => {
+    document.head.innerHTML = "";
+    const newDoc = htmlDoc(`<!doctype html><html><head>
+      <link rel="stylesheet" href="/added.css">
+      <meta name="theme-color" content="#222">
+    </head><body></body></html>`);
+
+    swapHeadElements(newDoc);
+
+    expect(document.head.querySelector('link[href="/added.css"]')).not.toBeNull();
+    expect(document.head.querySelector('meta[name="theme-color"]')).not.toBeNull();
+  });
+
+  it("preserves an inline <style> with identical text content (FOUT prevention)", () => {
+    const css = ".x { color: red; }";
+    document.head.innerHTML = `<style>${css}</style>`;
+    const oldStyle = document.head.querySelector("style")!;
+    const newDoc = htmlDoc(
+      `<!doctype html><html><head><style>${css}</style></head><body></body></html>`,
+    );
+
+    swapHeadElements(newDoc);
+
+    const styles = document.head.querySelectorAll("style");
+    expect(styles).toHaveLength(1);
+    expect(styles[0]).toBe(oldStyle);
+  });
+});
+
+describe("swapBodyElement — persist lift", () => {
+  it("preserves a persist-id'd element across body replacement", () => {
+    document.body.innerHTML = `
+      <header><h1>Old Title</h1></header>
+      <div ${PERSIST_ATTR}="player" id="kept"><span>state</span></div>
+      <main>old content</main>
+    `;
+    const keptOriginal = document.querySelector("#kept")!;
+
+    const newDoc = htmlDoc(`<!doctype html><html><head></head><body>
+      <header><h1>New Title</h1></header>
+      <div ${PERSIST_ATTR}="player" id="incoming"></div>
+      <main>new content</main>
+    </body></html>`);
+
+    swapBodyElement(newDoc.body, document.body);
+
+    // The original DOM node should still be in document — same identity.
+    const keptAfter = document.querySelector(`[${PERSIST_ATTR}="player"]`);
+    expect(keptAfter).toBe(keptOriginal);
+    // It should have replaced the incoming target (positioned where the new
+    // marker was), so its parent is the new body and the placeholder #incoming
+    // is gone.
+    expect(document.querySelector("#incoming")).toBeNull();
+    // Surrounding markup is the new content.
+    expect(document.querySelector("h1")?.textContent).toBe("New Title");
+    expect(document.querySelector("main")?.textContent).toBe("new content");
+  });
+
+  it("discards an old persist element when the new body has no matching id", () => {
+    document.body.innerHTML = `<div ${PERSIST_ATTR}="orphan">orphan</div>`;
+    const newDoc = htmlDoc(`<!doctype html><html><head></head><body><p>fresh</p></body></html>`);
+
+    swapBodyElement(newDoc.body, document.body);
+
+    expect(document.querySelector(`[${PERSIST_ATTR}="orphan"]`)).toBeNull();
+    expect(document.querySelector("p")?.textContent).toBe("fresh");
+  });
+
+  it("upgrades declarative shadow-root templates after swap", () => {
+    document.body.innerHTML = "";
+    const newDoc = htmlDoc(`<!doctype html><html><head></head><body>
+      <div id="host"><template shadowrootmode="open"><span>shadow</span></template></div>
+    </body></html>`);
+
+    swapBodyElement(newDoc.body, document.body);
+
+    const host = document.querySelector("#host")!;
+    expect(host.shadowRoot).not.toBeNull();
+    expect(host.shadowRoot?.querySelector("span")?.textContent).toBe("shadow");
+    // The <template> should have been removed once attached.
+    expect(host.querySelector("template")).toBeNull();
+  });
+});
+
+describe("saveFocus / restoreFocus", () => {
+  it("restores caret position on a persisted <input>", () => {
+    document.body.innerHTML = `<form ${PERSIST_ATTR}="form"><input id="i" value="hello"></form>`;
+    const input = document.getElementById("i") as HTMLInputElement;
+    input.focus();
+    input.setSelectionRange(2, 4);
+
+    const restore = saveFocus();
+
+    // Simulate a swap: rebuild the same persisted subtree in place. The
+    // saved closure captured the original input reference.
+    restore();
+
+    expect(document.activeElement).toBe(input);
+    expect(input.selectionStart).toBe(2);
+    expect(input.selectionEnd).toBe(4);
+  });
+
+  it("does nothing when activeElement is not inside a persist subtree", () => {
+    document.body.innerHTML = `<button id="b">click</button>`;
+    const btn = document.getElementById("b") as HTMLButtonElement;
+    btn.focus();
+    expect(document.activeElement).toBe(btn);
+
+    const restore = saveFocus();
+    // Move focus elsewhere then call restore — the saved closure should be a
+    // no-op (activeElement: null).
+    btn.blur();
+    restore();
+    // Focus should not have been forced back onto the button.
+    expect(document.activeElement).not.toBe(btn);
+  });
+
+  it("restoreFocus tolerates a null activeElement (no throw)", () => {
+    expect(() => restoreFocus({ activeElement: null })).not.toThrow();
+  });
+});
+
+describe("script re-exec — deselectScripts + detectScriptExecuted", () => {
+  it("detectScriptExecuted is true the second time the same src appears", () => {
+    const s = document.createElement("script");
+    s.src = "/a.js";
+    expect(detectScriptExecuted(s)).toBe(false);
+    expect(detectScriptExecuted(s)).toBe(true);
+  });
+
+  it("deselectScripts marks an already-seen script as executed in the new doc", () => {
+    // Build the new doc by hand rather than parseFromString — happy-dom 15.11
+    // can still fetch <script src> through the parser even when fileloading
+    // settings are disabled. document.implementation.createHTMLDocument() gives
+    // us a parserless document that never tries to load anything.
+    const newDoc = document.implementation.createHTMLDocument();
+    const seenScript = newDoc.createElement("script");
+    seenScript.src = "data:application/javascript,/*seen*/";
+    newDoc.head.appendChild(seenScript);
+    const freshScript = newDoc.createElement("script");
+    freshScript.src = "data:application/javascript,/*fresh*/";
+    newDoc.head.appendChild(freshScript);
+
+    // Pre-seed the dedup set by visiting /seen.js once.
+    detectScriptExecuted(seenScript);
+
+    deselectScripts(newDoc);
+
+    expect(seenScript.dataset["zfbExec"]).toBe("");
+    expect(freshScript.dataset["zfbExec"]).toBeUndefined();
+  });
+
+  it("data-zfb-rerun bypasses dedup so re-execution proceeds", () => {
+    const newDoc = document.implementation.createHTMLDocument();
+    const loud = newDoc.createElement("script");
+    loud.src = "data:application/javascript,/*loud*/";
+    loud.setAttribute("data-zfb-rerun", "");
+    newDoc.head.appendChild(loud);
+
+    // Pre-seed the dedup set.
+    const seed = newDoc.createElement("script");
+    seed.src = "data:application/javascript,/*loud*/";
+    detectScriptExecuted(seed);
+
+    deselectScripts(newDoc);
+
+    expect(loud.dataset["zfbExec"]).toBeUndefined();
+  });
+});
+
+describe("swapRootAttributes", () => {
+  it("replaces <html> attributes with the new doc's set", () => {
+    document.documentElement.setAttribute("class", "old-theme");
+    document.documentElement.setAttribute("lang", "en");
+    const newDoc = htmlDoc(
+      `<!doctype html><html class="new-theme" lang="ja"><head></head><body></body></html>`,
+    );
+
+    swapRootAttributes(newDoc);
+
+    expect(document.documentElement.getAttribute("class")).toBe("new-theme");
+    expect(document.documentElement.getAttribute("lang")).toBe("ja");
+  });
+
+  it("preserves data-zfb-transition and data-zfb-transition-fallback", () => {
+    document.documentElement.setAttribute("data-zfb-transition", "forward");
+    document.documentElement.setAttribute("data-zfb-transition-fallback", "old");
+    const newDoc = htmlDoc(`<!doctype html><html lang="en"><head></head><body></body></html>`);
+
+    swapRootAttributes(newDoc);
+
+    // Non-overridable attrs reinserted — these belong to the running transition,
+    // not to either page's source markup.
+    expect(document.documentElement.getAttribute("data-zfb-transition")).toBe("forward");
+    expect(document.documentElement.getAttribute("data-zfb-transition-fallback")).toBe("old");
+    expect(document.documentElement.getAttribute("lang")).toBe("en");
+  });
+});
+
+describe("swap() composition", () => {
+  it("runs deselect + root + head + body + restoreFocus end-to-end", () => {
+    document.documentElement.setAttribute("lang", "en");
+    document.head.innerHTML = `<title>Old</title>`;
+    document.body.innerHTML = `<main>old</main>`;
+
+    const newDoc = htmlDoc(`<!doctype html><html lang="ja"><head>
+      <title>New</title>
+    </head><body>
+      <main>new</main>
+    </body></html>`);
+
+    expect(() => swap(newDoc)).not.toThrow();
+
+    expect(document.documentElement.getAttribute("lang")).toBe("ja");
+    expect(document.title).toBe("New");
+    expect(document.querySelector("main")?.textContent).toBe("new");
+  });
+});

--- a/packages/zfb-runtime/src/__tests__/view-transitions.test.ts
+++ b/packages/zfb-runtime/src/__tests__/view-transitions.test.ts
@@ -2,39 +2,28 @@
 //
 // Cross-document View Transitions are opted in via the
 // `@view-transition { navigation: auto; }` CSS at-rule on the consumer's
-// top-level stylesheet, NOT via this component. The component is kept as
-// a typed no-op so existing `<ViewTransitions />` mounts compile unchanged.
+// top-level stylesheet, NOT via this component. The component is kept as a
+// typed no-op so existing `<ViewTransitions />` mounts in downstream code
+// compile unchanged. Per the W3D port (zudolab/zudo-doc#1519) the inline IIFE
+// that the component used to emit was deleted; <ClientRouter /> is now the
+// SPA opt-in. This test pins the back-compat contract: ViewTransitions() must
+// return `[]` so the JSX call site emits no DOM.
 //
-// Previously this file held ~22 tests covering meta-tag SSR shape, inline
-// IIFE SSR shape, and a happy-dom click-intercept smoke suite (modifier
-// keys, target=_blank, mailto:/tel:/javascript:, hash-only, cross-origin,
-// download attr, default-prevented events, happy-path interception, etc.).
-// All of that machinery is gone. The contract is now: `ViewTransitions()`
-// returns `[]` (empty readonly array of structural VNodes).
-//
-// The intentionally minimal test surface here is the new SSR contract plus
-// a TS-level assertion that the public type signature is preserved.
+// Previously this file held ~18 click-intercept smoke tests against the
+// deleted IIFE. They are gone — the click/submit intercept is now exercised
+// by `__tests__/client-router/router.test.ts`.
 
 import { describe, expect, it } from "vitest";
 
 import { ViewTransitions, type ViewTransitionsElement } from "../view-transitions.js";
 
-describe("ViewTransitions — typed no-op contract", () => {
-  it("returns an empty array (no DOM injection)", () => {
-    expect(ViewTransitions()).toEqual([]);
-  });
-
-  it("returns a stable readonly array shape", () => {
+describe("ViewTransitions — typed no-op back-compat contract", () => {
+  it("returns an empty array so existing JSX mounts emit no DOM", () => {
     const fragment = ViewTransitions();
-    expect(Array.isArray(fragment)).toBe(true);
-    expect(fragment).toHaveLength(0);
-  });
-
-  it("preserves the public type signature () => readonly ViewTransitionsElement[]", () => {
-    // TS-level contract: this satisfies-check would fail at compile time
-    // if `ViewTransitions` ever stopped returning `readonly
-    // ViewTransitionsElement[]`. The runtime check is incidental — the
-    // value of this test is that `tsc --noEmit` enforces the shape.
+    expect(fragment).toEqual([]);
+    // The TS signature `() => readonly ViewTransitionsElement[]` is enforced
+    // at compile time by `pnpm typecheck`; the runtime check below is the
+    // observable half of that contract.
     const _typeCheck: () => readonly ViewTransitionsElement[] = ViewTransitions;
     expect(typeof _typeCheck).toBe("function");
   });

--- a/packages/zfb-runtime/src/client-router.ts
+++ b/packages/zfb-runtime/src/client-router.ts
@@ -1,0 +1,117 @@
+// `@takazudo/zfb-runtime` — `<ClientRouter />` component.
+//
+// Ported from Astro's `ClientRouter.astro` (155 lines).
+// Source: packages/astro/components/ClientRouter.astro
+// Issue: zudolab/zudo-doc#1519 (W3D), parent epic zudolab/zudo-doc#1510.
+//
+// Named-cause deviation — inline script split (W1B §13.6):
+//   Astro's <script> block is processed by Vite at build time as a bundled
+//   module with virtual-module imports (`astro:transitions/client`). The zfb
+//   port emits meta tags + global styles from the JSX component, while the
+//   click/form intercepts live in `client-router/router.ts` and are registered
+//   via `init()`. The component calls `init()` as a side effect on first import.
+//   No inline <script> dangerouslySetInnerHTML is emitted.
+//
+// Named-cause deviation — no JSX (W1B: "follow existing component-emission pattern"):
+//   `@takazudo/zfb-runtime` does not depend on Preact and has no JSX compiler
+//   options configured in its tsconfig. The existing component-emission pattern
+//   (established by `Island` in @takazudo/zfb, and `ViewTransitions` in this
+//   package) uses plain VNode-shaped objects with `constructor: undefined` — the
+//   sentinel recognised by both Preact and React renderers. Following that pattern
+//   avoids adding Preact as a dependency and avoids tsconfig JSX changes.
+//
+// The component renders three sibling elements to <head>:
+//   1. A <style> tag with the `.zfb-route-announcer` ARIA helper class.
+//   2. <meta name="zfb-view-transitions-enabled" content="true" />
+//   3. <meta name="zfb-view-transitions-fallback" content={fallback} />
+//
+// The route-announcer <div> is injected into <body> by `announce()` in
+// `client-router/router.ts` on every navigation.
+
+import { init } from "./client-router/router.js";
+
+// Side-effect: wire click + submit intercepts on first import of this component.
+// Guarded by the idempotent `initialized` flag in router.ts — safe for multiple
+// <ClientRouter /> mounts and HMR re-runs. (W3C3 init idempotency.)
+if (typeof document !== "undefined") {
+  init();
+}
+
+export interface ClientRouterProps {
+  /** Fallback animation strategy when native View Transitions are not supported. */
+  fallback?: "none" | "animate" | "swap";
+}
+
+/**
+ * Public element shape for each node returned by `<ClientRouter />`.
+ * Structural type — intentionally matches the Preact/React VNode object shape
+ * so consumers do not type-infer through the internal representation.
+ */
+export type ClientRouterElement = {
+  readonly type: string;
+  readonly props: Readonly<Record<string, unknown>>;
+  readonly key: unknown;
+};
+
+/**
+ * Construct a VNode-shaped object. Sets `constructor: undefined` so that both
+ * Preact's and React's renderers treat it as a structural VNode rather than
+ * foreign data. (Mirrors the `makeVNode` pattern in `@takazudo/zfb`'s Island.)
+ */
+function makeVNode(type: string, props: Record<string, unknown>): ClientRouterElement {
+  const v = { type, props, key: null } as {
+    type: string;
+    props: Record<string, unknown>;
+    key: null;
+    constructor?: unknown;
+  };
+  v.constructor = undefined;
+  return v as ClientRouterElement;
+}
+
+// CSS for the route-announcer element. Ported verbatim from Astro's
+// `<style is:global>` block in ClientRouter.astro (lines 11–23), renaming
+// `.astro-route-announcer` → `.zfb-route-announcer` per W1B §5.
+// This is a global (non-scoped) <style> because the announcer <div> is
+// appended to document.body at runtime, outside any Preact-controlled subtree.
+const announcerCss = `
+.zfb-route-announcer {
+	position: absolute;
+	left: 0;
+	top: 0;
+	clip: rect(0 0 0 0);
+	clip-path: inset(50%);
+	overflow: hidden;
+	white-space: nowrap;
+	width: 1px;
+	height: 1px;
+}
+`;
+
+/**
+ * `<ClientRouter />` — SPA soft-swap navigation with View Transition animations.
+ *
+ * Mount once in your page `<head>`. Emits the opt-in meta tags and the global
+ * `.zfb-route-announcer` stylesheet that the route-announcer ARIA div needs.
+ * Click and form-submit intercepts are registered as a side effect of importing
+ * this component (idempotent — safe to mount multiple times).
+ *
+ * @example
+ * ```tsx
+ * import { ClientRouter } from "@takazudo/zfb-runtime";
+ * // In your page <head>:
+ * <ClientRouter fallback="animate" />
+ * ```
+ */
+export function ClientRouter({
+  fallback = "animate",
+}: ClientRouterProps): readonly ClientRouterElement[] {
+  return [
+    // Global styles for the ARIA route-announcer div injected into <body>.
+    makeVNode("style", { dangerouslySetInnerHTML: { __html: announcerCss } }),
+    // Opt-in meta tag: router checks for this to decide whether to intercept navigations.
+    makeVNode("meta", { name: "zfb-view-transitions-enabled", content: "true" }),
+    // Fallback strategy meta tag: read by getFallback() in router.ts.
+    makeVNode("meta", { name: "zfb-view-transitions-fallback", content: fallback }),
+  ];
+}

--- a/packages/zfb-runtime/src/client-router/cssesc.ts
+++ b/packages/zfb-runtime/src/client-router/cssesc.ts
@@ -1,0 +1,103 @@
+/* eslint-disable regexp/control-character-escape */
+/* eslint-disable no-control-regex */
+/* eslint-disable regexp/no-optional-assertion */
+/* eslint-disable regexp/no-useless-escape */
+/* eslint-disable regexp/no-obscure-range */
+// ESM vendored version of cssesc: https://github.com/mathiasbynens/cssesc/blob/cb894eb42f27c8d3cd793f16afe35b3ab38000a1/cssesc.js
+// See https://github.com/withastro/astro/pull/15669
+
+const regexAnySingleEscape = /[ -,\.\/:-@\[-\^`\{-~]/;
+const regexSingleEscape = /[ -,\.\/:-@\[\]\^`\{-~]/;
+const regexExcessiveSpaces = /(^|\\+)?(\\[A-F0-9]{1,6})\x20(?![a-fA-F0-9\x20])/g;
+
+interface Options {
+  escapeEverything: boolean;
+  isIdentifier: boolean;
+  quotes: "single" | "double";
+  wrap: boolean;
+}
+
+const DEFAULT_OPTIONS: Options = {
+  escapeEverything: false,
+  isIdentifier: false,
+  quotes: "single",
+  wrap: false,
+};
+
+export default function cssesc(string: string, options: Partial<Options> = {}) {
+  options = { ...DEFAULT_OPTIONS, ...options };
+  const quote = options.quotes === "double" ? '"' : "'";
+  const { isIdentifier } = options;
+
+  const firstChar = string.charAt(0);
+  let output = "";
+  let counter = 0;
+  const length = string.length;
+  while (counter < length) {
+    const character = string.charAt(counter++);
+    let codePoint = character.charCodeAt(0);
+    let value: string;
+    // If it's not a printable ASCII character…
+    if (codePoint < 0x20 || codePoint > 0x7e) {
+      if (codePoint >= 0xd800 && codePoint <= 0xdbff && counter < length) {
+        // It's a high surrogate, and there is a next character.
+        const extra = string.charCodeAt(counter++);
+        if ((extra & 0xfc00) === 0xdc00) {
+          // next character is low surrogate
+          codePoint = ((codePoint & 0x3ff) << 10) + (extra & 0x3ff) + 0x10000;
+        } else {
+          // It's an unmatched surrogate; only append this code unit, in case
+          // the next code unit is the high surrogate of a surrogate pair.
+          counter--;
+        }
+      }
+      value = "\\" + codePoint.toString(16).toUpperCase() + " ";
+    } else {
+      if (options.escapeEverything) {
+        if (regexAnySingleEscape.test(character)) {
+          value = "\\" + character;
+        } else {
+          value = "\\" + codePoint.toString(16).toUpperCase() + " ";
+        }
+      } else if (/[\t\n\f\r\x0B]/.test(character)) {
+        value = "\\" + codePoint.toString(16).toUpperCase() + " ";
+      } else if (
+        character === "\\" ||
+        (!isIdentifier &&
+          ((character === '"' && quote === character) ||
+            (character === "'" && quote === character))) ||
+        (isIdentifier && regexSingleEscape.test(character))
+      ) {
+        value = "\\" + character;
+      } else {
+        value = character;
+      }
+    }
+    output += value;
+  }
+
+  if (isIdentifier) {
+    if (/^-[-\d]/.test(output)) {
+      output = "\\-" + output.slice(1);
+    } else if (/\d/.test(firstChar)) {
+      output = "\\3" + firstChar + " " + output.slice(1);
+    }
+  }
+
+  // Remove spaces after `\HEX` escapes that are not followed by a hex digit,
+  // since they're redundant. Note that this is only possible if the escape
+  // sequence isn't preceded by an odd number of backslashes.
+  output = output.replace(regexExcessiveSpaces, function ($0, $1, $2) {
+    if ($1 && $1.length % 2) {
+      // It's not safe to remove the space, so don't.
+      return $0;
+    }
+    // Strip the space.
+    return ($1 || "") + $2;
+  });
+
+  if (!isIdentifier && options.wrap) {
+    return quote + output + quote;
+  }
+  return output;
+}

--- a/packages/zfb-runtime/src/client-router/events.ts
+++ b/packages/zfb-runtime/src/client-router/events.ts
@@ -1,0 +1,198 @@
+/// <reference lib="dom" />
+import { swap } from "./swap-functions.js";
+import type { Direction, NavigationTypeString } from "./types.js";
+
+export const TRANSITION_BEFORE_PREPARATION = "zfb:before-preparation";
+export const TRANSITION_AFTER_PREPARATION = "zfb:after-preparation";
+export const TRANSITION_BEFORE_SWAP = "zfb:before-swap";
+export const TRANSITION_AFTER_SWAP = "zfb:after-swap";
+export const TRANSITION_PAGE_LOAD = "zfb:page-load";
+
+type Events = "zfb:after-preparation" | "zfb:after-swap" | "zfb:page-load";
+export const triggerEvent = (name: Events) => document.dispatchEvent(new Event(name));
+export const onPageLoad = () => triggerEvent("zfb:page-load");
+
+/*
+ * Common stuff
+ */
+class BeforeEvent extends Event {
+  readonly from: URL;
+  to: URL;
+  direction: Direction | string;
+  readonly navigationType: NavigationTypeString;
+  readonly sourceElement: Element | undefined;
+  readonly info: any;
+  newDocument: Document;
+  readonly signal: AbortSignal;
+
+  constructor(
+    type: string,
+    eventInitDict: EventInit | undefined,
+    from: URL,
+    to: URL,
+    direction: Direction | string,
+    navigationType: NavigationTypeString,
+    sourceElement: Element | undefined,
+    info: any,
+    newDocument: Document,
+    signal: AbortSignal,
+  ) {
+    super(type, eventInitDict);
+    this.from = from;
+    this.to = to;
+    this.direction = direction;
+    this.navigationType = navigationType;
+    this.sourceElement = sourceElement;
+    this.info = info;
+    this.newDocument = newDocument;
+    this.signal = signal;
+
+    Object.defineProperties(this, {
+      from: { enumerable: true },
+      to: { enumerable: true, writable: true },
+      direction: { enumerable: true, writable: true },
+      navigationType: { enumerable: true },
+      sourceElement: { enumerable: true },
+      info: { enumerable: true },
+      newDocument: { enumerable: true, writable: true },
+      signal: { enumerable: true },
+    });
+  }
+}
+
+/*
+ * TransitionBeforePreparationEvent
+
+ */
+export const isTransitionBeforePreparationEvent = (
+  value: any,
+): value is TransitionBeforePreparationEvent => value.type === TRANSITION_BEFORE_PREPARATION;
+export class TransitionBeforePreparationEvent extends BeforeEvent {
+  formData: FormData | undefined;
+  loader: () => Promise<void>;
+  constructor(
+    from: URL,
+    to: URL,
+    direction: Direction | string,
+    navigationType: NavigationTypeString,
+    sourceElement: Element | undefined,
+    info: any,
+    newDocument: Document,
+    signal: AbortSignal,
+    formData: FormData | undefined,
+    loader: (event: TransitionBeforePreparationEvent) => Promise<void>,
+  ) {
+    super(
+      TRANSITION_BEFORE_PREPARATION,
+      { cancelable: true },
+      from,
+      to,
+      direction,
+      navigationType,
+      sourceElement,
+      info,
+      newDocument,
+      signal,
+    );
+    this.formData = formData;
+    this.loader = loader.bind(this, this);
+    Object.defineProperties(this, {
+      formData: { enumerable: true },
+      loader: { enumerable: true, writable: true },
+    });
+  }
+}
+
+/*
+ * TransitionBeforeSwapEvent
+ */
+export const isTransitionBeforeSwapEvent = (value: any): value is TransitionBeforeSwapEvent =>
+  value.type === TRANSITION_BEFORE_SWAP;
+export class TransitionBeforeSwapEvent extends BeforeEvent {
+  override readonly direction: Direction | string;
+  readonly viewTransition: ViewTransition;
+  swap: () => void;
+
+  constructor(afterPreparation: BeforeEvent, viewTransition: ViewTransition) {
+    super(
+      TRANSITION_BEFORE_SWAP,
+      undefined,
+      afterPreparation.from,
+      afterPreparation.to,
+      afterPreparation.direction,
+      afterPreparation.navigationType,
+      afterPreparation.sourceElement,
+      afterPreparation.info,
+      afterPreparation.newDocument,
+      afterPreparation.signal,
+    );
+    this.direction = afterPreparation.direction;
+    this.viewTransition = viewTransition;
+    this.swap = () => swap(this.newDocument);
+
+    Object.defineProperties(this, {
+      direction: { enumerable: true },
+      viewTransition: { enumerable: true },
+      swap: { enumerable: true, writable: true },
+    });
+  }
+}
+
+export async function doPreparation(
+  from: URL,
+  to: URL,
+  direction: Direction | string,
+  navigationType: NavigationTypeString,
+  sourceElement: Element | undefined,
+  info: any,
+  signal: AbortSignal,
+  formData: FormData | undefined,
+  defaultLoader: (event: TransitionBeforePreparationEvent) => Promise<void>,
+) {
+  const event = new TransitionBeforePreparationEvent(
+    from,
+    to,
+    direction,
+    navigationType,
+    sourceElement,
+    info,
+    window.document,
+    signal,
+    formData,
+    defaultLoader,
+  );
+  if (document.dispatchEvent(event)) {
+    await event.loader();
+    if (!event.defaultPrevented) {
+      triggerEvent("zfb:after-preparation");
+      if (event.navigationType !== "traverse") {
+        // save the current scroll position before we change the DOM and transition to the new page
+        updateScrollPosition({ scrollX, scrollY });
+      }
+    }
+  }
+  return event;
+}
+
+// only update history entries that are managed by us
+// leave other entries alone and do not accidentally add state.
+export const updateScrollPosition = (positions: { scrollX: number; scrollY: number }) => {
+  if (history.state) {
+    history.scrollRestoration = "manual";
+    history.replaceState({ ...history.state, ...positions }, "");
+  }
+};
+
+export async function doSwap(
+  afterPreparation: BeforeEvent,
+  viewTransition: ViewTransition,
+  afterDispatch?: () => Promise<void>,
+) {
+  const event = new TransitionBeforeSwapEvent(afterPreparation, viewTransition);
+  document.dispatchEvent(event);
+  if (afterDispatch) {
+    await afterDispatch();
+  }
+  event.swap();
+  return event;
+}

--- a/packages/zfb-runtime/src/client-router/index.ts
+++ b/packages/zfb-runtime/src/client-router/index.ts
@@ -18,8 +18,9 @@ export type { Direction, Fallback, NavigationTypeString, Options } from "./types
 
 export { swapFunctions, swap } from "./swap-functions.js";
 
-// W3C1 router-core public surface. `navigate()` is intentionally NOT re-exported
-// here yet — W3C2 will add it once the public entry point is implemented.
-export { supportsViewTransitions, transitionEnabledOnThisPage } from "./router.js";
+// Router public surface.
+//   - W3C1: `supportsViewTransitions`, `transitionEnabledOnThisPage`.
+//   - W3C2: `navigate()` (public navigation entry).
+export { navigate, supportsViewTransitions, transitionEnabledOnThisPage } from "./router.js";
 
 // (cssesc is an internal helper, not part of the public surface — not re-exported.)

--- a/packages/zfb-runtime/src/client-router/index.ts
+++ b/packages/zfb-runtime/src/client-router/index.ts
@@ -16,4 +16,6 @@ export {
 
 export type { Direction, Fallback, NavigationTypeString, Options } from "./types.js";
 
+export { swapFunctions, swap } from "./swap-functions.js";
+
 // (cssesc is an internal helper, not part of the public surface — not re-exported.)

--- a/packages/zfb-runtime/src/client-router/index.ts
+++ b/packages/zfb-runtime/src/client-router/index.ts
@@ -18,4 +18,8 @@ export type { Direction, Fallback, NavigationTypeString, Options } from "./types
 
 export { swapFunctions, swap } from "./swap-functions.js";
 
+// W3C1 router-core public surface. `navigate()` is intentionally NOT re-exported
+// here yet — W3C2 will add it once the public entry point is implemented.
+export { supportsViewTransitions, transitionEnabledOnThisPage } from "./router.js";
+
 // (cssesc is an internal helper, not part of the public surface — not re-exported.)

--- a/packages/zfb-runtime/src/client-router/index.ts
+++ b/packages/zfb-runtime/src/client-router/index.ts
@@ -1,6 +1,9 @@
 // Public API surface for the client-router module.
 // This file is the barrel for @takazudo/zfb-runtime's client-router export.
-// Subsequent W3 sub-issues will add re-exports of swap-functions, router, and the component.
+// W3D adds the <ClientRouter /> component and ClientRouterProps re-exports.
+
+// Component (W3D).
+export { ClientRouter, type ClientRouterProps } from "../client-router.js";
 
 export {
   TRANSITION_BEFORE_PREPARATION,

--- a/packages/zfb-runtime/src/client-router/index.ts
+++ b/packages/zfb-runtime/src/client-router/index.ts
@@ -1,0 +1,19 @@
+// Public API surface for the client-router module.
+// This file is the barrel for @takazudo/zfb-runtime's client-router export.
+// Subsequent W3 sub-issues will add re-exports of swap-functions, router, and the component.
+
+export {
+  TRANSITION_BEFORE_PREPARATION,
+  TRANSITION_AFTER_PREPARATION,
+  TRANSITION_BEFORE_SWAP,
+  TRANSITION_AFTER_SWAP,
+  TRANSITION_PAGE_LOAD,
+  TransitionBeforePreparationEvent,
+  TransitionBeforeSwapEvent,
+  isTransitionBeforePreparationEvent,
+  isTransitionBeforeSwapEvent,
+} from "./events.js";
+
+export type { Direction, Fallback, NavigationTypeString, Options } from "./types.js";
+
+// (cssesc is an internal helper, not part of the public surface — not re-exported.)

--- a/packages/zfb-runtime/src/client-router/index.ts
+++ b/packages/zfb-runtime/src/client-router/index.ts
@@ -21,6 +21,8 @@ export { swapFunctions, swap } from "./swap-functions.js";
 // Router public surface.
 //   - W3C1: `supportsViewTransitions`, `transitionEnabledOnThisPage`.
 //   - W3C2: `navigate()` (public navigation entry).
-export { navigate, supportsViewTransitions, transitionEnabledOnThisPage } from "./router.js";
+//   - W3C3: `init()` (idempotent bootstrap: registers click + form intercept listeners).
+export { navigate, supportsViewTransitions, transitionEnabledOnThisPage, init } from "./router.js";
+export type { InitOptions } from "./router.js";
 
 // (cssesc is an internal helper, not part of the public surface — not re-exported.)

--- a/packages/zfb-runtime/src/client-router/router.ts
+++ b/packages/zfb-runtime/src/client-router/router.ts
@@ -26,9 +26,12 @@
 //     code; same observable behavior in browser and on SSR.
 //   - `announce()` is a TODO stub (W3C3 owns the route announcer).
 //
-// W3C1 deferred to W3C2:
+// W3C2 additions (this file):
 //   - `navigate()` public entry.
-//   - `onPopState`, `onScrollEnd`, top-level `if (inBrowser)` init block.
+//   - `onPopState`, `onScrollEnd`.
+//   - Top-level `if (inBrowser)` initialization block (seeds `currentHistoryIndex`
+//     from `history.state`, registers popstate / load / scrollend listeners, and
+//     marks already-executed scripts with `dataset["zfbExec"] = ""`).
 //
 // W3C1 deferred to W3C3:
 //   - `announce()` route-announcer implementation.
@@ -101,9 +104,21 @@ let parser: DOMParser;
 // The History API does not tell you if navigation is forward or back, so
 // you can figure it using an index. On pushState the index is incremented so you
 // can use that to determine popstate if going forward or back.
-// W3C2 owns the init block that seeds this from history.state on page load and
-// handles the popstate-driven update.
 let currentHistoryIndex = 0;
+
+if (inBrowser) {
+  if (history.state) {
+    // Here we reloaded a page with history state
+    // (e.g. history navigation from non-transition page or browser reload)
+    currentHistoryIndex = history.state.index;
+    scrollTo({ left: history.state.scrollX, top: history.state.scrollY });
+  } else if (transitionEnabledOnThisPage()) {
+    // This page is loaded from the browser address bar or via a link from extern,
+    // it needs a state in the history
+    history.replaceState({ index: currentHistoryIndex, scrollX, scrollY }, "");
+    history.scrollRestoration = "manual";
+  }
+}
 
 // returns the contents of the page or null if the router can't deal with it.
 async function fetchHTML(
@@ -599,6 +614,112 @@ async function transition(
   }
 }
 
-// W3C2 will add `navigate()` (public entry), `onPopState`, `onScrollEnd`, and the
-// top-level `if (inBrowser)` initialization block here.
+let navigateOnServerWarned = false;
+
+export async function navigate(href: string, options?: Options) {
+  if (inBrowser === false) {
+    if (!navigateOnServerWarned) {
+      // instantiate an error for the stacktrace to show to user.
+      const warning = new Error(
+        "The view transitions client API was called during a server side render. This may be unintentional as the navigate() function is expected to be called in response to user interactions. Please make sure that your usage is correct.",
+      );
+      warning.name = "Warning";
+      // biome-ignore lint/suspicious/noConsole: allowed
+      console.warn(warning);
+      navigateOnServerWarned = true;
+    }
+    return;
+  }
+  await transition("forward", originalLocation, new URL(href, location.href), options ?? {});
+}
+
+function onPopState(ev: PopStateEvent) {
+  if (!transitionEnabledOnThisPage() && ev.state) {
+    // The current page doesn't have View Transitions enabled
+    // but the page we navigate to does (because it set the state).
+    // Do a full page refresh to reload the client-side router from the new page.
+    location.reload();
+    return;
+  }
+
+  // History entries without state are created by the browser (e.g. for hash links)
+  // Our view transition entries always have state.
+  // Just ignore stateless entries.
+  // The browser will handle navigation fine without our help
+  if (ev.state === null) {
+    return;
+  }
+  const state: State = history.state;
+  const nextIndex = state.index;
+  const direction: Direction = nextIndex > currentHistoryIndex ? "forward" : "back";
+  currentHistoryIndex = nextIndex;
+  transition(
+    direction,
+    originalLocation,
+    new URL(location.href),
+    {},
+    state,
+    ev.hasUAVisualTransition,
+  );
+}
+
+const onScrollEnd = () => {
+  // NOTE: our "popstate" event handler may call `pushState()` or
+  // `replaceState()` and then `scrollTo()`, which will fire "scroll" and
+  // "scrollend" events. To avoid redundant work and expensive calls to
+  // `replaceState()`, we simply check that the values are different before
+  // updating.
+  if (history.state && (scrollX !== history.state.scrollX || scrollY !== history.state.scrollY)) {
+    updateScrollPosition({ scrollX, scrollY });
+  }
+};
+
+// initialization
+if (inBrowser) {
+  if (supportsViewTransitions || getFallback() !== "none") {
+    originalLocation = new URL(location.href);
+    addEventListener("popstate", onPopState);
+    addEventListener("load", onPageLoad);
+    // There's not a good way to record scroll position before a history back
+    // navigation, so we will record it when the user has stopped scrolling.
+    if ("onscrollend" in window) addEventListener("scrollend", onScrollEnd);
+    else {
+      // Keep track of state between intervals
+      let intervalId: number | undefined, lastY: number, lastX: number, lastIndex: State["index"];
+      const scrollInterval = () => {
+        // Check the index to see if a popstate event was fired
+        if (lastIndex !== history.state?.index) {
+          clearInterval(intervalId);
+          intervalId = undefined;
+          return;
+        }
+        // Check if the user stopped scrolling
+        if (lastY === scrollY && lastX === scrollX) {
+          // Cancel the interval and update scroll positions
+          clearInterval(intervalId);
+          intervalId = undefined;
+          onScrollEnd();
+          return;
+        } else {
+          ((lastY = scrollY), (lastX = scrollX));
+        }
+      };
+      // We can't know when or how often scroll events fire, so we'll just use them to start intervals
+      addEventListener(
+        "scroll",
+        () => {
+          if (intervalId !== undefined) return;
+          ((lastIndex = history.state?.index), (lastY = scrollY), (lastX = scrollX));
+          intervalId = window.setInterval(scrollInterval, 50);
+        },
+        { passive: true },
+      );
+    }
+  }
+  for (const script of document.getElementsByTagName("script")) {
+    detectScriptExecuted(script);
+    script.dataset["zfbExec"] = "";
+  }
+}
+
 // W3C3 will add the click + form intercept and the route announcer body of `announce()`.

--- a/packages/zfb-runtime/src/client-router/router.ts
+++ b/packages/zfb-runtime/src/client-router/router.ts
@@ -1,0 +1,604 @@
+/// <reference lib="dom" />
+/// <reference lib="dom.iterable" />
+// Ported from Astro transitions/router.ts (transition orchestration half).
+// Source: https://raw.githubusercontent.com/withastro/astro/main/packages/astro/src/transitions/router.ts
+// Issue: zudolab/zudo-doc#1516 (W3C1), parent epic zudolab/zudo-doc#1510.
+//
+// Mechanical renames per W1B §13.5:
+//   astro:* event names         → zfb:*
+//   data-astro-* attributes     → data-zfb-*
+//   astro-view-transitions-*    → zfb-view-transitions-*
+//   .astro-route-announcer      → .zfb-route-announcer
+//   dataset.astroExec           → dataset.zfbExec
+//   dataset.astroHistory        → dataset.zfbHistory
+//   dataset.astroRerun          → dataset.zfbRerun
+//
+// Named-cause deviations:
+//   - `internalFetchHeaders` import dropped; replaced with `{}` (W1B §13.5 — zfb adapters
+//     do not currently expose a per-fetch internal-headers contract).
+//   - `prepareForClientOnlyComponents` dropped entirely (W1B §13.5 / W3C2 — DEV-only
+//     iframe trick that compensates for Vite per-component CSS injection on hydrate;
+//     not applicable to zfb islands which inject CSS via the bundle).
+//   - `import.meta.env.SSR` access uses `(import.meta as any).env?.SSR` (no Vite
+//     ambient types in zfb-runtime tsconfig — same workaround used in W3B).
+//   - `inBrowser` evaluates to `typeof document !== "undefined"` rather than relying
+//     on the SSR flag, because the runtime package serves both server- and client-side
+//     code; same observable behavior in browser and on SSR.
+//   - `announce()` is a TODO stub (W3C3 owns the route announcer).
+//
+// W3C1 deferred to W3C2:
+//   - `navigate()` public entry.
+//   - `onPopState`, `onScrollEnd`, top-level `if (inBrowser)` init block.
+//
+// W3C1 deferred to W3C3:
+//   - `announce()` route-announcer implementation.
+//   - Click + form intercept.
+
+import {
+  doPreparation,
+  doSwap,
+  onPageLoad,
+  triggerEvent,
+  updateScrollPosition,
+  type TransitionBeforePreparationEvent,
+} from "./events.js";
+import { detectScriptExecuted } from "./swap-functions.js";
+import type { Direction, Fallback, Options } from "./types.js";
+
+type State = {
+  index: number;
+  scrollX: number;
+  scrollY: number;
+};
+type Navigation = { controller: AbortController };
+type Transition = {
+  // The view transitions object (API and simulation)
+  viewTransition?: ViewTransition;
+  // Simulation: Whether transition was skipped
+  transitionSkipped: boolean;
+  // Simulation: The resolve function of the finished promise
+  viewTransitionFinished?: () => void;
+};
+
+// Adapter-specific internal fetch headers. zfb adapters do not currently expose this
+// contract — the empty object preserves the call-shape so the loop in fetchHTML is a
+// no-op until/unless an adapter wires this up.
+const internalFetchHeaders: Record<string, string> = {};
+
+// Detect browser context. Astro uses `import.meta.env.SSR === false` (Vite-injected).
+// The zfb-runtime tsconfig has no Vite ambient types; checking for `document` is
+// behaviorally identical and avoids a Vite type dependency.
+const inBrowser = typeof document !== "undefined";
+
+export const supportsViewTransitions = inBrowser && !!document.startViewTransition;
+
+export const transitionEnabledOnThisPage = () =>
+  inBrowser && !!document.querySelector('[name="zfb-view-transitions-enabled"]');
+
+const samePage = (thisLocation: URL, otherLocation: URL) =>
+  thisLocation.pathname === otherLocation.pathname && thisLocation.search === otherLocation.search;
+
+// The previous navigation that might still be in processing
+let mostRecentNavigation: Navigation | undefined;
+// The previous transition that might still be in processing
+let mostRecentTransition: Transition | undefined;
+// When we traverse the history, the window.location is already set to the new location.
+// This variable tells us where we came from
+let originalLocation: URL;
+
+// W3C3: route announcer. Stub for now — see W1B §13 / Astro's announce() impl.
+const announce = () => {
+  // TODO(W3C3): port Astro's announce() — appends a polite-live <div> and writes
+  // document.title or first <h1> for screen readers. Intentionally a no-op in W3C1.
+};
+
+const PERSIST_ATTR = "data-zfb-transition-persist";
+const DIRECTION_ATTR = "data-zfb-transition";
+const OLD_NEW_ATTR = "data-zfb-transition-fallback";
+
+let parser: DOMParser;
+
+// The History API does not tell you if navigation is forward or back, so
+// you can figure it using an index. On pushState the index is incremented so you
+// can use that to determine popstate if going forward or back.
+// W3C2 owns the init block that seeds this from history.state on page load and
+// handles the popstate-driven update.
+let currentHistoryIndex = 0;
+
+// returns the contents of the page or null if the router can't deal with it.
+async function fetchHTML(
+  href: string,
+  init?: RequestInit,
+): Promise<null | { html: string; redirected?: string; mediaType: DOMParserSupportedType }> {
+  try {
+    // Apply adapter-specific headers for internal fetches
+    const headers = new Headers(init?.headers);
+    for (const [key, value] of Object.entries(internalFetchHeaders) as [string, string][]) {
+      headers.set(key, value);
+    }
+    const res = await fetch(href, { ...init, headers });
+    const contentType = res.headers.get("content-type") ?? "";
+    // drop potential charset (+ other name/value pairs) as parser needs the mediaType
+    const mediaType = contentType.split(";", 1)[0]!.trim();
+    // the DOMParser can handle two types of HTML
+    if (mediaType !== "text/html" && mediaType !== "application/xhtml+xml") {
+      // everything else (e.g. audio/mp3) will be handled by the browser but not by us
+      return null;
+    }
+    const html = await res.text();
+    // exactOptionalPropertyTypes: true forbids assigning `undefined` to a `redirected?: string`
+    // slot, so omit the property when not redirected instead of setting it to undefined.
+    return res.redirected ? { html, redirected: res.url, mediaType } : { html, mediaType };
+  } catch {
+    // can't fetch, let someone else deal with it.
+    return null;
+  }
+}
+
+export function getFallback(): Fallback {
+  const el = document.querySelector('[name="zfb-view-transitions-fallback"]');
+  if (el) {
+    return el.getAttribute("content") as Fallback;
+  }
+  return "animate";
+}
+
+function runScripts() {
+  let wait = Promise.resolve();
+  let needsWaitForInlineModuleScript = false;
+  // The original code made the assumption that all inline scripts are directly executed when inserted into the DOM.
+  // This is not true for inline module scripts, which are deferred but still executed in order.
+  // inline module scripts cannot be awaited for with onload.
+  // Thus to be able to wait for the execution of all scripts, we make sure that the last inline module script
+  // is always followed by an external module script
+  for (const script of document.getElementsByTagName("script")) {
+    script.dataset["zfbExec"] === undefined &&
+      script.getAttribute("type") === "module" &&
+      (needsWaitForInlineModuleScript = script.getAttribute("src") === null);
+  }
+  needsWaitForInlineModuleScript &&
+    document.body.insertAdjacentHTML(
+      "beforeend",
+      `<script type="module" src="data:application/javascript,"/>`,
+    );
+
+  for (const script of document.getElementsByTagName("script")) {
+    if (script.dataset["zfbExec"] === "") continue;
+    const type = script.getAttribute("type");
+    if (type && type !== "module" && type !== "text/javascript") continue;
+    const newScript = document.createElement("script");
+    newScript.innerHTML = script.innerHTML;
+    for (const attr of script.attributes) {
+      if (attr.name === "src") {
+        const p = new Promise((r) => {
+          newScript.onload = newScript.onerror = r;
+        });
+        wait = wait.then(() => p as any);
+      }
+      newScript.setAttribute(attr.name, attr.value);
+    }
+    newScript.dataset["zfbExec"] = "";
+    script.replaceWith(newScript);
+  }
+  return wait;
+}
+
+// Add a new entry to the browser history. This also sets the new page in the browser address bar.
+// Sets the scroll position according to the hash fragment of the new location.
+const moveToLocation = (
+  to: URL,
+  from: URL,
+  options: Options,
+  pageTitleForBrowserHistory: string,
+  historyState?: State,
+) => {
+  const intraPage = samePage(from, to);
+
+  const targetPageTitle = document.title;
+  document.title = pageTitleForBrowserHistory;
+
+  let scrolledToTop = false;
+  if (to.href !== location.href && !historyState) {
+    if (options.history === "replace") {
+      const current = history.state;
+      history.replaceState(
+        {
+          ...options.state,
+          index: current.index,
+          scrollX: current.scrollX,
+          scrollY: current.scrollY,
+        },
+        "",
+        to.href,
+      );
+    } else {
+      history.pushState(
+        { ...options.state, index: ++currentHistoryIndex, scrollX: 0, scrollY: 0 },
+        "",
+        to.href,
+      );
+    }
+  }
+  document.title = targetPageTitle;
+  // now we are on the new page for non-history navigation!
+  // (with history navigation page change happens before popstate is fired)
+  originalLocation = to;
+
+  // freshly loaded pages start from the top
+  if (!intraPage) {
+    scrollTo({ left: 0, top: 0, behavior: "instant" });
+    scrolledToTop = true;
+  }
+
+  if (historyState) {
+    scrollTo(historyState.scrollX, historyState.scrollY);
+  } else {
+    if (to.hash) {
+      // because we are already on the target page ...
+      // ... what comes next is an intra-page navigation
+      // that won't reload the page but instead scroll to the fragment
+      history.scrollRestoration = "auto";
+      const savedState = history.state;
+      location.href = to.href; // this kills the history state on Firefox
+      if (!history.state) {
+        history.replaceState(savedState, ""); // this restores the history state
+        if (intraPage) {
+          window.dispatchEvent(new PopStateEvent("popstate"));
+        }
+      }
+    } else {
+      if (!scrolledToTop) {
+        scrollTo({ left: 0, top: 0, behavior: "instant" });
+      }
+    }
+    history.scrollRestoration = "manual";
+  }
+};
+
+function preloadStyleLinks(newDocument: Document) {
+  const links: Promise<any>[] = [];
+  for (const el of newDocument.querySelectorAll("head link[rel=stylesheet]")) {
+    // Do not preload links that are already on the page.
+    if (
+      !document.querySelector(
+        `[${PERSIST_ATTR}="${el.getAttribute(
+          PERSIST_ATTR,
+        )}"], link[rel=stylesheet][href="${el.getAttribute("href")}"]`,
+      )
+    ) {
+      const c = document.createElement("link");
+      c.setAttribute("rel", "preload");
+      c.setAttribute("as", "style");
+      c.setAttribute("href", el.getAttribute("href")!);
+      links.push(
+        new Promise<any>((resolve) => {
+          ["load", "error"].forEach((evName) => c.addEventListener(evName, resolve));
+          document.head.append(c);
+        }),
+      );
+    }
+  }
+  return links;
+}
+
+// replace head and body of the windows document with contents from newDocument
+// if !popstate, update the history entry and scroll position according to toLocation
+// if popState is given, this holds the scroll position for history navigation
+// if fallback === "animate" then simulate view transitions
+async function updateDOM(
+  preparationEvent: TransitionBeforePreparationEvent,
+  options: Options,
+  currentTransition: Transition,
+  historyState?: State,
+  fallback?: Fallback,
+) {
+  async function animate(phase: string) {
+    function isInfinite(animation: Animation) {
+      const effect = animation.effect;
+      if (!effect || !(effect instanceof KeyframeEffect) || !effect.target) return false;
+      const style = window.getComputedStyle(effect.target, effect.pseudoElement);
+      return style.animationIterationCount === "infinite";
+    }
+    const currentAnimations = document.getAnimations();
+    // Trigger view transition animations waiting for data-zfb-transition-fallback
+    document.documentElement.setAttribute(OLD_NEW_ATTR, phase);
+    const nextAnimations = document.getAnimations();
+    const newAnimations = nextAnimations.filter(
+      (a) => !currentAnimations.includes(a) && !isInfinite(a),
+    );
+    // Wait for all new animations to finish (resolved or rejected).
+    // Do not reject on canceled ones.
+    return Promise.allSettled(newAnimations.map((a) => a.finished));
+  }
+
+  const animateFallbackOld = async () => {
+    if (
+      fallback === "animate" &&
+      !currentTransition.transitionSkipped &&
+      !preparationEvent.signal.aborted
+    ) {
+      try {
+        await animate("old");
+      } catch {
+        // animate might reject as a consequence of a call to skipTransition()
+        // ignored on purpose
+      }
+    }
+  };
+
+  const pageTitleForBrowserHistory = document.title; // document.title will be overridden by swap()
+  const swapEvent = await doSwap(
+    preparationEvent,
+    currentTransition.viewTransition!,
+    animateFallbackOld,
+  );
+  moveToLocation(swapEvent.to, swapEvent.from, options, pageTitleForBrowserHistory, historyState);
+  triggerEvent("zfb:after-swap");
+
+  // Resolve the finished promise of the simulation's ViewTransition.
+  // For 'animate', wait for the new-page animation to complete first.
+  // For other fallback modes (e.g. 'swap'), resolve immediately — no animation needed.
+  if (fallback === "animate" && !currentTransition.transitionSkipped && !swapEvent.signal.aborted) {
+    animate("new").finally(() => currentTransition.viewTransitionFinished!());
+  } else {
+    currentTransition.viewTransitionFinished?.();
+  }
+}
+
+function abortAndRecreateMostRecentNavigation(): Navigation {
+  mostRecentNavigation?.controller.abort();
+  return (mostRecentNavigation = {
+    controller: new AbortController(),
+  });
+}
+
+async function transition(
+  direction: Direction,
+  from: URL,
+  to: URL,
+  options: Options,
+  historyState?: State,
+  hasUAVisualTransition = false,
+) {
+  // The most recent navigation always has precedence
+  // Yes, there can be several navigation instances as the user can click links
+  // while we fetch content or simulate view transitions. Even synchronous creations are possible
+  // e.g. by calling navigate() from a transition event.
+  // Invariant: all but the most recent navigation are already aborted.
+
+  const currentNavigation = abortAndRecreateMostRecentNavigation();
+
+  // not ours
+  if (!transitionEnabledOnThisPage() || location.origin !== to.origin) {
+    if (currentNavigation === mostRecentNavigation) mostRecentNavigation = undefined;
+    location.href = to.href;
+    return;
+  }
+
+  const navigationType = historyState
+    ? "traverse"
+    : options.history === "replace"
+      ? "replace"
+      : "push";
+
+  if (navigationType !== "traverse") {
+    updateScrollPosition({ scrollX, scrollY });
+  }
+  if (samePage(from, to) && !options.formData) {
+    if ((direction !== "back" && to.hash) || (direction === "back" && from.hash)) {
+      moveToLocation(to, from, options, document.title, historyState);
+      if (currentNavigation === mostRecentNavigation) mostRecentNavigation = undefined;
+      return;
+    }
+  }
+
+  const prepEvent = await doPreparation(
+    from,
+    to,
+    direction,
+    navigationType,
+    options.sourceElement,
+    options.info,
+    currentNavigation!.controller.signal,
+    options.formData,
+    defaultLoader,
+  );
+  if (prepEvent.defaultPrevented || prepEvent.signal.aborted) {
+    if (currentNavigation === mostRecentNavigation) mostRecentNavigation = undefined;
+    if (!prepEvent.signal.aborted) {
+      // not aborted -> delegate to browser
+      location.href = to.href;
+    }
+    // and / or exit
+    return;
+  }
+
+  async function defaultLoader(preparationEvent: TransitionBeforePreparationEvent) {
+    const href = preparationEvent.to.href;
+    const init: RequestInit = { signal: preparationEvent.signal };
+    if (preparationEvent.formData) {
+      init.method = "POST";
+      const form =
+        preparationEvent.sourceElement instanceof HTMLFormElement
+          ? preparationEvent.sourceElement
+          : preparationEvent.sourceElement instanceof HTMLElement &&
+              "form" in preparationEvent.sourceElement
+            ? (preparationEvent.sourceElement.form as HTMLFormElement)
+            : preparationEvent.sourceElement?.closest("form");
+      // Form elements without enctype explicitly set default to application/x-www-form-urlencoded.
+      // In order to maintain compatibility with Astro 4.x, we need to check the value of enctype
+      // on the attributes property rather than accessing .enctype directly. Astro 5.x may
+      // introduce defaulting to application/x-www-form-urlencoded as a breaking change, and then
+      // we can access .enctype directly.
+      //
+      // Note: getNamedItem can return null in real life, even if TypeScript doesn't think so, hence
+      // the ?.
+      init.body =
+        from !== undefined &&
+        Reflect.get(HTMLFormElement.prototype, "attributes", form).getNamedItem("enctype")
+          ?.value === "application/x-www-form-urlencoded"
+          ? new URLSearchParams(preparationEvent.formData as any)
+          : preparationEvent.formData;
+    }
+    const response = await fetchHTML(href, init);
+    // If there is a problem fetching the new page, just do an MPA navigation to it.
+    if (response === null) {
+      preparationEvent.preventDefault();
+      return;
+    }
+    // if there was a redirection, show the final URL in the browser's address bar
+    if (response.redirected) {
+      const redirectedTo = new URL(response.redirected);
+      // but do not redirect cross origin
+      if (redirectedTo.origin !== preparationEvent.to.origin) {
+        preparationEvent.preventDefault();
+        return;
+      }
+      // preserve fragment
+      const fragment = preparationEvent.to.hash;
+      preparationEvent.to = redirectedTo;
+      preparationEvent.to.hash = fragment;
+    }
+
+    parser ??= new DOMParser();
+
+    preparationEvent.newDocument = parser.parseFromString(response.html, response.mediaType);
+    // The next line might look like a hack,
+    // but it is actually necessary as noscript elements
+    // and their contents are returned as markup by the parser,
+    // see https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString
+    preparationEvent.newDocument.querySelectorAll("noscript").forEach((el) => el.remove());
+
+    // If ClientRouter is not enabled on the incoming page, do a full page load to it.
+    // Unless this was a form submission, in which case we do not want to trigger another mutation.
+    if (
+      !preparationEvent.newDocument.querySelector('[name="zfb-view-transitions-enabled"]') &&
+      !preparationEvent.formData
+    ) {
+      preparationEvent.preventDefault();
+      return;
+    }
+
+    const links = preloadStyleLinks(preparationEvent.newDocument);
+    links.length && !preparationEvent.signal.aborted && (await Promise.all(links));
+
+    // W3C2: prepareForClientOnlyComponents() goes here. Astro's DEV-only iframe
+    // trick that hoists Vite per-component CSS for client:only islands does not
+    // apply to zfb (W1B §13.5 — zfb islands inject CSS via the bundle), so the
+    // call is intentionally absent rather than stubbed.
+  }
+  async function abortAndRecreateMostRecentTransition(): Promise<Transition> {
+    if (mostRecentTransition) {
+      if (mostRecentTransition.viewTransition) {
+        try {
+          mostRecentTransition.viewTransition.skipTransition();
+        } catch {
+          // might throw AbortError DOMException. Ignored on purpose.
+        }
+        try {
+          // UpdateCallbackDone might already been settled, i.e. if the previous transition finished updating the DOM.
+          // Could not take long, we wait for it to avoid parallel updates
+          // (which are very unlikely as long as swap() is not async).
+          await mostRecentTransition.viewTransition.updateCallbackDone;
+        } catch {
+          // There was an error in the update callback of the transition which we cancel.
+          // Ignored on purpose
+        }
+      }
+    }
+    return (mostRecentTransition = { transitionSkipped: false });
+  }
+
+  const currentTransition = await abortAndRecreateMostRecentTransition();
+
+  if (prepEvent.signal.aborted) {
+    if (currentNavigation === mostRecentNavigation) mostRecentNavigation = undefined;
+    return;
+  }
+
+  document.documentElement.setAttribute(DIRECTION_ATTR, prepEvent.direction);
+  if (supportsViewTransitions && !hasUAVisualTransition) {
+    // This automatically cancels any previous transition
+    // We also already took care that the earlier update callback got through
+    currentTransition.viewTransition = document.startViewTransition(
+      async () => await updateDOM(prepEvent, options, currentTransition, historyState),
+    );
+  } else {
+    // Simulation mode requires a bit more manual work.
+    // Also used when PopStateEvent.hasUAVisualTransition indicates the browser already
+    // provided a visual transition (e.g. Safari swipe gesture) — in that case, fallback
+    // is "swap" to skip animations.
+    const updateDone = (async () => {
+      // Immediately paused to set up the ViewTransition object for Fallback mode
+      await Promise.resolve(); // hop through the micro task queue
+      await updateDOM(
+        prepEvent,
+        options,
+        currentTransition,
+        historyState,
+        hasUAVisualTransition ? "swap" : getFallback(),
+      );
+      return undefined;
+    })();
+
+    // When the updateDone promise is settled,
+    // we have run and awaited all swap functions and the after-swap event
+    // This qualifies for "updateCallbackDone".
+    //
+    // For the build in ViewTransition, "ready" settles shortly after "updateCallbackDone",
+    // i.e. after all pseudo elements are created and the animation is about to start.
+    // In simulation mode the "old" animation starts before swap,
+    // the "new" animation starts after swap. That is not really comparable.
+    // Thus we go with "very, very shortly after updateCallbackDone" and make both equal.
+    //
+    // "finished" resolves after all animations are done.
+
+    currentTransition.viewTransition = {
+      updateCallbackDone: updateDone, // this is about correct
+      ready: updateDone, // good enough
+      // Finished promise could have been done better: finished rejects iff updateDone does.
+      // Our simulation always resolves, never rejects.
+      finished: new Promise((r) => (currentTransition.viewTransitionFinished = r as () => void)), // see end of updateDOM
+      skipTransition: () => {
+        currentTransition.transitionSkipped = true;
+        // This cancels all animations of the simulation
+        document.documentElement.removeAttribute(OLD_NEW_ATTR);
+      },
+      types: new Set<string>(), // empty by default
+    };
+  }
+  // In earlier versions was then'ed on viewTransition.ready which would not execute
+  // if the visual part of the transition has errors or was skipped
+  currentTransition.viewTransition?.updateCallbackDone.finally(async () => {
+    await runScripts();
+    onPageLoad();
+    announce();
+  });
+  // finished.ready and finished.finally are the same for the simulation but not
+  // necessarily for native view transition, where finished rejects when updateCallbackDone does.
+  currentTransition.viewTransition?.finished.finally(() => {
+    // exactOptionalPropertyTypes: true forbids assigning `undefined` to an optional
+    // `viewTransition?: ViewTransition` slot — `delete` is the equivalent reset.
+    delete currentTransition.viewTransition;
+    if (currentTransition === mostRecentTransition) mostRecentTransition = undefined;
+    if (currentNavigation === mostRecentNavigation) mostRecentNavigation = undefined;
+    document.documentElement.removeAttribute(DIRECTION_ATTR);
+    document.documentElement.removeAttribute(OLD_NEW_ATTR);
+  });
+  try {
+    // Compatibility:
+    // In an earlier version we awaited viewTransition.ready, which includes animation setup.
+    // Scripts that depend on the view transition pseudo elements should hook on viewTransition.ready.
+    await currentTransition.viewTransition?.updateCallbackDone;
+  } catch (e) {
+    // This log doesn't make it worse than before, where we got error messages about uncaught exceptions, which can't be caught when the trigger was a click or history traversal.
+    // Needs more investigation on root causes if errors still occur sporadically
+    const err = e as Error;
+    // biome-ignore lint/suspicious/noConsole: allowed
+    console.log("[zfb]", err.name, err.message, err.stack);
+  }
+}
+
+// W3C2 will add `navigate()` (public entry), `onPopState`, `onScrollEnd`, and the
+// top-level `if (inBrowser)` initialization block here.
+// W3C3 will add the click + form intercept and the route announcer body of `announce()`.

--- a/packages/zfb-runtime/src/client-router/router.ts
+++ b/packages/zfb-runtime/src/client-router/router.ts
@@ -89,10 +89,24 @@ let mostRecentTransition: Transition | undefined;
 // This variable tells us where we came from
 let originalLocation: URL;
 
-// W3C3: route announcer. Stub for now — see W1B §13 / Astro's announce() impl.
+// Route announcer — ported from Astro's announce(). Creates (or reuses) a single
+// shared aria-live <div> per navigation, so screen readers announce the new page title.
+// The 60ms delay is Astro's magic number: screen readers need to see the element change
+// and may miss it if it happens too quickly.
 const announce = () => {
-  // TODO(W3C3): port Astro's announce() — appends a polite-live <div> and writes
-  // document.title or first <h1> for screen readers. Intentionally a no-op in W3C1.
+  let div = document.createElement("div");
+  div.setAttribute("aria-live", "assertive");
+  div.setAttribute("aria-atomic", "true");
+  div.className = "zfb-route-announcer";
+  document.body.append(div);
+  setTimeout(
+    () => {
+      let title = document.title || document.querySelector("h1")?.textContent || location.pathname;
+      div.textContent = title;
+    },
+    // Screen readers need to see the element change; 60ms is Astro's empirically chosen delay.
+    60,
+  );
 };
 
 const PERSIST_ATTR = "data-zfb-transition-persist";
@@ -722,4 +736,154 @@ if (inBrowser) {
   }
 }
 
-// W3C3 will add the click + form intercept and the route announcer body of `announce()`.
+// ---- W3C3: click + form intercept, public idempotent init() ----
+
+// Returns true when the modifier-key combo or mouse button means "open in new tab / download".
+// Matches Astro's `leavesWindow` helper in ClientRouter.astro.
+const leavesWindow = (ev: MouseEvent): boolean =>
+  (ev.button !== undefined && ev.button !== 0) || // non-left-click
+  ev.metaKey || // new tab (Mac)
+  ev.ctrlKey || // new tab (Windows/Linux)
+  ev.altKey || // download
+  ev.shiftKey; // new window
+
+// Track the last clicked element that will leave the window so form submit can check it.
+let lastClickedElementLeavingWindow: EventTarget | null = null;
+
+function handleClick(ev: MouseEvent): void {
+  let link: EventTarget | null = ev.target;
+
+  // Record whether this click will leave the window (used by form submit handler).
+  lastClickedElementLeavingWindow = leavesWindow(ev) ? link : null;
+
+  // Shadow DOM: prefer composedPath target over ev.target.
+  if (ev.composed) {
+    link = ev.composedPath()[0] ?? link;
+  }
+
+  // Walk up to the nearest <a>, <area>, or <svg:a>.
+  if (link instanceof Element) {
+    link = link.closest("a, area");
+  }
+
+  if (
+    !(link instanceof HTMLAnchorElement) &&
+    !(link instanceof SVGAElement) &&
+    !(link instanceof HTMLAreaElement)
+  ) {
+    return;
+  }
+
+  const linkEl = link as HTMLAnchorElement | SVGAElement | HTMLAreaElement;
+  const linkTarget =
+    linkEl instanceof HTMLElement ? linkEl.target : (linkEl as SVGAElement).target.baseVal;
+  const href = linkEl instanceof HTMLElement ? linkEl.href : (linkEl as SVGAElement).href.baseVal;
+
+  if (!href) return;
+
+  const origin = new URL(href, location.href).origin;
+
+  if (
+    // data-zfb-reload: caller wants a full browser reload, not a SPA transition.
+    (linkEl as HTMLElement).dataset["zfbReload"] !== undefined ||
+    // download attribute: let browser handle download.
+    linkEl.hasAttribute("download") ||
+    // Non-self target opens in a new context — skip.
+    (linkTarget && linkTarget !== "_self") ||
+    // Cross-origin: not ours to handle.
+    origin !== location.origin ||
+    // Modifier key / non-left-click combo: user wants new tab / window / download.
+    lastClickedElementLeavingWindow !== null ||
+    // Another handler already handled this event.
+    ev.defaultPrevented
+  ) {
+    return;
+  }
+
+  ev.preventDefault();
+  navigate(href, {
+    // data-zfb-history="replace" opts a link into replaceState instead of pushState.
+    history: (linkEl as HTMLElement).dataset["zfbHistory"] === "replace" ? "replace" : "auto",
+    sourceElement: linkEl,
+  });
+}
+
+function handleSubmit(ev: SubmitEvent): void {
+  const el = ev.target as HTMLElement;
+  const submitter = ev.submitter as HTMLElement | null;
+
+  // If the submit was triggered by a modifier-key click, treat as normal browser submit.
+  const clickedWithKeys = submitter !== null && submitter === lastClickedElementLeavingWindow;
+  lastClickedElementLeavingWindow = null;
+
+  if (
+    el.tagName !== "FORM" ||
+    ev.defaultPrevented ||
+    el.dataset["zfbReload"] !== undefined ||
+    clickedWithKeys
+  ) {
+    return;
+  }
+
+  const form = el as HTMLFormElement;
+  const formData = new FormData(form, submitter ?? undefined);
+
+  // form.action / form.method can be shadowed by <input name="action"> / <input name="method">,
+  // so fall back to getAttribute() when the property is not a string. (Astro's comment.)
+  const formAction = typeof form.action === "string" ? form.action : form.getAttribute("action");
+  const formMethod = typeof form.method === "string" ? form.method : form.getAttribute("method");
+
+  // Resolve action: submitter formaction attr overrides form action, fallback to current path.
+  let action = submitter?.getAttribute("formaction") ?? formAction ?? location.pathname;
+  // Resolve method: submitter formmethod attr overrides form method, fallback to "get".
+  const method = submitter?.getAttribute("formmethod") ?? formMethod ?? "get";
+
+  // The "dialog" method is a special keyword used within <dialog> elements —
+  // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-method
+  if (method === "dialog" || location.origin !== new URL(action, location.href).origin) {
+    // No SPA transition in these cases — let browser handle it.
+    return;
+  }
+
+  const options: import("./types.js").Options = { sourceElement: submitter ?? form };
+  if (method === "get") {
+    const params = new URLSearchParams(formData as any);
+    const url = new URL(action, location.href);
+    url.search = params.toString();
+    action = url.toString();
+  } else {
+    options.formData = formData;
+  }
+
+  ev.preventDefault();
+  navigate(action, options);
+}
+
+export interface InitOptions {
+  /** Reserved for forward-compat with Astro's prefetch integration. Ignored in v1. */
+  prefetchAll?: boolean;
+}
+
+// Guard flag — ensures click + submit listeners are registered only once even if
+// init() is called multiple times (e.g. two <ClientRouter> mounts on the same page).
+let initialized = false;
+
+/**
+ * Wire up the client-router's click and form-submit intercepts.
+ * Safe to call multiple times — subsequent calls are no-ops (idempotent).
+ *
+ * @param _options - Forward-compat hook matching Astro's init() signature. Ignored in v1.
+ */
+export function init(_options?: InitOptions): void {
+  if (initialized) return;
+  initialized = true;
+
+  if (!inBrowser) return;
+  if (!supportsViewTransitions && getFallback() === "none") return;
+
+  document.addEventListener("click", handleClick);
+  document.addEventListener("submit", handleSubmit as EventListener);
+
+  // Prefetch hook intentionally omitted from v1 — see https://github.com/zudolab/zudo-doc/issues/1527
+  // (Followup tracker for porting Astro prefetch module).
+}

--- a/packages/zfb-runtime/src/client-router/router.ts
+++ b/packages/zfb-runtime/src/client-router/router.ts
@@ -47,6 +47,11 @@ import {
 } from "./events.js";
 import { detectScriptExecuted } from "./swap-functions.js";
 import type { Direction, Fallback, Options } from "./types.js";
+// Island re-bootstrap and deferred-cancel after body swap (W1B §12.2, §12.5).
+// mountNewIslands() is called after runScripts() and before onPageLoad().
+// cancelPendingIslands() is called before doSwap() so deferred callbacks
+// (rIC/IntersectionObserver) do not fire against orphan elements.
+import { cancelPendingIslands, mountNewIslands } from "@takazudo/zfb/runtime";
 
 type State = {
   index: number;
@@ -356,6 +361,10 @@ async function updateDOM(
   };
 
   const pageTitleForBrowserHistory = document.title; // document.title will be overridden by swap()
+  // Cancel deferred-hydration callbacks for old-body islands before the swap
+  // so rIC / IntersectionObserver fires do not run against orphan elements.
+  // Called before doSwap() which dispatches `zfb:before-swap` then mutates the DOM.
+  cancelPendingIslands();
   const swapEvent = await doSwap(
     preparationEvent,
     currentTransition.viewTransition!,
@@ -600,6 +609,11 @@ async function transition(
   // if the visual part of the transition has errors or was skipped
   currentTransition.viewTransition?.updateCallbackDone.finally(async () => {
     await runScripts();
+    // Mount new island markers introduced by the body swap. Fire-and-forget;
+    // each island's scheduleHydrate call is async (idle / visible). Called after
+    // runScripts() so any new mountIslands() registration from inline scripts in
+    // the new page has already run. Called before onPageLoad() per W1B §12.2.
+    mountNewIslands();
     onPageLoad();
     announce();
   });

--- a/packages/zfb-runtime/src/client-router/swap-functions.ts
+++ b/packages/zfb-runtime/src/client-router/swap-functions.ts
@@ -1,8 +1,280 @@
 /// <reference lib="dom" />
-// Stub — full implementation lands in W3B (client-router/swap-functions).
-// This file exists solely so events.ts can import `swap` and typecheck in W3A.
-// W3B replaces this file entirely with the ported swap-functions logic.
+/// <reference lib="dom.iterable" />
+// Ported verbatim from Astro transitions/swap-functions.ts. Mechanical renames
+// applied per W1B §13.4 (data-astro-* → data-zfb-*, dataset.astro* → dataset.zfb*,
+// astro-island element-name branch → data-zfb-island marker per W1B §12.3 island-lifecycle
+// contract). vueScopedStyleId is intentionally KEPT verbatim per W2A §2.8 (the W3B
+// issue body's "DELETE" instruction is overridden by W2A's reclassification).
 
-export function swap(_newDocument: Document): void {
-  throw new Error("swap-functions not yet implemented — pending W3B");
+export type SavedFocus = {
+  activeElement: HTMLElement | null;
+  start?: number | null;
+  end?: number | null;
+};
+
+const PERSIST_ATTR = "data-zfb-transition-persist";
+
+const NON_OVERRIDABLE_ZFB_ATTRS = ["data-zfb-transition", "data-zfb-transition-fallback"];
+
+const knownVueScopedStyles = new Map<string, HTMLStyleElement>();
+
+const scriptsAlreadyRan = new Set<string>();
+export function detectScriptExecuted(script: HTMLScriptElement) {
+  const key = script.src ? new URL(script.src, location.href).href : script.textContent!;
+  if (scriptsAlreadyRan.has(key)) return true;
+  scriptsAlreadyRan.add(key);
+  return false;
 }
+
+/*
+ * 	Mark new scripts that should not execute
+ */
+export function deselectScripts(doc: Document) {
+  for (const s2 of doc.scripts) {
+    if (
+      // Check if the script should be rerun regardless of it being the same
+      !s2.hasAttribute("data-zfb-rerun") &&
+      // Check if the script has already been executed
+      detectScriptExecuted(s2)
+    ) {
+      // the old script is in the new document and doesn't have the rerun attribute
+      // we mark it as executed to prevent re-execution
+      s2.dataset["zfbExec"] = "";
+    }
+  }
+}
+
+/*
+ * swap attributes of the html element
+ * delete all attributes from the current document
+ * insert all attributes from doc
+ * reinsert all original attributes that are referenced in NON_OVERRIDABLE_ZFB_ATTRS'
+ */
+export function swapRootAttributes(newDoc: Document) {
+  const currentRoot = document.documentElement;
+  const nonOverridableZfbAttributes = [...currentRoot.attributes].filter(
+    ({ name }) => (currentRoot.removeAttribute(name), NON_OVERRIDABLE_ZFB_ATTRS.includes(name)),
+  );
+  [...newDoc.documentElement.attributes, ...nonOverridableZfbAttributes].forEach(
+    ({ name, value }) => currentRoot.setAttribute(name, value),
+  );
+}
+
+/*
+ * make the old head look like the new one
+ */
+export function swapHeadElements(doc: Document) {
+  for (const el of Array.from(document.head.children)) {
+    const newEl = persistedHeadElement(el as HTMLElement, doc);
+    // If the element exists in the document already, remove it
+    // from the new document and leave the current node alone
+    if (newEl) {
+      newEl.remove();
+    } else {
+      if ((import.meta as any).env?.DEV && el instanceof HTMLStyleElement) {
+        // In DEV mode, keep updated Vue scoped styles for later reuse
+        const viteDevId = vueScopedStyleId(el);
+        viteDevId && knownVueScopedStyles.set(viteDevId, el);
+      }
+      // If the element does not exist in the new document, remove the element from current the head.
+      el.remove();
+    }
+  }
+
+  // Everything left in the new head is new, append it all.
+  if ((import.meta as any).env?.DEV) {
+    // In DEV mode, replace known Vue scoped styles with the versions we remembered
+    [...doc.head.children].forEach((child) => {
+      document.head.append(knownVueScopedStyles.get((child as any).dataset?.viteDevId) || child);
+    });
+  } else {
+    document.head.append(...doc.head.children);
+  }
+}
+
+export function swapBodyElement(newElement: Element, oldElement: Element) {
+  // Lift persist elements to <html> before the body swap so they stay in the DOM
+  // throughout replaceWith(). This prevents Safari from losing WebGL context on
+  // <canvas> elements due to brief DOM detachment. Uses moveBefore() where available
+  // (Chrome 133+) for zero-detachment atomic moves.
+  const persistPairs: { old: Element; newTarget: Element }[] = [];
+  const docEl = oldElement.ownerDocument.documentElement;
+
+  // moveBefore() is not yet in TypeScript's DOM lib, feature-detect and wrap.
+  const moveBefore: ((parent: Node, node: Node, child: Node | null) => void) | null =
+    typeof (docEl as any).moveBefore === "function"
+      ? (parent, node, child) => (parent as any).moveBefore(node, child)
+      : null;
+
+  for (const el of oldElement.querySelectorAll(`[${PERSIST_ATTR}]`)) {
+    const id = el.getAttribute(PERSIST_ATTR);
+    const newEl = newElement.querySelector(`[${PERSIST_ATTR}="${id}"]`);
+    if (!newEl) continue; // no matching target — leave in old body to be discarded
+    persistPairs.push({ old: el, newTarget: newEl });
+    if (moveBefore) {
+      moveBefore(docEl, el, null);
+    } else {
+      docEl.appendChild(el);
+    }
+  }
+
+  // this will reset scroll Position
+  oldElement.replaceWith(newElement);
+
+  // Move persist elements into the new body at the position of their targets
+  for (const { old: el, newTarget } of persistPairs) {
+    if (moveBefore) {
+      moveBefore(newTarget.parentNode!, el, newTarget);
+      newTarget.remove();
+    } else {
+      newTarget.replaceWith(el);
+    }
+    // For islands, copy over the props to allow them to re-render
+    if (
+      newTarget.matches("[data-zfb-island]") &&
+      shouldCopyProps(el as HTMLElement) &&
+      !isSameProps(el, newTarget)
+    ) {
+      el.setAttribute("ssr", "");
+      // zfb island wrapper writes SSR props to data-props, not props (different attribute, not just renamed).
+      el.setAttribute("data-props", newTarget.getAttribute("data-props")!);
+    }
+  }
+
+  // This will upgrade any Declarative Shadow DOM in the new body.
+  attachShadowRoots(newElement);
+}
+
+/**
+ * Attach Shadow DOM roots for templates with the declarative `shadowrootmode` attribute.
+ * @see https://web.dev/articles/declarative-shadow-dom#polyfill
+ * @param root DOM subtree to attach shadow roots within.
+ */
+function attachShadowRoots(root: Element | ShadowRoot) {
+  root.querySelectorAll<HTMLTemplateElement>("template[shadowrootmode]").forEach((template) => {
+    const mode = template.getAttribute("shadowrootmode");
+    const parent = template.parentNode;
+    if ((mode === "closed" || mode === "open") && parent instanceof HTMLElement) {
+      // Skip if shadow root already exists (e.g., from transition-persisted elements)
+      if (parent.shadowRoot) {
+        template.remove();
+        return;
+      }
+      const shadowRoot = parent.attachShadow({ mode });
+      shadowRoot.appendChild(template.content);
+      template.remove();
+      attachShadowRoots(shadowRoot);
+    }
+  });
+}
+
+export const saveFocus = (): (() => void) => {
+  const activeElement = document.activeElement as HTMLElement;
+  // The element that currently has the focus is part of a DOM tree
+  // that will survive the transition to the new document.
+  // Save the element and the cursor position
+  if (activeElement?.closest(`[${PERSIST_ATTR}]`)) {
+    if (activeElement instanceof HTMLInputElement || activeElement instanceof HTMLTextAreaElement) {
+      const start = activeElement.selectionStart;
+      const end = activeElement.selectionEnd;
+      return () => restoreFocus({ activeElement, start, end });
+    }
+    return () => restoreFocus({ activeElement });
+  } else {
+    return () => restoreFocus({ activeElement: null });
+  }
+};
+
+export const restoreFocus = ({ activeElement, start, end }: SavedFocus) => {
+  if (activeElement) {
+    activeElement.focus();
+    if (activeElement instanceof HTMLInputElement || activeElement instanceof HTMLTextAreaElement) {
+      if (typeof start === "number") activeElement.selectionStart = start;
+      if (typeof end === "number") activeElement.selectionEnd = end;
+    }
+  }
+};
+
+export const vueScopedStyleId = (el: HTMLStyleElement): string => {
+  const viteDevId = el.dataset["viteDevId"] || "";
+
+  const url = new URL(viteDevId, location.href);
+  return url.searchParams.get("vue") !== null &&
+    url.searchParams.get("type") === "style" &&
+    url.searchParams.has("scoped")
+    ? viteDevId
+    : "";
+};
+
+// Check for a head element that should persist and returns it,
+// either because it has the data attribute or because replacing it would cause avoidable FOUC.
+const persistedHeadElement = (el: HTMLElement, newDoc: Document): Element | null => {
+  const id = el.getAttribute(PERSIST_ATTR);
+  const newEl = id && newDoc.head.querySelector(`[${PERSIST_ATTR}="${id}"]`);
+  if (newEl) {
+    return newEl;
+  }
+  if (el.matches("link[rel=stylesheet]")) {
+    const href = el.getAttribute("href");
+    return newDoc.head.querySelector(`link[rel=stylesheet][href="${href}"]`);
+  }
+  // In dev mode, Vite injects <style data-vite-dev-id="..."> elements whose
+  // textContent may later be transformed (especially Vue's `:deep()` → `[data-v-xxx]`).
+  // Match these by their stable dev ID so the already-transformed style is preserved
+  // across ClientRouter soft navigations instead of being replaced by the raw version.
+  // There are other ids that can't be preserved and need a refresh, like Uno's /__uno.css,
+  // which keeps the same id, but with different contents.
+  // To avoid enumerating all exceptions, we only apply the auto-persist logic to elements
+  // that look like Vue's dev styles.
+  if ((import.meta as any).env?.DEV && el instanceof HTMLStyleElement) {
+    const viteDevId = vueScopedStyleId(el);
+    if (viteDevId) {
+      return newDoc.head.querySelector(`style[data-vite-dev-id="${viteDevId}"]`);
+    }
+  }
+  // Preserve inline <style> elements with identical content across navigations.
+  // This prevents unnecessary removal and re-insertion of styles (e.g. @font-face
+  // declarations from <Font>), which would cause the browser to re-evaluate them
+  // and trigger a flash of unstyled text (FOUT).
+  if (el.tagName === "STYLE" && el.textContent) {
+    const styles = newDoc.head.querySelectorAll("style");
+    for (const s of styles) {
+      if (s.textContent === el.textContent) {
+        return s;
+      }
+    }
+  }
+  // Preserve font preload links across navigations to avoid re-fetching cached fonts.
+  if (el.matches("link[rel=preload][as=font]")) {
+    const href = el.getAttribute("href");
+    return newDoc.head.querySelector(`link[rel=preload][as=font][href="${href}"]`);
+  }
+  return null;
+};
+
+const shouldCopyProps = (el: HTMLElement): boolean => {
+  const persistProps = el.dataset["zfbTransitionPersistProps"];
+  return persistProps == null || persistProps === "false";
+};
+
+const isSameProps = (oldEl: Element, newEl: Element) => {
+  // zfb island wrapper writes SSR props to data-props, not props (different attribute, not just renamed).
+  return oldEl.getAttribute("data-props") === newEl.getAttribute("data-props");
+};
+
+export const swapFunctions = {
+  deselectScripts,
+  swapRootAttributes,
+  swapHeadElements,
+  swapBodyElement,
+  saveFocus,
+};
+
+export const swap = (doc: Document) => {
+  deselectScripts(doc);
+  swapRootAttributes(doc);
+  swapHeadElements(doc);
+  const restoreFocusFunction = saveFocus();
+  swapBodyElement(doc.body, document.body);
+  restoreFocusFunction();
+};

--- a/packages/zfb-runtime/src/client-router/swap-functions.ts
+++ b/packages/zfb-runtime/src/client-router/swap-functions.ts
@@ -1,0 +1,8 @@
+/// <reference lib="dom" />
+// Stub — full implementation lands in W3B (client-router/swap-functions).
+// This file exists solely so events.ts can import `swap` and typecheck in W3A.
+// W3B replaces this file entirely with the ported swap-functions logic.
+
+export function swap(_newDocument: Document): void {
+  throw new Error("swap-functions not yet implemented — pending W3B");
+}

--- a/packages/zfb-runtime/src/client-router/types.ts
+++ b/packages/zfb-runtime/src/client-router/types.ts
@@ -1,0 +1,11 @@
+/// <reference lib="dom" />
+export type Fallback = "none" | "animate" | "swap";
+export type Direction = "forward" | "back";
+export type NavigationTypeString = "push" | "replace" | "traverse";
+export type Options = {
+  history?: "auto" | "push" | "replace";
+  info?: any;
+  state?: any;
+  formData?: FormData;
+  sourceElement?: Element; // more than HTMLElement, e.g. SVGAElement
+};

--- a/packages/zfb-runtime/src/index.ts
+++ b/packages/zfb-runtime/src/index.ts
@@ -26,3 +26,25 @@ export type {
 export type { FrameworkAdapter } from "./framework.js";
 export type { ContentSnapshot, EntrySnapshot } from "./snapshot.js";
 export { ViewTransitions, type ViewTransitionsElement } from "./view-transitions.js";
+
+// Client-router public surface (W3D — mirrors @takazudo/zfb-runtime/client-router barrel).
+// See W1B §2 for the full public API spec.
+export { ClientRouter, type ClientRouterProps } from "./client-router.js";
+export {
+  navigate,
+  supportsViewTransitions,
+  transitionEnabledOnThisPage,
+} from "./client-router/router.js";
+export {
+  TRANSITION_BEFORE_PREPARATION,
+  TRANSITION_AFTER_PREPARATION,
+  TRANSITION_BEFORE_SWAP,
+  TRANSITION_AFTER_SWAP,
+  TRANSITION_PAGE_LOAD,
+  TransitionBeforePreparationEvent,
+  TransitionBeforeSwapEvent,
+  isTransitionBeforePreparationEvent,
+  isTransitionBeforeSwapEvent,
+} from "./client-router/events.js";
+export { swapFunctions, swap } from "./client-router/swap-functions.js";
+export type { Direction, Fallback, NavigationTypeString, Options } from "./client-router/types.js";

--- a/packages/zfb-runtime/src/view-transitions.ts
+++ b/packages/zfb-runtime/src/view-transitions.ts
@@ -1,5 +1,8 @@
 // `@takazudo/zfb-runtime` — `<ViewTransitions />` component (typed no-op).
 //
+// For SPA soft-swap navigation with view-transition animation, use `<ClientRouter />`
+// from this package — see `./client-router.ts`.
+//
 // Originally mirrored Astro's `<ViewTransitions />` integration by injecting
 // (a) a `<meta name="view-transition" content="same-origin">` opt-in tag and
 // (b) an inline client-router IIFE that intercepted same-origin `<a>` clicks

--- a/packages/zfb/src/index.ts
+++ b/packages/zfb/src/index.ts
@@ -14,7 +14,8 @@ export {
   type IslandElement,
   type IslandProps,
 } from "./island.js";
-export { scheduleHydrate } from "./runtime.js";
+export { scheduleHydrate, mountIslands, mountNewIslands, cancelPendingIslands } from "./runtime.js";
+export type { IslandManifest, IslandManifestValue } from "./runtime.js";
 export { DEFAULT_WHEN, isWhen, WHEN_VALUES, type When } from "./types.js";
 
 // `defaultComponents` (htmlOverrides convention) is re-exported from the

--- a/packages/zfb/src/runtime.ts
+++ b/packages/zfb/src/runtime.ts
@@ -229,6 +229,19 @@ const mounted = new WeakSet<Element>();
 // (after `mounted.add`) and failure branches.
 const pending = new WeakSet<Element>();
 
+// Module-level captured manifest — set by the first `mountIslands` call and reused by
+// `mountNewIslands()` so the client-router does not need to know the manifest directly.
+// Named technical cause (W1B §12.1): the router lives in @takazudo/zfb-runtime; the
+// islands manifest lives in @takazudo/zfb. Passing the manifest through the swap event
+// would require widening the event API or threading manifest into router options. The
+// captured-manifest pattern keeps the package boundary clean.
+let capturedManifest: IslandManifest | null = null;
+
+// Map of element → cancel-function for deferred-hydration islands (data-when="idle"|"visible").
+// Populated in scheduleMount; consulted on `zfb:before-swap` so deferred fires do not run
+// against orphan elements after a body swap. (W1B §12.5)
+const pendingCancels = new Map<Element, () => void>();
+
 /**
  * Walk the DOM and mount every `[data-zfb-island]` / `[data-zfb-island-skip-ssr]`
  * element using `manifest`.
@@ -236,9 +249,15 @@ const pending = new WeakSet<Element>();
  * No-op when `document` is undefined (SSR, edge runtime). Safe to call
  * multiple times: each element is mounted at most once thanks to the
  * `mounted` WeakSet guard.
+ *
+ * The manifest is captured at module level so `mountNewIslands()` can re-use
+ * it after an SPA body swap without needing the caller to re-supply it.
  */
 export function mountIslands(manifest: IslandManifest): void {
   if (typeof document === "undefined") return;
+
+  // Capture the manifest for post-swap re-walks via mountNewIslands().
+  capturedManifest = manifest;
 
   const ssrIslands = document.querySelectorAll<HTMLElement>("[data-zfb-island]");
   for (const el of Array.from(ssrIslands)) {
@@ -257,6 +276,54 @@ export function mountIslands(manifest: IslandManifest): void {
     const name = el.getAttribute("data-zfb-island-skip-ssr");
     if (!name) continue;
     scheduleMount(manifest, el, name, "render");
+  }
+}
+
+/**
+ * Re-walk the current document body and mount any new island markers introduced
+ * by an SPA body swap. Uses the manifest captured by the previous `mountIslands`
+ * call — no manifest arg required.
+ *
+ * The caller (client-router `router.ts`) invokes this after `swap()` + `runScripts()`
+ * and before dispatching `zfb:page-load`, per W1B §12.2 contract.
+ *
+ * No-op when called before `mountIslands` (capturedManifest is null) or when
+ * `document` is undefined.
+ */
+export function mountNewIslands(): void {
+  if (typeof document === "undefined") return;
+  if (capturedManifest === null) return;
+
+  const manifest = capturedManifest;
+
+  const ssrIslands = document.querySelectorAll<HTMLElement>("[data-zfb-island]");
+  for (const el of Array.from(ssrIslands)) {
+    const name = el.getAttribute("data-zfb-island");
+    if (!name) continue;
+    scheduleMount(manifest, el, name, "hydrate");
+  }
+
+  const skipSsrIslands = document.querySelectorAll<HTMLElement>("[data-zfb-island-skip-ssr]");
+  for (const el of Array.from(skipSsrIslands)) {
+    const name = el.getAttribute("data-zfb-island-skip-ssr");
+    if (!name) continue;
+    scheduleMount(manifest, el, name, "render");
+  }
+}
+
+/**
+ * Cancel deferred-hydration callbacks for all islands in the old body before a
+ * swap. Prevents idle / visibility callbacks from running against orphan elements
+ * after `swapBodyElement` removes them from the live document. (W1B §12.5)
+ *
+ * Call this on `zfb:before-swap` (or equivalently, in the router's swap sequence
+ * before `swap()` mutates the DOM). Fire-and-forget; safe to call if nothing is
+ * pending.
+ */
+export function cancelPendingIslands(): void {
+  for (const [el, cancel] of pendingCancels) {
+    cancel();
+    pendingCancels.delete(el);
   }
 }
 
@@ -306,6 +373,10 @@ function scheduleMount(
     // scheduler (rIC/rAF/visibility) after a sibling caller already
     // mounted or started importing for this element.
     if (mounted.has(element) || pending.has(element)) return;
+
+    // When the deferred fire actually runs, the cancel handle is no longer
+    // needed — remove it so pendingCancels doesn't hold stale entries.
+    pendingCancels.delete(element);
 
     // Mark as pending BEFORE firing the import so any concurrent
     // `mountIslands` invocation that arrives during the await window
@@ -370,7 +441,12 @@ function scheduleMount(
     return;
   }
 
-  scheduleHydrate(element, when, fire);
+  const cancel = scheduleHydrate(element, when, fire);
+  // Track deferred-hydration cancel handle so cancelPendingIslands() can abort
+  // idle / visibility callbacks before a body swap. (W1B §12.5)
+  if (when && when !== "load") {
+    pendingCancels.set(element, cancel);
+  }
 }
 
 /**
@@ -400,6 +476,9 @@ function fireInlineMount(
     // scheduler (rIC/rAF/visibility) after a sibling caller already
     // mounted this element.
     if (mounted.has(element)) return;
+    // When the deferred fire actually runs, the cancel handle is no longer
+    // needed — remove it so pendingCancels doesn't hold stale entries.
+    pendingCancels.delete(element);
     mounted.add(element);
     fn(props, element, mode);
   };
@@ -410,7 +489,12 @@ function fireInlineMount(
   }
 
   const when = element.getAttribute("data-when") ?? undefined;
-  scheduleHydrate(element, when, fire);
+  const cancel = scheduleHydrate(element, when, fire);
+  // Track deferred-hydration cancel handle so cancelPendingIslands() can abort
+  // idle / visibility callbacks before a body swap. (W1B §12.5)
+  if (when && when !== "load") {
+    pendingCancels.set(element, cancel);
+  }
 }
 
 function readProps(element: Element): Record<string, unknown> {


### PR DESCRIPTION
## Risk classification: substantial upstream runtime change requiring maintainer signoff

The rationale axis is **not** "material risk in product terms" — the feature is opt-in via `<ClientRouter />` mount, so non-adopting consumers see no change. The classification is driven by the combination of:

1. ~1500 lines of new client runtime
2. New custom-event vocabulary published to the public API
3. Subtle browser-behaviour risk inherent in any SPA-router pattern
4. Maintainer review burden commensurate with the size

**One-line rationale:** ~1500 LoC of new public-API client runtime crosses the substantial-change threshold and warrants explicit maintainer signoff even when it is opt-in.

## Host epic (downstream consumer driving this port)

zudolab/zudo-doc#1510

## Port spec

See `packages/zfb-runtime/docs/client-router/port-spec.md` (imported from the W1B spec authored downstream). Every deviation from the Astro source has a named technical cause recorded there.

## Migration guide

`<ClientRouter />` is **opt-in** — non-adopting consumers continue to ship full-page-load navigations exactly as today. To adopt:

1. Mount `<ClientRouter />` in your root layout's `<head>`.
2. Annotate persistent islands / heads / scripts with `data-zfb-transition-persist` etc. as documented in the port spec §5.
3. (Optional) Subscribe to the new `zfb:before-preparation`, `zfb:after-preparation`, `zfb:before-swap`, `zfb:after-swap`, `zfb:page-load` events on `document` for bespoke lifecycle hooks.

The previously-deprecated `<ViewTransitions />` typed no-op stays exported for back-compat — see the surviving back-compat assertion in `packages/zfb-runtime/src/__tests__/view-transitions.test.ts`.

## Test surface

- Unit: swap-functions (head dedup, body persist lift, focus save/restore, script re-exec)
- Unit: events lifecycle dispatch ordering (doPreparation, doSwap)
- Integration: `navigate()` happy path with mocked `fetch` + happy-dom
- Integration: lifecycle event ordering across the full pipeline
- Integration: popstate forward / back
- Integration: fallback when `document.startViewTransition` is undefined
- Integration: hash-only same-page navigation skip
- Integration: non-opt-in target page graceful full-load degrade
- Integration: redirected fetch (`res.redirected`) preserves fragment
- Integration: non-HTML fetch response degrades to full browser load
- Integration: idempotent `init()` (no double-register of listeners)

Legacy ~18 click-intercept smoke tests on the deleted IIFE removed; `<ViewTransitions />` retained as a typed no-op with a single back-compat assertion.

## CI

`pnpm test` clean in `packages/zfb-runtime` (65 tests across 5 files); `pnpm typecheck` clean across the workspace.