### PR TITLE
docs(api): rewrite api/ docs against actual SDK source, drop v0 framing

### DIFF
--- a/docs/src/content/docs/api/define-config.mdx
+++ b/docs/src/content/docs/api/define-config.mdx
@@ -7,28 +7,52 @@ sidebar_position: 1
 ## Signature
 
 ```ts
-defineConfig(config: Config): Config
+defineConfig(config: ZfbConfig): ZfbConfig
 ```
 
-`defineConfig` is re-exported from `zfb/config`. The helper is identity-typed: it returns its argument unchanged. Its only job is to give your editor IntelliSense and type-checking against the `Config` shape. The actual schema is enforced by Rust serde at config-load time, so the same rules apply whether you author your config in TypeScript or JSON.
+`defineConfig` is exported from `zfb/config`. The helper is identity-typed: it returns its argument unchanged. Its only job is to give your editor IntelliSense and type-checking against the `ZfbConfig` shape. The actual schema is enforced by Rust serde at config-load time, so the same rules apply whether you author your config in TypeScript or JSON.
 
 ## Config shape
 
 All keys are camelCase and mirror `crates/zfb/src/config.rs`.
 
-- `outDir`: string, default `"dist"`
-- `publicDir`: string, default `"public"`
-- `host`: string, default `"localhost"`
-- `port`: number, default `3000`
-- `framework`: `"preact" | "react"`, default `"preact"`
-- `collections`: array of `CollectionDef`. Each entry has `name` (the call-site identifier, e.g. `"blog"`), `path` (directory relative to the project root), and optional `schema` (reserved — accepted today but not enforced; see the v0 note below).
-- `tailwind?`: `{ enabled: boolean }`
-- `plugins?`: array — schema TBD; not yet consumed in v0.
+- `outDir?: string` — output directory. Default: `"dist"`.
+- `publicDir?: string` — static assets directory, copied verbatim. Default: `"public"`.
+- `host?: string` — dev/preview server bind host.
+- `port?: number` — dev/preview server port.
+- `framework?: "preact" | "react"` — JSX framework runtime. Default: `"preact"`.
+- `collections?: CollectionDef[]` — content collections. Each entry has `name` (identifier used in `getCollection` calls), `path` (directory relative to the project root), and optional `schema` (accepted but not enforced — reserved for a future release).
+- `tailwind?: { enabled?: boolean }` — Tailwind options.
+- `plugins?: PluginConfig[]` — user-supplied plugins. See [Plugins](/api/plugins) for the `PluginConfig` shape.
+- `adapter?: string` — deploy-target adapter package name. Omit for a pure static build. A package like `"@takazudo/zfb-adapter-cloudflare"` wraps the SSR bundle into a deploy-ready entry (e.g. `dist/_worker.js` for Cloudflare Pages).
+- `base?: string` — public URL prefix for asset URLs. Use when the site is deployed under a sub-path (e.g. `"/pj/my-site/"`).
+- `stripMdExt?: boolean` — strip `.md`/`.mdx` extensions from internal link hrefs during MDX compilation and append a trailing `/`. Default: `false`.
+- `trailingSlash?: boolean` — append a trailing `/` to extensionless absolute hrefs when rewriting base paths. Default: `false`.
+- `resolveMarkdownLinks?: ResolveMarkdownLinksConfig` — markdown link resolver settings. Enable to rewrite `[label](./other.mdx)` links to their rendered route URLs.
 
 ## Examples
 
+```ts
+// zfb.config.ts — the recommended form
+import { defineConfig } from "zfb/config";
+
+export default defineConfig({
+  outDir: "dist",
+  framework: "preact",
+  collections: [
+    {
+      name: "blog",
+      path: "content/blog",
+    },
+  ],
+  tailwind: { enabled: true },
+});
+```
+
+The loader accepts `zfb.config.ts` (preferred) and `zfb.config.json` (legacy fallback). When only `zfb.config.json` is present it is read via `serde_json`; note that JSON configs cannot reference local plugin modules by relative path — use `zfb.config.ts` for any project that declares plugins.
+
 ```json
-// zfb.config.json — the form actually loaded by v0
+// zfb.config.json — legacy form, still supported
 {
   "outDir": "dist",
   "framework": "preact",
@@ -41,37 +65,6 @@ All keys are camelCase and mirror `crates/zfb/src/config.rs`.
   "tailwind": { "enabled": true }
 }
 ```
