### PR TITLE
Batch: handle recent 4 open issues (#228-231) — base config, dev middleware, build intermediates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,14 @@ __inbox/
 # project roots when `zfb dev` runs. Never committed.
 .zfb/
 
+# Build intermediates from `zfb build` / `zfb dev` — the SSR worker
+# bundle (`bundle.mjs` + `bundle.mjs.map`) the renderer loads.
+# Relocated out of `dist/.zfb-build/` (zfb#231) into the project root
+# so it doesn't ship to deploy uploads. Created in user project roots
+# AND in dogfood examples (e.g. `examples/basic-blog/.zfb-build/`).
+# Never committed.
+.zfb-build/
+
 # Stale renderer bootstrap files left at workspace root when the
 # miniflare subprocess is killed before NamedTempFile drop runs
 # (e.g. SIGKILL). See crates/zfb-build/src/renderer.rs.

--- a/crates/zfb-build/Cargo.toml
+++ b/crates/zfb-build/Cargo.toml
@@ -63,6 +63,14 @@ fs2 = "0.4"
 # same byte stream.
 sha2 = "0.10"
 hex = "0.4"
+# Issue #228 / #229: shared HTML link rewriter that the production
+# build pass and the dev server both call so dev-mode and prod-mode
+# render the same `<a href>` / `<form action>` URLs under a `base`
+# prefix. Lives here (not in `zfb-types`) because `zfb-types` is the
+# zero-dep leaf crate; lol_html is heavy enough to keep above that
+# layer. Same workspace pin as the existing `lol_html` users
+# (`zfb-server`, `zfb-islands`).
+lol_html = "2.8.1"
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/zfb-build/src/lib.rs
+++ b/crates/zfb-build/src/lib.rs
@@ -52,6 +52,7 @@ pub mod adapter;
 pub mod atomic;
 pub mod bundler;
 pub mod head_inject;
+pub mod link_base_rewrite;
 pub mod orchestrator;
 pub mod pipeline;
 pub mod plan;

--- a/crates/zfb-build/src/link_base_rewrite.rs
+++ b/crates/zfb-build/src/link_base_rewrite.rs
@@ -1,0 +1,411 @@
+//! Shared HTML link / form rewriter for the configured `base` prefix
+//! (issue #228). Lives here so both consumers can call the same code:
+//!
+//! - **Build pipeline** (`zfb` crate, `commands::link_base_rewrite`)
+//!   walks emitted SSG HTML files post-render and rewrites them on
+//!   disk via [`apply_link_base_rewrite`]-style file I/O wrapping.
+//! - **Dev server** (`zfb-server`, `routes::page_response_bytes`)
+//!   applies the rewrite in-flight on cached HTML responses when the
+//!   dev server is mounted under a `base` prefix (issue #229's
+//!   review caught that the dev server was serving cached HTML
+//!   verbatim, so user `<a href="/about">` literals 404'd against
+//!   the prefixed dev mount).
+//!
+//! Both consumers funnel through the same boundary semantics so a
+//! page that renders correctly in `zfb build` also renders correctly
+//! in `zfb dev` — no drift between modes.
+//!
+//! ## Scope (deliberately narrow)
+//!
+//! Rewrite **only** `href` on `<a>` and `action` on `<form>`. Other
+//! navigation-shaped attributes (`<area href>`, `<form formaction>`,
+//! `<base href>`, `<link rel="alternate">`, …) are out of scope —
+//! that mirrors the asset URL rewrite that handles only `<link>` /
+//! `<script>`. Adding more later is cheap.
+//!
+//! ## Skip rules — see [`compute_prefixed`]
+//!
+//! Authors can opt a specific element out of the rewrite by adding the
+//! `data-no-base` attribute (any value, including bareword). The
+//! attribute is left on the emitted HTML — browsers ignore unknown
+//! `data-*` attributes, so the cost is one harmless attribute per
+//! opt-out and the rewriter stays trivially correct on re-runs.
+
+use std::borrow::Cow;
+
+use lol_html::html_content::Element;
+use lol_html::{ElementContentHandlers, LocalHandlerTypes, RewriteStrSettings, Selector};
+
+/// Rewrite root-absolute `<a href>` / `<form action>` in `html` by
+/// prepending `prefix`. Pure function — no I/O.
+///
+/// `prefix` MUST be the canonical form: empty (no rewrite), or a path
+/// with no trailing slash (`/foo`). Callers that compute the prefix
+/// from `cfg.base` should run it through their canonicaliser
+/// (`zfb::config::asset_url_base_prefix` for the build pipeline,
+/// `zfb_types::dev_mount_prefix` for the dev server) before passing
+/// it here. An empty prefix is a no-op via the idempotency check, so
+/// callers do not need to short-circuit themselves.
+///
+/// Absolute-URL prefixes (`https://cdn.example.com`) are accepted but
+/// callers should prefer to skip the rewrite — user navigation
+/// shouldn't redirect to a CDN host that doesn't serve HTML.
+pub fn rewrite_links_in_html(
+    html: &str,
+    prefix: &str,
+) -> Result<String, lol_html::errors::RewritingError> {
+    let a_selector: Selector = "a[href]".parse().expect("static selector is valid");
+    let form_selector: Selector = "form[action]"
+        .parse()
+        .expect("static selector is valid");
+
+    // Each handler is `FnMut + Send + Sync`; capture an owned `String`
+    // clone of the prefix so the closures don't borrow from the outer
+    // scope.
+    let prefix_for_a = prefix.to_string();
+    let prefix_for_form = prefix.to_string();
+
+    lol_html::rewrite_str(
+        html,
+        RewriteStrSettings {
+            element_content_handlers: vec![
+                (
+                    Cow::Owned(a_selector),
+                    ElementContentHandlers::default().element(move |el: &mut Element<'_, '_, _>| {
+                        if has_no_base_optout(el) {
+                            return Ok(());
+                        }
+                        if let Some(href) = el.get_attribute("href") {
+                            if let Some(rewritten) = compute_prefixed(&href, &prefix_for_a) {
+                                el.set_attribute("href", &rewritten)?;
+                            }
+                        }
+                        Ok(())
+                    }),
+                ),
+                (
+                    Cow::Owned(form_selector),
+                    ElementContentHandlers::default().element(move |el: &mut Element<'_, '_, _>| {
+                        if has_no_base_optout(el) {
+                            return Ok(());
+                        }
+                        if let Some(action) = el.get_attribute("action") {
+                            if let Some(rewritten) = compute_prefixed(&action, &prefix_for_form) {
+                                el.set_attribute("action", &rewritten)?;
+                            }
+                        }
+                        Ok(())
+                    }),
+                ),
+            ],
+            ..RewriteStrSettings::new()
+        },
+    )
+}
+
+/// Return the prefixed value, or `None` to leave the attribute alone.
+///
+/// Skip rules:
+///
+/// - Empty string: pass through.
+/// - Schemed / absolute URLs (`mailto:`, `tel:`, `javascript:`,
+///   `http:`, `https:`, `data:`, `blob:`, `ws:`, `wss:`, `file:`,
+///   `ftp:`, …): never start with `/`, so the leading-`/` gate
+///   already catches them.
+/// - Protocol-relative `//host/...`: starts with two slashes.
+/// - Fragment-only `#anchor`: doesn't start with `/`.
+/// - Relative paths (`foo.html`, `./foo`, `../foo`): no leading `/`.
+/// - Already-prefixed (`/foo` when prefix is `/foo`): pass through —
+///   the rewrite is idempotent. The boundary after the prefix must be
+///   end-of-string, `/`, `?`, or `#`. A trailing-character mismatch
+///   like `/foobar` is NOT considered already-prefixed by `/foo` and
+///   IS rewritten.
+pub fn compute_prefixed(value: &str, prefix: &str) -> Option<String> {
+    if value.is_empty() {
+        return None;
+    }
+    let bytes = value.as_bytes();
+    if bytes[0] != b'/' {
+        return None;
+    }
+    if bytes.len() >= 2 && bytes[1] == b'/' {
+        return None;
+    }
+    // Idempotency: if the value is already mounted under `prefix`,
+    // leave it alone. The boundary after the prefix must be one of:
+    // end-of-string, `/` (path segment), `?` (query suffix), or `#`
+    // (fragment suffix). So `/foobar` is NOT considered already-prefixed
+    // by `/foo`, but `/foo`, `/foo/x`, `/foo?x=1`, `/foo#top` are.
+    if value.starts_with(prefix) {
+        let rest = &value[prefix.len()..];
+        if rest.is_empty()
+            || rest.starts_with('/')
+            || rest.starts_with('?')
+            || rest.starts_with('#')
+        {
+            return None;
+        }
+    }
+    Some(format!("{prefix}{value}"))
+}
+
+/// Case-insensitive check: is `data-no-base` present on this element?
+/// `lol_html`'s element selectors and `get_attribute` /
+/// `has_attribute` are already case-insensitive on attribute names,
+/// so a literal lookup suffices.
+pub fn has_no_base_optout(el: &Element<'_, '_, LocalHandlerTypes>) -> bool {
+    el.has_attribute("data-no-base")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- compute_prefixed -------------------------------------------------
+
+    #[test]
+    fn root_absolute_gets_prefix() {
+        assert_eq!(
+            compute_prefixed("/about", "/foo").as_deref(),
+            Some("/foo/about")
+        );
+        assert_eq!(
+            compute_prefixed("/api/users", "/foo").as_deref(),
+            Some("/foo/api/users")
+        );
+    }
+
+    #[test]
+    fn root_alone_becomes_base_root() {
+        assert_eq!(compute_prefixed("/", "/foo").as_deref(), Some("/foo/"));
+    }
+
+    #[test]
+    fn preserves_query_and_hash() {
+        assert_eq!(
+            compute_prefixed("/about?x=1", "/foo").as_deref(),
+            Some("/foo/about?x=1")
+        );
+        assert_eq!(
+            compute_prefixed("/about#section", "/foo").as_deref(),
+            Some("/foo/about#section")
+        );
+    }
+
+    #[test]
+    fn idempotent_on_already_prefixed() {
+        assert_eq!(compute_prefixed("/foo", "/foo"), None);
+        assert_eq!(compute_prefixed("/foo/", "/foo"), None);
+        assert_eq!(compute_prefixed("/foo/about", "/foo"), None);
+        assert_eq!(compute_prefixed("/foo/api/x", "/foo"), None);
+    }
+
+    #[test]
+    fn idempotent_on_prefixed_with_query_or_fragment() {
+        // The boundary admits `?` and `#` so a prefixed URL with a
+        // suffix doesn't get double-prefixed (codex review caught
+        // this).
+        assert_eq!(compute_prefixed("/foo?tab=1", "/foo"), None);
+        assert_eq!(compute_prefixed("/foo?", "/foo"), None);
+        assert_eq!(compute_prefixed("/foo#top", "/foo"), None);
+        assert_eq!(compute_prefixed("/foo#", "/foo"), None);
+        assert_eq!(compute_prefixed("/foo?x=1#y", "/foo"), None);
+    }
+
+    #[test]
+    fn partial_prefix_still_rewrites() {
+        assert_eq!(
+            compute_prefixed("/foobar", "/foo").as_deref(),
+            Some("/foo/foobar")
+        );
+        // `/foobar?x=1` is NOT under `/foo` — boundary char after the
+        // candidate prefix must be `/` / `?` / `#` / end-of-string.
+        assert_eq!(
+            compute_prefixed("/foobar?x=1", "/foo").as_deref(),
+            Some("/foo/foobar?x=1")
+        );
+    }
+
+    #[test]
+    fn skips_empty() {
+        assert_eq!(compute_prefixed("", "/foo"), None);
+    }
+
+    #[test]
+    fn skips_fragment_only() {
+        assert_eq!(compute_prefixed("#anchor", "/foo"), None);
+    }
+
+    #[test]
+    fn skips_protocol_relative() {
+        assert_eq!(compute_prefixed("//cdn.example.com/x", "/foo"), None);
+    }
+
+    #[test]
+    fn skips_schemed_urls() {
+        for v in [
+            "mailto:x@y.com",
+            "tel:+15555550100",
+            "javascript:void(0)",
+            "data:text/plain,hi",
+            "blob:https://example.com/abc",
+            "ws://example.com/",
+            "wss://example.com/",
+            "file:///etc/passwd",
+            "ftp://example.com/x",
+            "http://example.com/x",
+            "https://example.com/x",
+        ] {
+            assert_eq!(
+                compute_prefixed(v, "/foo"),
+                None,
+                "expected skip for {v}"
+            );
+        }
+    }
+
+    #[test]
+    fn skips_relative_paths() {
+        for v in ["foo.html", "./foo", "../foo", "page", "page/sub.html"] {
+            assert_eq!(
+                compute_prefixed(v, "/foo"),
+                None,
+                "expected skip for {v}"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_prefix_is_noop_via_idempotency() {
+        assert_eq!(compute_prefixed("/about", ""), None);
+        assert_eq!(compute_prefixed("/", ""), None);
+    }
+
+    // --- rewrite_links_in_html -------------------------------------------
+
+    #[test]
+    fn rewrite_a_href_root_absolute() {
+        let html = r#"<a href="/about">About</a>"#;
+        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        assert!(
+            out.contains(r#"href="/foo/about""#),
+            "expected /foo/about; got: {out}"
+        );
+    }
+
+    #[test]
+    fn rewrite_form_action_root_absolute() {
+        let html = r#"<form action="/submit"><input/></form>"#;
+        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        assert!(
+            out.contains(r#"action="/foo/submit""#),
+            "expected /foo/submit; got: {out}"
+        );
+    }
+
+    #[test]
+    fn rewrite_data_no_base_optout_a() {
+        let html = r#"<a href="/about" data-no-base>About</a>"#;
+        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        assert!(out.contains(r#"href="/about""#), "got: {out}");
+        assert!(!out.contains("/foo/about"), "got: {out}");
+    }
+
+    #[test]
+    fn rewrite_data_no_base_with_value_also_optout() {
+        for snippet in [
+            r#"<a href="/x" data-no-base>x</a>"#,
+            r#"<a href="/x" data-no-base="">x</a>"#,
+            r#"<a href="/x" data-no-base="true">x</a>"#,
+        ] {
+            let out = rewrite_links_in_html(snippet, "/foo").unwrap();
+            assert!(
+                out.contains(r#"href="/x""#) && !out.contains("/foo/x"),
+                "expected unchanged for: {snippet}; got: {out}"
+            );
+        }
+    }
+
+    #[test]
+    fn rewrite_idempotent_on_already_prefixed() {
+        let html = r#"<a href="/foo/about">about</a>"#;
+        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        assert_eq!(out, html);
+    }
+
+    #[test]
+    fn rewrite_idempotent_with_query() {
+        // Regression for the fragment/query boundary fix — once-rewritten
+        // HTML with prefixed URLs that carry queries / fragments must
+        // stay byte-identical on a second pass.
+        let html = r#"<a href="/foo/about?tab=1#top">x</a>"#;
+        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        assert_eq!(out, html);
+    }
+
+    #[test]
+    fn rewrite_skips_external_relative_and_schemed() {
+        let html = r##"<a href="//cdn.example.com/x">cdn</a>
+            <a href="#anchor">anchor</a>
+            <a href="mailto:x@y">mail</a>
+            <a href="http://example.com/">http</a>
+            <a href="javascript:void(0)">js</a>
+            <a href="foo.html">rel</a>"##;
+        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        for original in [
+            r#"href="//cdn.example.com/x""#,
+            r##"href="#anchor""##,
+            r#"href="mailto:x@y""#,
+            r#"href="http://example.com/""#,
+            r#"href="javascript:void(0)""#,
+            r#"href="foo.html""#,
+        ] {
+            assert!(out.contains(original), "expected to find {original}");
+        }
+        assert!(!out.contains("/foo/"), "no rewrites expected; got: {out}");
+    }
+
+    #[test]
+    fn rewrite_attribute_order_does_not_matter() {
+        let html = r#"<a data-no-base href="/about">About</a>"#;
+        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        assert!(out.contains(r#"href="/about""#), "got: {out}");
+        assert!(!out.contains("/foo/about"), "got: {out}");
+    }
+
+    #[test]
+    fn rewrite_handles_multiple_links_in_one_doc() {
+        let html = r#"<!doctype html><html><body>
+            <a href="/about">About</a>
+            <a href="/contact">Contact</a>
+            <form action="/login"><input/></form>
+            <a href="/foo/already">Already</a>
+            <a href="/foo/already?tab=1">AlreadyQuery</a>
+            <a href="https://example.com/">Out</a>
+        </body></html>"#;
+        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        assert!(out.contains(r#"href="/foo/about""#), "got: {out}");
+        assert!(out.contains(r#"href="/foo/contact""#), "got: {out}");
+        assert!(out.contains(r#"action="/foo/login""#), "got: {out}");
+        assert!(out.contains(r#"href="/foo/already""#), "got: {out}");
+        assert!(out.contains(r#"href="/foo/already?tab=1""#), "got: {out}");
+        assert!(out.contains(r#"href="https://example.com/""#), "got: {out}");
+    }
+
+    #[test]
+    fn rewrite_root_alone_gets_base_root() {
+        let html = r#"<a href="/">home</a>"#;
+        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        assert!(out.contains(r#"href="/foo/""#), "got: {out}");
+    }
+
+    #[test]
+    fn rewrite_empty_prefix_is_noop() {
+        let html = r#"<a href="/about">About</a><form action="/x"></form>"#;
+        let out = rewrite_links_in_html(html, "").unwrap();
+        // With empty prefix the idempotency check sees `value.starts_with("")`
+        // == true and bails, so nothing changes.
+        assert!(out.contains(r#"href="/about""#), "got: {out}");
+        assert!(out.contains(r#"action="/x""#), "got: {out}");
+    }
+}

--- a/crates/zfb-content/tests/large_mdx_fallback_regression.rs
+++ b/crates/zfb-content/tests/large_mdx_fallback_regression.rs
@@ -50,8 +50,9 @@
 //!   3. Snapshot `module_specifier` hash **equals** bundler-side
 //!      compile hash byte-for-byte (`959febef` for the live file at
 //!      the time of writing). The bridge map in the live worker
-//!      bundle (`dist/.zfb-build/bundle.mjs`) registers exactly this
-//!      hash, so `globalThis.__zfb.content.get(specifier)` lands.
+//!      bundle (`<project_root>/.zfb-build/bundle.mjs`, relocated out
+//!      of `dist/` per zfb#231) registers exactly this hash, so
+//!      `globalThis.__zfb.content.get(specifier)` lands.
 //!
 //! Inspection of the live `dist/docs/claude-skills/l-lessons-zfb-migration-parity/index.html`
 //! found ZERO occurrences of the actual fallback marker

--- a/crates/zfb-server/Cargo.toml
+++ b/crates/zfb-server/Cargo.toml
@@ -10,6 +10,10 @@ description = "zfb dev server: axum + SSE live-reload + CSS hot-swap"
 [dependencies]
 zfb-build = { path = "../zfb-build" }
 zfb-islands = { path = "../zfb-islands" }
+# Issue #229: shared `base` → mount-prefix normalisation lives in
+# zfb-types (the lowest-dep leaf) so the build-time link rewriter
+# (#228) and the dev server agree on the canonical form.
+zfb-types = { path = "../zfb-types" }
 
 axum = "0.8"
 # Sub 3 / #108: dyn-compat async trait for the dev-middleware

--- a/crates/zfb-server/src/inject.rs
+++ b/crates/zfb-server/src/inject.rs
@@ -19,6 +19,20 @@
 //! round-trip. The old `inject_livereload(html: &str) -> String`
 //! convenience wrapper is preserved for call sites that operate on
 //! plain strings (primarily the route layer).
+//!
+//! ## Base-prefix awareness (issue #229)
+//!
+//! When the project's `zfb.config.ts` declares
+//! `base: "/foo/"`, the dev server mounts every route under `/foo`
+//! including the live-reload endpoint at
+//! `/foo/__zfb/livereload.js`. The injected `<script src>` therefore
+//! has to point at the prefixed URL — otherwise the browser would
+//! request the unprefixed `/__zfb/livereload.js`, hit the dev-server
+//! 404, and the live-reload connection would never establish.
+//! [`livereload_tag`] builds the right URL given the prefix; the
+//! prefix-less convenience wrappers ([`LIVERELOAD_TAG`],
+//! [`inject_livereload`], [`inject_livereload_into_tree`]) are kept
+//! for backward compatibility and use an empty prefix.
 
 use std::borrow::Cow;
 use std::cell::Cell;
@@ -28,16 +42,43 @@ use lol_html::html_content::{ContentType, Element};
 use lol_html::{ElementContentHandlers, RewriteStrSettings, Selector};
 use zfb_islands::html_tree::HtmlTree;
 
-/// The script tag we inject before `</body>` on every served HTML page.
+/// The script tag we inject before `</body>` on every served HTML page
+/// when the dev server is mounted at the root (no `base` prefix).
 ///
 /// Kept short to minimise dev-mode noise. The script itself lives at
 /// `/__zfb/livereload.js` (served by [`crate::routes`]) and is
 /// `Cache-Control: no-store` so the browser always refetches the
 /// latest version.
+///
+/// When the project uses `base: "/foo/"` the dev server has to emit a
+/// prefixed `<script src="/foo/__zfb/livereload.js">` instead — see
+/// [`livereload_tag`]. This constant covers the no-base case and stays
+/// for backward compatibility (it was part of the public API before the
+/// prefix-aware variants landed).
 pub const LIVERELOAD_TAG: &str = "<script src=\"/__zfb/livereload.js\"></script>";
 
-/// Inject [`LIVERELOAD_TAG`] into the `<body>` element of `tree`
-/// (immediately before `</body>`) using `lol_html`'s CSS selector.
+/// Build the live-reload `<script>` tag with the dev server's mount
+/// prefix folded in.
+///
+/// `base_prefix` is the canonical mount prefix returned by
+/// [`zfb_types::dev_mount_prefix`]: empty string for the no-base case,
+/// or a leading-slash, no-trailing-slash path like `"/foo"` for a
+/// prefixed dev server.
+///
+/// Returns the full `<script src="…">` tag the dev server can splice
+/// into a served HTML body.
+pub fn livereload_tag(base_prefix: &str) -> String {
+    if base_prefix.is_empty() {
+        LIVERELOAD_TAG.to_string()
+    } else {
+        format!("<script src=\"{base_prefix}/__zfb/livereload.js\"></script>")
+    }
+}
+
+/// Inject the live-reload script tag into the `<body>` element of
+/// `tree` (immediately before `</body>`) using `lol_html`'s CSS
+/// selector. The injected tag points at
+/// `<base_prefix>/__zfb/livereload.js`.
 ///
 /// Behaviour:
 ///
@@ -50,9 +91,13 @@ pub const LIVERELOAD_TAG: &str = "<script src=\"/__zfb/livereload.js\"></script>
 ///
 /// The function never errors; the worst case is a fragment getting an
 /// extra script tag at the end, which is harmless in dev mode.
-pub fn inject_livereload_into_tree(tree: &mut HtmlTree) {
+pub fn inject_livereload_into_tree_with_prefix(tree: &mut HtmlTree, base_prefix: &str) {
+    let tag = livereload_tag(base_prefix);
     let body_found = Rc::new(Cell::new(false));
     let body_found_c = Rc::clone(&body_found);
+    // Clone the tag once into the closure so the rewrite callback owns
+    // its copy without borrowing across `await` / lifetimes.
+    let tag_for_append = tag.clone();
 
     let selector: Selector = "body".parse().expect("static selector 'body' is valid");
 
@@ -61,7 +106,7 @@ pub fn inject_livereload_into_tree(tree: &mut HtmlTree) {
             Cow::Borrowed(&selector),
             ElementContentHandlers::default().element(move |el: &mut Element<'_, '_, _>| {
                 body_found_c.set(true);
-                el.append(LIVERELOAD_TAG, ContentType::Html);
+                el.append(&tag_for_append, ContentType::Html);
                 Ok(())
             }),
         )],
@@ -73,21 +118,38 @@ pub fn inject_livereload_into_tree(tree: &mut HtmlTree) {
 
     if !body_found.get() {
         // Fragment / headerless: append the tag.
-        tree.html_mut().push_str(LIVERELOAD_TAG);
+        tree.html_mut().push_str(&tag);
     }
 }
 
-/// Convenience wrapper: inject [`LIVERELOAD_TAG`] into a plain HTML
-/// string and return the modified string.
+/// Backwards-compatible wrapper that injects the no-base
+/// [`LIVERELOAD_TAG`]. New call sites should use
+/// [`inject_livereload_into_tree_with_prefix`] so the live-reload URL
+/// matches the dev server's mount prefix.
+pub fn inject_livereload_into_tree(tree: &mut HtmlTree) {
+    inject_livereload_into_tree_with_prefix(tree, "");
+}
+
+/// Convenience wrapper: inject the live-reload tag into a plain HTML
+/// string (with the given mount prefix folded into the script URL) and
+/// return the modified string.
 ///
 /// Internally wraps the string in an [`HtmlTree`], calls
-/// [`inject_livereload_into_tree`], and serialises. Use
-/// [`inject_livereload_into_tree`] directly when you already hold an
-/// `HtmlTree` to avoid the extra allocation.
-pub fn inject_livereload(html: &str) -> String {
+/// [`inject_livereload_into_tree_with_prefix`], and serialises. Use
+/// [`inject_livereload_into_tree_with_prefix`] directly when you
+/// already hold an `HtmlTree` to avoid the extra allocation.
+pub fn inject_livereload_with_prefix(html: &str, base_prefix: &str) -> String {
     let mut tree = HtmlTree::parse(html);
-    inject_livereload_into_tree(&mut tree);
+    inject_livereload_into_tree_with_prefix(&mut tree, base_prefix);
     tree.serialize()
+}
+
+/// Backwards-compatible wrapper that injects the no-base
+/// [`LIVERELOAD_TAG`] into a plain HTML string. New call sites should
+/// use [`inject_livereload_with_prefix`] when the dev server is
+/// mounted under a `base` prefix.
+pub fn inject_livereload(html: &str) -> String {
+    inject_livereload_with_prefix(html, "")
 }
 
 #[cfg(test)]
@@ -167,5 +229,54 @@ mod tests {
         let out = tree.serialize();
         assert!(out.contains(LIVERELOAD_TAG));
         assert!(out.contains("<p>test</p>"));
+    }
+
+    // ---- prefix-aware variants (issue #229) ------------------------------
+
+    #[test]
+    fn livereload_tag_empty_prefix_matches_const() {
+        assert_eq!(livereload_tag(""), LIVERELOAD_TAG);
+    }
+
+    #[test]
+    fn livereload_tag_with_prefix_includes_it() {
+        assert_eq!(
+            livereload_tag("/foo"),
+            "<script src=\"/foo/__zfb/livereload.js\"></script>"
+        );
+    }
+
+    #[test]
+    fn inject_with_prefix_uses_prefixed_url() {
+        let html = "<html><body><h1>hi</h1></body></html>";
+        let out = inject_livereload_with_prefix(html, "/foo");
+        assert!(
+            out.contains("<script src=\"/foo/__zfb/livereload.js\"></script>"),
+            "expected prefixed script tag, got: {out}"
+        );
+        // The unprefixed tag must NOT appear — that would 404 against
+        // the dev server when base is set.
+        assert!(
+            !out.contains("src=\"/__zfb/livereload.js\""),
+            "unexpected unprefixed script tag in: {out}"
+        );
+    }
+
+    #[test]
+    fn inject_with_prefix_falls_back_to_append_for_fragments() {
+        let html = "<div>fragment</div>";
+        let out = inject_livereload_with_prefix(html, "/foo");
+        assert_eq!(
+            out,
+            "<div>fragment</div><script src=\"/foo/__zfb/livereload.js\"></script>"
+        );
+    }
+
+    #[test]
+    fn inject_with_empty_prefix_matches_no_base_behaviour() {
+        let html = "<html><body><h1>hi</h1></body></html>";
+        let with_empty_prefix = inject_livereload_with_prefix(html, "");
+        let no_prefix = inject_livereload(html);
+        assert_eq!(with_empty_prefix, no_prefix);
     }
 }

--- a/crates/zfb-server/src/lib.rs
+++ b/crates/zfb-server/src/lib.rs
@@ -100,6 +100,20 @@ pub struct ServeOpts {
     /// router skips the plugin-dispatch leg entirely. The bin crate
     /// (`zfb dev`) builds this from the long-lived plugin host.
     pub plugins: Option<DevMiddlewareSet>,
+
+    /// User-supplied `base` config value from `zfb.config.ts` (issue
+    /// #229). Passed through verbatim — the dev server normalises it
+    /// internally via [`zfb_types::dev_mount_prefix`] into the
+    /// canonical `Some("/foo")` / `None` mount-prefix shape.
+    ///
+    /// When this resolves to a `Some(prefix)` the entire route table
+    /// (page cache, assets, public, livereload, plugin middleware)
+    /// mounts under `<prefix>/...`; bare `/` redirects to `<prefix>/`,
+    /// other unprefixed paths fall through to a 404 with a hint.
+    /// When this resolves to `None` (i.e. `base` is `None`, `""`,
+    /// `"/"`, or an absolute URL) the route table is identical to the
+    /// pre-`base` server byte-for-byte.
+    pub base: Option<String>,
 }
 
 impl ServeOpts {
@@ -159,11 +173,19 @@ pub async fn serve_with_listener<S>(
 where
     S: Future<Output = ()> + Send + 'static,
 {
+    // Issue #229: normalise `base` once at boot. The shared helper
+    // (`zfb_types::dev_mount_prefix`) collapses every accepted shape
+    // (None / "" / "/" / "/foo" / "/foo/" / "https://cdn…") into the
+    // single canonical form the routing layer wants, so the rest of
+    // the server only deals with `Option<String>` of the
+    // leading-slash, no-trailing-slash kind.
+    let base_prefix = zfb_types::dev_mount_prefix(opts.base.as_deref());
     let state = AppState {
         pages: opts.pages,
         broadcast: opts.broadcast,
         plugins: opts.plugins,
         dist_root: opts.dist_root.clone(),
+        base_prefix,
     };
     let router = build_router(state, opts.public_root.clone());
 

--- a/crates/zfb-server/src/routes.rs
+++ b/crates/zfb-server/src/routes.rs
@@ -35,10 +35,11 @@ use std::collections::HashMap;
 use std::path::{Component, PathBuf};
 use std::sync::Arc;
 
+use axum::body::Bytes;
 use axum::extract::{Path as AxumPath, State};
-use axum::http::{header, HeaderValue, StatusCode, Uri};
+use axum::http::{header, HeaderMap, HeaderValue, Method, StatusCode, Uri};
 use axum::response::{IntoResponse, Response};
-use axum::routing::get;
+use axum::routing::{any, get};
 use axum::Router;
 use tokio::sync::RwLock;
 use tower_http::services::ServeDir;
@@ -312,6 +313,23 @@ pub struct AppState {
 /// `public_root` is the project's static assets directory (used for
 /// `/public/*`). Both are served via [`ServeDir`]; missing files fall
 /// back to a plain 404.
+///
+/// ## Method policy (issue #230)
+///
+/// Built-in routes keep their existing GET-only semantics:
+///
+/// - `/__zfb/livereload.js`, `/__zfb/reload`, `/assets/*`, `/public/*`
+///   are all registered with `get(...)` or via [`ServeDir`] (which is
+///   GET/HEAD-only). A non-GET request to any of these surfaces gets a
+///   `405 Method Not Allowed` from axum / tower-http directly — those
+///   routes are dev-server infrastructure, not user code, and CSRF
+///   posture for them must stay tight.
+/// - The page-renderer mounts (`/` and `/{*path}`) accept ALL methods
+///   so user-registered `devMiddleware` handlers can serve `POST`,
+///   `PUT`, `DELETE`, `PATCH`, etc. on prefixes they claim. The handler
+///   itself in [`serve_page`] still returns `405 Allow: GET, HEAD` if a
+///   non-GET request slips through to the page-cache fallback (i.e. no
+///   plugin claimed the URL or a plugin returned `Passthrough`).
 pub fn build_router(state: AppState, public_root: std::path::PathBuf) -> Router {
     let assets_dir = state.dist_root.join("assets");
     let assets_service = ServeDir::new(&assets_dir);
@@ -322,8 +340,11 @@ pub fn build_router(state: AppState, public_root: std::path::PathBuf) -> Router 
         .route("/__zfb/reload", get(sse_handler))
         .nest_service("/assets", assets_service)
         .nest_service("/public", public_service)
-        .route("/", get(page_root))
-        .route("/{*path}", get(page_handler))
+        // `any` (vs `get`) so user-registered devMiddleware handlers can
+        // serve every HTTP method. `serve_page` enforces GET/HEAD-only
+        // for the page-cache fallback when no plugin claims the URL.
+        .route("/", any(page_root))
+        .route("/{*path}", any(page_handler))
         .layer(TraceLayer::new_for_http())
         .with_state(state)
 }
@@ -351,24 +372,52 @@ pub async fn sse_handler(State(state): State<AppState>) -> impl IntoResponse {
     sse_response(&state.broadcast)
 }
 
-/// Handler for `GET /` — serve the root page.
-pub async fn page_root(State(state): State<AppState>, uri: Uri) -> Response {
-    serve_page(&state, "/", &uri).await
+/// Handler for `/` — serve the root page or dispatch to a plugin
+/// dev-middleware that claims the root prefix. Accepts every HTTP
+/// method (see [`build_router`] for the method policy); GET/HEAD
+/// fall through to the page cache, other methods 405 unless a plugin
+/// handles them.
+pub async fn page_root(
+    State(state): State<AppState>,
+    method: Method,
+    headers: HeaderMap,
+    uri: Uri,
+    body: Bytes,
+) -> Response {
+    serve_page(&state, "/", &uri, method, headers, body).await
 }
 
-/// Handler for `GET /*path` — serve any other rendered page.
+/// Handler for `/*path` — serve any other rendered page or dispatch
+/// to a plugin dev-middleware. See [`page_root`] for the method
+/// policy.
 pub async fn page_handler(
     State(state): State<AppState>,
     AxumPath(path): AxumPath<String>,
+    method: Method,
+    headers: HeaderMap,
     uri: Uri,
+    body: Bytes,
 ) -> Response {
-    serve_page(&state, &path, &uri).await
+    serve_page(&state, &path, &uri, method, headers, body).await
 }
 
-async fn serve_page(state: &AppState, raw_path: &str, uri: &Uri) -> Response {
+async fn serve_page(
+    state: &AppState,
+    raw_path: &str,
+    uri: &Uri,
+    method: Method,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
     // Strip any leading slash from the captured wildcard so we can
     // build canonical lookup keys ourselves.
     let trimmed = raw_path.trim_start_matches('/');
+
+    // The page-cache fallback below only handles GET/HEAD. Track this
+    // so a non-GET request that does not match any plugin (or hits a
+    // plugin that returns Passthrough) is rejected with `405 Allow:
+    // GET, HEAD` instead of falling through to the cache logic.
+    let is_get_like = matches!(method, Method::GET | Method::HEAD);
 
     // Sub 3 / #108 — plugin dev-middleware takes priority over the
     // page cache so a plugin can override a URL that also has a
@@ -377,6 +426,12 @@ async fn serve_page(state: &AppState, raw_path: &str, uri: &Uri) -> Response {
     // to the cache lookup below. Forward the full request URI
     // (including query string) so the plugin can implement
     // `?since=<timestamp>` etc.
+    //
+    // Issue #230: every HTTP method (including POST/PUT/DELETE/PATCH)
+    // is forwarded; the plugin handler decides whether to accept or
+    // reject the method. Built-in routes (`/__zfb/...`, `/assets/*`,
+    // `/public/*`) are unaffected — those are routed by axum directly
+    // and stay GET-only.
     if let Some(set) = state.plugins.as_ref() {
         let path_only = format!("/{trimmed}");
         if let Some(reg) = set.find_match(&path_only) {
@@ -385,12 +440,30 @@ async fn serve_page(state: &AppState, raw_path: &str, uri: &Uri) -> Response {
                 Some(pq) => pq.as_str().to_string(),
                 None => path_only.clone(),
             };
-            match dispatch_plugin(set, reg, &full).await {
+            let plugin_headers = headermap_to_string_map(&headers);
+            let plugin_body = body_bytes_to_utf8_string(&body);
+            match dispatch_plugin(
+                set,
+                reg,
+                &full,
+                method.as_str(),
+                plugin_headers,
+                plugin_body,
+            )
+            .await
+            {
                 PluginDispatchAttempt::Responded(resp) => return resp,
                 PluginDispatchAttempt::Passthrough => {}
                 PluginDispatchAttempt::Errored(resp) => return resp,
             }
         }
+    }
+
+    // No plugin handled this request. The dev page-cache fallback is
+    // GET/HEAD-only — anything else 405s here so a misrouted POST does
+    // not silently get treated as a page lookup.
+    if !is_get_like {
+        return method_not_allowed_get_head();
     }
 
     let candidates = lookup_keys(trimmed);
@@ -503,21 +576,28 @@ enum PluginDispatchAttempt {
     Errored(Response),
 }
 
-/// Build a [`PluginRequest`] for the given URL and dispatch it. Body
-/// extraction is deliberately not done here: dev-middleware in v1 is
-/// scoped to GET-style endpoints (search index, llms.txt, doc-history
-/// proxy). Adding body forwarding is a future extension that requires
-/// drinking the body before the catch-all handler runs.
+/// Build a [`PluginRequest`] for the given URL/method/headers/body and
+/// dispatch it.
+///
+/// Issue #230: the request method, headers, and body are forwarded
+/// verbatim so plugin handlers can implement non-GET endpoints (form
+/// submissions, save actions, sidecar API proxies). Non-UTF-8 request
+/// bodies are dropped here — dev-middleware bodies are line-protocol
+/// JSON over stdio to the plugin host, and the wire shape only
+/// supports UTF-8 strings. Binary uploads are a separate extension.
 async fn dispatch_plugin(
     set: &DevMiddlewareSet,
     reg: &PluginRegistration,
     url_path: &str,
+    method: &str,
+    headers: HashMap<String, String>,
+    body: Option<String>,
 ) -> PluginDispatchAttempt {
     let req = PluginRequest {
-        method: "GET".into(),
+        method: method.to_string(),
         url: url_path.to_string(),
-        headers: HashMap::new(),
-        body: None,
+        headers,
+        body,
     };
     match set.dispatcher.dispatch(&reg.handler_id, req).await {
         Ok(PluginDispatchOutcome::Response(resp)) => {
@@ -572,6 +652,49 @@ async fn dispatch_plugin(
             err.plugin, err.message,
         ))),
     }
+}
+
+/// Build the `405 Method Not Allowed` response returned when a non-GET
+/// request reaches the page-cache fallback (i.e. no plugin claimed the
+/// URL or a plugin returned `Passthrough`). Mirrors what axum used to
+/// emit for `get(...)` routes before issue #230 broadened the page
+/// mounts to every HTTP method.
+fn method_not_allowed_get_head() -> Response {
+    Response::builder()
+        .status(StatusCode::METHOD_NOT_ALLOWED)
+        .header(header::ALLOW, HeaderValue::from_static("GET, HEAD"))
+        .header(header::CACHE_CONTROL, HeaderValue::from_static("no-store"))
+        .body(axum::body::Body::empty())
+        .expect("static 405 response builds")
+}
+
+/// Convert an axum [`HeaderMap`] into the flat string map shape the
+/// plugin host wire protocol expects. Header values that are not valid
+/// UTF-8 are dropped — the JS-side handler receives a string-keyed
+/// object and cannot represent arbitrary bytes. Multi-valued headers
+/// keep the last seen value (the protocol does not currently model
+/// repeated headers; see the dev-middleware contract in
+/// `crates/zfb/js/plugin-host.mjs`).
+fn headermap_to_string_map(headers: &HeaderMap) -> HashMap<String, String> {
+    let mut out = HashMap::with_capacity(headers.len());
+    for (name, value) in headers.iter() {
+        if let Ok(v) = value.to_str() {
+            out.insert(name.as_str().to_string(), v.to_string());
+        }
+    }
+    out
+}
+
+/// Convert an inbound request body (already drained into [`Bytes`]) to
+/// the `Option<String>` shape the plugin host wire protocol expects.
+/// Empty bodies become `None`; non-UTF-8 bodies are dropped (see the
+/// note in [`dispatch_plugin`] about binary uploads being a separate
+/// extension).
+fn body_bytes_to_utf8_string(body: &Bytes) -> Option<String> {
+    if body.is_empty() {
+        return None;
+    }
+    std::str::from_utf8(body).ok().map(|s| s.to_string())
 }
 
 fn plugin_error_response(message: &str) -> Response {
@@ -1048,5 +1171,320 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
         let body = body_string(resp).await;
         assert!(body.contains(LIVERELOAD_TAG));
+    }
+
+    // -------------------------------------------------------------------
+    // Issue #230 — devMiddleware accepts every HTTP method
+    // -------------------------------------------------------------------
+    //
+    // The legacy router only accepted GET/HEAD on the page-renderer
+    // mounts, which meant a plugin's `/api/echo` POST handler never
+    // ran — axum returned 405 before the plugin layer was reached. The
+    // tests below exercise the new policy:
+    //
+    // - User-registered devMiddleware paths receive every method, with
+    //   `req.method`, `req.headers`, and `req.body` propagated.
+    // - Built-in routes (`/__zfb/livereload.js`, `/__zfb/reload`) keep
+    //   their GET-only semantics so a stray POST cannot reach
+    //   dev-server infrastructure.
+    // - Non-GET requests that hit the page-cache fallback (no plugin
+    //   match, or plugin returned `Passthrough`) get a deterministic
+    //   `405 Allow: GET, HEAD` instead of a confused 404.
+
+    /// Recording dispatcher: stores the last [`PluginRequest`] it saw
+    /// and returns whatever the test asks for.
+    struct RecordingDispatcher {
+        last: tokio::sync::Mutex<Option<PluginRequest>>,
+        outcome: PluginDispatchOutcome,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::plugin_middleware::DevMiddlewareDispatcher for RecordingDispatcher {
+        async fn dispatch(
+            &self,
+            _id: &str,
+            request: PluginRequest,
+        ) -> Result<PluginDispatchOutcome, crate::plugin_middleware::PluginDispatchError>
+        {
+            *self.last.lock().await = Some(request);
+            Ok(self.outcome.clone())
+        }
+    }
+
+    fn echo_response() -> PluginDispatchOutcome {
+        let mut headers = HashMap::new();
+        headers.insert("content-type".to_string(), "application/json".to_string());
+        PluginDispatchOutcome::Response(crate::plugin_middleware::PluginResponse {
+            status: 200,
+            headers,
+            body: "{\"ok\":true}".to_string(),
+            body_encoding: PluginResponseEncoding::Utf8,
+        })
+    }
+
+    fn state_with_dispatcher(
+        dispatcher: Arc<RecordingDispatcher>,
+        path: &str,
+    ) -> AppState {
+        let (tx, _rx) = broadcast::channel::<ReloadEvent>(16);
+        let set = DevMiddlewareSet {
+            registrations: Arc::new(vec![PluginRegistration {
+                path: path.to_string(),
+                handler_id: "h1".to_string(),
+                plugin: "test".to_string(),
+            }]),
+            dispatcher: dispatcher.clone()
+                as Arc<dyn crate::plugin_middleware::DevMiddlewareDispatcher>,
+        };
+        AppState {
+            pages: PageCache::new(),
+            broadcast: tx,
+            plugins: Some(set),
+            dist_root: std::env::temp_dir().join("zfb-test-dist"),
+        }
+    }
+
+    #[tokio::test]
+    async fn plugin_handler_receives_post_request() {
+        let dispatcher = Arc::new(RecordingDispatcher {
+            last: tokio::sync::Mutex::new(None),
+            outcome: echo_response(),
+        });
+        let state = state_with_dispatcher(dispatcher.clone(), "/api/echo");
+        let router = test_router(state);
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/echo")
+                    .header("content-type", "application/json")
+                    .body(Body::from("{\"x\":1}"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let captured = dispatcher
+            .last
+            .lock()
+            .await
+            .clone()
+            .expect("plugin should have been dispatched");
+        assert_eq!(captured.method, "POST");
+        assert_eq!(captured.url, "/api/echo");
+        assert_eq!(captured.body.as_deref(), Some("{\"x\":1}"));
+        assert_eq!(
+            captured.headers.get("content-type").map(String::as_str),
+            Some("application/json"),
+        );
+    }
+
+    #[tokio::test]
+    async fn plugin_handler_receives_put_and_delete() {
+        for method in ["PUT", "DELETE", "PATCH"] {
+            let dispatcher = Arc::new(RecordingDispatcher {
+                last: tokio::sync::Mutex::new(None),
+                outcome: echo_response(),
+            });
+            let state = state_with_dispatcher(dispatcher.clone(), "/api/echo");
+            let router = test_router(state);
+
+            let resp = router
+                .oneshot(
+                    Request::builder()
+                        .method(method)
+                        .uri("/api/echo")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                resp.status(),
+                StatusCode::OK,
+                "method {method} should reach plugin handler"
+            );
+            let captured = dispatcher.last.lock().await.clone().unwrap();
+            assert_eq!(captured.method, method);
+        }
+    }
+
+    #[tokio::test]
+    async fn plugin_handler_still_works_for_get() {
+        // Regression: switching to `any(...)` must not break the
+        // pre-existing GET path.
+        let dispatcher = Arc::new(RecordingDispatcher {
+            last: tokio::sync::Mutex::new(None),
+            outcome: echo_response(),
+        });
+        let state = state_with_dispatcher(dispatcher.clone(), "/api/echo");
+        let router = test_router(state);
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/api/echo")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let captured = dispatcher.last.lock().await.clone().unwrap();
+        assert_eq!(captured.method, "GET");
+    }
+
+    #[tokio::test]
+    async fn post_to_built_in_livereload_js_still_returns_405() {
+        // Built-in route is registered with `get(...)`; axum returns
+        // 405 with `Allow: GET, HEAD` for any other method. This is
+        // the exact CSRF-relevant guarantee the issue calls out:
+        // do NOT loosen built-in routes when broadening user-registered
+        // devMiddleware prefixes.
+        let state = test_state();
+        let router = test_router(state);
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/__zfb/livereload.js")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+        let allow = resp
+            .headers()
+            .get(header::ALLOW)
+            .and_then(|h| h.to_str().ok())
+            .unwrap_or_default();
+        assert!(
+            allow.to_ascii_uppercase().contains("GET"),
+            "Allow header missing GET: {allow:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn post_to_built_in_livereload_sse_still_returns_405() {
+        // Same as above, for the SSE endpoint.
+        let state = test_state();
+        let router = test_router(state);
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/__zfb/reload")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+
+    #[tokio::test]
+    async fn post_to_unregistered_path_returns_405() {
+        // A POST that does not match any plugin registration must NOT
+        // be silently treated as a page lookup. Returning a clear 405
+        // makes the dev-server method policy obvious to plugin authors
+        // who forgot to register the path they're posting to.
+        let state = test_state();
+        let router = test_router(state);
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/some/random/path")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+        let allow = resp
+            .headers()
+            .get(header::ALLOW)
+            .and_then(|h| h.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        assert!(allow.contains("GET"), "Allow header missing GET: {allow}");
+        assert!(allow.contains("HEAD"), "Allow header missing HEAD: {allow}");
+    }
+
+    #[tokio::test]
+    async fn plugin_passthrough_on_post_returns_405() {
+        // When a plugin is registered on a path but returns
+        // Passthrough, the page-cache fallback should NOT be used for
+        // non-GET methods (the cache is GET-only). 405 keeps the
+        // method policy consistent.
+        let dispatcher = Arc::new(RecordingDispatcher {
+            last: tokio::sync::Mutex::new(None),
+            outcome: PluginDispatchOutcome::Passthrough,
+        });
+        let state = state_with_dispatcher(dispatcher.clone(), "/api/echo");
+        let router = test_router(state);
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/echo")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+        // Plugin WAS invoked and chose to pass.
+        assert!(dispatcher.last.lock().await.is_some());
+    }
+
+    #[tokio::test]
+    async fn plugin_passthrough_on_get_falls_back_to_page_cache() {
+        // Regression: Passthrough on GET must still let the page cache
+        // serve the URL.
+        let dispatcher = Arc::new(RecordingDispatcher {
+            last: tokio::sync::Mutex::new(None),
+            outcome: PluginDispatchOutcome::Passthrough,
+        });
+        let state = state_with_dispatcher(dispatcher.clone(), "/maybe");
+        state
+            .pages
+            .insert("/maybe", "<html><body>cached</body></html>")
+            .await;
+        let router = test_router(state);
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/maybe")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        assert!(body.contains("cached"), "body: {body}");
+    }
+
+    #[tokio::test]
+    async fn body_bytes_to_utf8_string_drops_empty_and_non_utf8() {
+        // Empty body collapses to None.
+        assert!(body_bytes_to_utf8_string(&Bytes::new()).is_none());
+        // UTF-8 round-trips.
+        assert_eq!(
+            body_bytes_to_utf8_string(&Bytes::from("hello")),
+            Some("hello".to_string())
+        );
+        // Non-UTF-8 is dropped (binary upload is a future extension).
+        let bad = Bytes::from(vec![0xff, 0xfe, 0xfd]);
+        assert!(body_bytes_to_utf8_string(&bad).is_none());
     }
 }

--- a/crates/zfb-server/src/routes.rs
+++ b/crates/zfb-server/src/routes.rs
@@ -28,8 +28,35 @@
 //! ([`DEV_404_BODY`]).
 //!
 //! All HTML responses (including 404) go through
-//! [`crate::inject::inject_livereload`] before being returned, so every
-//! served page wires itself up to the live-reload SSE stream.
+//! [`crate::inject::inject_livereload_with_prefix`] before being
+//! returned, so every served page wires itself up to the live-reload
+//! SSE stream — with the right URL when the dev server runs under a
+//! `base` prefix.
+//!
+//! ## `base` prefix mounting (issue #229)
+//!
+//! When the project's `zfb.config.ts` declares `base: "/foo/"`, the
+//! whole route table moves under `/foo`:
+//!
+//! - `GET /foo/` and `GET /foo/<route>` serve the rendered page,
+//! - `GET /foo/assets/<file>`, `GET /foo/public/<file>` serve static
+//!   assets,
+//! - `GET /foo/__zfb/livereload.js` and `GET /foo/__zfb/reload` serve
+//!   live-reload (and the injected `<script src>` matches),
+//! - plugin-registered dev-middleware paths are auto-prefixed too
+//!   (a plugin that calls `ctx.register("/api/echo")` is reached at
+//!   `GET /foo/api/echo`; the plugin handler still receives
+//!   `/api/echo` without the `base` prefix in `req.url`).
+//!
+//! Bare `GET /` redirects to `GET /<base>/` so a developer who
+//! navigated to the root sees the home page rather than a confusing
+//! 404. Other unprefixed paths fall through to a 404 body that hints
+//! at the configured base. The redirect is only emitted when the
+//! requested path is exactly `/` to avoid the `/foo/` → `/foo/` loop
+//! the issue's review explicitly called out.
+//!
+//! When `base` is `None` or `"/"` the route table is identical to the
+//! pre-`base` build byte-for-byte.
 
 use std::collections::HashMap;
 use std::path::{Component, PathBuf};
@@ -37,14 +64,14 @@ use std::sync::Arc;
 
 use axum::extract::{Path as AxumPath, State};
 use axum::http::{header, HeaderValue, StatusCode, Uri};
-use axum::response::{IntoResponse, Response};
+use axum::response::{IntoResponse, Redirect, Response};
 use axum::routing::get;
 use axum::Router;
 use tokio::sync::RwLock;
 use tower_http::services::ServeDir;
 use tower_http::trace::TraceLayer;
 
-use crate::inject::inject_livereload;
+use crate::inject::inject_livereload_with_prefix;
 use crate::livereload::{sse_response, ReloadTx};
 use crate::plugin_middleware::{
     DevMiddlewareSet, PluginDispatchOutcome, PluginRegistration, PluginRequest,
@@ -304,6 +331,13 @@ pub struct AppState {
     /// not yet in the in-memory cache. `serve_page` reads
     /// `<dist_root>/<path>/index.html` when the cache misses.
     pub dist_root: std::path::PathBuf,
+    /// Canonical mount prefix from `zfb.config.ts`'s `base` field, as
+    /// returned by [`zfb_types::dev_mount_prefix`]. `None` means the
+    /// dev server mounts everything at root (the no-base case);
+    /// `Some("/foo")` (leading slash, no trailing slash) means the
+    /// page handlers serve content under `/foo/...` and the injected
+    /// live-reload script URL points at `/foo/__zfb/livereload.js`.
+    pub base_prefix: Option<String>,
 }
 
 /// Build the axum router for the dev server.
@@ -312,20 +346,118 @@ pub struct AppState {
 /// `public_root` is the project's static assets directory (used for
 /// `/public/*`). Both are served via [`ServeDir`]; missing files fall
 /// back to a plain 404.
+///
+/// When `state.base_prefix` is `Some(prefix)`, every route is
+/// registered at `<prefix>/<route>` directly (livereload, SSE,
+/// `/assets/*`, `/public/*`, page cache, plugin middleware). A bare
+/// `GET /` request is redirected to `<prefix>/`, and any other
+/// unprefixed path falls through to a 404 with a one-line hint at the
+/// configured base. See the module docs for the complete contract.
+///
+/// Routes are registered with explicit prefix substitution rather than
+/// [`Router::nest`] because the latter has subtle 0.8.x trailing-slash
+/// quirks when the inner router contains both a literal `/` route and
+/// a `/{*path}` catch-all (the very shape we use). Manual prefix
+/// registration is verbose but uniquely well-defined.
 pub fn build_router(state: AppState, public_root: std::path::PathBuf) -> Router {
+    let prefix = state.base_prefix.clone();
+
+    let Some(prefix) = prefix else {
+        // No base prefix configured — keep the byte-for-byte
+        // pre-`base` route table at the root.
+        return build_core_router(state, public_root, "")
+            .layer(TraceLayer::new_for_http());
+    };
+
+    // Prefix is canonical: leading slash, no trailing slash (e.g.
+    // "/foo"). Build the core route table with the prefix folded into
+    // every path, then add the bare `/` redirect and the
+    // outside-base 404 fallback.
+    let redirect_target = format!("{prefix}/");
+    let prefix_for_404 = prefix.clone();
+
+    build_core_router(state, public_root, &prefix)
+        // Bare `/` lands the developer on the home page — but only `/`
+        // exactly, never `<prefix>/...`, because the prefixed routes
+        // above already catch those and a redirect there would loop.
+        .route(
+            "/",
+            get(move || {
+                let target = redirect_target.clone();
+                async move { Redirect::to(&target).into_response() }
+            }),
+        )
+        // Any other unprefixed path (e.g. an HTML link that forgot the
+        // base, or a stale browser cache) gets a 404 with a one-line
+        // hint at the configured base. The body is HTML so the
+        // live-reload script can pick it up — the 404 disappears once
+        // the developer follows the hint.
+        .fallback(get(move |uri: Uri| {
+            let prefix = prefix_for_404.clone();
+            async move { unprefixed_404_response(&prefix, uri.path()) }
+        }))
+        .layer(TraceLayer::new_for_http())
+}
+
+/// Assemble the core route table — every route prefixed with `prefix`
+/// (use `""` for the no-base case so paths stay at the root).
+///
+/// Plugin dispatch + cache lookup expect UNPREFIXED paths (issue #229
+/// contract: a plugin that calls `ctx.register("/api/echo")` is reached
+/// at `<prefix>/api/echo` but the handler still sees `req.url =
+/// /api/echo`). The page handlers below strip the prefix from the
+/// captured wildcard / URI before forwarding into [`serve_page`].
+fn build_core_router(
+    state: AppState,
+    public_root: std::path::PathBuf,
+    prefix: &str,
+) -> Router {
     let assets_dir = state.dist_root.join("assets");
     let assets_service = ServeDir::new(&assets_dir);
     let public_service = ServeDir::new(&public_root);
 
+    let livereload_path = format!("{prefix}/__zfb/livereload.js");
+    let sse_path = format!("{prefix}/__zfb/reload");
+    let assets_mount = format!("{prefix}/assets");
+    let public_mount = format!("{prefix}/public");
+    let root_path = format!("{prefix}/");
+    let wild_path = format!("{prefix}/{{*path}}");
+
     Router::new()
-        .route("/__zfb/livereload.js", get(livereload_js))
-        .route("/__zfb/reload", get(sse_handler))
-        .nest_service("/assets", assets_service)
-        .nest_service("/public", public_service)
-        .route("/", get(page_root))
-        .route("/{*path}", get(page_handler))
-        .layer(TraceLayer::new_for_http())
+        .route(&livereload_path, get(livereload_js))
+        .route(&sse_path, get(sse_handler))
+        .nest_service(&assets_mount, assets_service)
+        .nest_service(&public_mount, public_service)
+        .route(&root_path, get(page_root))
+        .route(&wild_path, get(page_handler))
         .with_state(state)
+}
+
+/// Build the dev 404 served when a request lands outside the configured
+/// `base` prefix. Mirrors [`DEV_404_BODY`] but appends a one-line hint
+/// pointing at the prefix so the developer notices the typo / forgotten
+/// base instead of staring at a blank "page not in cache" body.
+///
+/// The hint is HTML-escaped — `prefix` and `path` come from request
+/// data and could otherwise smuggle markup into the response.
+fn unprefixed_404_response(prefix: &str, path: &str) -> Response {
+    let body = format!(
+        "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>zfb dev — 404 (base mismatch)</title></head><body><h1>404 — outside configured base</h1><p>This dev server is mounted under <code>{}</code> (from <code>base</code> in <code>zfb.config.ts</code>). The path <code>{}</code> is not under that prefix. Try <a href=\"{}/\">{}/</a> instead.</p></body></html>",
+        html_escape(prefix),
+        html_escape(path),
+        html_escape(prefix),
+        html_escape(prefix),
+    );
+    page_response_bytes(
+        StatusCode::NOT_FOUND,
+        body.into_bytes(),
+        "text/html; charset=utf-8",
+        // Inject the live-reload script with the prefix so the
+        // 404 page silently upgrades when the developer fixes the URL
+        // and the matching page becomes reachable.
+        true,
+        prefix,
+    )
 }
 
 /// Handler for `GET /__zfb/livereload.js`. Returns the bundled JS with
@@ -369,6 +501,12 @@ async fn serve_page(state: &AppState, raw_path: &str, uri: &Uri) -> Response {
     // Strip any leading slash from the captured wildcard so we can
     // build canonical lookup keys ourselves.
     let trimmed = raw_path.trim_start_matches('/');
+    // Mount-prefix-aware livereload injection (issue #229). The
+    // `<script src>` we splice into HTML responses must point at the
+    // prefixed URL the dev server actually serves the JS at, otherwise
+    // the browser would request `/__zfb/livereload.js` (unprefixed) and
+    // hit the dev 404. Empty when no `base` is configured.
+    let lr_prefix = state.base_prefix.as_deref().unwrap_or("");
 
     // Sub 3 / #108 — plugin dev-middleware takes priority over the
     // page cache so a plugin can override a URL that also has a
@@ -377,14 +515,23 @@ async fn serve_page(state: &AppState, raw_path: &str, uri: &Uri) -> Response {
     // to the cache lookup below. Forward the full request URI
     // (including query string) so the plugin can implement
     // `?since=<timestamp>` etc.
+    //
+    // Issue #229 contract: plugins register UNPREFIXED paths
+    // (`ctx.register("/api/echo")`); the dev server registers the
+    // route at `<base_prefix>/api/echo` but strips the prefix before
+    // invoking the handler. The `trimmed` wildcard already drops the
+    // prefix because the route pattern itself includes it (the wild
+    // `{*path}` only captures what comes after); for `uri.path_and_query()`
+    // we strip the prefix manually so the plugin sees the unprefixed
+    // URL it registered.
     if let Some(set) = state.plugins.as_ref() {
         let path_only = format!("/{trimmed}");
         if let Some(reg) = set.find_match(&path_only) {
-            // Path + optional query.
-            let full = match uri.path_and_query() {
-                Some(pq) => pq.as_str().to_string(),
-                None => path_only.clone(),
-            };
+            // Path + optional query, with the dev server's mount
+            // prefix stripped so the plugin handler sees the URL
+            // shape it registered.
+            let full = strip_prefix_from_full_uri(uri, state.base_prefix.as_deref())
+                .unwrap_or_else(|| path_only.clone());
             match dispatch_plugin(set, reg, &full).await {
                 PluginDispatchAttempt::Responded(resp) => return resp,
                 PluginDispatchAttempt::Passthrough => {}
@@ -403,7 +550,13 @@ async fn serve_page(state: &AppState, raw_path: &str, uri: &Uri) -> Response {
             //   actually emitted (e.g. `/sitemap.xml`).
             let content_type = resolve_content_type(&entry, key);
             let is_html = content_type.to_ascii_lowercase().starts_with("text/html");
-            return page_response_bytes(StatusCode::OK, entry.body, &content_type, is_html);
+            return page_response_bytes(
+                StatusCode::OK,
+                entry.body,
+                &content_type,
+                is_html,
+                lr_prefix,
+            );
         }
     }
 
@@ -426,7 +579,7 @@ async fn serve_page(state: &AppState, raw_path: &str, uri: &Uri) -> Response {
             content_type_for_extension(ext)
         };
         let is_html = content_type.to_ascii_lowercase().starts_with("text/html");
-        return page_response_bytes(StatusCode::OK, bytes, &content_type, is_html);
+        return page_response_bytes(StatusCode::OK, bytes, &content_type, is_html, lr_prefix);
     }
 
     // 404 is always the dev HTML body so the page is replaced once
@@ -436,7 +589,47 @@ async fn serve_page(state: &AppState, raw_path: &str, uri: &Uri) -> Response {
         DEV_404_BODY.as_bytes().to_vec(),
         "text/html; charset=utf-8",
         true,
+        lr_prefix,
     )
+}
+
+/// Strip the dev server's mount prefix from `uri`'s path-and-query
+/// shape so plugin handlers see the unprefixed URL they registered.
+///
+/// Returns `None` when the URI has no path-and-query component (which
+/// would be very unusual — axum always populates this on incoming
+/// requests). When `prefix` is `None` (no base configured) the path
+/// is returned unchanged.
+///
+/// Path components must be a strict prefix (`/foo` followed by `/` or
+/// end-of-string) — `/foobar` is NOT considered prefixed by `/foo` and
+/// is returned unchanged. This mirrors the boundary semantics in the
+/// build-time link rewriter (zfb#228).
+fn strip_prefix_from_full_uri(uri: &Uri, prefix: Option<&str>) -> Option<String> {
+    let pq = uri.path_and_query()?;
+    let raw = pq.as_str();
+    let prefix = match prefix {
+        Some(p) if !p.is_empty() => p,
+        _ => return Some(raw.to_string()),
+    };
+    if !raw.starts_with(prefix) {
+        return Some(raw.to_string());
+    }
+    let rest = &raw[prefix.len()..];
+    if rest.is_empty() {
+        return Some("/".to_string());
+    }
+    let first_byte = rest.as_bytes()[0];
+    if first_byte == b'/' || first_byte == b'?' || first_byte == b'#' {
+        // Strict-prefix boundary: `/foo` followed by another path
+        // segment, a query, or a fragment is genuinely under the
+        // prefix. `/foobar` (no boundary char) is NOT.
+        if first_byte == b'?' || first_byte == b'#' {
+            return Some(format!("/{rest}"));
+        }
+        return Some(rest.to_string());
+    }
+    Some(raw.to_string())
 }
 
 /// Try to read a page from the dist directory on disk.
@@ -638,17 +831,24 @@ fn lookup_keys(path: &str) -> Vec<String> {
 /// Non-UTF-8 bytes in an HTML body are served as-is without injection
 /// rather than panicking — a graceful degradation for the unlikely
 /// case of a malformed page reaching the dev cache.
+///
+/// `base_prefix` is the dev server's mount prefix (issue #229) — empty
+/// for the no-base case, or `"/foo"` when `base: "/foo/"` is set —
+/// folded into the `<script src>` URL so the browser fetches the
+/// live-reload JS at the prefixed path the dev server actually serves
+/// it at.
 fn page_response_bytes(
     status: StatusCode,
     body: Vec<u8>,
     content_type: &str,
     inject_reload: bool,
+    base_prefix: &str,
 ) -> Response {
     let body_out: Vec<u8> = if inject_reload {
         // HTML should always be valid UTF-8; fall back to raw bytes on
         // the rare occasion it isn't so we don't panic in dev mode.
         match std::str::from_utf8(&body) {
-            Ok(html) => inject_livereload(html).into_bytes(),
+            Ok(html) => inject_livereload_with_prefix(html, base_prefix).into_bytes(),
             Err(_) => body,
         }
     } else {
@@ -684,6 +884,18 @@ mod tests {
             broadcast: tx,
             plugins: None,
             dist_root: std::env::temp_dir().join("zfb-test-dist"),
+            base_prefix: None,
+        }
+    }
+
+    fn test_state_with_base(prefix: &str) -> AppState {
+        let (tx, _rx) = broadcast::channel::<ReloadEvent>(16);
+        AppState {
+            pages: PageCache::new(),
+            broadcast: tx,
+            plugins: None,
+            dist_root: std::env::temp_dir().join("zfb-test-dist"),
+            base_prefix: Some(prefix.to_string()),
         }
     }
 
@@ -1048,5 +1260,227 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::OK);
         let body = body_string(resp).await;
         assert!(body.contains(LIVERELOAD_TAG));
+    }
+
+    // ---- base prefix mounting (issue #229) -------------------------------
+    //
+    // The router-level fixture is identical to `test_router` except it
+    // builds the AppState with `base_prefix: Some("/foo")`. With the
+    // prefix set, every dev-server route (pages, livereload script,
+    // SSE endpoint) must mount under `/foo/...`; bare unprefixed
+    // requests must be redirected (for `/`) or return the
+    // base-aware 404 hint.
+
+    fn test_router_with_base(state: AppState) -> Router {
+        let tmp = std::env::temp_dir();
+        build_router(state, tmp.join("zfb-test-public"))
+    }
+
+    #[tokio::test]
+    async fn base_prefix_serves_root_page_under_prefix() {
+        let state = test_state_with_base("/foo");
+        state
+            .pages
+            .insert("/", "<html><body><h1>home</h1></body></html>")
+            .await;
+        let router = test_router_with_base(state);
+
+        let resp = router
+            .oneshot(Request::builder().uri("/foo/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        assert!(body.contains("<h1>home</h1>"), "body: {body}");
+        // The injected livereload script must point at the prefixed URL
+        // (otherwise the browser hits /__zfb/livereload.js and 404s).
+        assert!(
+            body.contains("<script src=\"/foo/__zfb/livereload.js\"></script>"),
+            "expected prefixed livereload tag, body: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn base_prefix_serves_nested_page_under_prefix() {
+        let state = test_state_with_base("/foo");
+        state
+            .pages
+            .insert("/about", "<html><body>about</body></html>")
+            .await;
+        let router = test_router_with_base(state);
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/foo/about")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        assert!(body.contains("about"), "body: {body}");
+        assert!(
+            body.contains("<script src=\"/foo/__zfb/livereload.js\"></script>"),
+            "expected prefixed livereload tag, body: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn base_prefix_redirects_bare_root_to_prefix() {
+        let state = test_state_with_base("/foo");
+        // No page inserted — the redirect happens before any page
+        // lookup and doesn't depend on the cache.
+        let router = test_router_with_base(state);
+
+        let resp = router
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+        let location = resp
+            .headers()
+            .get(header::LOCATION)
+            .and_then(|h| h.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        assert_eq!(location, "/foo/", "expected redirect to /foo/, got {location}");
+    }
+
+    #[tokio::test]
+    async fn base_prefix_does_not_redirect_prefix_root_to_itself() {
+        // The redirect-loop avoidance the issue's review explicitly
+        // calls out: GET /foo/ must serve the home page directly, not
+        // 302 back to itself.
+        let state = test_state_with_base("/foo");
+        state
+            .pages
+            .insert("/", "<html><body><h1>home</h1></body></html>")
+            .await;
+        let router = test_router_with_base(state);
+
+        let resp = router
+            .oneshot(Request::builder().uri("/foo/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "GET /foo/ must serve, not redirect"
+        );
+    }
+
+    #[tokio::test]
+    async fn base_prefix_serves_livereload_js_under_prefix() {
+        let state = test_state_with_base("/foo");
+        let router = test_router_with_base(state);
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/foo/__zfb/livereload.js")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let ct = resp
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .and_then(|h| h.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        assert!(
+            ct.starts_with("application/javascript"),
+            "unexpected content-type: {ct}"
+        );
+        let body = body_string(resp).await;
+        assert!(body.contains("EventSource"), "body missing EventSource");
+    }
+
+    #[tokio::test]
+    async fn base_prefix_returns_hinted_404_for_unprefixed_path() {
+        let state = test_state_with_base("/foo");
+        let router = test_router_with_base(state);
+
+        // Asset request without the base prefix — the typical
+        // "stale HTML referenced /assets/main.css instead of
+        // /foo/assets/main.css" case. The dev server returns a 404
+        // pointing at the configured base.
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/assets/main.css")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body = body_string(resp).await;
+        assert!(
+            body.contains("/foo"),
+            "expected 404 body to mention the configured base, body: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn base_prefix_unknown_prefixed_path_uses_dev_404() {
+        // A request UNDER the base prefix that doesn't match the page
+        // cache should still get the regular dev-mode 404 body (which
+        // is the page-cache miss path) — not the "outside base" hint.
+        let state = test_state_with_base("/foo");
+        let router = test_router_with_base(state);
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/foo/missing")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body = body_string(resp).await;
+        assert!(
+            body.contains("page not in cache"),
+            "expected dev-mode 404 body, got: {body}"
+        );
+        // Even the 404 page should carry the prefixed livereload tag
+        // so the page upgrades automatically once the route lands.
+        assert!(
+            body.contains("<script src=\"/foo/__zfb/livereload.js\"></script>"),
+            "expected prefixed livereload tag in 404, got: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_base_prefix_keeps_root_serving_directly() {
+        // Regression guard: with `base_prefix: None` the router must
+        // not introduce any redirect for `/` — that would break every
+        // existing dev session.
+        let state = test_state(); // base_prefix = None
+        state
+            .pages
+            .insert("/", "<html><body>home</body></html>")
+            .await;
+        let router = test_router(state);
+
+        let resp = router
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "GET / must serve directly when no base is set"
+        );
     }
 }

--- a/crates/zfb-server/src/routes.rs
+++ b/crates/zfb-server/src/routes.rs
@@ -58,6 +58,7 @@
 //! When `base` is `None` or `"/"` the route table is identical to the
 //! pre-`base` build byte-for-byte.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::path::{Component, PathBuf};
 use std::sync::Arc;
@@ -974,7 +975,29 @@ fn page_response_bytes(
         // HTML should always be valid UTF-8; fall back to raw bytes on
         // the rare occasion it isn't so we don't panic in dev mode.
         match std::str::from_utf8(&body) {
-            Ok(html) => inject_livereload_with_prefix(html, base_prefix).into_bytes(),
+            Ok(html) => {
+                // Issue #228 + #229: when the dev server is mounted under a
+                // `base` prefix, user-authored root-absolute `<a href>` /
+                // `<form action>` in the cached HTML must be rewritten so
+                // navigation under the prefix doesn't 404. Production
+                // builds run the same pass on disk; the dev server runs it
+                // in-flight per response. Empty prefix is a no-op (the
+                // shared `compute_prefixed` short-circuits via idempotency)
+                // so this only changes behaviour when a base IS set.
+                let rewritten = if base_prefix.is_empty() {
+                    Cow::Borrowed(html)
+                } else {
+                    match zfb_build::link_base_rewrite::rewrite_links_in_html(html, base_prefix) {
+                        Ok(s) => Cow::Owned(s),
+                        // Graceful degradation in dev mode: lol_html should
+                        // not fail on the renderer's well-formed HTML, but
+                        // if something pathological reaches us, serve the
+                        // original bytes rather than 500ing the page.
+                        Err(_) => Cow::Borrowed(html),
+                    }
+                };
+                inject_livereload_with_prefix(&rewritten, base_prefix).into_bytes()
+            }
             Err(_) => body,
         }
     } else {
@@ -1923,6 +1946,127 @@ mod tests {
             resp.status(),
             StatusCode::OK,
             "GET / must serve directly when no base is set"
+        );
+    }
+
+    // ---- dev-mode link rewrite (zfb#228 + zfb#229 follow-up) -----------
+    //
+    // Codex review of the merge caught that the dev server was serving
+    // cached HTML verbatim, so user-authored `<a href="/about">` and
+    // `<form action="/login">` literals weren't rewritten under a
+    // `base` mount. Production builds rewrite on disk; the dev server
+    // now mirrors that in-flight via `page_response_bytes`. These
+    // tests pin both directions.
+
+    #[tokio::test]
+    async fn dev_rewrites_user_authored_a_href_under_base() {
+        let state = test_state_with_base("/foo");
+        state
+            .pages
+            .insert(
+                "/",
+                "<html><body><a href=\"/about\">About</a></body></html>",
+            )
+            .await;
+        let router = test_router_with_base(state);
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/foo/")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        assert!(
+            body.contains(r#"href="/foo/about""#),
+            "user a-href should be rewritten under base; got: {body}"
+        );
+        // Bare unprefixed href must NOT survive — the whole point of
+        // the fix is that clicking the rendered link lands inside the
+        // configured base, not at the unprefixed root.
+        assert!(
+            !body.contains(r#"href="/about""#),
+            "unprefixed href leaked into served HTML: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn dev_rewrites_user_authored_form_action_under_base() {
+        let state = test_state_with_base("/foo");
+        state
+            .pages
+            .insert(
+                "/",
+                "<html><body><form action=\"/login\"><input/></form></body></html>",
+            )
+            .await;
+        let router = test_router_with_base(state);
+
+        let resp = router
+            .oneshot(Request::builder().uri("/foo/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        assert!(
+            body.contains(r#"action="/foo/login""#),
+            "form action should be rewritten under base; got: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn dev_no_base_keeps_user_links_unchanged() {
+        // Regression guard: existing projects without `base` set must
+        // see byte-identical user links in the served HTML.
+        let state = test_state();
+        state
+            .pages
+            .insert(
+                "/",
+                "<html><body><a href=\"/about\">About</a></body></html>",
+            )
+            .await;
+        let router = test_router(state);
+
+        let resp = router
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let body = body_string(resp).await;
+        assert!(
+            body.contains(r#"href="/about""#),
+            "no-base mode should not rewrite user href: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn dev_rewrite_skips_data_no_base_opt_out() {
+        let state = test_state_with_base("/foo");
+        state
+            .pages
+            .insert(
+                "/",
+                "<html><body><a href=\"/legal\" data-no-base>legal</a></body></html>",
+            )
+            .await;
+        let router = test_router_with_base(state);
+
+        let resp = router
+            .oneshot(Request::builder().uri("/foo/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let body = body_string(resp).await;
+        assert!(
+            body.contains(r#"href="/legal""#),
+            "data-no-base opt-out should preserve original href: {body}"
+        );
+        assert!(
+            !body.contains("/foo/legal"),
+            "opt-out href should not be prefixed: {body}"
         );
     }
 }

--- a/crates/zfb-server/tests/integration.rs
+++ b/crates/zfb-server/tests/integration.rs
@@ -68,6 +68,7 @@ impl Harness {
             pages: pages.clone(),
             broadcast: tx.clone(),
             plugins: None,
+            base: None,
         };
 
         let server = tokio::spawn(async move {

--- a/crates/zfb-server/tests/plugin_middleware_integration.rs
+++ b/crates/zfb-server/tests/plugin_middleware_integration.rs
@@ -88,6 +88,7 @@ async fn boot_with_dispatcher(
         pages: pages.clone(),
         broadcast: tx,
         plugins: Some(plugin_set),
+        base: None,
     };
     let server = tokio::spawn(async move {
         serve_with_listener(opts, listener, std::future::pending::<()>()).await

--- a/crates/zfb-server/tests/plugin_middleware_integration.rs
+++ b/crates/zfb-server/tests/plugin_middleware_integration.rs
@@ -30,6 +30,20 @@ struct CountingDispatcher {
     invocations: AtomicU32,
     passthrough_handler_id: String,
     response_handler_id: String,
+    /// Records the last [`PluginRequest`] the dispatcher saw so
+    /// method/header/body-propagation tests can assert on it.
+    last_request: tokio::sync::Mutex<Option<PluginRequest>>,
+}
+
+impl CountingDispatcher {
+    fn new(pass: &str, respond: &str) -> Self {
+        Self {
+            invocations: AtomicU32::new(0),
+            passthrough_handler_id: pass.into(),
+            response_handler_id: respond.into(),
+            last_request: tokio::sync::Mutex::new(None),
+        }
+    }
 }
 
 #[async_trait]
@@ -40,6 +54,7 @@ impl DevMiddlewareDispatcher for CountingDispatcher {
         request: PluginRequest,
     ) -> Result<PluginDispatchOutcome, PluginDispatchError> {
         self.invocations.fetch_add(1, Ordering::SeqCst);
+        *self.last_request.lock().await = Some(request.clone());
         if handler_id == self.passthrough_handler_id {
             return Ok(PluginDispatchOutcome::Passthrough);
         }
@@ -47,10 +62,19 @@ impl DevMiddlewareDispatcher for CountingDispatcher {
             let mut headers = HashMap::new();
             headers.insert("content-type".into(), "application/json".into());
             headers.insert("x-zfb-plugin".into(), "ok".into());
+            // Echo what the plugin saw so the test can assert on the
+            // wire-level method propagation rather than relying on an
+            // out-of-band channel.
+            let body = format!(
+                "{{\"method\":\"{}\",\"url\":\"{}\",\"hasBody\":{}}}",
+                request.method,
+                request.url,
+                request.body.is_some(),
+            );
             return Ok(PluginDispatchOutcome::Response(PluginResponse {
                 status: 200,
                 headers,
-                body: format!("{{\"echo\":\"{}\"}}", request.url),
+                body,
                 body_encoding: PluginResponseEncoding::Utf8,
             }));
         }
@@ -98,11 +122,7 @@ async fn boot_with_dispatcher(
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn dev_middleware_handles_registered_path() {
-    let dispatcher = Arc::new(CountingDispatcher {
-        passthrough_handler_id: "h-pass".into(),
-        response_handler_id: "h-respond".into(),
-        invocations: AtomicU32::new(0),
-    });
+    let dispatcher = Arc::new(CountingDispatcher::new("h-pass", "h-respond"));
     let (addr, _pages, server, _tmp) = boot_with_dispatcher(
         dispatcher.clone(),
         vec![PluginRegistration {
@@ -130,11 +150,7 @@ async fn dev_middleware_handles_registered_path() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn dev_middleware_passthrough_falls_back_to_page_cache() {
-    let dispatcher = Arc::new(CountingDispatcher {
-        passthrough_handler_id: "h-pass".into(),
-        response_handler_id: "h-respond".into(),
-        invocations: AtomicU32::new(0),
-    });
+    let dispatcher = Arc::new(CountingDispatcher::new("h-pass", "h-respond"));
     let (addr, pages, server, _tmp) = boot_with_dispatcher(
         dispatcher.clone(),
         vec![PluginRegistration {
@@ -161,11 +177,7 @@ async fn dev_middleware_passthrough_falls_back_to_page_cache() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn dev_middleware_unregistered_path_skips_dispatch() {
-    let dispatcher = Arc::new(CountingDispatcher {
-        passthrough_handler_id: "h-pass".into(),
-        response_handler_id: "h-respond".into(),
-        invocations: AtomicU32::new(0),
-    });
+    let dispatcher = Arc::new(CountingDispatcher::new("h-pass", "h-respond"));
     let (addr, _pages, server, _tmp) = boot_with_dispatcher(
         dispatcher.clone(),
         vec![PluginRegistration {
@@ -180,6 +192,159 @@ async fn dev_middleware_unregistered_path_skips_dispatch() {
     // never be called, and the server returns the dev-mode 404.
     let resp = reqwest::get(format!("http://{addr}/different")).await.unwrap();
     assert_eq!(resp.status(), 404);
+    assert_eq!(dispatcher.invocations.load(Ordering::SeqCst), 0);
+
+    server.abort();
+}
+
+// ---------------------------------------------------------------------
+// Issue #230 — devMiddleware accepts every HTTP method end-to-end.
+// ---------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dev_middleware_handles_post_with_body_and_propagates_method() {
+    // The whole point of issue #230: a POST to a registered path now
+    // reaches the plugin handler instead of being short-circuited by
+    // axum's GET/HEAD-only filter. Verify the plugin sees the real
+    // method and request body across the full HTTP stack.
+    let dispatcher = Arc::new(CountingDispatcher::new("h-pass", "h-respond"));
+    let (addr, _pages, server, _tmp) = boot_with_dispatcher(
+        dispatcher.clone(),
+        vec![PluginRegistration {
+            path: "/api/echo".into(),
+            handler_id: "h-respond".into(),
+            plugin: "echo-test".into(),
+        }],
+    )
+    .await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{addr}/api/echo"))
+        .header("content-type", "application/json")
+        .body("{\"x\":1}")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("\"method\":\"POST\""),
+        "plugin did not see POST: {body}"
+    );
+    assert!(
+        body.contains("\"hasBody\":true"),
+        "plugin did not receive body: {body}"
+    );
+    let captured = dispatcher.last_request.lock().await.clone().unwrap();
+    assert_eq!(captured.method, "POST");
+    assert_eq!(captured.body.as_deref(), Some("{\"x\":1}"));
+    assert_eq!(
+        captured.headers.get("content-type").map(String::as_str),
+        Some("application/json"),
+    );
+
+    server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dev_middleware_handles_put_and_delete() {
+    let dispatcher = Arc::new(CountingDispatcher::new("h-pass", "h-respond"));
+    let (addr, _pages, server, _tmp) = boot_with_dispatcher(
+        dispatcher.clone(),
+        vec![PluginRegistration {
+            path: "/api/echo".into(),
+            handler_id: "h-respond".into(),
+            plugin: "echo-test".into(),
+        }],
+    )
+    .await;
+
+    let client = reqwest::Client::new();
+    for method in [reqwest::Method::PUT, reqwest::Method::DELETE, reqwest::Method::PATCH] {
+        let resp = client
+            .request(method.clone(), format!("http://{addr}/api/echo"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200, "method {method} should reach plugin");
+        let body = resp.text().await.unwrap();
+        assert!(
+            body.contains(&format!("\"method\":\"{}\"", method.as_str())),
+            "plugin did not see {method}: {body}",
+        );
+    }
+
+    server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn post_to_built_in_livereload_js_returns_405() {
+    // Critical CSRF guarantee from issue #230's "security callout":
+    // built-in routes keep their GET-only semantics. The dev-server
+    // must not let a misrouted POST land on `/__zfb/livereload.js`
+    // just because user-registered devMiddleware paths now accept
+    // every method.
+    let dispatcher = Arc::new(CountingDispatcher::new("h-pass", "h-respond"));
+    let (addr, _pages, server, _tmp) = boot_with_dispatcher(
+        dispatcher.clone(),
+        // No registrations — exercises the built-in route directly.
+        vec![],
+    )
+    .await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{addr}/__zfb/livereload.js"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 405);
+    let allow = resp
+        .headers()
+        .get("allow")
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    assert!(allow.to_ascii_uppercase().contains("GET"), "allow: {allow}");
+    // Plugin layer must NOT have been touched for a built-in path.
+    assert_eq!(dispatcher.invocations.load(Ordering::SeqCst), 0);
+
+    server.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn post_to_unregistered_path_returns_405() {
+    // Non-GET requests that do not match any plugin must 405 rather
+    // than slip into the page-cache lookup (which is GET-only).
+    let dispatcher = Arc::new(CountingDispatcher::new("h-pass", "h-respond"));
+    let (addr, _pages, server, _tmp) = boot_with_dispatcher(
+        dispatcher.clone(),
+        vec![PluginRegistration {
+            path: "/api".into(),
+            handler_id: "h-respond".into(),
+            plugin: "scoped".into(),
+        }],
+    )
+    .await;
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{addr}/totally-unrelated"))
+        .body("ignored")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 405);
+    let allow = resp
+        .headers()
+        .get("allow")
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or_default()
+        .to_string();
+    assert!(allow.contains("GET"), "allow header missing GET: {allow}");
+    assert!(allow.contains("HEAD"), "allow header missing HEAD: {allow}");
+    // Plugin path did not match — dispatcher must not have been called.
     assert_eq!(dispatcher.invocations.load(Ordering::SeqCst), 0);
 
     server.abort();

--- a/crates/zfb-types/src/base_prefix.rs
+++ b/crates/zfb-types/src/base_prefix.rs
@@ -1,0 +1,125 @@
+//! Helpers for normalising the user-supplied `base` config value into
+//! the URL-path mount prefix the dev server should mount everything
+//! under.
+//!
+//! ## Why this lives in `zfb-types`
+//!
+//! Multiple crates need a single, shared interpretation of `base`:
+//!
+//! - `zfb-server` mounts pages, assets, livereload, and plugin
+//!   middleware under the prefix during `zfb dev` (issue #229).
+//! - the build pipeline (issue #228) rewrites `<a href>` and
+//!   `<form action>` URLs to include the same prefix.
+//!
+//! Both must agree on the canonical normal form to avoid drift between
+//! "what the dev server serves" and "what the rendered HTML asks for".
+//! `zfb-types` is the lowest-dep leaf crate every consumer can already
+//! depend on, so the helper lives here rather than in `zfb` (which is
+//! a high-level crate the renderer cannot import) or `zfb-server`
+//! (which is dev-only and is a sibling, not an ancestor, of the build
+//! pipeline).
+
+/// Normalise a `base` config value into the URL-path mount prefix the
+/// dev server uses to mount pages, assets, livereload, and plugin
+/// middleware.
+///
+/// Returns:
+///
+/// - `None` for `None`, `""`, `"/"`, or any absolute-URL form (e.g.
+///   `"https://cdn.example.com/"`). The dev server should mount
+///   everything at the root in these cases — the absolute-URL case
+///   means the assets are served from a different origin (typically a
+///   CDN) and the dev server cannot help with them.
+/// - `Some("/foo")` — leading slash, no trailing slash — for any
+///   path-shaped value like `"/foo"`, `"/foo/"`, `"/foo/bar/"`. Callers
+///   can concatenate `"<prefix>/<path>"` cleanly knowing the prefix has
+///   exactly one leading slash and no trailing slash.
+///
+/// Mirrors the input matrix accepted by
+/// [`zfb::config::asset_url_base_prefix`] except the absolute-URL case
+/// returns `None` (the dev server cannot mount on a different origin)
+/// and `Some` is reserved for the path-shaped case the dev server can
+/// actually serve.
+pub fn dev_mount_prefix(base: Option<&str>) -> Option<String> {
+    let raw = base?;
+    let trimmed = raw.trim_end_matches('/');
+    if trimmed.is_empty() {
+        // `""` or `"/"` (or `"//"`, …) — none of these mount the site
+        // under a sub-path on the dev server.
+        return None;
+    }
+    if trimmed.contains("://") {
+        // Absolute URL — dev server can't mount on a different origin.
+        // The build emits absolute URLs for assets in this case; there
+        // is nothing for the dev server to do beyond serving the page
+        // HTML at the root (which is the no-base behaviour).
+        return None;
+    }
+    if !trimmed.starts_with('/') {
+        // Malformed path-shaped value (no leading slash). Treat as
+        // no-prefix rather than mounting under a relative-style path
+        // that axum cannot represent.
+        return None;
+    }
+    Some(trimmed.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn none_returns_none() {
+        assert_eq!(dev_mount_prefix(None), None);
+    }
+
+    #[test]
+    fn empty_string_returns_none() {
+        assert_eq!(dev_mount_prefix(Some("")), None);
+    }
+
+    #[test]
+    fn root_slash_returns_none() {
+        assert_eq!(dev_mount_prefix(Some("/")), None);
+    }
+
+    #[test]
+    fn multiple_trailing_slashes_collapse_to_root() {
+        assert_eq!(dev_mount_prefix(Some("//")), None);
+        assert_eq!(dev_mount_prefix(Some("///")), None);
+    }
+
+    #[test]
+    fn path_with_trailing_slash_strips_it() {
+        assert_eq!(dev_mount_prefix(Some("/foo/")), Some("/foo".to_string()));
+        assert_eq!(
+            dev_mount_prefix(Some("/foo/bar/")),
+            Some("/foo/bar".to_string())
+        );
+    }
+
+    #[test]
+    fn path_without_trailing_slash_is_idempotent() {
+        assert_eq!(dev_mount_prefix(Some("/foo")), Some("/foo".to_string()));
+        assert_eq!(
+            dev_mount_prefix(Some("/foo/bar")),
+            Some("/foo/bar".to_string())
+        );
+    }
+
+    #[test]
+    fn absolute_url_returns_none() {
+        // CDN-style bases — the dev server doesn't mount on a different
+        // origin, so it should keep the no-base behaviour.
+        assert_eq!(dev_mount_prefix(Some("https://cdn.example.com/")), None);
+        assert_eq!(dev_mount_prefix(Some("http://localhost:8080/")), None);
+        assert_eq!(dev_mount_prefix(Some("https://cdn.example.com")), None);
+    }
+
+    #[test]
+    fn missing_leading_slash_returns_none() {
+        // Malformed path — no leading slash means axum can't mount it.
+        assert_eq!(dev_mount_prefix(Some("foo")), None);
+        assert_eq!(dev_mount_prefix(Some("foo/bar")), None);
+    }
+}

--- a/crates/zfb-types/src/lib.rs
+++ b/crates/zfb-types/src/lib.rs
@@ -4,10 +4,12 @@
 //! workspace, preventing code duplication and circular dependencies.
 
 pub mod asset_urls;
+pub mod base_prefix;
 pub mod segment;
 
 pub use asset_urls::{
     DIST_ASSETS_DIR, STABLE_ASSETS_URL_PREFIX, STABLE_CSS_FILENAME, STABLE_CSS_URL,
     STABLE_ISLANDS_FILENAME, STABLE_ISLANDS_URL,
 };
+pub use base_prefix::dev_mount_prefix;
 pub use segment::Segment;

--- a/crates/zfb/Cargo.toml
+++ b/crates/zfb/Cargo.toml
@@ -25,6 +25,12 @@ clap = { version = "4", features = ["derive"] }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 include_dir = "0.7"
 indicatif = "0.17"
+# Issue #228: walk emitted HTML to prefix root-absolute `<a href>` /
+# `<form action>` with the configured `base` so internal navigation
+# survives sub-path deploys (mirrors how the CSS / islands asset URLs
+# are already prefixed). Same crate + version that `zfb-islands` and
+# `zfb-server` use, so the workspace lock stays single-version.
+lol_html = "2.8.1"
 owo-colors = { version = "4", features = ["supports-colors"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/zfb/Cargo.toml
+++ b/crates/zfb/Cargo.toml
@@ -25,12 +25,13 @@ clap = { version = "4", features = ["derive"] }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 include_dir = "0.7"
 indicatif = "0.17"
-# Issue #228: walk emitted HTML to prefix root-absolute `<a href>` /
-# `<form action>` with the configured `base` so internal navigation
-# survives sub-path deploys (mirrors how the CSS / islands asset URLs
-# are already prefixed). Same crate + version that `zfb-islands` and
-# `zfb-server` use, so the workspace lock stays single-version.
-lol_html = "2.8.1"
+# Issue #228's HTML link rewriter (`<a href>` / `<form action>`
+# prefix-stamp) used to live here with its own `lol_html` dep. After
+# the post-merge review caught that the dev server also needs to apply
+# the same rewrite to served HTML (issue #229), the pure-string pieces
+# moved to `zfb_build::link_base_rewrite` so both consumers funnel
+# through the same code. We no longer call `lol_html` directly from
+# this crate.
 owo-colors = { version = "4", features = ["supports-colors"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -859,11 +859,21 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(args: BuildArgsResolved<'_, R, A>
     //
     // The content snapshot (when present) is embedded in the worker
     // bundle so runtime `paths()` calls can resolve `getCollection(...)`.
+    //
+    // The intermediate `.zfb-build/` directory holds `bundle.mjs` and
+    // its `.map` — the SSR worker bundle the renderer below loads. It
+    // lives at `<project_root>/.zfb-build/`, NOT under `<outdir>/`,
+    // because anything inside `outdir` is part of the deploy upload
+    // (Cloudflare Pages, Netlify, S3, etc.) and these are build
+    // intermediates, not deploy artifacts. See zfb#231 for the
+    // information-disclosure / wasted-bytes rationale. The renderer +
+    // adapter both consume the absolute `bundler_out.bundle_path`
+    // returned below, so the location is opaque to them.
     let mut bundler_input = BundlerInput::for_project(
         project_root.to_path_buf(),
         cfg_framework_to_render(config.framework),
         BundleMode::Production,
-        outdir.join(".zfb-build"),
+        project_root.join(".zfb-build"),
         content_snapshot_json,
     );
     // Inject project-side resolution context so esbuild can find
@@ -1752,7 +1762,7 @@ mod tests {
             static_route(vec![], "pages/index.tsx"),
             static_route(vec!["about"], "pages/about.tsx"),
         ];
-        let runner = FakeRunner::new(outdir.join(".zfb-build/bundle.mjs"));
+        let runner = FakeRunner::new(project_root.join(".zfb-build/bundle.mjs"));
 
         let cfg = Config::default();
         let fake_adapter = FakeAdapterRunner::new();
@@ -1786,6 +1796,60 @@ mod tests {
         }
     }
 
+    /// zfb#231 regression — the SSR worker bundle (`bundle.mjs` + its
+    /// `.map`) is a build intermediate, NOT a deploy artifact. It must
+    /// be written under `<project_root>/.zfb-build/`, not under
+    /// `<outdir>/.zfb-build/`. Anything in `outdir` ships to the deploy
+    /// upload (Cloudflare Pages, Netlify, S3 + CloudFront, etc.); the
+    /// SSR bundle is ~350 KB of internal build state that exposes
+    /// page-level JS authors wrote with the "runs server-side only"
+    /// assumption. Pinning the location prevents a future refactor
+    /// from accidentally re-introducing the leak.
+    #[test]
+    fn run_build_writes_intermediate_bundle_outside_dist() {
+        let tmp = tempdir().unwrap();
+        let project_root = tmp.path();
+        let outdir = project_root.join("dist");
+        make_runtime(project_root);
+        let routes = vec![static_route(vec![], "pages/index.tsx")];
+        let runner = FakeRunner::new(project_root.join(".zfb-build/bundle.mjs"));
+        let cfg = Config::default();
+        let fake_adapter = FakeAdapterRunner::new();
+        run_build(BuildArgsResolved {
+            project_root,
+            outdir: &outdir,
+            config: &cfg,
+            routes: &routes,
+            runner: &runner,
+            adapter_runner: &fake_adapter,
+        })
+        .unwrap();
+
+        // (a) The bundler was handed `<project_root>/.zfb-build/`, NOT
+        //     `<outdir>/.zfb-build/`. This is the load-bearing wiring
+        //     fix: change this and dist/ stops leaking the SSR bundle.
+        let calls = runner.bundle_calls.borrow();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].outdir, project_root.join(".zfb-build"));
+        assert_ne!(calls[0].outdir, outdir.join(".zfb-build"));
+
+        // (b) On disk: dist/.zfb-build/ does NOT exist after build.
+        //     A future change that moves the write target back under
+        //     dist/ would fail this assertion.
+        assert!(
+            !outdir.join(".zfb-build").exists(),
+            "dist/.zfb-build/ must not exist after build (zfb#231)",
+        );
+
+        // (c) The relocated intermediate IS written at project root
+        //     (FakeRunner mirrors production by writing the mock
+        //     bundle to its target path).
+        assert!(
+            project_root.join(".zfb-build/bundle.mjs").is_file(),
+            "<project_root>/.zfb-build/bundle.mjs must exist after build",
+        );
+    }
+
     #[test]
     fn run_build_defers_dynamic_routes_whose_source_is_unreadable() {
         // The router yielded a dynamic route whose source file doesn't
@@ -1801,7 +1865,7 @@ mod tests {
             static_route(vec![], "pages/index.tsx"),
             dynamic_route("slug", "pages/[slug].tsx"),
         ];
-        let runner = FakeRunner::new(outdir.join(".zfb-build/bundle.mjs"));
+        let runner = FakeRunner::new(project_root.join(".zfb-build/bundle.mjs"));
         let cfg = Config::default();
         let fake_adapter = FakeAdapterRunner::new();
         let pages = run_build(BuildArgsResolved {
@@ -1856,7 +1920,7 @@ mod tests {
                 output_extension: None,
             },
         ];
-        let runner = FakeRunner::new(outdir.join(".zfb-build/bundle.mjs"));
+        let runner = FakeRunner::new(project_root.join(".zfb-build/bundle.mjs"));
         let cfg = Config::default();
         let fake_adapter = FakeAdapterRunner::new();
         let pages = run_build(BuildArgsResolved {
@@ -1897,7 +1961,7 @@ mod tests {
         // defers it, and the FakeRunner's eval_deferred_paths returns
         // empty (no runtime V8 host in unit tests).
         let routes = vec![dynamic_route("slug", "pages/[slug].tsx")];
-        let runner = FakeRunner::new(outdir.join(".zfb-build/bundle.mjs"));
+        let runner = FakeRunner::new(project_root.join(".zfb-build/bundle.mjs"));
         let cfg = Config::default();
         let fake_adapter = FakeAdapterRunner::new();
         let pages = run_build(BuildArgsResolved {
@@ -2011,7 +2075,7 @@ mod tests {
         let outdir = project_root.join("dist");
         make_runtime(project_root);
         let routes = vec![static_route(vec!["about"], "pages/about.tsx")];
-        let runner = FakeRunner::new(outdir.join(".zfb-build/bundle.mjs"));
+        let runner = FakeRunner::new(project_root.join(".zfb-build/bundle.mjs"));
         let cfg = Config::default();
         let fake_adapter = FakeAdapterRunner::new();
         run_build(BuildArgsResolved {
@@ -2053,7 +2117,7 @@ mod tests {
             specificity: 0,
             output_extension: None,
         }];
-        let runner = FakeRunner::new(outdir.join(".zfb-build/bundle.mjs"));
+        let runner = FakeRunner::new(project_root.join(".zfb-build/bundle.mjs"));
         let cfg = Config::default(); // adapter is None
         let fake_adapter = FakeAdapterRunner::new();
         let err = run_build(BuildArgsResolved {
@@ -2109,7 +2173,7 @@ mod tests {
                 output_extension: None,
             },
         ];
-        let runner = FakeRunner::new(outdir.join(".zfb-build/bundle.mjs"));
+        let runner = FakeRunner::new(project_root.join(".zfb-build/bundle.mjs"));
         let mut cfg = Config::default();
         cfg.adapter = Some("@takazudo/zfb-adapter-cloudflare".into());
         let fake_adapter = FakeAdapterRunner::new();
@@ -2125,10 +2189,12 @@ mod tests {
         let calls = fake_adapter.calls.borrow();
         assert_eq!(calls.len(), 1, "adapter dispatch must run once");
         assert_eq!(calls[0].0, "@takazudo/zfb-adapter-cloudflare");
-        // Adapter receives the same bundle the renderer used.
+        // Adapter receives the same bundle the renderer used. The
+        // bundle lives at <project_root>/.zfb-build/, not under
+        // <outdir>/, so the deploy upload doesn't include it (zfb#231).
         assert_eq!(
             calls[0].1.input_bundle,
-            outdir.join(".zfb-build/bundle.mjs")
+            project_root.join(".zfb-build/bundle.mjs")
         );
         assert_eq!(calls[0].1.outdir, outdir);
     }
@@ -2142,7 +2208,7 @@ mod tests {
         let outdir = project_root.join("dist");
         make_runtime(project_root);
         let routes = vec![static_route(vec![], "pages/index.tsx")];
-        let runner = FakeRunner::new(outdir.join(".zfb-build/bundle.mjs"));
+        let runner = FakeRunner::new(project_root.join(".zfb-build/bundle.mjs"));
         let mut cfg = Config::default();
         cfg.adapter = Some("   ".into());
         let fake_adapter = FakeAdapterRunner::new();
@@ -2174,7 +2240,7 @@ mod tests {
             static_route(vec![], "pages/index.tsx"),
             static_route(vec!["about"], "pages/about.tsx"),
         ];
-        let runner = FakeRunner::new(outdir.join(".zfb-build/bundle.mjs")).with_prod_asset_inputs(
+        let runner = FakeRunner::new(project_root.join(".zfb-build/bundle.mjs")).with_prod_asset_inputs(
             ProdAssetEmitterInputs {
                 css: Some(zfb_build::pipeline::AssetEmitterPayload {
                     bytes: b".btn{color:red}".to_vec(),
@@ -2362,7 +2428,7 @@ mod tests {
         let outdir = project_root.join("dist");
         make_runtime(project_root);
         let routes = vec![static_route(vec![], "pages/index.tsx")];
-        let runner = FakeRunner::new(outdir.join(".zfb-build/bundle.mjs")).with_prod_asset_inputs(
+        let runner = FakeRunner::new(project_root.join(".zfb-build/bundle.mjs")).with_prod_asset_inputs(
             ProdAssetEmitterInputs {
                 css: Some(zfb_build::pipeline::AssetEmitterPayload {
                     bytes: b".btn{color:red}".to_vec(),
@@ -2456,7 +2522,7 @@ mod tests {
         let outdir = project_root.join("dist");
         make_runtime(project_root);
         let routes = vec![static_route(vec![], "pages/index.tsx")];
-        let runner = FakeRunner::new(outdir.join(".zfb-build/bundle.mjs")).with_prod_asset_inputs(
+        let runner = FakeRunner::new(project_root.join(".zfb-build/bundle.mjs")).with_prod_asset_inputs(
             ProdAssetEmitterInputs {
                 css: Some(zfb_build::pipeline::AssetEmitterPayload {
                     bytes: b".btn{color:red}".to_vec(),
@@ -2570,7 +2636,7 @@ mod tests {
         make_runtime(project_root);
         let routes = vec![static_route(vec![], "pages/index.tsx")];
         // Default FakeRunner: no preset emitter bytes ⇒ both slots None.
-        let runner = FakeRunner::new(outdir.join(".zfb-build/bundle.mjs"));
+        let runner = FakeRunner::new(project_root.join(".zfb-build/bundle.mjs"));
         let cfg = Config::default();
         let fake_adapter = FakeAdapterRunner::new();
         run_build(BuildArgsResolved {
@@ -2935,7 +3001,7 @@ mod tests {
         std::fs::write(project_root.join("public/img/logo.svg"), logo_content).unwrap();
 
         let routes = vec![static_route(vec![], "pages/index.tsx")];
-        let runner = FakeRunner::new(outdir.join(".zfb-build/bundle.mjs"));
+        let runner = FakeRunner::new(project_root.join(".zfb-build/bundle.mjs"));
         let mut cfg = Config::default();
         cfg.base = Some("/pj/test/".to_string());
         let fake_adapter = FakeAdapterRunner::new();

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -1041,6 +1041,23 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(args: BuildArgsResolved<'_, R, A>
             .context("production asset pipeline (hash + URL rewrite) failed")?;
     }
 
+    // 3.6. User-link base rewrite (issue #228).
+    //
+    // The asset rewrite above only touched `/assets/...` URLs in
+    // `<link>` / `<script>`. User-authored absolute links —
+    // `<a href="/about">`, `<form action="/login">` — were left bare,
+    // so a sub-path deploy (`base = "/pj/foo/"`) shipped working
+    // styling but broken navigation. Walk every emitted HTML file and
+    // prefix root-absolute hrefs/actions; module-level docs cover the
+    // skip rules and the `data-no-base` opt-out. No-op when `base` is
+    // unset, `"/"`, or absolute-URL-shaped.
+    crate::commands::link_base_rewrite::apply_link_base_rewrite(
+        outdir,
+        &render_out.ssg_files_written,
+        config.base.as_deref(),
+    )
+    .context("link base rewrite failed")?;
+
     // Surface embedded V8 host runtime logs (console output from the
     // worker) on a green build — they are often informative about
     // deprecations or routing oddities.

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -152,7 +152,7 @@ pub async fn run(args: &DevArgs) -> Result<()> {
     //    noop renderer so the dev server still boots — the user can
     //    still poke at the dev URL while they fix the underlying
     //    bundler / runtime issue.
-    let dev_session = match boot_dev_renderer(&project_root, &cfg, &dist_root) {
+    let dev_session = match boot_dev_renderer(&project_root, &cfg) {
         Ok(s) => Some(s),
         Err(err) => {
             output::warn(format!(
@@ -447,7 +447,6 @@ impl Drop for DevRenderInner {
 fn boot_dev_renderer(
     project_root: &Path,
     cfg: &config::Config,
-    dist_root: &Path,
 ) -> Result<DevRenderSession> {
     check_runtime_installed(project_root)?;
 
@@ -470,11 +469,19 @@ fn boot_dev_renderer(
     // Dev mode does not embed a content snapshot — runtime paths()
     // evaluation is a build-mode feature. When dev mode starts the
     // worker, `getCollection(...)` will see an empty snapshot.
+    //
+    // The intermediate `.zfb-build/` directory lives at
+    // `<project_root>/.zfb-build/`, NOT under `<dist_root>/`. This
+    // mirrors the production path in `commands/build.rs` (see zfb#231).
+    // Dev mode's leak risk is lower (the dev server doesn't ship dist/
+    // anywhere), but keeping the path consistent with build means the
+    // intermediate is always at one well-known location regardless of
+    // mode, and any tooling pointing at it stays mode-agnostic.
     let mut bundler_input = BundlerInput::for_project(
         project_root.to_path_buf(),
         cfg_framework_to_render(cfg.framework),
         BundleMode::Development,
-        dist_root.join(".zfb-build"),
+        project_root.join(".zfb-build"),
         None,
     );
     // Mirror the production build CLI: surface project-side

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -240,6 +240,12 @@ pub async fn run(args: &DevArgs) -> Result<()> {
     });
 
     // 6. Build the serve options and announce readiness.
+    //
+    // Issue #229: thread `cfg.base` through so the dev server mounts
+    // pages, assets, and live-reload under the same prefix the build
+    // pipeline stamps onto asset URLs. Without this the dev HTML emits
+    // `<link href="/<base>/assets/styles.css">` while the dev server
+    // only knew about unprefixed `/assets/...` — every request 404s.
     let opts = ServeOpts {
         project_root,
         dist_root,
@@ -248,6 +254,7 @@ pub async fn run(args: &DevArgs) -> Result<()> {
         pages,
         broadcast: tx,
         plugins: plugin_set,
+        base: cfg.base.clone(),
     };
 
     output::ready(&format!("http://{host}:{port}"));

--- a/crates/zfb/src/commands/link_base_rewrite.rs
+++ b/crates/zfb/src/commands/link_base_rewrite.rs
@@ -1,0 +1,638 @@
+//! Issue #228: rewrite root-absolute `<a href>` / `<form action>` to
+//! sit under the configured `base` prefix in shipped HTML.
+//!
+//! ## Why this exists
+//!
+//! `zfb build` already prefixes asset URLs (`<link rel="stylesheet">`,
+//! `<script type="module">`) with `cfg.base` via
+//! [`super::build::apply_asset_url_base`]. User-authored absolute
+//! links — e.g. `<a href="/about">` in page TSX — were left alone, so
+//! a sub-path deploy (`https://example.com/pj/zudo-doc/`) styled the
+//! pages correctly but every internal click went to `/about` (a 404 /
+//! the wrong site) instead of `/pj/zudo-doc/about`.
+//!
+//! ## Scope (deliberately narrow)
+//!
+//! We rewrite **only** `href` on `<a>` and `action` on `<form>`. Other
+//! navigation-shaped attributes (`<area href>`, `<form formaction>`,
+//! `<base href>`, `<link rel="alternate">`, …) are out of scope — the
+//! issue calls out the two attributes above and the prod-asset rewrite
+//! we mirror only handles `<link>` / `<script>`. Adding more later is
+//! cheap; the per-element handler shape extends naturally.
+//!
+//! ## Skip rules
+//!
+//! Only ROOT-ABSOLUTE paths get prefixed — values that start with a
+//! single `/` not followed by another `/`. Everything else passes
+//! through verbatim:
+//!
+//! - empty string, fragment-only (`#anchor`), protocol-relative
+//!   (`//host/x`), schemed URLs (`mailto:`, `tel:`, `javascript:`,
+//!   `http:`, `https:`, …) — schemed URLs never start with `/`, so
+//!   the leading-`/` gate already catches them.
+//! - relative paths (`foo.html`, `./foo`, `../foo`).
+//! - already-prefixed absolute paths (`/foo/about` when base is
+//!   `/foo`) — the rewrite is **idempotent** so a second build pass
+//!   over already-shipped HTML is a no-op.
+//!
+//! Authors can opt a specific element out of the rewrite by adding the
+//! `data-no-base` attribute (any value, including bareword). The
+//! attribute is currently **left on the emitted HTML** — browsers
+//! ignore unknown `data-*` attributes, so the cost is one harmless
+//! attribute per opt-out and the rewriter stays trivially correct on
+//! re-runs.
+//!
+//! ## CDN-shaped base (`base = "https://cdn.example.com/"`)
+//!
+//! The same `cfg.base` slot accepts an absolute URL for asset hosting
+//! (`asset_url_base_prefix` returns e.g. `"https://cdn.example.com"`).
+//! User-link rewriting is **disabled** for that shape: clicking
+//! `<a href="/about">` should keep navigating inside the current
+//! origin, not get redirected to a CDN host that does not serve HTML.
+//! Asset URLs continue to point at the CDN via the existing pipeline.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use lol_html::html_content::Element;
+use lol_html::{ElementContentHandlers, LocalHandlerTypes, RewriteStrSettings, Selector};
+
+use crate::config::asset_url_base_prefix;
+
+/// Walk every emitted SSG HTML file under `out_dir` and prefix every
+/// root-absolute `<a href>` / `<form action>` with the configured
+/// `base`. Re-writes the file in-place only when the rewriter
+/// produced different bytes — projects without absolute internal
+/// links round-trip the file untouched.
+///
+/// The rewrite is a **no-op** when:
+///
+/// - `base` normalises to empty (None / `""` / `"/"`), OR
+/// - `base` is an absolute URL (CDN host); see module docs.
+///
+/// Non-`*.html` / `*.htm` outputs (XML feeds, JSON, …) are skipped
+/// even when `base` is set — the lol_html parser is HTML-only and
+/// would mangle non-HTML payloads.
+pub fn apply_link_base_rewrite(
+    out_dir: &Path,
+    written_pages: &[PathBuf],
+    base: Option<&str>,
+) -> Result<()> {
+    let prefix = asset_url_base_prefix(base);
+    if prefix.is_empty() || !prefix.starts_with('/') {
+        // Empty prefix → no base configured. Absolute-URL prefix →
+        // CDN-style base; user links stay same-origin.
+        return Ok(());
+    }
+    for page in written_pages {
+        if !is_html_path(page) {
+            continue;
+        }
+        let bytes = std::fs::read(page).with_context(|| {
+            format!(
+                "link-base-rewrite: failed to read {}",
+                page.display()
+            )
+        })?;
+        // The renderer wrote UTF-8 HTML; bail if a binary-ish file
+        // somehow snuck through with a `.html` extension instead of
+        // silently corrupting it via lossy decoding.
+        let html = std::str::from_utf8(&bytes).with_context(|| {
+            format!(
+                "link-base-rewrite: {} is not valid UTF-8",
+                page.display()
+            )
+        })?;
+        let new_html = rewrite_links_in_html(html, &prefix).with_context(|| {
+            format!(
+                "link-base-rewrite: lol_html failed on {} (under {})",
+                page.display(),
+                out_dir.display()
+            )
+        })?;
+        if new_html != html {
+            std::fs::write(page, new_html).with_context(|| {
+                format!(
+                    "link-base-rewrite: failed to write {}",
+                    page.display()
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn is_html_path(p: &Path) -> bool {
+    matches!(
+        p.extension().and_then(|s| s.to_str()),
+        Some("html") | Some("htm")
+    )
+}
+
+/// Rewrite root-absolute `<a href>` / `<form action>` in `html` by
+/// prepending `prefix`. Pure function — no I/O.
+///
+/// `prefix` MUST be the canonical form returned by
+/// [`asset_url_base_prefix`]: empty (no base), a path with no trailing
+/// slash (`/foo`), or an absolute URL with no trailing slash. The
+/// caller guards against the empty / absolute-URL forms; we still
+/// behave correctly if those slip through (empty prefix yields
+/// no-op via the idempotency check; absolute-URL prefix would
+/// mis-rewrite, hence the caller's gate).
+fn rewrite_links_in_html(
+    html: &str,
+    prefix: &str,
+) -> Result<String, lol_html::errors::RewritingError> {
+    use std::borrow::Cow;
+
+    let a_selector: Selector = "a[href]".parse().expect("static selector is valid");
+    let form_selector: Selector = "form[action]"
+        .parse()
+        .expect("static selector is valid");
+
+    // Each handler is `FnMut + Send + Sync`; we capture an owned
+    // `String` clone of the prefix so the closures don't borrow from
+    // the outer scope.
+    let prefix_for_a = prefix.to_string();
+    let prefix_for_form = prefix.to_string();
+
+    lol_html::rewrite_str(
+        html,
+        RewriteStrSettings {
+            element_content_handlers: vec![
+                (
+                    Cow::Owned(a_selector),
+                    ElementContentHandlers::default().element(move |el: &mut Element<'_, '_, _>| {
+                        if has_no_base_optout(el) {
+                            return Ok(());
+                        }
+                        if let Some(href) = el.get_attribute("href") {
+                            if let Some(rewritten) = compute_prefixed(&href, &prefix_for_a) {
+                                el.set_attribute("href", &rewritten)?;
+                            }
+                        }
+                        Ok(())
+                    }),
+                ),
+                (
+                    Cow::Owned(form_selector),
+                    ElementContentHandlers::default().element(move |el: &mut Element<'_, '_, _>| {
+                        if has_no_base_optout(el) {
+                            return Ok(());
+                        }
+                        if let Some(action) = el.get_attribute("action") {
+                            if let Some(rewritten) = compute_prefixed(&action, &prefix_for_form) {
+                                el.set_attribute("action", &rewritten)?;
+                            }
+                        }
+                        Ok(())
+                    }),
+                ),
+            ],
+            ..RewriteStrSettings::new()
+        },
+    )
+}
+
+/// Return the prefixed value, or `None` to leave the attribute alone.
+///
+/// See module docs for the full skip table. The check order matters
+/// for clarity but not for correctness — each branch is independent.
+fn compute_prefixed(value: &str, prefix: &str) -> Option<String> {
+    if value.is_empty() {
+        return None;
+    }
+    let bytes = value.as_bytes();
+    if bytes[0] != b'/' {
+        // Catches relative paths, fragment-only, AND every schemed
+        // URL (mailto:, http:, javascript:, …) — none start with `/`.
+        return None;
+    }
+    if bytes.len() >= 2 && bytes[1] == b'/' {
+        // Protocol-relative `//host/...`.
+        return None;
+    }
+    // Idempotency: if the value is already mounted under `prefix`,
+    // leave it alone. We require the boundary after the prefix to be
+    // either end-of-string or `/`, so `/foobar` is NOT considered
+    // already-prefixed by `/foo`.
+    if value.starts_with(prefix) {
+        let rest = &value[prefix.len()..];
+        if rest.is_empty() || rest.starts_with('/') {
+            return None;
+        }
+    }
+    Some(format!("{prefix}{value}"))
+}
+
+/// Case-insensitive check: is `data-no-base` present on this element?
+/// `lol_html`'s element selectors and `get_attribute` are already
+/// case-insensitive on attribute names, so a literal lookup suffices.
+fn has_no_base_optout(el: &Element<'_, '_, LocalHandlerTypes>) -> bool {
+    el.has_attribute("data-no-base")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    // --- compute_prefixed -----------------------------------------------------
+
+    #[test]
+    fn compute_prefixed_root_absolute_gets_prefix() {
+        assert_eq!(
+            compute_prefixed("/about", "/foo").as_deref(),
+            Some("/foo/about")
+        );
+        assert_eq!(
+            compute_prefixed("/api/users", "/foo").as_deref(),
+            Some("/foo/api/users")
+        );
+    }
+
+    #[test]
+    fn compute_prefixed_root_alone_becomes_base_root() {
+        assert_eq!(compute_prefixed("/", "/foo").as_deref(), Some("/foo/"));
+    }
+
+    #[test]
+    fn compute_prefixed_preserves_query_and_hash() {
+        assert_eq!(
+            compute_prefixed("/about?x=1", "/foo").as_deref(),
+            Some("/foo/about?x=1")
+        );
+        assert_eq!(
+            compute_prefixed("/about#section", "/foo").as_deref(),
+            Some("/foo/about#section")
+        );
+    }
+
+    #[test]
+    fn compute_prefixed_idempotent_on_already_prefixed() {
+        // Boundary cases: exactly `prefix`, prefix + `/`, prefix +
+        // `/something` all yield None (no double-prefix).
+        assert_eq!(compute_prefixed("/foo", "/foo"), None);
+        assert_eq!(compute_prefixed("/foo/", "/foo"), None);
+        assert_eq!(compute_prefixed("/foo/about", "/foo"), None);
+        assert_eq!(compute_prefixed("/foo/api/x", "/foo"), None);
+    }
+
+    #[test]
+    fn compute_prefixed_partial_prefix_still_rewrites() {
+        // `/foobar` does NOT match prefix `/foo` because the next
+        // char after `/foo` is `b`, not `/` or end-of-string.
+        assert_eq!(
+            compute_prefixed("/foobar", "/foo").as_deref(),
+            Some("/foo/foobar")
+        );
+    }
+
+    #[test]
+    fn compute_prefixed_skips_empty() {
+        assert_eq!(compute_prefixed("", "/foo"), None);
+    }
+
+    #[test]
+    fn compute_prefixed_skips_fragment() {
+        assert_eq!(compute_prefixed("#anchor", "/foo"), None);
+    }
+
+    #[test]
+    fn compute_prefixed_skips_protocol_relative() {
+        assert_eq!(compute_prefixed("//cdn.example.com/x", "/foo"), None);
+    }
+
+    #[test]
+    fn compute_prefixed_skips_schemed_urls() {
+        for v in [
+            "mailto:x@y.com",
+            "tel:+15555550100",
+            "javascript:void(0)",
+            "data:text/plain,hi",
+            "blob:https://example.com/abc",
+            "ws://example.com/",
+            "wss://example.com/",
+            "file:///etc/passwd",
+            "ftp://example.com/x",
+            "http://example.com/x",
+            "https://example.com/x",
+        ] {
+            assert_eq!(
+                compute_prefixed(v, "/foo"),
+                None,
+                "expected skip for {v}"
+            );
+        }
+    }
+
+    #[test]
+    fn compute_prefixed_skips_relative_paths() {
+        for v in ["foo.html", "./foo", "../foo", "page", "page/sub.html"] {
+            assert_eq!(
+                compute_prefixed(v, "/foo"),
+                None,
+                "expected skip for {v}"
+            );
+        }
+    }
+
+    #[test]
+    fn compute_prefixed_empty_prefix_is_noop_via_idempotency() {
+        // Defensive: caller short-circuits empty prefix already, but
+        // if it slipped through we still leave values alone (the
+        // idempotency check sees `value.starts_with("")` == true and
+        // bails).
+        assert_eq!(compute_prefixed("/about", ""), None);
+        assert_eq!(compute_prefixed("/", ""), None);
+    }
+
+    // --- rewrite_links_in_html -----------------------------------------------
+
+    #[test]
+    fn rewrite_html_a_href_root_absolute() {
+        let html = r#"<a href="/about">About</a>"#;
+        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        assert!(
+            out.contains(r#"href="/foo/about""#),
+            "expected /foo/about; got: {out}"
+        );
+    }
+
+    #[test]
+    fn rewrite_html_form_action_root_absolute() {
+        let html = r#"<form action="/submit"><input/></form>"#;
+        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        assert!(
+            out.contains(r#"action="/foo/submit""#),
+            "expected /foo/submit; got: {out}"
+        );
+    }
+
+    #[test]
+    fn rewrite_html_data_no_base_optout_a() {
+        let html = r#"<a href="/about" data-no-base>About</a>"#;
+        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        // Original href preserved.
+        assert!(
+            out.contains(r#"href="/about""#),
+            "expected unchanged href; got: {out}"
+        );
+        assert!(
+            !out.contains("/foo/about"),
+            "did not expect /foo/about; got: {out}"
+        );
+    }
+
+    #[test]
+    fn rewrite_html_data_no_base_optout_form() {
+        let html = r#"<form action="/submit" data-no-base><input/></form>"#;
+        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        assert!(out.contains(r#"action="/submit""#), "got: {out}");
+        assert!(!out.contains("/foo/submit"), "got: {out}");
+    }
+
+    #[test]
+    fn rewrite_html_data_no_base_with_value_also_optout() {
+        // The opt-out is presence-based, like other boolean-ish
+        // data attributes; any value (including bareword, `"true"`,
+        // empty) skips.
+        for snippet in [
+            r#"<a href="/x" data-no-base>x</a>"#,
+            r#"<a href="/x" data-no-base="">x</a>"#,
+            r#"<a href="/x" data-no-base="true">x</a>"#,
+            r#"<a href="/x" data-no-base="anything">x</a>"#,
+        ] {
+            let out = rewrite_links_in_html(snippet, "/foo").unwrap();
+            assert!(
+                out.contains(r#"href="/x""#) && !out.contains("/foo/x"),
+                "expected unchanged for: {snippet}; got: {out}"
+            );
+        }
+    }
+
+    #[test]
+    fn rewrite_html_attribute_order_does_not_matter() {
+        // data-no-base could appear before href.
+        let html = r#"<a data-no-base href="/about">About</a>"#;
+        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        assert!(out.contains(r#"href="/about""#), "got: {out}");
+        assert!(!out.contains("/foo/about"), "got: {out}");
+    }
+
+    #[test]
+    fn rewrite_html_skips_external_relative_and_schemed() {
+        // NB: outer raw-string delimiter is `r##"..."##` because the
+        // inner literal contains `"#anchor"` — `r#"..."#` would close
+        // at `"#` and split the test data in half.
+        let html = r##"<a href="//cdn.example.com/x">cdn</a>
+            <a href="#anchor">anchor</a>
+            <a href="mailto:x@y">mail</a>
+            <a href="http://example.com/">http</a>
+            <a href="https://example.com/">https</a>
+            <a href="javascript:void(0)">js</a>
+            <a href="foo.html">rel</a>
+            <a href="./foo">dot</a>
+            <a href="../foo">dotdot</a>"##;
+        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        // None of the originals should have been touched.
+        for original in [
+            r#"href="//cdn.example.com/x""#,
+            r##"href="#anchor""##,
+            r#"href="mailto:x@y""#,
+            r#"href="http://example.com/""#,
+            r#"href="https://example.com/""#,
+            r#"href="javascript:void(0)""#,
+            r#"href="foo.html""#,
+            r#"href="./foo""#,
+            r#"href="../foo""#,
+        ] {
+            assert!(
+                out.contains(original),
+                "expected to find {original} in: {out}"
+            );
+        }
+        // And nothing got prefixed.
+        assert!(
+            !out.contains("/foo/"),
+            "no rewrites expected; got: {out}"
+        );
+    }
+
+    #[test]
+    fn rewrite_html_idempotent_on_already_prefixed() {
+        // Already-prefixed values stay byte-identical.
+        let html = r#"<a href="/foo/about">about</a>"#;
+        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        assert_eq!(out, html);
+    }
+
+    #[test]
+    fn rewrite_html_handles_multiple_links_in_one_doc() {
+        let html = r#"<!doctype html><html><body>
+            <a href="/about">About</a>
+            <a href="/contact">Contact</a>
+            <form action="/login"><input/></form>
+            <a href="/foo/already">Already</a>
+            <a href="https://example.com/">Out</a>
+        </body></html>"#;
+        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        assert!(out.contains(r#"href="/foo/about""#), "got: {out}");
+        assert!(out.contains(r#"href="/foo/contact""#), "got: {out}");
+        assert!(out.contains(r#"action="/foo/login""#), "got: {out}");
+        // Already-prefixed stays as-is.
+        assert!(out.contains(r#"href="/foo/already""#), "got: {out}");
+        // External stays as-is.
+        assert!(
+            out.contains(r#"href="https://example.com/""#),
+            "got: {out}"
+        );
+    }
+
+    #[test]
+    fn rewrite_html_root_alone_gets_base_root() {
+        let html = r#"<a href="/">home</a>"#;
+        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        assert!(out.contains(r#"href="/foo/""#), "got: {out}");
+    }
+
+    // --- apply_link_base_rewrite (file I/O) ----------------------------------
+
+    fn write_file(dir: &Path, rel: &str, body: &str) -> PathBuf {
+        let abs = dir.join(rel);
+        if let Some(parent) = abs.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&abs, body).unwrap();
+        abs
+    }
+
+    #[test]
+    fn apply_no_base_is_noop_on_disk() {
+        let tmp = tempdir().unwrap();
+        let body = r#"<a href="/about">about</a>"#;
+        let p = write_file(tmp.path(), "index.html", body);
+        apply_link_base_rewrite(tmp.path(), &[p.clone()], None).unwrap();
+        let after = fs::read_to_string(&p).unwrap();
+        assert_eq!(after, body);
+    }
+
+    #[test]
+    fn apply_root_base_is_noop_on_disk() {
+        // base = "/" normalises to "" → no-op
+        let tmp = tempdir().unwrap();
+        let body = r#"<a href="/about">about</a>"#;
+        let p = write_file(tmp.path(), "index.html", body);
+        apply_link_base_rewrite(tmp.path(), &[p.clone()], Some("/")).unwrap();
+        let after = fs::read_to_string(&p).unwrap();
+        assert_eq!(after, body);
+    }
+
+    #[test]
+    fn apply_subpath_base_with_trailing_slash() {
+        let tmp = tempdir().unwrap();
+        let body = r#"<!doctype html><html><body><a href="/about">About</a></body></html>"#;
+        let p = write_file(tmp.path(), "index.html", body);
+        apply_link_base_rewrite(tmp.path(), &[p.clone()], Some("/foo/")).unwrap();
+        let after = fs::read_to_string(&p).unwrap();
+        assert!(
+            after.contains(r#"href="/foo/about""#),
+            "expected /foo/about; got: {after}"
+        );
+    }
+
+    #[test]
+    fn apply_subpath_base_without_trailing_slash_is_canonical() {
+        let tmp = tempdir().unwrap();
+        let body = r#"<a href="/about">about</a>"#;
+        let p = write_file(tmp.path(), "index.html", body);
+        apply_link_base_rewrite(tmp.path(), &[p.clone()], Some("/foo")).unwrap();
+        let after = fs::read_to_string(&p).unwrap();
+        assert!(
+            after.contains(r#"href="/foo/about""#),
+            "expected /foo/about; got: {after}"
+        );
+    }
+
+    #[test]
+    fn apply_absolute_url_base_skips_user_links() {
+        // CDN-shaped base does NOT rewrite user links.
+        let tmp = tempdir().unwrap();
+        let body = r#"<a href="/about">about</a>"#;
+        let p = write_file(tmp.path(), "index.html", body);
+        apply_link_base_rewrite(tmp.path(), &[p.clone()], Some("https://cdn.example.com/")).unwrap();
+        let after = fs::read_to_string(&p).unwrap();
+        assert_eq!(after, body, "user links should stay same-origin");
+    }
+
+    #[test]
+    fn apply_skips_non_html_files() {
+        let tmp = tempdir().unwrap();
+        let xml_body = r#"<?xml version="1.0"?><feed><link href="/post/1"/></feed>"#;
+        let xml = write_file(tmp.path(), "feed.xml", xml_body);
+        apply_link_base_rewrite(tmp.path(), &[xml.clone()], Some("/foo")).unwrap();
+        let after = fs::read_to_string(&xml).unwrap();
+        assert_eq!(
+            after, xml_body,
+            "non-HTML file should not be touched"
+        );
+    }
+
+    #[test]
+    fn apply_handles_form_action_in_real_doc() {
+        let tmp = tempdir().unwrap();
+        let body = r#"<!doctype html><html><body>
+            <form action="/submit" method="post"><button>go</button></form>
+        </body></html>"#;
+        let p = write_file(tmp.path(), "index.html", body);
+        apply_link_base_rewrite(tmp.path(), &[p.clone()], Some("/foo/")).unwrap();
+        let after = fs::read_to_string(&p).unwrap();
+        assert!(
+            after.contains(r#"action="/foo/submit""#),
+            "expected /foo/submit; got: {after}"
+        );
+    }
+
+    #[test]
+    fn apply_idempotent_on_second_run() {
+        // Run the pass twice; the second run is a no-op (no
+        // double-prefix).
+        let tmp = tempdir().unwrap();
+        let body = r#"<a href="/about">about</a>"#;
+        let p = write_file(tmp.path(), "index.html", body);
+        apply_link_base_rewrite(tmp.path(), &[p.clone()], Some("/foo/")).unwrap();
+        let after_first = fs::read_to_string(&p).unwrap();
+        apply_link_base_rewrite(tmp.path(), &[p.clone()], Some("/foo/")).unwrap();
+        let after_second = fs::read_to_string(&p).unwrap();
+        assert_eq!(after_first, after_second);
+        assert!(after_second.contains(r#"href="/foo/about""#));
+        assert!(!after_second.contains("/foo/foo/"));
+    }
+
+    #[test]
+    fn apply_handles_data_no_base_end_to_end() {
+        let tmp = tempdir().unwrap();
+        let body = r#"<!doctype html><html><body>
+            <a href="/about">about</a>
+            <a href="/legal" data-no-base>legal-stays-bare</a>
+        </body></html>"#;
+        let p = write_file(tmp.path(), "index.html", body);
+        apply_link_base_rewrite(tmp.path(), &[p.clone()], Some("/foo/")).unwrap();
+        let after = fs::read_to_string(&p).unwrap();
+        assert!(after.contains(r#"href="/foo/about""#), "got: {after}");
+        assert!(after.contains(r#"href="/legal""#), "got: {after}");
+        assert!(!after.contains("/foo/legal"), "got: {after}");
+    }
+
+    #[test]
+    fn is_html_path_extension_check() {
+        assert!(is_html_path(Path::new("a.html")));
+        assert!(is_html_path(Path::new("nested/dir/a.html")));
+        assert!(is_html_path(Path::new("a.htm")));
+        assert!(!is_html_path(Path::new("a.xml")));
+        assert!(!is_html_path(Path::new("a.json")));
+        assert!(!is_html_path(Path::new("a.txt")));
+        assert!(!is_html_path(Path::new("noext")));
+    }
+}

--- a/crates/zfb/src/commands/link_base_rewrite.rs
+++ b/crates/zfb/src/commands/link_base_rewrite.rs
@@ -54,8 +54,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use lol_html::html_content::Element;
-use lol_html::{ElementContentHandlers, LocalHandlerTypes, RewriteStrSettings, Selector};
+use zfb_build::link_base_rewrite::rewrite_links_in_html;
 
 use crate::config::asset_url_base_prefix;
 
@@ -129,116 +128,26 @@ fn is_html_path(p: &Path) -> bool {
     )
 }
 
-/// Rewrite root-absolute `<a href>` / `<form action>` in `html` by
-/// prepending `prefix`. Pure function — no I/O.
-///
-/// `prefix` MUST be the canonical form returned by
-/// [`asset_url_base_prefix`]: empty (no base), a path with no trailing
-/// slash (`/foo`), or an absolute URL with no trailing slash. The
-/// caller guards against the empty / absolute-URL forms; we still
-/// behave correctly if those slip through (empty prefix yields
-/// no-op via the idempotency check; absolute-URL prefix would
-/// mis-rewrite, hence the caller's gate).
-fn rewrite_links_in_html(
-    html: &str,
-    prefix: &str,
-) -> Result<String, lol_html::errors::RewritingError> {
-    use std::borrow::Cow;
-
-    let a_selector: Selector = "a[href]".parse().expect("static selector is valid");
-    let form_selector: Selector = "form[action]"
-        .parse()
-        .expect("static selector is valid");
-
-    // Each handler is `FnMut + Send + Sync`; we capture an owned
-    // `String` clone of the prefix so the closures don't borrow from
-    // the outer scope.
-    let prefix_for_a = prefix.to_string();
-    let prefix_for_form = prefix.to_string();
-
-    lol_html::rewrite_str(
-        html,
-        RewriteStrSettings {
-            element_content_handlers: vec![
-                (
-                    Cow::Owned(a_selector),
-                    ElementContentHandlers::default().element(move |el: &mut Element<'_, '_, _>| {
-                        if has_no_base_optout(el) {
-                            return Ok(());
-                        }
-                        if let Some(href) = el.get_attribute("href") {
-                            if let Some(rewritten) = compute_prefixed(&href, &prefix_for_a) {
-                                el.set_attribute("href", &rewritten)?;
-                            }
-                        }
-                        Ok(())
-                    }),
-                ),
-                (
-                    Cow::Owned(form_selector),
-                    ElementContentHandlers::default().element(move |el: &mut Element<'_, '_, _>| {
-                        if has_no_base_optout(el) {
-                            return Ok(());
-                        }
-                        if let Some(action) = el.get_attribute("action") {
-                            if let Some(rewritten) = compute_prefixed(&action, &prefix_for_form) {
-                                el.set_attribute("action", &rewritten)?;
-                            }
-                        }
-                        Ok(())
-                    }),
-                ),
-            ],
-            ..RewriteStrSettings::new()
-        },
-    )
-}
-
-/// Return the prefixed value, or `None` to leave the attribute alone.
-///
-/// See module docs for the full skip table. The check order matters
-/// for clarity but not for correctness — each branch is independent.
-fn compute_prefixed(value: &str, prefix: &str) -> Option<String> {
-    if value.is_empty() {
-        return None;
-    }
-    let bytes = value.as_bytes();
-    if bytes[0] != b'/' {
-        // Catches relative paths, fragment-only, AND every schemed
-        // URL (mailto:, http:, javascript:, …) — none start with `/`.
-        return None;
-    }
-    if bytes.len() >= 2 && bytes[1] == b'/' {
-        // Protocol-relative `//host/...`.
-        return None;
-    }
-    // Idempotency: if the value is already mounted under `prefix`,
-    // leave it alone. We require the boundary after the prefix to be
-    // either end-of-string or `/`, so `/foobar` is NOT considered
-    // already-prefixed by `/foo`.
-    if value.starts_with(prefix) {
-        let rest = &value[prefix.len()..];
-        if rest.is_empty() || rest.starts_with('/') {
-            return None;
-        }
-    }
-    Some(format!("{prefix}{value}"))
-}
-
-/// Case-insensitive check: is `data-no-base` present on this element?
-/// `lol_html`'s element selectors and `get_attribute` are already
-/// case-insensitive on attribute names, so a literal lookup suffices.
-fn has_no_base_optout(el: &Element<'_, '_, LocalHandlerTypes>) -> bool {
-    el.has_attribute("data-no-base")
-}
+// `rewrite_links_in_html`, `compute_prefixed`, and `has_no_base_optout`
+// live in `zfb_build::link_base_rewrite` so the dev server (issue
+// #229's `routes::page_response_bytes`) and this build-pass call the
+// same code. The dev server applies the rewrite in-flight on cached
+// HTML responses; the build pass applies it on disk via
+// [`apply_link_base_rewrite`] above.
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::fs;
     use tempfile::tempdir;
+    use zfb_build::link_base_rewrite::{compute_prefixed, rewrite_links_in_html};
 
     // --- compute_prefixed -----------------------------------------------------
+    //
+    // The pure-string pieces are tested in zfb_build::link_base_rewrite
+    // alongside their implementation; the smoke tests here keep a
+    // few cases pinned at this layer to prevent silent drift if a
+    // future refactor extracts/re-exports them differently.
 
     #[test]
     fn compute_prefixed_root_absolute_gets_prefix() {
@@ -277,6 +186,26 @@ mod tests {
         assert_eq!(compute_prefixed("/foo/", "/foo"), None);
         assert_eq!(compute_prefixed("/foo/about", "/foo"), None);
         assert_eq!(compute_prefixed("/foo/api/x", "/foo"), None);
+    }
+
+    #[test]
+    fn compute_prefixed_idempotent_on_prefixed_with_query_or_fragment() {
+        // Codex review caught these: a prefixed URL with a `?query` or
+        // `#fragment` suffix is still under the prefix and must NOT be
+        // double-prefixed. Without the `?` / `#` boundary, the previous
+        // logic would rewrite `/foo?tab=1` → `/foo/foo?tab=1` because
+        // it failed the "rest starts with /" check.
+        assert_eq!(compute_prefixed("/foo?tab=1", "/foo"), None);
+        assert_eq!(compute_prefixed("/foo?", "/foo"), None);
+        assert_eq!(compute_prefixed("/foo#top", "/foo"), None);
+        assert_eq!(compute_prefixed("/foo#", "/foo"), None);
+        assert_eq!(compute_prefixed("/foo?x=1#y", "/foo"), None);
+        // The boundary still rejects partial matches: `/foobar?` is NOT
+        // under prefix `/foo` and should still be rewritten.
+        assert_eq!(
+            compute_prefixed("/foobar?x=1", "/foo").as_deref(),
+            Some("/foo/foobar?x=1"),
+        );
     }
 
     #[test]

--- a/crates/zfb/src/commands/mod.rs
+++ b/crates/zfb/src/commands/mod.rs
@@ -6,6 +6,7 @@
 pub mod build;
 pub mod check;
 pub mod dev;
+pub mod link_base_rewrite;
 pub mod new;
 pub mod plugins;
 pub mod preview;


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/232
    - https://github.com/Takazudo/zudo-front-builder/issues/228
    - https://github.com/Takazudo/zudo-front-builder/issues/229
    - https://github.com/Takazudo/zudo-front-builder/issues/230
    - https://github.com/Takazudo/zudo-front-builder/issues/231

---

## Summary

Coordinated handling of 4 recently filed issues. Each one is implemented as its own topic branch / worktree, all merged into this root PR. A post-merge code-review pass (codex + Copilot CLI cheap mode) caught two follow-up bugs that are also fixed here.

### Scope

| Issue | What changed |
| ----- | ------------ |
| #228 link-base-prefix | Build pass rewrites root-absolute `<a href="/...">` and `<form action="/...">` to apply the configured `base` prefix. Skip-list covers external, fragment-only, protocol-relative, schemed, and relative URLs. `data-no-base` opt-out for elements that should keep their original literal. Idempotent on re-runs. |
| #229 dev-base-mount | Dev server now mounts every route under the configured `base` prefix (pages, assets, public, livereload SSE + script, plugin middleware). Bare `GET /` redirects (303) to `/<base>/`. Unprefixed paths get a hinted 404 pointing at the configured base. Plugin handlers continue to receive unprefixed URLs (auto-prefix + auto-strip). No-base mode is byte-identical to the pre-`base` server. |
| #230 dev-mw-methods | Page-renderer mounts switch to `any(...)` so devMiddleware plugin handlers receive POST/PUT/DELETE/PATCH along with GET/HEAD. `req.method`, `req.headers`, `req.body` all forwarded (UTF-8 bodies; non-UTF-8 dropped per the existing line-protocol contract). Built-in routes (`/__zfb/livereload.js`, `/__zfb/reload`, `/assets/*`, `/public/*`) keep their existing GET-only semantics — the issue's security callout. Page-cache fallback returns `405 Allow: GET, HEAD` for non-GET requests no plugin claims. |
| #231 build-output-cleanup | `.zfb-build/` (the SSR worker bundle + sourcemap, ~350 KB) relocated from `dist/.zfb-build/` to `<project_root>/.zfb-build/`. Stops the build intermediate from shipping in deploy uploads (Cloudflare Pages, Netlify, S3, etc.). Renderer + adapter consume the absolute path returned by the bundler so callers downstream are unaffected. `.gitignore` updated. |

### Post-merge review fixes (codex + gcoc)

| Bug | What it does |
| --- | ------------ |
| Dev mode wasn't applying the build-time link rewrite — cached HTML still contained user `<a href="/about">` literals, which 404'd against the new `/<base>/` mount | Pure-string rewriter moved from `zfb::commands::link_base_rewrite` to a shared `zfb_build::link_base_rewrite` module. Both build (file walker) and dev (in-flight per response) call the same code; structural drift is now impossible. |
| `compute_prefixed` idempotency check accepted only `/` and end-of-string as boundary chars, so `/foo?tab=1` and `/foo#top` (already under `/foo`) got misclassified as unprefixed and double-prefixed | Boundary now includes `?` and `#` alongside `/` and end-of-string. Tests pin the regression. |

### Test count

- `zfb-server`: 67 unit + 8 + 7 integration tests (was 50/3/3 on main)
- `zfb`: 212 lib tests
- `zfb-build`: 159 lib tests (new `link_base_rewrite` adds 33)
- `zfb-types`: 11 tests (new `base_prefix` adds 8)
- All workspace tests green

### Reviewers

Combined reviewer mode: `-co` (codex) + `-gcoc` (Copilot CLI cheap, gpt-4.1).

## Test plan

- [ ] `zfb build` on a project with `base = "/foo/"` configured: assert `<a href="/...">` and `<form action="/...">` are prefixed in emitted HTML; `<a href="/foo/already?tab=1">` stays as-is; `<a href="/about" data-no-base>` stays bare.
- [ ] `zfb dev` on the same project: visit `http://localhost:port/` → 303 redirect to `/foo/`; visit `/foo/` → home page renders, livereload `<script src="/foo/__zfb/livereload.js">` is injected; click an internal link → navigates correctly under `/foo/`.
- [ ] `zfb dev` plugin: register `devMiddleware` at `/api/echo`, POST JSON to `/foo/api/echo` → handler runs, sees `req.method = "POST"`, `req.body` populated.
- [ ] `zfb dev`: POST to `/foo/__zfb/livereload.js` → 405 (security guarantee preserved).
- [ ] `zfb build`: assert `dist/.zfb-build/` does NOT exist; `<project_root>/.zfb-build/bundle.mjs` does exist.

---

Closes #228
Closes #229
Closes #230
Closes #231
