### PR TITLE
fix(embedded-v8): add browser Event/CustomEvent globals for top-level extends

### DIFF
--- a/crates/zfb-render/src/embedded_v8/extensions.rs
+++ b/crates/zfb-render/src/embedded_v8/extensions.rs
@@ -80,6 +80,13 @@ pub const HOST_GLOBALS_SHIM_SRC: &str = include_str!("js/globals_shim.js");
 /// scope and intentional gaps.
 pub const WEB_POLYFILLS_SRC: &str = include_str!("js/web_polyfills.js");
 
+/// Browser-Event globals: `Event`, `CustomEvent`, `EventTarget`.
+/// Needed so consumer bundles whose top-level code declares
+/// `class X extends Event` (e.g. `@takazudo/zfb-runtime`'s
+/// client-router events module) can be loaded by the embedded V8
+/// host. See `js/browser_event.js` for the rationale and scope.
+pub const BROWSER_EVENT_SRC: &str = include_str!("js/browser_event.js");
+
 /// The v1 set of specifiers the `node:*` stub recognises. Returned in
 /// stable order for diagnostics. Helpers / tests use this list to
 /// drive parameterised assertions.

--- a/crates/zfb-render/src/embedded_v8/js/browser_event.js
+++ b/crates/zfb-render/src/embedded_v8/js/browser_event.js
@@ -1,0 +1,116 @@
+// Minimal browser Event / CustomEvent / EventTarget polyfills for the
+// embedded V8 host.
+//
+// Why this exists
+// ---------------
+// The just-shipped client-router surface in `@takazudo/zfb-runtime`
+// (`packages/zfb-runtime/src/client-router/events.ts`) declares three
+// classes at module top level that extend the browser Event global:
+//
+//   class BeforeEvent extends Event { ... }
+//   export class TransitionBeforePreparationEvent extends BeforeEvent { ... }
+//   export class TransitionBeforeSwapEvent extends BeforeEvent { ... }
+//
+// `extends Event` is evaluated at module-load time. When a consumer
+// bundle that imports the client-router surface is loaded by the
+// embedded V8 host for SSG `paths()` evaluation, the bundle aborts at
+// load time with:
+//
+//   ReferenceError: Event is not defined
+//
+// Surfaced by zudolab/zudo-doc#1521 (W5A pin bump). Upstream tests run
+// in jsdom (which has Event); the embedded V8 host has no DOM and no
+// browser globals, so this stub fills the gap.
+//
+// Scope
+// -----
+// SSG `paths()` evaluation walks module top level only — it never
+// dispatches events, never touches an EventTarget instance method, and
+// never reads back from a constructed Event. The stubs only need to be
+// shaped enough that:
+//
+//   - `class X extends Event` is structurally valid (Event is a
+//     constructable class with a prototype).
+//   - `super(type, init)` from a subclass succeeds and produces an
+//     object with the spec-shaped fields the subclass may read off
+//     `this` (defaultPrevented, type, etc.).
+//   - `new CustomEvent(type, { detail })` survives if any path
+//     constructs one (none currently does at module top level, but
+//     consumers may add more).
+//
+// We deliberately do NOT implement event propagation, listener
+// management, or capture/bubble semantics — those would never fire on
+// the SSG path, and a buggy implementation would mask real bugs.
+//
+// If the SSG path ever does need real dispatch (e.g. a future
+// build-time-rendering surface that simulates a navigation), expand
+// the EventTarget stub with a real listener registry. Until then, the
+// methods are no-ops.
+
+(function installBrowserEventGlobals(globalThis) {
+  class Event {
+    constructor(type, eventInitDict) {
+      this.type = String(type ?? "");
+      const init = eventInitDict || {};
+      this.bubbles = !!init.bubbles;
+      this.cancelable = !!init.cancelable;
+      this.composed = !!init.composed;
+      this.defaultPrevented = false;
+      this.target = null;
+      this.currentTarget = null;
+      this.eventPhase = 0;
+      this.isTrusted = false;
+      this.timeStamp = 0;
+    }
+    preventDefault() {
+      if (this.cancelable) {
+        this.defaultPrevented = true;
+      }
+    }
+    stopPropagation() {}
+    stopImmediatePropagation() {}
+    composedPath() {
+      return [];
+    }
+  }
+  // WHATWG-defined constants — some libraries probe these.
+  Event.NONE = 0;
+  Event.CAPTURING_PHASE = 1;
+  Event.AT_TARGET = 2;
+  Event.BUBBLING_PHASE = 3;
+
+  class CustomEvent extends Event {
+    constructor(type, eventInitDict) {
+      super(type, eventInitDict);
+      const init = eventInitDict || {};
+      this.detail = init.detail === undefined ? null : init.detail;
+    }
+  }
+
+  // Minimal EventTarget. Listeners are registered into an internal
+  // map but never invoked — `dispatchEvent` is a no-op that returns
+  // true (i.e. "default not prevented"). See header for why we don't
+  // implement real dispatch.
+  class EventTarget {
+    constructor() {
+      this._zfbListeners = new Map();
+    }
+    addEventListener(type, _listener, _options) {
+      const t = String(type);
+      if (!this._zfbListeners.has(t)) {
+        this._zfbListeners.set(t, []);
+      }
+    }
+    removeEventListener(_type, _listener, _options) {}
+    dispatchEvent(event) {
+      // Match the spec return contract: true unless preventDefault was
+      // called on a cancelable event. We never invoke listeners, so
+      // defaultPrevented stays whatever the caller set on the event.
+      return !(event && event.defaultPrevented);
+    }
+  }
+
+  globalThis.Event = Event;
+  globalThis.CustomEvent = CustomEvent;
+  globalThis.EventTarget = EventTarget;
+})(globalThis);