-
-```ts
-// zfb.config.ts — aspirational form, NOT yet loaded.
-// Documented here for forward compatibility; once the runtime ships
-// (ADR-001) this richer schema lands. Do NOT ship this alongside a
-// zfb.config.json — the v0 loader rejects when both files are present.
-import { defineConfig } from "zfb/config";
-
-export default defineConfig({
-  outDir: "dist",
-  framework: "preact",
-  collections: {
-    blog: {
-      type: "content",
-      directory: "content/blog",
-      schema: {
-        title: "string",
-        date: "date",
-        draft: "boolean?",
-      },
-    },
-  },
-  tailwind: { enabled: true },
-});
-```
-
-<Warning title="v0: schema is intentionally narrow">
-
-  Today the loader accepts only the JSON form above — `collections` is an array of `{ name, path, schema? }`, and `schema` is parsed but not enforced (it lands as opaque JSON, reserved for v1.1). The richer object-keyed shape with `type: "content" | "data"` and per-field validators is the planned future schema and is shown in the TypeScript example purely so you can author against it now and switch over later. `zfb.config.ts` parsing itself is pending the JS runtime decision (see [ADR-001](/architecture/js-runtime)). For now, write your configuration as `zfb.config.json` — the loader reads that form today.
-
-</Warning>
 
 ## Validation
 

--- a/docs/src/content/docs/api/get-collection.mdx
+++ b/docs/src/content/docs/api/get-collection.mdx
@@ -7,19 +7,36 @@ sidebar_position: 2
 ## Signature
 
 ```ts
-getCollection(name: string): CollectionEntry[]
+getCollection<T = Record<string, unknown>>(name: string): CollectionEntry<T>[]
 ```
 
-Call `getCollection` from a page module to load every entry in a named collection. The collection must be declared in your `zfb.config` under `collections`. Schema validation runs against each entry as it is read, so by the time the array reaches your component, frontmatter is already typed and verified.
+Call `getCollection` from a page module to load every entry in a named collection. The collection must be declared in your `zfb.config` under `collections`. The function is synchronous — it returns a plain array, not a Promise. Schema validation runs against each entry as it is read, so by the time the array reaches your component, frontmatter is already typed and verified.
 
 ## CollectionEntry shape
 
-Each entry, per the current sketch in `zfb-content`, has the following fields:
+Each entry has the following fields:
 
-- `slug`: string — the filename without its extension, normalized to kebab-case.
-- `data`: object — the validated frontmatter (for `content` collections) or the parsed file body (for `data` collections).
-- `body`: string — rendered HTML for markdown entries; the raw value for data entries.
-- `id`: string — the full path relative to the collection's `directory`.
+- `slug: string` — the filename without its `.md` extension, normalized to forward-slash paths. Nested files produce path-based slugs (e.g. `"2024/hello"`).
+- `data: T` — the parsed frontmatter, typed by the generic parameter.
+- `body: string` — the raw markdown body with frontmatter stripped.
+- `module_specifier: string` — stable bridge key in the form `mdx://<collection>/<slug>`. Used internally by the renderer; pass to `Content` lookup if building a custom bridge.
+- `Content: (props: ContentProps) => ContentElement` — renderable component for this entry. Renders via the renderer bridge when available; falls back to a `<pre data-zfb-content-fallback>` block in test and dev contexts where the bridge is absent.
+
+## ContentProps
+
+```ts
+type ContentProps = {
+  components?: Record<string, unknown>;
+};
+```
+
+The `components` prop mirrors the Astro `<Content components={...}>` convention: a flat map of element name to override component. Use `defaultComponents` from `"@takazudo/zfb"` as a base:
+
+```tsx
+import { defaultComponents } from "@takazudo/zfb";
+
+<entry.Content components={{ ...defaultComponents, h2: MyHeading }} />
+```
 
 ## Example
 
