### PR TITLE
fix(zfb-runtime): add = {} default to ClientRouter destructured props

### DIFF
--- a/packages/zfb-runtime/src/client-router.ts
+++ b/packages/zfb-runtime/src/client-router.ts
@@ -105,7 +105,7 @@ const announcerCss = `
  */
 export function ClientRouter({
   fallback = "animate",
-}: ClientRouterProps): readonly ClientRouterElement[] {
+}: ClientRouterProps = {}): readonly ClientRouterElement[] {
   return [
     // Global styles for the ARIA route-announcer div injected into <body>.
     makeVNode("style", { dangerouslySetInnerHTML: { __html: announcerCss } }),


### PR DESCRIPTION
## Summary

Two-line fix: add `= {}` default to the destructured props parameter of `ClientRouter()` so calling it with no arguments matches the documented optional-props contract.

## Why

The current signature is:

```ts
export function ClientRouter({ fallback = "animate" }: ClientRouterProps): readonly ClientRouterElement[]
```

The destructured parameter has no `= {}` default. Calling `ClientRouter()` with no arguments passes `undefined` to the destructure, which throws:

```
TypeError: Cannot read properties of undefined (reading 'fallback')
```

at SSR render time inside the embedded V8 host (zudo-doc's host page).

Downstream consumers (specifically `_zfb-runtime-shim.d.ts` in zudo-doc) declare the props as **optional**:

```ts
export function ClientRouter(props?: ClientRouterProps): readonly ClientRouterElement[];
```

So a no-arg call is the documented contract — the runtime impl just doesn't honour it.

## Discovery

Surfaced by [zudolab/zudo-doc#1522](https://github.com/zudolab/zudo-doc/issues/1522) (W6A — host-side atomic switch to Strategy B). Investigation in [zudolab/zudo-doc#1528](https://github.com/zudolab/zudo-doc/pull/1528) traced the generic \"render failed\" build error to this destructure crash.

The host has applied an in-line workaround (`ClientRouter({})`) so W6A can land without blocking on this PR. Once this merges and the zudo-doc pin is bumped, the workaround can be reverted to the cleaner no-arg call.

## The fix

```diff
-export function ClientRouter({
-  fallback = "animate",
-}: ClientRouterProps): readonly ClientRouterElement[] {
+export function ClientRouter({
+  fallback = "animate",
+}: ClientRouterProps = {}): readonly ClientRouterElement[] {
```

## Tests

No new tests — this is a 2-line ergonomics fix on a public API. Existing W3D tests cover the with-args path; this fix just makes the no-args path also work as the type signature already documents.

## Compat

Pure addition of a default value. Existing callers that pass props are unaffected. Callers that pass nothing previously crashed; they now get the documented default behaviour (`fallback = "animate"`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)