### PR TITLE
feat(content): nested-route source map, multi-locale resolveMarkdownLinks, basePath trailing-slash

### DIFF
--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -187,20 +187,38 @@ pub enum OnBrokenLinks {
 /// Options for the `ResolveLinksPlugin` in the bundler pipeline.
 ///
 /// When present on [`BundlerInput`], the bundler builds a
-/// `path → URL` source map from `docs_dir`, appends
+/// `path → URL` source map from every entry in `routes`, appends
 /// [`zfb_content::plugins::ResolveLinksPlugin`] to the mdast pipeline of
 /// every materialisation call, and handles broken links according to
 /// `on_broken_links` after the walk completes.
+///
+/// Each entry in `routes` is one source dir + its route prefix
+/// (e.g. EN docs at `src/content/docs/` → `/docs/`, JA docs at
+/// `src/content/docs-ja/` → `/ja/docs/`). The bundler scans them all
+/// and merges the resulting `path → URL` map. Required for any project
+/// with locale mirrors so each mirror dir resolves under its own route
+/// prefix — see `zudolab/zudo-doc#1577` for the host-side bug this
+/// surfaces when only a single dir is configured.
 #[derive(Debug, Clone)]
 pub struct ResolveMarkdownLinksSpec {
-    /// Directory (absolute or project-relative) whose `.md`/`.mdx` files
-    /// are scanned to build the source map.
-    pub docs_dir: PathBuf,
-    /// Route prefix applied to every slug when building the source map
-    /// (e.g. `"/docs/"`). Must include the trailing slash.
-    pub route_prefix: String,
+    /// Per-dir source map. Empty `routes` is a no-op (caller would
+    /// just not pass `Some` in that case).
+    pub routes: Vec<ResolveMarkdownLinksRoute>,
     /// What to do with unresolved `.md`/`.mdx` links.
     pub on_broken_links: OnBrokenLinks,
+}
+
+/// One entry in [`ResolveMarkdownLinksSpec::routes`]. Mirrors
+/// [`zfb_content::plugins::util::source_map::CollectionRoute`] minus the
+/// informational `name` (callers don't surface route names).
+#[derive(Debug, Clone)]
+pub struct ResolveMarkdownLinksRoute {
+    /// Directory (absolute or project-relative) whose `.md`/`.mdx`
+    /// files are scanned.
+    pub docs_dir: PathBuf,
+    /// Route prefix applied to every slug from this dir
+    /// (e.g. `"/docs/"`). Must include the trailing slash.
+    pub route_prefix: String,
 }
 
 /// All the inputs the bundler needs.
@@ -531,21 +549,29 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
 
     // 1b. Build the resolve-links source map when the feature is enabled.
     //
-    // The map is built once here (before the shadow walk) from the
-    // configured `docs_dir` and shared across all materialise calls via
-    // a reference. An empty map is used when the feature is disabled so
+    // The map is built once here (before the shadow walk) from every
+    // configured route and shared across all materialise calls via a
+    // reference. An empty map is used when the feature is disabled so
     // the materialise helpers can always receive a reference without
     // conditional logic at each call site.
+    //
+    // Multi-route shape (sub #234) lets locale mirrors map to distinct
+    // route prefixes — required for any project with EN+JA mirrors, or
+    // any other multi-collection layout, so each mirror dir resolves
+    // under its own route prefix (`/docs/` vs `/ja/docs/`).
     let resolve_source_map: HashMap<std::path::PathBuf, String> =
         if let Some(spec) = &input.resolve_markdown_links {
-            let docs_dir = resolver.resolve(&spec.docs_dir);
-            build_docs_source_map(DocsSourceMapOptions {
-                collections: vec![CollectionRoute {
-                    name: "docs".to_string(),
-                    dir: docs_dir,
-                    route_prefix: spec.route_prefix.clone(),
-                }],
-            })
+            let collections: Vec<CollectionRoute> = spec
+                .routes
+                .iter()
+                .enumerate()
+                .map(|(i, r)| CollectionRoute {
+                    name: format!("routes[{i}]"),
+                    dir: resolver.resolve(&r.docs_dir),
+                    route_prefix: r.route_prefix.clone(),
+                })
+                .collect();
+            build_docs_source_map(DocsSourceMapOptions { collections })
         } else {
             HashMap::new()
         };

--- a/crates/zfb-build/src/lib.rs
+++ b/crates/zfb-build/src/lib.rs
@@ -67,7 +67,7 @@ pub use adapter::{
 pub use atomic::{atomic_write, atomic_write_string, validate_output_path};
 pub use bundler::{
     bundle, BundleManifest, BundleMode, BundlerInput, BundlerOutput, ContentCollectionSpec,
-    OnBrokenLinks, ResolveMarkdownLinksSpec, RouteEntry,
+    OnBrokenLinks, ResolveMarkdownLinksRoute, ResolveMarkdownLinksSpec, RouteEntry,
 };
 pub use head_inject::{
     css_link_tag, inject_prod_head_assets, island_module_script_tag, ProdHeadAssets,

--- a/crates/zfb-build/src/link_base_rewrite.rs
+++ b/crates/zfb-build/src/link_base_rewrite.rs
@@ -47,12 +47,27 @@ use lol_html::{ElementContentHandlers, LocalHandlerTypes, RewriteStrSettings, Se
 /// it here. An empty prefix is a no-op via the idempotency check, so
 /// callers do not need to short-circuit themselves.
 ///
+/// `add_trailing_slash` controls whether extensionless `<a>` hrefs gain
+/// a trailing `/` after the prefix is prepended (so
+/// `/docs/getting-started` becomes `/foo/docs/getting-started/` rather
+/// than `/foo/docs/getting-started`). Hrefs that already end in `/`,
+/// carry a file extension (`.png`, `.pdf`, …), or opt out via
+/// `data-no-base` are unaffected. The trailing slash is inserted before
+/// any `?query` or `#fragment` suffix so
+/// `/x?y=1` becomes `/foo/x/?y=1`. See [`compute_prefixed`] /
+/// [`compute_prefixed_with_trailing_slash`] for the full rule set.
+///
+/// `add_trailing_slash` does NOT affect `<form action>` rewriting —
+/// form endpoints stay verbatim because they are POST/GET targets, not
+/// canonical page URLs.
+///
 /// Absolute-URL prefixes (`https://cdn.example.com`) are accepted but
 /// callers should prefer to skip the rewrite — user navigation
 /// shouldn't redirect to a CDN host that doesn't serve HTML.
 pub fn rewrite_links_in_html(
     html: &str,
     prefix: &str,
+    add_trailing_slash: bool,
 ) -> Result<String, lol_html::errors::RewritingError> {
     let a_selector: Selector = "a[href]".parse().expect("static selector is valid");
     let form_selector: Selector = "form[action]"
@@ -76,7 +91,11 @@ pub fn rewrite_links_in_html(
                             return Ok(());
                         }
                         if let Some(href) = el.get_attribute("href") {
-                            if let Some(rewritten) = compute_prefixed(&href, &prefix_for_a) {
+                            if let Some(rewritten) = compute_prefixed_with_trailing_slash(
+                                &href,
+                                &prefix_for_a,
+                                add_trailing_slash,
+                            ) {
                                 el.set_attribute("href", &rewritten)?;
                             }
                         }
@@ -90,6 +109,8 @@ pub fn rewrite_links_in_html(
                             return Ok(());
                         }
                         if let Some(action) = el.get_attribute("action") {
+                            // Form actions are POST/GET targets, not
+                            // page URLs — never append trailing slash.
                             if let Some(rewritten) = compute_prefixed(&action, &prefix_for_form) {
                                 el.set_attribute("action", &rewritten)?;
                             }
@@ -147,6 +168,125 @@ pub fn compute_prefixed(value: &str, prefix: &str) -> Option<String> {
         }
     }
     Some(format!("{prefix}{value}"))
+}
+
+/// Same as [`compute_prefixed`] but optionally appends a trailing `/`
+/// to extensionless paths after prefixing.
+///
+/// When `add_trailing_slash == false`, behaviour is byte-identical to
+/// `compute_prefixed`. When `true`, the path portion of the result
+/// (everything before the first `?` or `#`) gains a trailing `/` if:
+///
+/// - the path doesn't already end in `/`, AND
+/// - the last path segment has no file extension (no `.` after the
+///   final `/`).
+///
+/// Examples (with `prefix = "/foo"`, `add_trailing_slash = true`):
+///
+/// | input                       | output                            |
+/// |-----------------------------|-----------------------------------|
+/// | `/docs/getting-started`     | `/foo/docs/getting-started/`      |
+/// | `/docs/x?tab=1`             | `/foo/docs/x/?tab=1`              |
+/// | `/docs/x#top`               | `/foo/docs/x/#top`                |
+/// | `/docs/already/`            | `/foo/docs/already/` (no change)  |
+/// | `/img/logo.png`             | `/foo/img/logo.png` (extension)   |
+/// | `/foo/about` (idempotent)   | unchanged                         |
+///
+/// The skip rules from [`compute_prefixed`] still apply — empty,
+/// schemed, protocol-relative, fragment-only, relative paths, and
+/// already-prefixed values pass through unchanged.
+pub fn compute_prefixed_with_trailing_slash(
+    value: &str,
+    prefix: &str,
+    add_trailing_slash: bool,
+) -> Option<String> {
+    if !add_trailing_slash {
+        return compute_prefixed(value, prefix);
+    }
+
+    // The trailing-slash post-process is ONLY safe to run on values
+    // that look like root-absolute internal paths. Anything compute_prefixed
+    // would skip outright (empty, protocol-relative `//`, fragment-only,
+    // schemed URLs, relative paths) must pass through untouched — appending
+    // `/` to e.g. `//cdn.example.com/x` would silently rewrite the host.
+    //
+    // We accept the value when EITHER:
+    //   - compute_prefixed returns Some(prefixed) — it was eligible for
+    //     base-prefixing, so it is a root-absolute internal path; OR
+    //   - compute_prefixed returns None *and* the value already starts
+    //     with `prefix` (idempotent case) — it is already-prefixed
+    //     internal navigation, so we still apply the trailing slash to
+    //     normalise once-rewritten HTML.
+    //
+    // Skipped-without-being-prefixed values (external / fragment-only /
+    // relative / etc.) yield None.
+    let candidate = match compute_prefixed(value, prefix) {
+        Some(prefixed) => prefixed,
+        None => {
+            // Already-prefixed branch — only when the value itself is
+            // an internal root-absolute path mounted under `prefix`.
+            // Empty prefix is a special case: every leading-`/` value
+            // is "already under" an empty prefix per the idempotency
+            // check, so we'd treat all of them as eligible. Skip the
+            // empty-prefix case to preserve the no-base no-op contract.
+            if prefix.is_empty() || !is_under_prefix(value, prefix) {
+                return None;
+            }
+            value.to_string()
+        }
+    };
+    let with_slash = maybe_insert_trailing_slash(&candidate);
+    if with_slash == value {
+        // Nothing changed — return None so the caller leaves the
+        // attribute alone (preserves `set_attribute` no-op semantics).
+        None
+    } else {
+        Some(with_slash)
+    }
+}
+
+/// True when `value` starts with `prefix` and the boundary character
+/// after the prefix is one of: end-of-string, `/`, `?`, `#`. This is
+/// the same idempotency check `compute_prefixed` uses internally.
+fn is_under_prefix(value: &str, prefix: &str) -> bool {
+    if !value.starts_with(prefix) {
+        return false;
+    }
+    let rest = &value[prefix.len()..];
+    rest.is_empty()
+        || rest.starts_with('/')
+        || rest.starts_with('?')
+        || rest.starts_with('#')
+}
+
+/// Insert `/` between the path part and the `?query`/`#fragment`
+/// suffix when the path part is extensionless and not already
+/// slash-terminated.
+///
+/// This is the trailing-slash policy enforcer used by
+/// [`compute_prefixed_with_trailing_slash`]. It treats inputs that
+/// don't begin with `/` as a no-op so it is safe to call on any value.
+fn maybe_insert_trailing_slash(value: &str) -> String {
+    if !value.starts_with('/') {
+        return value.to_string();
+    }
+    // Split off the suffix (?... or #...) so we only touch the path.
+    let suffix_idx = value
+        .find(|c: char| c == '?' || c == '#')
+        .unwrap_or(value.len());
+    let (path, suffix) = value.split_at(suffix_idx);
+    if path.is_empty() {
+        return value.to_string();
+    }
+    if path.ends_with('/') {
+        return value.to_string();
+    }
+    let last_segment = path.rsplit('/').next().unwrap_or("");
+    if last_segment.contains('.') {
+        // Has a file extension (`.png`, `.pdf`, …) — leave it alone.
+        return value.to_string();
+    }
+    format!("{path}/{suffix}")
 }
 
 /// Case-insensitive check: is `data-no-base` present on this element?
@@ -286,7 +426,7 @@ mod tests {
     #[test]
     fn rewrite_a_href_root_absolute() {
         let html = r#"<a href="/about">About</a>"#;
-        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        let out = rewrite_links_in_html(html, "/foo", false).unwrap();
         assert!(
             out.contains(r#"href="/foo/about""#),
             "expected /foo/about; got: {out}"
@@ -296,7 +436,7 @@ mod tests {
     #[test]
     fn rewrite_form_action_root_absolute() {
         let html = r#"<form action="/submit"><input/></form>"#;
-        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        let out = rewrite_links_in_html(html, "/foo", false).unwrap();
         assert!(
             out.contains(r#"action="/foo/submit""#),
             "expected /foo/submit; got: {out}"
@@ -306,7 +446,7 @@ mod tests {
     #[test]
     fn rewrite_data_no_base_optout_a() {
         let html = r#"<a href="/about" data-no-base>About</a>"#;
-        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        let out = rewrite_links_in_html(html, "/foo", false).unwrap();
         assert!(out.contains(r#"href="/about""#), "got: {out}");
         assert!(!out.contains("/foo/about"), "got: {out}");
     }
@@ -318,7 +458,7 @@ mod tests {
             r#"<a href="/x" data-no-base="">x</a>"#,
             r#"<a href="/x" data-no-base="true">x</a>"#,
         ] {
-            let out = rewrite_links_in_html(snippet, "/foo").unwrap();
+            let out = rewrite_links_in_html(snippet, "/foo", false).unwrap();
             assert!(
                 out.contains(r#"href="/x""#) && !out.contains("/foo/x"),
                 "expected unchanged for: {snippet}; got: {out}"
@@ -329,7 +469,7 @@ mod tests {
     #[test]
     fn rewrite_idempotent_on_already_prefixed() {
         let html = r#"<a href="/foo/about">about</a>"#;
-        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        let out = rewrite_links_in_html(html, "/foo", false).unwrap();
         assert_eq!(out, html);
     }
 
@@ -339,7 +479,7 @@ mod tests {
         // HTML with prefixed URLs that carry queries / fragments must
         // stay byte-identical on a second pass.
         let html = r#"<a href="/foo/about?tab=1#top">x</a>"#;
-        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        let out = rewrite_links_in_html(html, "/foo", false).unwrap();
         assert_eq!(out, html);
     }
 
@@ -351,7 +491,7 @@ mod tests {
             <a href="http://example.com/">http</a>
             <a href="javascript:void(0)">js</a>
             <a href="foo.html">rel</a>"##;
-        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        let out = rewrite_links_in_html(html, "/foo", false).unwrap();
         for original in [
             r#"href="//cdn.example.com/x""#,
             r##"href="#anchor""##,
@@ -368,7 +508,7 @@ mod tests {
     #[test]
     fn rewrite_attribute_order_does_not_matter() {
         let html = r#"<a data-no-base href="/about">About</a>"#;
-        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        let out = rewrite_links_in_html(html, "/foo", false).unwrap();
         assert!(out.contains(r#"href="/about""#), "got: {out}");
         assert!(!out.contains("/foo/about"), "got: {out}");
     }
@@ -383,7 +523,7 @@ mod tests {
             <a href="/foo/already?tab=1">AlreadyQuery</a>
             <a href="https://example.com/">Out</a>
         </body></html>"#;
-        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        let out = rewrite_links_in_html(html, "/foo", false).unwrap();
         assert!(out.contains(r#"href="/foo/about""#), "got: {out}");
         assert!(out.contains(r#"href="/foo/contact""#), "got: {out}");
         assert!(out.contains(r#"action="/foo/login""#), "got: {out}");
@@ -395,17 +535,190 @@ mod tests {
     #[test]
     fn rewrite_root_alone_gets_base_root() {
         let html = r#"<a href="/">home</a>"#;
-        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        let out = rewrite_links_in_html(html, "/foo", false).unwrap();
         assert!(out.contains(r#"href="/foo/""#), "got: {out}");
     }
 
     #[test]
     fn rewrite_empty_prefix_is_noop() {
         let html = r#"<a href="/about">About</a><form action="/x"></form>"#;
-        let out = rewrite_links_in_html(html, "").unwrap();
+        let out = rewrite_links_in_html(html, "", false).unwrap();
         // With empty prefix the idempotency check sees `value.starts_with("")`
         // == true and bails, so nothing changes.
         assert!(out.contains(r#"href="/about""#), "got: {out}");
         assert!(out.contains(r#"action="/x""#), "got: {out}");
+    }
+
+    // --- compute_prefixed_with_trailing_slash ----------------------------
+    //
+    // sub #234 / zudolab/zudo-doc#1579: extensionless absolute hrefs gain
+    // a trailing `/` after prefixing so dist HTML matches the canonical
+    // trailing-slash URL shape on deploy targets that 301-redirect
+    // `/foo` → `/foo/`. Hrefs with a file extension, hrefs already
+    // ending in `/`, and the `?query`/`#fragment` boundary all need to
+    // be respected — see [`maybe_insert_trailing_slash`] for the rule
+    // set.
+
+    #[test]
+    fn ts_off_matches_compute_prefixed() {
+        // When add_trailing_slash is false the helper is byte-identical
+        // to compute_prefixed.
+        for v in ["/about", "/x?y=1", "/x#frag", "/foo", "/foo/x"] {
+            assert_eq!(
+                compute_prefixed_with_trailing_slash(v, "/foo", false),
+                compute_prefixed(v, "/foo"),
+                "ts_off divergence for {v}"
+            );
+        }
+    }
+
+    #[test]
+    fn ts_on_appends_slash_to_extensionless_path() {
+        assert_eq!(
+            compute_prefixed_with_trailing_slash("/docs/getting-started", "/foo", true).as_deref(),
+            Some("/foo/docs/getting-started/")
+        );
+        assert_eq!(
+            compute_prefixed_with_trailing_slash("/about", "/foo", true).as_deref(),
+            Some("/foo/about/")
+        );
+    }
+
+    #[test]
+    fn ts_on_inserts_slash_before_query_and_fragment() {
+        assert_eq!(
+            compute_prefixed_with_trailing_slash("/docs/x?tab=1", "/foo", true).as_deref(),
+            Some("/foo/docs/x/?tab=1")
+        );
+        assert_eq!(
+            compute_prefixed_with_trailing_slash("/docs/x#sec", "/foo", true).as_deref(),
+            Some("/foo/docs/x/#sec")
+        );
+        assert_eq!(
+            compute_prefixed_with_trailing_slash("/docs/x?a=1#sec", "/foo", true).as_deref(),
+            Some("/foo/docs/x/?a=1#sec")
+        );
+    }
+
+    #[test]
+    fn ts_on_skips_paths_with_file_extensions() {
+        // Asset paths must NOT gain a trailing slash — `/img/logo.png`
+        // would 404 as `/img/logo.png/`.
+        assert_eq!(
+            compute_prefixed_with_trailing_slash("/img/logo.png", "/foo", true).as_deref(),
+            Some("/foo/img/logo.png")
+        );
+        assert_eq!(
+            compute_prefixed_with_trailing_slash("/sitemap.xml", "/foo", true).as_deref(),
+            Some("/foo/sitemap.xml")
+        );
+        assert_eq!(
+            compute_prefixed_with_trailing_slash("/files/report.pdf?dl=1", "/foo", true)
+                .as_deref(),
+            Some("/foo/files/report.pdf?dl=1")
+        );
+    }
+
+    #[test]
+    fn ts_on_leaves_already_slash_terminated_alone() {
+        assert_eq!(
+            compute_prefixed_with_trailing_slash("/docs/x/", "/foo", true).as_deref(),
+            Some("/foo/docs/x/")
+        );
+        assert_eq!(
+            compute_prefixed_with_trailing_slash("/docs/x/?y=1", "/foo", true).as_deref(),
+            Some("/foo/docs/x/?y=1")
+        );
+    }
+
+    #[test]
+    fn ts_on_idempotent_on_already_prefixed_with_slash() {
+        // Already-prefixed-and-slash-terminated → unchanged → None.
+        assert_eq!(
+            compute_prefixed_with_trailing_slash("/foo/docs/x/", "/foo", true),
+            None
+        );
+    }
+
+    #[test]
+    fn ts_on_adds_slash_to_already_prefixed_extensionless_path() {
+        // Already-prefixed but missing the slash — apply the slash so
+        // a re-pass on freshly-emitted dist HTML normalises to the
+        // canonical shape (this is the actual zudo-doc#1579 case once
+        // the host enables trailing_slash).
+        assert_eq!(
+            compute_prefixed_with_trailing_slash("/foo/docs/x", "/foo", true).as_deref(),
+            Some("/foo/docs/x/")
+        );
+    }
+
+    #[test]
+    fn ts_on_root_alone_is_unchanged() {
+        // `/` already ends in `/`, no extension — pass-through.
+        assert_eq!(
+            compute_prefixed_with_trailing_slash("/", "/foo", true).as_deref(),
+            Some("/foo/")
+        );
+    }
+
+    #[test]
+    fn ts_on_skips_external_relative_and_schemed() {
+        for v in [
+            "//cdn.example.com/x",
+            "#anchor",
+            "mailto:x@y",
+            "http://example.com/x",
+            "javascript:void(0)",
+            "foo.html",
+            "./foo",
+            "../foo",
+        ] {
+            assert_eq!(
+                compute_prefixed_with_trailing_slash(v, "/foo", true),
+                None,
+                "ts_on should skip {v}"
+            );
+        }
+    }
+
+    #[test]
+    fn rewrite_html_with_ts_on_appends_slash() {
+        let html = r#"<a href="/docs/getting-started">Get</a>
+            <a href="/img/logo.png">img</a>
+            <a href="/docs/x/">stays</a>
+            <form action="/api/submit"><input/></form>"#;
+        let out = rewrite_links_in_html(html, "/foo", true).unwrap();
+        // Page link gains slash.
+        assert!(
+            out.contains(r#"href="/foo/docs/getting-started/""#),
+            "expected slash; got: {out}"
+        );
+        // Asset link does NOT.
+        assert!(
+            out.contains(r#"href="/foo/img/logo.png""#),
+            "expected no slash on asset; got: {out}"
+        );
+        // Already-slashed stays.
+        assert!(
+            out.contains(r#"href="/foo/docs/x/""#),
+            "expected unchanged; got: {out}"
+        );
+        // Form action never gets the slash treatment.
+        assert!(
+            out.contains(r#"action="/foo/api/submit""#),
+            "expected form action without slash; got: {out}"
+        );
+    }
+
+    #[test]
+    fn rewrite_html_with_ts_on_idempotent_on_canonical_shape() {
+        // Once-rewritten HTML in the canonical shape stays byte-identical
+        // on a re-pass — required so dev-mode and build-mode rewrites
+        // converge.
+        let html = r#"<a href="/foo/docs/x/">x</a>
+            <a href="/foo/docs/y/?tab=1">y</a>
+            <a href="/foo/img/logo.png">i</a>"#;
+        let out = rewrite_links_in_html(html, "/foo", true).unwrap();
+        assert_eq!(out, html);
     }
 }

--- a/crates/zfb-build/tests/bundler_resolve_links.rs
+++ b/crates/zfb-build/tests/bundler_resolve_links.rs
@@ -39,7 +39,7 @@ use std::process::Command;
 
 use zfb_build::{
     bundle, BundleMode, BundlerInput, ContentCollectionSpec, OnBrokenLinks,
-    ResolveMarkdownLinksSpec,
+    ResolveMarkdownLinksRoute, ResolveMarkdownLinksSpec,
 };
 use zfb_render::adapters::Framework;
 
@@ -146,9 +146,11 @@ fn make_input_with_resolve(
         strip_md_ext: false,
         code_highlight_theme: None,
         resolve_markdown_links: Some(ResolveMarkdownLinksSpec {
-            docs_dir: PathBuf::from("content/docs"),
-            // Route prefix for the docs collection.
-            route_prefix: "/docs/".to_string(),
+            routes: vec![ResolveMarkdownLinksRoute {
+                docs_dir: PathBuf::from("content/docs"),
+                // Route prefix for the docs collection.
+                route_prefix: "/docs/".to_string(),
+            }],
             on_broken_links,
         }),
     }

--- a/crates/zfb-build/tests/migration_fixes_integration_confirm.rs
+++ b/crates/zfb-build/tests/migration_fixes_integration_confirm.rs
@@ -45,7 +45,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 
-use zfb_build::{bundle, BundleMode, BundlerInput, ContentCollectionSpec, OnBrokenLinks, ResolveMarkdownLinksSpec};
+use zfb_build::{bundle, BundleMode, BundlerInput, ContentCollectionSpec, OnBrokenLinks, ResolveMarkdownLinksRoute, ResolveMarkdownLinksSpec};
 use zfb_render::adapters::Framework;
 
 // ---------------------------------------------------------------------------
@@ -415,8 +415,10 @@ fn make_full_fixture_input(
         code_highlight_theme: Some("InspiredGitHub".to_string()),
         // Warn on broken links — exercises sub #196 / #185 Gap 1.
         resolve_markdown_links: Some(ResolveMarkdownLinksSpec {
-            docs_dir: PathBuf::from("content/docs"),
-            route_prefix: "/docs/".to_string(),
+            routes: vec![ResolveMarkdownLinksRoute {
+                docs_dir: PathBuf::from("content/docs"),
+                route_prefix: "/docs/".to_string(),
+            }],
             on_broken_links: OnBrokenLinks::Warn,
         }),
     }

--- a/crates/zfb-content/src/plugins/util/source_map.rs
+++ b/crates/zfb-content/src/plugins/util/source_map.rs
@@ -37,10 +37,15 @@ pub struct DocsSourceMapOptions {
 /// Walk every collection's `dir` and return a map of
 /// `absolute_file_path` → `url_string`.
 ///
-/// URL is `{route_prefix}{slug}/`, where `slug` is the file stem
-/// (`my-post.md` → `my-post`). Nested directories are flattened — the
-/// slug is just the file stem regardless of depth. Non-`.md` / `.mdx`
-/// files are ignored.
+/// URL is `{route_prefix}{slug}/`, where `slug` is the file path
+/// relative to `route.dir` with the `.md` / `.mdx` extension stripped.
+/// Nested directories are preserved — `components/code-blocks.mdx`
+/// becomes `{route_prefix}components/code-blocks/`, not
+/// `{route_prefix}code-blocks/` (sub #234 nested-route fix). A trailing
+/// `/index` segment is dropped so directory-style URLs collapse to the
+/// parent (`guides/index.mdx` → `{route_prefix}guides/`,
+/// `index.mdx` → `{route_prefix}`). Non-`.md` / `.mdx` files are
+/// ignored.
 ///
 /// Missing directories are silently skipped (a collection with no
 /// content yet is not an error). I/O errors during traversal cause the
@@ -55,14 +60,47 @@ pub fn build_docs_source_map(options: DocsSourceMapOptions) -> HashMap<PathBuf, 
         let mut files: Vec<PathBuf> = Vec::new();
         let _ = collect_md_files(&route.dir, &mut files);
         for path in files {
-            let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            let Some(slug) = slug_for(&route.dir, &path) else {
                 continue;
             };
-            let url = format!("{}{}/", route.route_prefix, stem);
+            let url = if slug.is_empty() {
+                // `{route.dir}/index.mdx` → bare prefix (e.g. `/docs/`).
+                route.route_prefix.clone()
+            } else {
+                format!("{}{}/", route.route_prefix, slug)
+            };
             map.insert(path, url);
         }
     }
     map
+}
+
+/// Build the slug portion of the URL from `path`'s position under `dir`.
+///
+/// - Strips the `dir` prefix → keeps the nested directory structure.
+/// - Strips the `.md` / `.mdx` extension.
+/// - Drops a trailing `/index` segment so directory-style URLs collapse
+///   to the parent (`guides/index.mdx` → `guides`,
+///   `index.mdx` → `""` which the caller maps to the bare prefix).
+/// - Normalises platform path separators to `/`.
+///
+/// Returns `None` when the path can't be expressed relative to `dir`
+/// (caller skips such entries).
+fn slug_for(dir: &Path, path: &Path) -> Option<String> {
+    let rel = path.strip_prefix(dir).ok()?;
+    let mut s = rel.to_string_lossy().replace('\\', "/");
+    if let Some(stripped) = s.strip_suffix(".mdx") {
+        s = stripped.to_string();
+    } else if let Some(stripped) = s.strip_suffix(".md") {
+        s = stripped.to_string();
+    }
+    if s == "index" {
+        return Some(String::new());
+    }
+    if let Some(stripped) = s.strip_suffix("/index") {
+        s = stripped.to_string();
+    }
+    Some(s)
 }
 
 fn collect_md_files(dir: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
@@ -160,7 +198,100 @@ mod tests {
         });
         assert_eq!(map.len(), 2);
         assert_eq!(map.get(&a), Some(&"/docs/intro/".to_string()));
-        assert_eq!(map.get(&b), Some(&"/docs/advanced/".to_string()));
+        // sub #234: nested directory survives — was `/docs/advanced/`
+        // before the fix (file-stem flatten), broke 109 cross-page
+        // links in zudolab/zudo-doc#1577.
+        assert_eq!(map.get(&b), Some(&"/docs/nested/advanced/".to_string()));
+    }
+
+    #[test]
+    fn deeply_nested_paths_preserve_full_directory_structure() {
+        let tmp = TmpDir::new("deep");
+        let a = tmp.write("guides/layout-demos/hide-toc.mdx", "");
+        let b = tmp.write("components/basic-components.mdx", "");
+
+        let map = build_docs_source_map(DocsSourceMapOptions {
+            collections: vec![CollectionRoute {
+                name: "docs".into(),
+                dir: tmp.path.clone(),
+                route_prefix: "/docs/".into(),
+            }],
+        });
+        assert_eq!(
+            map.get(&a),
+            Some(&"/docs/guides/layout-demos/hide-toc/".to_string())
+        );
+        assert_eq!(
+            map.get(&b),
+            Some(&"/docs/components/basic-components/".to_string())
+        );
+    }
+
+    #[test]
+    fn nested_index_collapses_to_parent_directory_url() {
+        let tmp = TmpDir::new("indexed");
+        let a = tmp.write("guides/index.mdx", "");
+        let b = tmp.write("components/index.md", "");
+
+        let map = build_docs_source_map(DocsSourceMapOptions {
+            collections: vec![CollectionRoute {
+                name: "docs".into(),
+                dir: tmp.path.clone(),
+                route_prefix: "/docs/".into(),
+            }],
+        });
+        assert_eq!(map.get(&a), Some(&"/docs/guides/".to_string()));
+        assert_eq!(map.get(&b), Some(&"/docs/components/".to_string()));
+    }
+
+    #[test]
+    fn root_index_maps_to_bare_route_prefix() {
+        let tmp = TmpDir::new("root-index");
+        let a = tmp.write("index.mdx", "");
+
+        let map = build_docs_source_map(DocsSourceMapOptions {
+            collections: vec![CollectionRoute {
+                name: "docs".into(),
+                dir: tmp.path.clone(),
+                route_prefix: "/docs/".into(),
+            }],
+        });
+        assert_eq!(map.get(&a), Some(&"/docs/".to_string()));
+    }
+
+    #[test]
+    fn ja_locale_collection_uses_distinct_route_prefix() {
+        // sub #234 multi-locale wiring: one collection per locale, each
+        // with its own route_prefix. zudolab/zudo-doc#1577 surfaced this
+        // when JA mirror docs would have resolved to `/docs/...` instead
+        // of `/ja/docs/...` if the source map only knew one prefix.
+        let en = TmpDir::new("en");
+        let ja = TmpDir::new("ja");
+        let en_file = en.write("getting-started/installation.mdx", "");
+        let ja_file = ja.write("getting-started/installation.mdx", "");
+
+        let map = build_docs_source_map(DocsSourceMapOptions {
+            collections: vec![
+                CollectionRoute {
+                    name: "docs".into(),
+                    dir: en.path.clone(),
+                    route_prefix: "/docs/".into(),
+                },
+                CollectionRoute {
+                    name: "docs-ja".into(),
+                    dir: ja.path.clone(),
+                    route_prefix: "/ja/docs/".into(),
+                },
+            ],
+        });
+        assert_eq!(
+            map.get(&en_file),
+            Some(&"/docs/getting-started/installation/".to_string())
+        );
+        assert_eq!(
+            map.get(&ja_file),
+            Some(&"/ja/docs/getting-started/installation/".to_string())
+        );
     }
 
     #[test]

--- a/crates/zfb-server/src/lib.rs
+++ b/crates/zfb-server/src/lib.rs
@@ -114,6 +114,13 @@ pub struct ServeOpts {
     /// `"/"`, or an absolute URL) the route table is identical to the
     /// pre-`base` server byte-for-byte.
     pub base: Option<String>,
+
+    /// Mirror of `zfb.config.ts`'s `trailingSlash` field. Threaded
+    /// through to [`crate::routes::AppState::trailing_slash`] so the
+    /// in-flight base-rewrite pass appends `/` to extensionless
+    /// absolute hrefs the same way the production build does
+    /// (sub #234 / zudolab/zudo-doc#1579).
+    pub trailing_slash: bool,
 }
 
 impl ServeOpts {
@@ -186,6 +193,7 @@ where
         plugins: opts.plugins,
         dist_root: opts.dist_root.clone(),
         base_prefix,
+        trailing_slash: opts.trailing_slash,
     };
     let router = build_router(state, opts.public_root.clone());
 

--- a/crates/zfb-server/src/routes.rs
+++ b/crates/zfb-server/src/routes.rs
@@ -340,6 +340,12 @@ pub struct AppState {
     /// page handlers serve content under `/foo/...` and the injected
     /// live-reload script URL points at `/foo/__zfb/livereload.js`.
     pub base_prefix: Option<String>,
+    /// Mirror of `zfb.config.ts`'s `trailingSlash` field. When true,
+    /// the in-flight base-rewrite pass (sub #234 /
+    /// zudolab/zudo-doc#1579) appends `/` to extensionless absolute
+    /// hrefs after prefixing, so dev preview matches the canonical
+    /// trailing-slash URL shape that `zfb build` emits to disk.
+    pub trailing_slash: bool,
 }
 
 /// Build the axum router for the dev server.
@@ -483,6 +489,9 @@ fn unprefixed_404_response(prefix: &str, path: &str) -> Response {
         // and the matching page becomes reachable.
         true,
         prefix,
+        // Static 404 body — its `href="{prefix}/"` already ends in `/`,
+        // so the trailing-slash post-process is a no-op either way.
+        false,
     )
 }
 
@@ -633,6 +642,7 @@ async fn serve_page(
                 &content_type,
                 is_html,
                 lr_prefix,
+                state.trailing_slash,
             );
         }
     }
@@ -656,7 +666,14 @@ async fn serve_page(
             content_type_for_extension(ext)
         };
         let is_html = content_type.to_ascii_lowercase().starts_with("text/html");
-        return page_response_bytes(StatusCode::OK, bytes, &content_type, is_html, lr_prefix);
+        return page_response_bytes(
+            StatusCode::OK,
+            bytes,
+            &content_type,
+            is_html,
+            lr_prefix,
+            state.trailing_slash,
+        );
     }
 
     // 404 is always the dev HTML body so the page is replaced once
@@ -667,6 +684,7 @@ async fn serve_page(
         "text/html; charset=utf-8",
         true,
         lr_prefix,
+        state.trailing_slash,
     )
 }
 
@@ -964,12 +982,17 @@ fn lookup_keys(path: &str) -> Vec<String> {
 /// folded into the `<script src>` URL so the browser fetches the
 /// live-reload JS at the prefixed path the dev server actually serves
 /// it at.
+///
+/// `add_trailing_slash` mirrors `zfb.config.ts`'s `trailingSlash` field
+/// so the dev-mode rewrite shape matches the canonical build-mode
+/// shape (sub #234 / zudolab/zudo-doc#1579).
 fn page_response_bytes(
     status: StatusCode,
     body: Vec<u8>,
     content_type: &str,
     inject_reload: bool,
     base_prefix: &str,
+    add_trailing_slash: bool,
 ) -> Response {
     let body_out: Vec<u8> = if inject_reload {
         // HTML should always be valid UTF-8; fall back to raw bytes on
@@ -987,7 +1010,11 @@ fn page_response_bytes(
                 let rewritten = if base_prefix.is_empty() {
                     Cow::Borrowed(html)
                 } else {
-                    match zfb_build::link_base_rewrite::rewrite_links_in_html(html, base_prefix) {
+                    match zfb_build::link_base_rewrite::rewrite_links_in_html(
+                        html,
+                        base_prefix,
+                        add_trailing_slash,
+                    ) {
                         Ok(s) => Cow::Owned(s),
                         // Graceful degradation in dev mode: lol_html should
                         // not fail on the renderer's well-formed HTML, but
@@ -1034,6 +1061,7 @@ mod tests {
             plugins: None,
             dist_root: std::env::temp_dir().join("zfb-test-dist"),
             base_prefix: None,
+            trailing_slash: false,
         }
     }
 
@@ -1045,6 +1073,7 @@ mod tests {
             plugins: None,
             dist_root: std::env::temp_dir().join("zfb-test-dist"),
             base_prefix: Some(prefix.to_string()),
+            trailing_slash: false,
         }
     }
 
@@ -1480,6 +1509,7 @@ mod tests {
             plugins: Some(set),
             dist_root: std::env::temp_dir().join("zfb-test-dist"),
             base_prefix: None,
+            trailing_slash: false,
         }
     }
 

--- a/crates/zfb-server/tests/integration.rs
+++ b/crates/zfb-server/tests/integration.rs
@@ -69,6 +69,7 @@ impl Harness {
             broadcast: tx.clone(),
             plugins: None,
             base: None,
+            trailing_slash: false,
         };
 
         let server = tokio::spawn(async move {

--- a/crates/zfb-server/tests/plugin_middleware_integration.rs
+++ b/crates/zfb-server/tests/plugin_middleware_integration.rs
@@ -113,6 +113,7 @@ async fn boot_with_dispatcher(
         broadcast: tx,
         plugins: Some(plugin_set),
         base: None,
+        trailing_slash: false,
     };
     let server = tokio::spawn(async move {
         serve_with_listener(opts, listener, std::future::pending::<()>()).await

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -929,6 +929,37 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(args: BuildArgsResolved<'_, R, A>
     // `StripMdExtensionPlugin`. Mirrored in `commands/dev.rs` so dev
     // and build produce the same href shape (zfb#127 / #129).
     bundler_input.strip_md_ext = config.strip_md_ext;
+    // Thread the opt-in `resolveMarkdownLinks` config into the bundler
+    // so the hoisted MDX pre-compile pipeline appends
+    // `ResolveLinksPlugin`. Without this wiring the bundler's MDX
+    // pipeline only ran `StripMdExtensionPlugin`, and author-written
+    // relative `.mdx` links were emitted as relative href values that
+    // broke at the file→directory transformation in dist HTML
+    // (sub #234 / zudolab/zudo-doc#1577). The shared helper
+    // `resolve_links_routes_from_config` builds the same per-route map
+    // the snapshot path uses so content_hash stays deterministic.
+    if let Some(routes) = resolve_links_routes_from_config(project_root, config) {
+        let on_broken_links = match config
+            .resolve_markdown_links
+            .as_ref()
+            .map(|r| r.on_broken_links)
+            .unwrap_or_default()
+        {
+            crate::config::OnBrokenLinks::Warn => zfb_build::bundler::OnBrokenLinks::Warn,
+            crate::config::OnBrokenLinks::Error => zfb_build::bundler::OnBrokenLinks::Error,
+            crate::config::OnBrokenLinks::Ignore => zfb_build::bundler::OnBrokenLinks::Ignore,
+        };
+        bundler_input.resolve_markdown_links = Some(zfb_build::bundler::ResolveMarkdownLinksSpec {
+            routes: routes
+                .into_iter()
+                .map(|r| zfb_build::bundler::ResolveMarkdownLinksRoute {
+                    docs_dir: r.dir,
+                    route_prefix: r.route_prefix,
+                })
+                .collect(),
+            on_broken_links,
+        });
+    }
     // Thread the optional `codeHighlight.theme` from `zfb.config.ts`
     // so the hoisted MDX pre-compile pipeline uses the configured
     // syntect theme instead of the default `base16-ocean.dark`.
@@ -1065,6 +1096,7 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(args: BuildArgsResolved<'_, R, A>
         outdir,
         &render_out.ssg_files_written,
         config.base.as_deref(),
+        config.trailing_slash,
     )
     .context("link base rewrite failed")?;
 
@@ -1425,31 +1457,72 @@ fn strip_jsonc(input: &str) -> String {
 /// `ResolveLinksPlugin`, so `build_snapshot_with_config` can drive the
 /// snapshot-side pipeline through the same plugin shape. Returns `None`
 /// when the project doesn't enable `resolveMarkdownLinks`. See zfb#188.
+///
+/// The shape of `spec` decides which collections to scan:
+///
+/// - `spec.dirs` non-empty → use those entries verbatim.
+/// - `spec.dirs` empty → fall back to the legacy single-dir form, which
+///   pairs `spec.docs_dir` with the hard-coded `/docs/` route prefix.
+///
+/// The bundler-side wiring in `crates/zfb-build/src/bundler.rs` MUST
+/// produce the same URL strings or the snapshot's `content_hash` drifts
+/// from the bundler's bridge-map key, which silently misses the
+/// `globalThis.__zfb.content.get(specifier)` lookup at SSR time
+/// (zfb#187 / #188). The shared helper
+/// [`resolve_links_routes_from_config`] guarantees the two sites stay
+/// in sync.
 fn build_resolve_source_map_for_snapshot(
     project_root: &Path,
     config: &Config,
 ) -> Option<std::collections::HashMap<std::path::PathBuf, String>> {
     use zfb_content::plugins::util::source_map::{
-        build_docs_source_map, CollectionRoute, DocsSourceMapOptions,
+        build_docs_source_map, DocsSourceMapOptions,
     };
+    let routes = resolve_links_routes_from_config(project_root, config)?;
+    let map = build_docs_source_map(DocsSourceMapOptions {
+        collections: routes,
+    });
+    Some(map)
+}
+
+/// Build the `Vec<CollectionRoute>` the source-map helper expects from
+/// a project-root-relative `Config`.
+///
+/// Returns `None` when `resolveMarkdownLinks` is absent or disabled, so
+/// callers can short-circuit. When `spec.dirs` is non-empty, every
+/// entry becomes one `CollectionRoute`; otherwise the legacy single-dir
+/// fallback emits one route at the hard-coded `/docs/` prefix.
+///
+/// Both the snapshot-side helper above and the bundler-side wiring in
+/// `commands/build.rs::build` consume this so the `path → URL` map is
+/// identical at both sites — required for content-hash determinism.
+pub(crate) fn resolve_links_routes_from_config(
+    project_root: &Path,
+    config: &Config,
+) -> Option<Vec<zfb_content::plugins::util::source_map::CollectionRoute>> {
+    use zfb_content::plugins::util::source_map::CollectionRoute;
     let spec = config.resolve_markdown_links.as_ref()?;
     if !spec.enabled {
         return None;
     }
-    let docs_dir = project_root.join(&spec.docs_dir);
-    let map = build_docs_source_map(DocsSourceMapOptions {
-        collections: vec![CollectionRoute {
+    let routes = if !spec.dirs.is_empty() {
+        spec.dirs
+            .iter()
+            .enumerate()
+            .map(|(i, d)| CollectionRoute {
+                name: format!("dirs[{i}]"),
+                dir: project_root.join(&d.dir),
+                route_prefix: d.route_prefix.clone(),
+            })
+            .collect()
+    } else {
+        vec![CollectionRoute {
             name: "docs".to_string(),
-            dir: docs_dir,
-            // Match the bundler's hard-coded `/docs/` prefix in
-            // `crates/zfb-build/src/bundler.rs` (`build_docs_source_map`
-            // call). Both paths must produce the same URL strings or
-            // `[link](./other.mdx)` rewrites diverge byte-for-byte and
-            // the snapshot's content_hash drifts from the bundler's.
+            dir: project_root.join(&spec.docs_dir),
             route_prefix: "/docs/".to_string(),
-        }],
-    });
-    Some(map)
+        }]
+    };
+    Some(routes)
 }
 
 /// When `ZFB_DEBUG_SNAPSHOT` is truthy, build the content snapshot from

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -255,6 +255,7 @@ pub async fn run(args: &DevArgs) -> Result<()> {
         broadcast: tx,
         plugins: plugin_set,
         base: cfg.base.clone(),
+        trailing_slash: cfg.trailing_slash,
     };
 
     output::ready(&format!("http://{host}:{port}"));
@@ -534,6 +535,31 @@ fn boot_dev_renderer(
     // also reads this flag for in-process MDX rendering, so dev preview
     // matches built dist (zfb#127 / #129).
     bundler_input.strip_md_ext = cfg.strip_md_ext;
+    // Mirror the `commands/build.rs` wiring for `resolveMarkdownLinks`
+    // so dev preview rewrites `.mdx` link targets to their final route
+    // URLs the same way the production build does (sub #234).
+    if let Some(routes) = crate::commands::build::resolve_links_routes_from_config(project_root, cfg) {
+        let on_broken_links = match cfg
+            .resolve_markdown_links
+            .as_ref()
+            .map(|r| r.on_broken_links)
+            .unwrap_or_default()
+        {
+            crate::config::OnBrokenLinks::Warn => zfb_build::bundler::OnBrokenLinks::Warn,
+            crate::config::OnBrokenLinks::Error => zfb_build::bundler::OnBrokenLinks::Error,
+            crate::config::OnBrokenLinks::Ignore => zfb_build::bundler::OnBrokenLinks::Ignore,
+        };
+        bundler_input.resolve_markdown_links = Some(zfb_build::bundler::ResolveMarkdownLinksSpec {
+            routes: routes
+                .into_iter()
+                .map(|r| zfb_build::bundler::ResolveMarkdownLinksRoute {
+                    docs_dir: r.dir,
+                    route_prefix: r.route_prefix,
+                })
+                .collect(),
+            on_broken_links,
+        });
+    }
     // Thread the optional `codeHighlight.theme` from `zfb.config.ts`
     // so the hoisted MDX pre-compile pipeline uses the configured
     // syntect theme. Mirrors the `commands/build.rs` wiring.

--- a/crates/zfb/src/commands/link_base_rewrite.rs
+++ b/crates/zfb/src/commands/link_base_rewrite.rs
@@ -76,6 +76,7 @@ pub fn apply_link_base_rewrite(
     out_dir: &Path,
     written_pages: &[PathBuf],
     base: Option<&str>,
+    add_trailing_slash: bool,
 ) -> Result<()> {
     let prefix = asset_url_base_prefix(base);
     if prefix.is_empty() || !prefix.starts_with('/') {
@@ -102,13 +103,14 @@ pub fn apply_link_base_rewrite(
                 page.display()
             )
         })?;
-        let new_html = rewrite_links_in_html(html, &prefix).with_context(|| {
-            format!(
-                "link-base-rewrite: lol_html failed on {} (under {})",
-                page.display(),
-                out_dir.display()
-            )
-        })?;
+        let new_html = rewrite_links_in_html(html, &prefix, add_trailing_slash)
+            .with_context(|| {
+                format!(
+                    "link-base-rewrite: lol_html failed on {} (under {})",
+                    page.display(),
+                    out_dir.display()
+                )
+            })?;
         if new_html != html {
             std::fs::write(page, new_html).with_context(|| {
                 format!(
@@ -282,7 +284,7 @@ mod tests {
     #[test]
     fn rewrite_html_a_href_root_absolute() {
         let html = r#"<a href="/about">About</a>"#;
-        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        let out = rewrite_links_in_html(html, "/foo", false).unwrap();
         assert!(
             out.contains(r#"href="/foo/about""#),
             "expected /foo/about; got: {out}"
@@ -292,7 +294,7 @@ mod tests {
     #[test]
     fn rewrite_html_form_action_root_absolute() {
         let html = r#"<form action="/submit"><input/></form>"#;
-        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        let out = rewrite_links_in_html(html, "/foo", false).unwrap();
         assert!(
             out.contains(r#"action="/foo/submit""#),
             "expected /foo/submit; got: {out}"
@@ -302,7 +304,7 @@ mod tests {
     #[test]
     fn rewrite_html_data_no_base_optout_a() {
         let html = r#"<a href="/about" data-no-base>About</a>"#;
-        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        let out = rewrite_links_in_html(html, "/foo", false).unwrap();
         // Original href preserved.
         assert!(
             out.contains(r#"href="/about""#),
@@ -317,7 +319,7 @@ mod tests {
     #[test]
     fn rewrite_html_data_no_base_optout_form() {
         let html = r#"<form action="/submit" data-no-base><input/></form>"#;
-        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        let out = rewrite_links_in_html(html, "/foo", false).unwrap();
         assert!(out.contains(r#"action="/submit""#), "got: {out}");
         assert!(!out.contains("/foo/submit"), "got: {out}");
     }
@@ -333,7 +335,7 @@ mod tests {
             r#"<a href="/x" data-no-base="true">x</a>"#,
             r#"<a href="/x" data-no-base="anything">x</a>"#,
         ] {
-            let out = rewrite_links_in_html(snippet, "/foo").unwrap();
+            let out = rewrite_links_in_html(snippet, "/foo", false).unwrap();
             assert!(
                 out.contains(r#"href="/x""#) && !out.contains("/foo/x"),
                 "expected unchanged for: {snippet}; got: {out}"
@@ -345,7 +347,7 @@ mod tests {
     fn rewrite_html_attribute_order_does_not_matter() {
         // data-no-base could appear before href.
         let html = r#"<a data-no-base href="/about">About</a>"#;
-        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        let out = rewrite_links_in_html(html, "/foo", false).unwrap();
         assert!(out.contains(r#"href="/about""#), "got: {out}");
         assert!(!out.contains("/foo/about"), "got: {out}");
     }
@@ -364,7 +366,7 @@ mod tests {
             <a href="foo.html">rel</a>
             <a href="./foo">dot</a>
             <a href="../foo">dotdot</a>"##;
-        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        let out = rewrite_links_in_html(html, "/foo", false).unwrap();
         // None of the originals should have been touched.
         for original in [
             r#"href="//cdn.example.com/x""#,
@@ -393,7 +395,7 @@ mod tests {
     fn rewrite_html_idempotent_on_already_prefixed() {
         // Already-prefixed values stay byte-identical.
         let html = r#"<a href="/foo/about">about</a>"#;
-        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        let out = rewrite_links_in_html(html, "/foo", false).unwrap();
         assert_eq!(out, html);
     }
 
@@ -406,7 +408,7 @@ mod tests {
             <a href="/foo/already">Already</a>
             <a href="https://example.com/">Out</a>
         </body></html>"#;
-        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        let out = rewrite_links_in_html(html, "/foo", false).unwrap();
         assert!(out.contains(r#"href="/foo/about""#), "got: {out}");
         assert!(out.contains(r#"href="/foo/contact""#), "got: {out}");
         assert!(out.contains(r#"action="/foo/login""#), "got: {out}");
@@ -422,7 +424,7 @@ mod tests {
     #[test]
     fn rewrite_html_root_alone_gets_base_root() {
         let html = r#"<a href="/">home</a>"#;
-        let out = rewrite_links_in_html(html, "/foo").unwrap();
+        let out = rewrite_links_in_html(html, "/foo", false).unwrap();
         assert!(out.contains(r#"href="/foo/""#), "got: {out}");
     }
 
@@ -442,7 +444,7 @@ mod tests {
         let tmp = tempdir().unwrap();
         let body = r#"<a href="/about">about</a>"#;
         let p = write_file(tmp.path(), "index.html", body);
-        apply_link_base_rewrite(tmp.path(), &[p.clone()], None).unwrap();
+        apply_link_base_rewrite(tmp.path(), &[p.clone()], None, false).unwrap();
         let after = fs::read_to_string(&p).unwrap();
         assert_eq!(after, body);
     }
@@ -453,7 +455,7 @@ mod tests {
         let tmp = tempdir().unwrap();
         let body = r#"<a href="/about">about</a>"#;
         let p = write_file(tmp.path(), "index.html", body);
-        apply_link_base_rewrite(tmp.path(), &[p.clone()], Some("/")).unwrap();
+        apply_link_base_rewrite(tmp.path(), &[p.clone()], Some("/"), false).unwrap();
         let after = fs::read_to_string(&p).unwrap();
         assert_eq!(after, body);
     }
@@ -463,7 +465,7 @@ mod tests {
         let tmp = tempdir().unwrap();
         let body = r#"<!doctype html><html><body><a href="/about">About</a></body></html>"#;
         let p = write_file(tmp.path(), "index.html", body);
-        apply_link_base_rewrite(tmp.path(), &[p.clone()], Some("/foo/")).unwrap();
+        apply_link_base_rewrite(tmp.path(), &[p.clone()], Some("/foo/"), false).unwrap();
         let after = fs::read_to_string(&p).unwrap();
         assert!(
             after.contains(r#"href="/foo/about""#),
@@ -476,7 +478,7 @@ mod tests {
         let tmp = tempdir().unwrap();
         let body = r#"<a href="/about">about</a>"#;
         let p = write_file(tmp.path(), "index.html", body);
-        apply_link_base_rewrite(tmp.path(), &[p.clone()], Some("/foo")).unwrap();
+        apply_link_base_rewrite(tmp.path(), &[p.clone()], Some("/foo"), false).unwrap();
         let after = fs::read_to_string(&p).unwrap();
         assert!(
             after.contains(r#"href="/foo/about""#),
@@ -490,7 +492,7 @@ mod tests {
         let tmp = tempdir().unwrap();
         let body = r#"<a href="/about">about</a>"#;
         let p = write_file(tmp.path(), "index.html", body);
-        apply_link_base_rewrite(tmp.path(), &[p.clone()], Some("https://cdn.example.com/")).unwrap();
+        apply_link_base_rewrite(tmp.path(), &[p.clone()], Some("https://cdn.example.com/"), false).unwrap();
         let after = fs::read_to_string(&p).unwrap();
         assert_eq!(after, body, "user links should stay same-origin");
     }
@@ -500,7 +502,7 @@ mod tests {
         let tmp = tempdir().unwrap();
         let xml_body = r#"<?xml version="1.0"?><feed><link href="/post/1"/></feed>"#;
         let xml = write_file(tmp.path(), "feed.xml", xml_body);
-        apply_link_base_rewrite(tmp.path(), &[xml.clone()], Some("/foo")).unwrap();
+        apply_link_base_rewrite(tmp.path(), &[xml.clone()], Some("/foo"), false).unwrap();
         let after = fs::read_to_string(&xml).unwrap();
         assert_eq!(
             after, xml_body,
@@ -515,7 +517,7 @@ mod tests {
             <form action="/submit" method="post"><button>go</button></form>
         </body></html>"#;
         let p = write_file(tmp.path(), "index.html", body);
-        apply_link_base_rewrite(tmp.path(), &[p.clone()], Some("/foo/")).unwrap();
+        apply_link_base_rewrite(tmp.path(), &[p.clone()], Some("/foo/"), false).unwrap();
         let after = fs::read_to_string(&p).unwrap();
         assert!(
             after.contains(r#"action="/foo/submit""#),
@@ -530,9 +532,9 @@ mod tests {
         let tmp = tempdir().unwrap();
         let body = r#"<a href="/about">about</a>"#;
         let p = write_file(tmp.path(), "index.html", body);
-        apply_link_base_rewrite(tmp.path(), &[p.clone()], Some("/foo/")).unwrap();
+        apply_link_base_rewrite(tmp.path(), &[p.clone()], Some("/foo/"), false).unwrap();
         let after_first = fs::read_to_string(&p).unwrap();
-        apply_link_base_rewrite(tmp.path(), &[p.clone()], Some("/foo/")).unwrap();
+        apply_link_base_rewrite(tmp.path(), &[p.clone()], Some("/foo/"), false).unwrap();
         let after_second = fs::read_to_string(&p).unwrap();
         assert_eq!(after_first, after_second);
         assert!(after_second.contains(r#"href="/foo/about""#));
@@ -547,7 +549,7 @@ mod tests {
             <a href="/legal" data-no-base>legal-stays-bare</a>
         </body></html>"#;
         let p = write_file(tmp.path(), "index.html", body);
-        apply_link_base_rewrite(tmp.path(), &[p.clone()], Some("/foo/")).unwrap();
+        apply_link_base_rewrite(tmp.path(), &[p.clone()], Some("/foo/"), false).unwrap();
         let after = fs::read_to_string(&p).unwrap();
         assert!(after.contains(r#"href="/foo/about""#), "got: {after}");
         assert!(after.contains(r#"href="/legal""#), "got: {after}");

--- a/crates/zfb/src/config.rs
+++ b/crates/zfb/src/config.rs
@@ -301,6 +301,25 @@ pub struct Config {
     /// deserialises the JSON / TS form `base` 1:1.
     #[serde(default)]
     pub base: Option<String>,
+
+    /// Whether the basePath rewriter should append a trailing `/` to
+    /// extensionless absolute hrefs (`<a href="/docs/foo">` becomes
+    /// `<a href="/pj/zudo-doc/docs/foo/">` when `base = "/pj/zudo-doc/"`
+    /// and this is `true`).
+    ///
+    /// Off by default — preserves byte-for-byte parity with the
+    /// pre-`trailing_slash` build for projects that haven't opted in.
+    /// Enable when the deploy target serves canonical URLs with
+    /// trailing slashes (Cloudflare Pages with `trailingSlash: always`,
+    /// Netlify pretty URLs, etc.) so the dist HTML doesn't ship
+    /// non-canonical hrefs that 301-redirect on every click.
+    ///
+    /// Only the trailing slash for extensionless hrefs is affected.
+    /// Hrefs that already end in `/`, that have a file extension
+    /// (`.png`, `.pdf`, …), or that opt out via `data-no-base` pass
+    /// through unchanged.
+    #[serde(default)]
+    pub trailing_slash: bool,
 }
 
 impl Default for Config {
@@ -319,6 +338,7 @@ impl Default for Config {
             base: None,
             code_highlight: None,
             resolve_markdown_links: None,
+            trailing_slash: false,
         }
     }
 }
@@ -405,8 +425,17 @@ pub enum OnBrokenLinks {
 /// When `enabled` is `true`, the build appends `ResolveLinksPlugin` to the
 /// mdast pipeline after `AdmonitionsPlugin` so author-written
 /// `[label](./other.mdx)` links are rewritten to the corresponding rendered
-/// route URL (e.g. `/docs/other/`). The `docs_dir` field points at the
-/// directory whose `.md`/`.mdx` files are scanned to build the source map.
+/// route URL (e.g. `/docs/other/`).
+///
+/// Two ways to specify the source dirs:
+///
+/// - **Single dir (legacy):** set `docs_dir` and the build assumes the
+///   `/docs/` route prefix. Convenient for single-locale projects.
+/// - **Multi dir (`dirs` non-empty):** explicit list of `{ dir, route_prefix }`
+///   entries — required for any project with locale mirrors (e.g. `docs/`
+///   AND `docs-ja/`) so each dir maps to its own route prefix
+///   (`/docs/` vs `/ja/docs/`). When `dirs` is non-empty, `docs_dir` is
+///   ignored and only `dirs` is consulted.
 ///
 /// Default (absent / `enabled: false`) preserves the current pass-through
 /// behavior — links are not rewritten.
@@ -416,18 +445,41 @@ pub struct ResolveMarkdownLinksConfig {
     /// Whether to enable link resolution. Default: `false`.
     #[serde(default)]
     pub enabled: bool,
-    /// Directory (relative to project root) whose `.md`/`.mdx` files are
-    /// scanned to build the `path → URL` source map. Typically the same
-    /// directory as the content collection's `path`.
-    ///
-    /// `docs_dir` is interpreted relative to the project root the same
-    /// way `CollectionDef::path` is — it must be relative and must not
-    /// escape the root via `..`.
+    /// Legacy single-dir field. Used only when [`Self::dirs`] is empty.
+    /// When non-empty, scanned against the hard-coded `/docs/` route
+    /// prefix. Interpreted relative to the project root the same way
+    /// `CollectionDef::path` is — must be relative and must not escape
+    /// the root via `..`.
     #[serde(default)]
     pub docs_dir: PathBuf,
+    /// Explicit per-dir source map. Each entry is one collection
+    /// (e.g. EN docs at `src/content/docs/` → `/docs/`, JA docs at
+    /// `src/content/docs-ja/` → `/ja/docs/`). Takes precedence over
+    /// [`Self::docs_dir`] when non-empty.
+    ///
+    /// Required for any project with more than one docs root because
+    /// the legacy `docs_dir` shape only supports a single hard-coded
+    /// `/docs/` route prefix and cannot represent locale mirrors that
+    /// must resolve under `/{locale}/docs/`. See
+    /// `zudolab/zudo-doc#1577` for the host-side bug this surfaces.
+    #[serde(default)]
+    pub dirs: Vec<ResolveMarkdownLinksDir>,
     /// What to do when a `.md`/`.mdx` link cannot be resolved. Default: `"warn"`.
     #[serde(default)]
     pub on_broken_links: OnBrokenLinks,
+}
+
+/// One source dir entry for [`ResolveMarkdownLinksConfig::dirs`].
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolveMarkdownLinksDir {
+    /// Directory (relative to project root) whose `.md`/`.mdx` files
+    /// are scanned. Must be relative and must not escape the root via
+    /// `..` — validated at config load.
+    pub dir: PathBuf,
+    /// Route prefix prepended to each file's slug. Include leading and
+    /// trailing slashes (e.g. `"/docs/"` or `"/ja/docs/"`).
+    pub route_prefix: String,
 }
 
 impl Default for TailwindConfig {
@@ -972,8 +1024,14 @@ fn validate(cfg: &Config, dir: &Path) -> Result<()> {
             .with_context(|| format!("collection {:?}", c.name))?;
     }
     if let Some(rml) = &cfg.resolve_markdown_links {
-        ensure_path_in_root(&rml.docs_dir, dir)
-            .context("resolveMarkdownLinks.docsDir")?;
+        if !rml.docs_dir.as_os_str().is_empty() {
+            ensure_path_in_root(&rml.docs_dir, dir)
+                .context("resolveMarkdownLinks.docsDir")?;
+        }
+        for (i, d) in rml.dirs.iter().enumerate() {
+            ensure_path_in_root(&d.dir, dir)
+                .with_context(|| format!("resolveMarkdownLinks.dirs[{i}].dir"))?;
+        }
     }
     if let Some(b) = &cfg.base {
         // An absolute URL is fine ("https://cdn.example.com/..."); a

--- a/packages/zfb/src/config.ts
+++ b/packages/zfb/src/config.ts
@@ -128,6 +128,99 @@ export type ZfbConfig = {
    * Mirrors `Config::base` in crates/zfb/src/config.rs.
    */
   base?: string;
+
+  /**
+   * Markdown link resolver (port of `remarkResolveMarkdownLinks`).
+   *
+   * When `enabled: true`, the build appends `ResolveLinksPlugin` to the
+   * mdast pipeline so author-written `[label](./other.mdx)` links are
+   * rewritten to the corresponding rendered route URL — bypassing the
+   * file→directory transformation that breaks relative paths in dist
+   * HTML when `foo.mdx` becomes `foo/index.html`.
+   *
+   * Two ways to specify the source dirs:
+   *
+   * - **Single dir (legacy):** set `docsDir` and the build assumes the
+   *   `/docs/` route prefix. Convenient for single-locale projects.
+   * - **Multi dir (`dirs` non-empty):** explicit `{ dir, routePrefix }`
+   *   entries — required for any project with locale mirrors (e.g.
+   *   `docs/` AND `docs-ja/`) so each dir maps to its own route prefix
+   *   (`/docs/` vs `/ja/docs/`). When `dirs` is non-empty, `docsDir`
+   *   is ignored.
+   *
+   * Mirrors `Config::resolve_markdown_links` in crates/zfb/src/config.rs.
+   */
+  resolveMarkdownLinks?: ResolveMarkdownLinksConfig;
+
+  /**
+   * Whether the basePath rewriter should append a trailing `/` to
+   * extensionless absolute hrefs (`<a href="/docs/foo">` becomes
+   * `<a href="/pj/zudo-doc/docs/foo/">` when `base = "/pj/zudo-doc/"`
+   * and this is `true`).
+   *
+   * Off by default — preserves byte-for-byte parity with the
+   * pre-`trailingSlash` build for projects that haven't opted in.
+   * Enable when the deploy target serves canonical URLs with trailing
+   * slashes (Cloudflare Pages with `trailingSlash: always`, Netlify
+   * pretty URLs, etc.) so the dist HTML doesn't ship non-canonical
+   * hrefs that 301-redirect on every click.
+   *
+   * Only the trailing slash for extensionless hrefs is affected.
+   * Hrefs that already end in `/`, that have a file extension
+   * (`.png`, `.pdf`, …), or that opt out via `data-no-base` pass
+   * through unchanged.
+   *
+   * Mirrors `Config::trailing_slash` in crates/zfb/src/config.rs.
+   */
+  trailingSlash?: boolean;
+};
+
+/**
+ * What to do when a `.md`/`.mdx` link cannot be resolved.
+ *
+ * Mirrors `OnBrokenLinks` in crates/zfb/src/config.rs.
+ */
+export type OnBrokenLinks = "warn" | "error" | "ignore";
+
+/**
+ * Config for the markdown link resolver. See
+ * [`ZfbConfig.resolveMarkdownLinks`] for the design rationale.
+ */
+export type ResolveMarkdownLinksConfig = {
+  /** Whether to enable link resolution. Default: `false`. */
+  enabled?: boolean;
+
+  /**
+   * Legacy single-dir field. Used only when [`dirs`] is empty. When
+   * non-empty, scanned against the hard-coded `/docs/` route prefix.
+   */
+  docsDir?: string;
+
+  /**
+   * Explicit per-dir source map. Each entry is one collection (e.g.
+   * EN docs at `src/content/docs/` → `/docs/`, JA docs at
+   * `src/content/docs-ja/` → `/ja/docs/`). Takes precedence over
+   * [`docsDir`] when non-empty.
+   */
+  dirs?: ResolveMarkdownLinksDir[];
+
+  /** What to do with unresolved `.md`/`.mdx` links. Default: `"warn"`. */
+  onBrokenLinks?: OnBrokenLinks;
+};
+
+/** One source-dir entry for [`ResolveMarkdownLinksConfig.dirs`]. */
+export type ResolveMarkdownLinksDir = {
+  /**
+   * Directory (relative to project root) whose `.md`/`.mdx` files are
+   * scanned. Must be relative and must not escape the root via `..`.
+   */
+  dir: string;
+
+  /**
+   * Route prefix prepended to each file's slug. Include leading and
+   * trailing slashes (e.g. `"/docs/"` or `"/ja/docs/"`).
+   */
+  routePrefix: string;
 };
 
 /**


### PR DESCRIPTION
Three link-pipeline parity fixes surfaced by `zudolab/zudo-doc#1581` (the link-cleanup epic — host-side PR https://github.com/zudolab/zudo-doc/pull/1587).

## What's wrong today

When a host opts into `resolveMarkdownLinks: { enabled: true, ... }` in `zfb.config.ts`, three things go wrong:

1. **Nested directories collapse to file stems.** `crates/zfb-content/src/plugins/util/source_map.rs::build_docs_source_map` emits `{route_prefix}{file_stem}/` regardless of nesting, so `components/code-blocks.mdx` maps to `/docs/code-blocks/` instead of `/docs/components/code-blocks/`. Existing test on line 162-163 explicitly asserts the wrong shape (`nested/advanced.mdx` → `/docs/advanced/`).
2. **No way to wire a multi-locale source map.** The legacy `ResolveMarkdownLinksConfig` only accepts a single `docs_dir` paired with a hard-coded `/docs/` route prefix in `crates/zfb/src/commands/build.rs`. Projects with `docs/` AND `docs-{locale}/` mirrors have no way to map JA links to `/ja/docs/...`.
3. **The bundler ignores `Config::resolve_markdown_links` entirely.** `commands/build.rs` only constructs the snapshot-side source map (for SSR `content_hash` determinism) and never sets `BundlerInput::resolve_markdown_links`. So `ResolveLinksPlugin` never appears in the bundler's MDX pipeline. Opting into the feature does nothing — the only thing that runs is `StripMdExtensionPlugin`, which just strips `.mdx` and adds `/` (relative-path math at the file→directory transformation breaks the link).

Separately, the basePath rewriter (`zfb_build::link_base_rewrite::compute_prefixed`) prepends the configured base to root-absolute `<a href>` values but never appends the trailing slash that a `trailingSlash: true` deploy expects. On the host: `/docs/getting-started` rewrote to `/pj/zudo-doc/docs/getting-started` and Cloudflare 301-redirected every click to `/pj/zudo-doc/docs/getting-started/`.

## Changes

### `crates/zfb-content/src/plugins/util/source_map.rs`

`build_docs_source_map` now uses `slug_for(dir, path)` which strip-prefixes `dir`, strips `.md`/`.mdx`, and collapses a trailing `/index` segment so directory-style URLs collapse to the parent (`guides/index.mdx` → `/docs/guides/`, root `index.mdx` → `/docs/`). Updated the existing test that asserted the flatten behavior; added 4 new tests (deeply-nested EN, nested-index, root-index, multi-locale shape).

### `crates/zfb/src/config.rs`

Added `dirs: Vec<ResolveMarkdownLinksDir>` field to `ResolveMarkdownLinksConfig`. Each entry is `{ dir, route_prefix }`. When non-empty, takes precedence over the legacy `docs_dir`; when empty, falls back to the hard-coded `/docs/` shape. Added validation for each `dirs[i].dir` path.

Also added `trailing_slash: bool` (default `false`) so consumers can opt in to the basePath trailing-slash behavior.

### `crates/zfb-build/src/bundler.rs`

`ResolveMarkdownLinksSpec` reshaped from `(docs_dir, route_prefix)` to `routes: Vec<ResolveMarkdownLinksRoute>`. Bundler builds the source map by iterating every route entry.

### `crates/zfb/src/commands/build.rs` + `commands/dev.rs`

New shared helper `resolve_links_routes_from_config(project_root, config)` builds the `Vec<CollectionRoute>` consumed by both `build_resolve_source_map_for_snapshot` (snapshot side) and the `BundlerInput::resolve_markdown_links` wiring (bundler side) — the two sites MUST produce the same URL strings or `content_hash` drifts. Both `build` and `dev` now thread `Config::resolve_markdown_links` → `BundlerInput::resolve_markdown_links` and `Config::trailing_slash` → `apply_link_base_rewrite` / `ServeOpts::trailing_slash`.

### `crates/zfb-build/src/link_base_rewrite.rs`

Added `compute_prefixed_with_trailing_slash(value, prefix, add_trailing_slash)` next to `compute_prefixed`. When `add_trailing_slash` is `false`, byte-identical to `compute_prefixed`. When `true`, appends `/` to extensionless internal hrefs (preserving `?query` / `#fragment` suffixes; skipping `.png` / `.pdf` / etc.). Threaded through `rewrite_links_in_html` (3rd parameter) — `<a href>` honors the flag, `<form action>` does not (form endpoints are POST/GET targets, not canonical page URLs).

Updated all internal call sites (incl. dev server's `page_response_bytes` in `crates/zfb-server/src/routes.rs`) and added `trailing_slash: bool` to `AppState` / `ServeOpts`.

## Tests

All affected crates build clean and full unit-test suites pass:

- `cargo test -p zfb-content --lib` — 303 passed (incl. 4 new source_map tests).
- `cargo test -p zfb-build --lib` — 170 passed (incl. ~10 new trailing-slash + ts-on tests).
- `cargo test -p zfb --lib` — 212 passed.
- `cargo test -p zfb-server --lib` — 67 passed.

## Backward compatibility

- Legacy `ResolveMarkdownLinksConfig.docs_dir` still works when `dirs` is empty — single-dir projects opt-in path unchanged.
- `trailing_slash` defaults to `false` — projects that haven't opted in see byte-for-byte parity.
- `compute_prefixed` still works standalone (tests against it kept). New behavior is opt-in via the new `_with_trailing_slash` variant + the threaded `add_trailing_slash` parameter on `rewrite_links_in_html` (existing internal callers updated to pass `false`).

## Host-side validation

On host PR https://github.com/zudolab/zudo-doc/pull/1587:

- Broken links in built HTML: 109 → 5 (104 of 109 were the file→dir transformation bugs).
- Trailing-slash warnings: 54 → 0.
- All 5 remaining broken links are pre-existing JA content gaps (JA pages referencing EN-only siblings) — not regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)