@@ -28,8 +45,8 @@ A typical use case is rendering a list of blog posts on an index page.
 ```tsx
 import { getCollection } from "zfb/content";
 
-export default async function BlogIndex() {
-  const posts = await getCollection("blog");
+export default function BlogIndex() {
+  const posts = getCollection<{ title: string; date: string }>("blog");
 
   return (
     <ul>
@@ -43,10 +60,4 @@ export default async function BlogIndex() {
 }
 ```
 
-For dynamic per-entry pages, combine `getCollection` with a `paths()` export — see [paginate](/api/paginate) for the related pattern.
-
-<Warning title="v0 status">
-
-  Discovery and schema validation work today: `zfb` reads each collection directory, validates frontmatter against the declared schema, and surfaces errors with file paths. Wiring the `getCollection` call into the rendered page output requires the JS runtime, which is still pending — see [ADR-001](/architecture/js-runtime). You can declare collections and run the build to validate them; rendering will follow once the runtime ships.
-
-</Warning>
+Note that `getCollection` returns synchronously — no `await` needed. For dynamic per-entry pages, combine `getCollection` with a `paths()` export — see [paginate](/api/paginate) for the related pattern.

--- a/docs/src/content/docs/api/island.mdx
+++ b/docs/src/content/docs/api/island.mdx
@@ -1,21 +1,86 @@
 ---
-title: "Islands (\"use client\")"
-description: "Mark a component as a client-hydrated island with the \"use client\" directive."
+title: Island
+description: Wrap a component as a client-hydrated island using the Island JSX wrapper.
 sidebar_position: 4
 ---
 
-## The directive
+## The `<Island>` wrapper
 
-A component file whose first statement is the literal string `"use client"` is treated as an **island** — a piece of UI that ships JavaScript and hydrates in the browser. Everything else stays server-rendered HTML.
+Import `Island` from `"@takazudo/zfb"` and wrap any component that should hydrate in the browser. Everything else stays server-rendered HTML.
 
-When the islands pipeline (`crates/zfb-islands`, esbuild-backed) sees the directive, the component is:
+```tsx
+import { Island } from "@takazudo/zfb";
+import Counter from "./Counter";
 
-- Compiled to ESM separately, with its own dependency graph.
-- Embedded into pages via a small bootstrap that hydrates the component when its DOM marker enters the viewport. This is the default lazy strategy.
+export default function Page() {
+  return (
+    <main>
+      <h1>My Page</h1>
+      <Island when="visible">
+        <Counter />
+      </Island>
+    </main>
+  );
+}
+```
 
-## Example
+At SSR time the `<Island>` wrapper emits a `<div data-zfb-island="Counter" data-when="visible">` marker with the server-rendered child inside. The client runtime (`@takazudo/zfb-runtime`) queries these markers and mounts the component when the `when` condition fires.
 
