### PR TITLE
fix(zfb-runtime): expose ./client-router subpath export

### DIFF
--- a/packages/zfb-runtime/package.json
+++ b/packages/zfb-runtime/package.json
@@ -15,6 +15,10 @@
     "./snapshot": {
       "types": "./src/snapshot.ts",
       "default": "./src/snapshot.ts"
+    },
+    "./client-router": {
+      "types": "./src/client-router/index.ts",
+      "default": "./src/client-router/index.ts"
     }
   },
   "scripts": {


### PR DESCRIPTION
## Summary

Adds a public `./client-router` subpath to `@takazudo/zfb-runtime`'s package.json exports, mapping to the existing barrel at `src/client-router/index.ts`. Purely additive — no source changes, no behavioural changes.

## Why

Surfaced by [zudolab/zudo-doc#1524](https://github.com/zudolab/zudo-doc/issues/1524) (W7A end-to-end Playwright verify): all 4 GATEs that depend on the SPA router fired FAIL because the router code was absent from the client bundle.

The host's client-side bootstrap path needs to side-effect-import the client-router barrel so the top-of-module guard

```ts
if (typeof document !== "undefined") {
  init();
}
```

in `client-router.ts` fires in the browser. The host's existing imports of `@takazudo/zfb-runtime` (e.g. `<ClientRouter />` in `doc-layout.tsx`) all happen during SSR where `typeof document === "undefined"`, so the side effect is silently skipped server-side. The component's meta tags ship in the SSG HTML but the click/form intercepts are never registered, so every navigation is a full page load with no View Transition.

The barrel at `src/client-router/index.ts` was already exported transitively through `.` for the `ClientRouter` / `navigate` / etc. public surface; this just makes the full client-router barrel addressable as a subpath so it can be side-effect-imported from a `"use client"` host module without dragging in any server-only zfb-runtime modules (`createPageRouter`, `snapshot`, the `framework` adapter type, etc.).

## Test plan

- [x] `pnpm typecheck` — green (no source changes)
- [x] No source changes — only `package.json` exports map
- [ ] Downstream consumer (`zudolab/zudo-doc`) imports `@takazudo/zfb-runtime/client-router` from a `"use client"` bootstrap component; W7A Playwright GATEs flip from FAIL → PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)