--- a/crates/zfb-render/src/embedded_v8/mod.rs
+++ b/crates/zfb-render/src/embedded_v8/mod.rs
@@ -37,6 +37,13 @@
 //!   SSG path never makes outgoing network requests so the
 //!   `deno_fetch` hyper/rustls/h2/tower stack is dead weight).
 //!
+//! - Browser-Event globals (`Event`, `CustomEvent`, `EventTarget`)
+//!   are installed via [`extensions::BROWSER_EVENT_SRC`]. Needed so
+//!   bundles whose top-level code declares `class X extends Event`
+//!   (e.g. `@takazudo/zfb-runtime`'s client-router events module)
+//!   evaluate at all on the SSG path. See `js/browser_event.js` for
+//!   the scope and intentional gaps.
+//!
 //! - Per-dispatch flow: the host stashes the bundle's `default`
 //!   export at boot, then for each call it invokes the JS-side
 //!   `__zfb.dispatch(url, method, headers, body)` (see
@@ -186,16 +193,25 @@ impl EmbeddedV8RenderHost {
         Ok(host)
     }
 
-    /// Install the web platform polyfills and the host-bridge globals
-    /// shim. Order matters: the polyfills (Request / Response / URL /
-    /// fetch / encoders / etc.) ship before the host shim so the
-    /// host shim's `dispatch(...)` helper can use them when it
-    /// constructs a Request from `dispatch_fetch`'s arguments.
+    /// Install the web platform polyfills, the browser-event globals,
+    /// and the host-bridge globals shim. Order matters: the polyfills
+    /// (Request / Response / URL / fetch / encoders / etc.) and the
+    /// browser-event globals (`Event` / `CustomEvent` / `EventTarget`)
+    /// ship before the host shim so module-top-level
+    /// `class X extends Event` declarations in the bundle evaluate
+    /// against the stubbed globals, and so the host shim's
+    /// `dispatch(...)` helper can use Request / Response when it
+    /// constructs them from `dispatch_fetch`'s arguments.
     fn bootstrap_host_shim(&mut self) -> Result<()> {
         self.runtime
             .execute_script("zfb:web_polyfills", extensions::WEB_POLYFILLS_SRC)
             .map_err(|e| {
                 RenderError::Runtime(format!("web polyfills init failed: {e}"))
+            })?;
+        self.runtime
+            .execute_script("zfb:browser_event", extensions::BROWSER_EVENT_SRC)
+            .map_err(|e| {
+                RenderError::Runtime(format!("browser-event globals init failed: {e}"))
             })?;
         self.runtime
             .execute_script("zfb:host_shim", extensions::HOST_GLOBALS_SHIM_SRC)

--- a/crates/zfb-render/tests/embedded_v8_browser_event.rs
+++ b/crates/zfb-render/tests/embedded_v8_browser_event.rs
@@ -1,0 +1,167 @@
+//! Regression tests for the `Event` / `CustomEvent` / `EventTarget`
+//! globals stubbed by [`extensions::BROWSER_EVENT_SRC`].
+//!
+//! Surfaced by zudolab/zudo-doc#1521 (W5A): the just-shipped
+//! client-router surface in `@takazudo/zfb-runtime` declares three
+//! classes at module top level that extend the browser `Event`
+//! global. Without a stub, the embedded V8 host fails to load the
+//! bundle with:
+//!
+//!   ReferenceError: Event is not defined
+//!
+//! The host now provides minimal stubs sufficient for module-load
+//! evaluation. These tests pin the contract:
+//!
+//! - `class X extends Event {}` evaluates at module top level.
+//! - `super(type, init)` from a subclass produces an Event-shaped
+//!   instance (defaultPrevented, type, etc.).
+//! - `new CustomEvent(type, { detail })` works.
+//! - `new EventTarget()` works and methods are callable.
+//!
+//! We deliberately do NOT exercise event dispatch — the SSG path
+//! never dispatches events, and pinning behaviour we don't intend
+//! to support would make future expansion harder.
+
+#![cfg(feature = "embed_v8")]
+
+use zfb_render::{EmbeddedV8RenderHost, HttpRequestLike, RenderHost};
+
+#[tokio::test]
+async fn module_top_level_extends_event_loads() {
+    // Mirrors the failing case in `@takazudo/zfb-runtime`'s
+    // `client-router/events.ts`: a class hierarchy extending Event
+    // declared at module top level. If `Event` is missing from
+    // globalThis, this module aborts at load time before `fetch` is
+    // ever called.
+    let mut host = EmbeddedV8RenderHost::new().expect("host boot");
+    let bundle = r#"
+        class BeforeEvent extends Event {
+          constructor(type, init, payload) {
+            super(type, init);
+            this.payload = payload;
+          }
+        }
+        class TransitionBeforePreparationEvent extends BeforeEvent {
+          constructor(payload) {
+            super("zfb:before-preparation", { cancelable: true }, payload);
+          }
+        }
+        export default {
+          fetch(_request) {
+            const evt = new TransitionBeforePreparationEvent({ ok: true });
+            const body = JSON.stringify({
+              type: evt.type,
+              cancelable: evt.cancelable,
+              defaultPrevented: evt.defaultPrevented,
+              payload: evt.payload,
+            });
+            return new Response(body, {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            });
+          },
+        };
+    "#;
+    host.execute_module("bundle.mjs", bundle)
+        .await
+        .expect("bundle with `class X extends Event` should load");
+    let resp = host
+        .dispatch_fetch(HttpRequestLike::get("http://zfb.local/"))
+        .await
+        .expect("dispatch");
+    assert_eq!(resp.status, 200);
+    let body = resp.body_utf8().expect("utf-8 body");
+    assert!(body.contains(r#""type":"zfb:before-preparation""#), "body={body}");
+    assert!(body.contains(r#""cancelable":true"#), "body={body}");
+    assert!(body.contains(r#""defaultPrevented":false"#), "body={body}");
+    assert!(body.contains(r#""payload":{"ok":true}"#), "body={body}");
+}
+
+#[tokio::test]
+async fn custom_event_carries_detail() {
+    let mut host = EmbeddedV8RenderHost::new().expect("host boot");
+    let bundle = r#"
+        export default {
+          fetch(_request) {
+            const evt = new CustomEvent("zfb:custom", { detail: { id: 42 } });
+            return new Response(
+              JSON.stringify({ type: evt.type, detail: evt.detail }),
+              { status: 200, headers: { "content-type": "application/json" } }
+            );
+          },
+        };
+    "#;
+    host.execute_module("bundle.mjs", bundle)
+        .await
+        .expect("execute bundle");
+    let resp = host
+        .dispatch_fetch(HttpRequestLike::get("http://zfb.local/"))
+        .await
+        .expect("dispatch");
+    assert_eq!(resp.status, 200);
+    let body = resp.body_utf8().expect("utf-8 body");
+    assert!(body.contains(r#""detail":{"id":42}"#), "body={body}");
+}
+
+#[tokio::test]
+async fn event_target_subclass_constructs() {
+    // Some upstream user code subclasses EventTarget at module top
+    // level. The stubs only need to make `extends EventTarget` and
+    // `new Subclass()` succeed; we don't need real listener
+    // semantics on the SSG path.
+    let mut host = EmbeddedV8RenderHost::new().expect("host boot");
+    let bundle = r#"
+        class Bus extends EventTarget {}
+        const bus = new Bus();
+        export default {
+          fetch(_request) {
+            bus.addEventListener("ping", () => {});
+            const ok = bus.dispatchEvent(new Event("ping"));
+            return new Response(String(ok), { status: 200 });
+          },
+        };
+    "#;
+    host.execute_module("bundle.mjs", bundle)
+        .await
+        .expect("bundle with `class X extends EventTarget` should load");
+    let resp = host
+        .dispatch_fetch(HttpRequestLike::get("http://zfb.local/"))
+        .await
+        .expect("dispatch");
+    assert_eq!(resp.status, 200);
+    assert_eq!(resp.body_utf8(), Some("true"));
+}
+
+#[tokio::test]
+async fn prevent_default_records_on_cancelable_event() {
+    let mut host = EmbeddedV8RenderHost::new().expect("host boot");
+    let bundle = r#"
+        export default {
+          fetch(_request) {
+            const cancelable = new Event("a", { cancelable: true });
+            cancelable.preventDefault();
+            const passive = new Event("b");
+            passive.preventDefault();
+            return new Response(
+              JSON.stringify({
+                cancelable: cancelable.defaultPrevented,
+                passive: passive.defaultPrevented,
+              }),
+              { status: 200, headers: { "content-type": "application/json" } }
+            );
+          },
+        };
+    "#;
+    host.execute_module("bundle.mjs", bundle)
+        .await
+        .expect("execute bundle");
+    let resp = host
+        .dispatch_fetch(HttpRequestLike::get("http://zfb.local/"))
+        .await
+        .expect("dispatch");
+    let body = resp.body_utf8().expect("utf-8 body");
+    // preventDefault on a cancelable event should record; on a
+    // non-cancelable event it should be a no-op.
+    assert!(body.contains(r#""cancelable":true"#), "body={body}");
+    assert!(body.contains(r#""passive":false"#), "body={body}");
+}


### PR DESCRIPTION
## What

Adds minimal globalThis stubs for `Event`, `CustomEvent`, and `EventTarget` to the embedded V8 host. Mirrors the pattern of the `bdbfbfb` `node:async_hooks` hotfix — minimum viable shape so module-level `class X extends Event` loads, no DOM machinery beneath.

## Why

`packages/zfb-runtime/src/client-router/events.ts` (just merged in PR #224) declares three top-level Event subclasses:

```ts
class BeforeEvent extends Event { /* ... */ }
export class TransitionBeforePreparationEvent extends BeforeEvent { /* ... */ }
export class TransitionBeforeSwapEvent extends BeforeEvent { /* ... */ }
```

When the embedded V8 host loads a consumer bundle that imports the client-router surface, `extends Event` evaluates at bundle-load time and fails with `ReferenceError: Event is not defined`.

Surfaced by `zudolab/zudo-doc#1521` (W5A pin bump consuming PR #224). The consumer's CI run https://github.com/zudolab/zudo-doc/actions/runs/25501499041 fails identically across Build Site and E2E jobs:

```
embedded V8 host error: bundle load failed: runtime error: event loop error: ReferenceError: Event is not defined
```

Upstream tests didn't catch this because they run in jsdom (which has `Event`); the embedded V8 host is a separate runtime surface.

## Files changed

- `crates/zfb-render/src/embedded_v8/js/browser_event.js` — new pure-JS stubs (Event / CustomEvent / EventTarget). Header explains the scope and intentional gaps.
- `crates/zfb-render/src/embedded_v8/extensions.rs` — `BROWSER_EVENT_SRC` constant via `include_str!`.
- `crates/zfb-render/src/embedded_v8/mod.rs` — `bootstrap_host_shim` runs the new shim after the web polyfills and before the host shim.
- `crates/zfb-render/tests/embedded_v8_browser_event.rs` — regression tests.

## Risk classification

Low risk — small targeted compatibility fix following an established hotfix pattern (`bdbfbfb`). New surface is opt-in (stubs only matter when consumer code references the names; existing consumers without `extends Event` see no change). No public API surface change.

## Test

- New Rust regression tests (`embedded_v8_browser_event.rs`):
  - `module_top_level_extends_event_loads` — exact failing shape: `class BeforeEvent extends Event` declared at module top level. Asserts no `ReferenceError` at load and that subclass instances carry spec-shaped fields.
  - `custom_event_carries_detail` — `new CustomEvent(type, { detail })` round-trip.
  - `event_target_subclass_constructs` — `class X extends EventTarget` + `dispatchEvent(new Event(...))` returns true.
  - `prevent_default_records_on_cancelable_event` — preventDefault is recorded only on cancelable events.
- All existing embedded_v8 tests stay green: `embedded_v8_smoke`, `embedded_v8_node_stubs`, `embedded_v8_real_bundle_smoke`.
- `cargo test -p zfb-render` clean on the worktree.
- Manual verification deferred to consumer CI after re-bumping the pin to this SHA.

## Migration

None. This is a pure compat fix to the embedded V8 globals surface.