-The default template's counter shows the canonical shape: a leading `"use client"` line, then a normal Preact component.
+## IslandProps
+
+```ts
+interface IslandProps {
+  when?: When;
+  ssrFallback?: VNode;
+  children?: VNode;
+}
+```
+
+- `when` — hydration strategy. Defaults to `"load"`. See [Hydration strategies](#hydration-strategies) below.
+- `ssrFallback` — enables SSR-skip mode (equivalent to Astro's `client:only`). When provided, the heavy `children` are **not** evaluated server-side; `ssrFallback` is rendered in their place and the client swaps in the real component on hydration.
+- `children` — the component to hydrate.
+
+## Hydration strategies
+
+The `when` prop accepts three values, all shipped today:
+
+| Value | Behaviour |
+| --- | --- |
+| `"load"` | Hydrate immediately when the page's JavaScript runs. This is the default when `when` is omitted. |
+| `"visible"` | Hydrate when the island's root element enters the viewport (IntersectionObserver, threshold 0). Cheapest deferral for off-screen content. |
+| `"idle"` | Hydrate during the browser's next idle callback. Falls back to `setTimeout(0)` on platforms without `requestIdleCallback`. |
+
+## SSR-skip mode
+
+Pass `ssrFallback` to skip server rendering the heavy child entirely:
+
+```tsx
+import { Island } from "@takazudo/zfb";
+import HeavyChart from "./HeavyChart";
+
+export default function Page() {
+  return (
+    <Island ssrFallback={<div>Loading chart…</div>}>
+      <HeavyChart data={data} />
+    </Island>
+  );
+}
+```
+
+The server emits `<div data-zfb-island-skip-ssr="HeavyChart" data-when="load">…fallback…</div>`. On hydration the client runtime renders `HeavyChart` into the placeholder.
+
+## Exported constants and helpers
+
+The following are exported from `"@takazudo/zfb"` alongside `Island`:
+
+- `HYDRATE_MARKER_ATTR` — the `data-zfb-island` attribute name.
+- `SKIP_SSR_MARKER_ATTR` — the `data-zfb-island-skip-ssr` attribute name.
+- `ANONYMOUS_COMPONENT_NAME` — fallback name used when a wrapped child's identity cannot be determined.
+- `resolveWhen(when: unknown): When` — validates and normalises a `when` value. Unknown inputs fall back to `"load"` (with a warning in development).
+
+## "use client" directive
+
+zfb also supports a `"use client"` file-level directive as an alternative authoring style. A component file whose first statement is the literal string `"use client"` is treated as an island entry by the build scanner (`crates/zfb-islands`). The esbuild-backed bundler compiles it to ESM separately, with its own dependency graph.
 
 ```tsx
 "use client";
@@ -32,22 +97,6 @@ export default function Counter() {
 }
 ```
 
-Import the island from a server component or page module and render it as you would any other component. The build pipeline rewrites the import to insert the hydration marker and wire up the bootstrap.
-
-## Hydration directives
-
-Three directives are planned for picking when an island hydrates:
-
-- `client:load` — hydrate as soon as the page's JS runs.
-- `client:visible` — hydrate when the component scrolls into view (today's default behaviour).
-- `client:idle` — hydrate during the browser's next idle period.
-
-Only the default lazy/visible strategy is sketched in v0; the directive surface will land alongside the renderer.
-
-<Warning title="v0 status">
-
-  The `"use client"` detector and the esbuild-backed bundler are sketched in `crates/zfb-islands` but are not yet wired through the renderer (see [ADR-001](/architecture/js-runtime)). Components authored with `"use client"` will produce static SSR markup once the renderer lands; client hydration follows after that. You can write islands today using this pattern and they will activate as the pipeline completes.
-
-</Warning>
+Import the island from a server component or page module. The build pipeline wires the hydration bootstrap automatically.
 
 For the broader story on islands architecture and when to reach for one, see [Islands](/concepts/islands).

--- a/docs/src/content/docs/api/meta-export.mdx
+++ b/docs/src/content/docs/api/meta-export.mdx
@@ -6,9 +6,7 @@ sidebar_position: 5
 
 ## The pattern
 
-Every page module may export a `meta` constant (or an async function returning the same record) describing the page's `<head>` data — title, description, Open Graph tags, canonical URL, and so on. The renderer reads this export and merges it into the page layout's `<head>` block.
-
-The extraction goes through the `RenderHost::get_export` API, defined in `crates/zfb-render/src/render_host.rs`. That signature is the contract every JS runtime backend must satisfy when v0 of the renderer lands.
+Every page module may export a `meta` constant (or an async function returning the same record) describing the page's `<head>` data — title, description, Open Graph tags, canonical URL, and so on. The renderer reads this export via `RenderHost::get_export` and merges it into the page layout's `<head>` block.
 
 ## Example
 
@@ -30,20 +28,25 @@ export default function BlogPage() {
 
 If you need data from a collection or an async source to compute meta — for example, an OG image derived from a CMS field — export `meta` as an async function. The renderer awaits it before rendering the page shell.
 
-## Recommended schema
+```tsx
+export async function meta() {
+  const post = getCollection("blog")[0];
+  return {
+    title: post.data.title,
+    og: { image: `/og/${post.slug}.png` },
+  };
+}
+```
 
-The renderer treats `meta` as a permissive bag, but the following keys are the supported subset and what page layouts will look for first:
+## Supported keys
+
+The renderer treats `meta` as a permissive bag, but the following keys are the supported subset that page layouts look for:
 
 - `title?: string` — overrides the layout default for this page.
 - `description?: string` — used for the `<meta name="description">` tag and as the OG fallback.
 - `canonical?: string` — absolute URL for `<link rel="canonical">`.
 - `og?: { title?, description?, image?, type?, url? }` — Open Graph tags. Missing fields fall back to top-level `title` / `description` where it makes sense.
 - `twitter?: { card?, site?, creator?, image? }` — Twitter Card tags.
+- `layout?: string` — module specifier (relative path or bare specifier) for the page layout component. When absent, the project default layout is used.
 
 Unknown keys pass through untouched, which lets you stash structured data for plugins or custom layout components.
-
-<Warning title="v0 status">
-
-  The `meta` extraction interface is defined in `zfb-render`, but actual extraction at render time depends on the JS runtime (see [ADR-001](/architecture/js-runtime)). For now, you can plan and write your `meta` exports against this schema — they will flow through the renderer once the runtime ships.
-
-</Warning>

--- a/docs/src/content/docs/api/paginate.mdx
+++ b/docs/src/content/docs/api/paginate.mdx
@@ -7,35 +7,68 @@ sidebar_position: 3
 ## Signature
 
 ```ts
-paginate(items: T[], opts: { pageSize: number; route: string }): PaginationPath[]
+paginate<T, K extends string = string>(
+  items: readonly T[],
+  opts: PaginateOptions<K>,
+): PaginateRoute<T, K>[]
 ```
 
-Use `paginate` inside a `paths()` export to fan a list of items out across a paginated route. The function chunks `items` by `pageSize` and produces one `PaginationPath` per chunk. Each path knows its URL params and the props the page should receive.
+Use `paginate` inside a `paths()` export to fan a list of items out across a paginated route. The function chunks `items` by `pageSize` and produces one `PaginateRoute` per chunk, each carrying the URL params and page props the component receives.
 
-## PaginationPath shape
+`paginate` always emits at least one route — an empty input list yields a single empty page so the index route still renders rather than 404ing.
 
-- `params`: object — the URL params for the route. For paginated lists, this is typically `{ page: number }`.
-- `props`: object — passed to the page's default export. For a list page, this is usually `{ items: T[], page: number, totalPages: number }`.
+## PaginateOptions
+
+```ts
+type PaginateOptions<K extends string = string> = {
+  pageSize: number;
+  param: K;
+};
+```
+
+- `pageSize` — items per page. Must be a positive integer.
+- `param` — name of the dynamic URL segment to fill (e.g. `"page"` for a route file named `[page].tsx`).
+
+## PaginateRoute shape
+
+```ts
+type PaginateRoute<T, K extends string = string> = {
+  params: Record<K, string>;
+  props: { page: PaginatedPage<T> };
+};
+```
+
+Each route carries:
+
+- `params` — URL segment values. For a `param: "page"` call, this is `{ page: "1" }`, `{ page: "2" }`, etc.
+- `props.page` — a `PaginatedPage<T>` record with:
+  - `data: T[]` — items belonging to this page.
+  - `page: number` — 1-based page number.
+  - `lastPage: number` — total number of pages.
+  - `pageSize: number` — items per page (echoed for convenience).
+  - `total: number` — total item count across all pages.
 
 ## Example
 
-Paginate a blog index 10 posts at a time under `/blog/page/[page]`.
+Paginate a blog index 10 posts at a time under `/blog/page/[page].tsx`.
 
 ```tsx
-import { paginate, getCollection } from "zfb/content";
+import { paginate } from "zfb/paginate";
+import { getCollection } from "zfb/content";
 
-export async function paths() {
-  const posts = await getCollection("blog");
+export function paths() {
+  const posts = getCollection("blog");
   return paginate(posts, {
     pageSize: 10,
-    route: "/blog/page/[page]",
+    param: "page",
   });
 }
 
-export default function BlogPage({ items, page, totalPages }) {
+export default function BlogPage({ page }) {
+  const { data: items, page: currentPage, lastPage } = page;
   return (
     <section>
-      <h2>Blog — page {page} of {totalPages}</h2>
+      <h2>Blog — page {currentPage} of {lastPage}</h2>
       <ul>
         {items.map((post) => (
           <li key={post.slug}>
@@ -48,10 +81,6 @@ export default function BlogPage({ items, page, totalPages }) {
 }
 ```
 
-The `[page]` segment in `route` matches the `params.page` value emitted by `paginate`. Page numbers start at 1.
+The `param` value (`"page"`) must match the dynamic segment name in your route filename (`[page].tsx`). Page numbers start at 1 and are passed as strings in `params`.
 
-<Warning title="v0: paths() evaluation pending">
-
-  `paths()` is part of the routing model today — the router recognises dynamic routes and reserves the `paths` export name. Expanding `paths()` into concrete page instances at build time requires the JS runtime (see [ADR-001](/architecture/js-runtime)). `zfb build` currently warn-skips dynamic routes; you can write your `paginate` calls now and they will be honoured once the runtime lands.
-
-</Warning>
+The page component receives the `PaginatedPage` record as `props.page`. Destructure it to access `data`, `page`, `lastPage`, `pageSize`, and `total`.


### PR DESCRIPTION
## Summary

- Rewrote all 5 files under `docs/src/content/docs/api/` to match actual exports in `packages/zfb/src/`
- Removed all `<Warning title="v0 status">` blocks
- Updated docs for Astro/Next.js audience with correct API signatures

## Code-vs-doc mismatches surfaced

| File | Mismatch |
|---|---|
| `define-config.mdx` | Type name was `Config`, actual is `ZfbConfig`; missing fields: `adapter`, `base`, `stripMdExt`, `trailingSlash`, `resolveMarkdownLinks`; `plugins` were "schema TBD, not consumed in v0" — they are fully implemented; `zfb.config.ts` was "aspirational/NOT yet loaded" — it is the recommended form, JSON is legacy fallback |
| `get-collection.mdx` | Signature was non-generic async — actual is `getCollection<T>(name): CollectionEntry<T>[]` (synchronous per ADR-004); `CollectionEntry` was missing `module_specifier` and `Content` fields; had a nonexistent `id` field; `body` was described as "rendered HTML" — it is raw markdown |
| `island.mdx` | Doc focused only on `"use client"` directive; the primary shipped API is `<Island when="...">` JSX wrapper; `When` values were "planned" — all three (`"load"`, `"visible"`, `"idle"`) are implemented; exported constants (`HYDRATE_MARKER_ATTR`, `SKIP_SSR_MARKER_ATTR`, `ANONYMOUS_COMPONENT_NAME`, `resolveWhen`) were undocumented |
| `paginate.mdx` | `opts.route: string` does not exist — actual param is `opts.param: K`; `PaginatedPage` fields were `items`/`totalPages` — actual fields are `data`/`lastPage`/`total`; import was `from "zfb/content"` — correct path is `from "zfb/paginate"` |
| `meta-export.mdx` | "when v0 of the renderer lands" framing removed; added async `meta()` function example; added `layout` key to supported schema |

## Test plan

- [x] `pnpm --filter docs build` exits clean (103 pages built)
- [x] Stale-text grep returns zero hits
- [x] All documented signatures verified by `rg` against `packages/zfb/src/`
- [x] `/light-review -co -gcoc` completed with no high-priority findings

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)