### PR TITLE
docs(getting-started): rewrite for Astro/Next.js users, drop v0/WIP framing

### DIFF
--- a/docs/src/content/docs-ja/getting-started/index.mdx
+++ b/docs/src/content/docs-ja/getting-started/index.mdx
@@ -1,8 +1,8 @@
 ---
-title: ようこそ
-sidebar_position: 1
+title: はじめに
+sidebar_position: 0
 ---
 
-# ようこそ
+はじめにのセクションへようこそ。以下からトピックを選択してください。
 
-このドキュメントサイトは [zudo-doc](https://github.com/zudolab/zudo-doc) で作成されました。
+<CategoryNav category="getting-started" />

--- a/docs/src/content/docs/getting-started/index.mdx
+++ b/docs/src/content/docs/getting-started/index.mdx
@@ -1,47 +1,8 @@
 ---
-title: Welcome
-sidebar_position: 1
+title: Getting Started
+sidebar_position: 0
 ---
 
-zfb (zudo-front-builder) is a static-site framework where you write pages in TSX and the build produces plain HTML — no Node.js or server required at runtime.
+Welcome to the Getting Started section. Choose a topic below to begin.
 
-## What zfb is
-
-zfb is a **build-time engine**. You write pages and components in TSX; zfb compiles them with SWC, renders them through a V8-based runtime during the build, and writes the output to `dist/` as static HTML. Once built, the site is a folder of files — no application server, no runtime dependency.
-
-The engine is written in Rust. Rust handles orchestration, file-watching, content parsing, routing, and atomic writes. Node.js (via a miniflare/workerd worker) is the render runtime during `zfb dev` and `zfb build` — it evaluates your compiled TSX and returns HTML strings. When you deploy the built output, nothing from that toolchain is needed on the host.
-
-## What you write
-
-Your project has a `pages/` directory. Each file in it is a route. A page is a `.tsx` file that exports a React component as its default export, plus an optional `meta` export for `<head>` data:
-
-```tsx
-// pages/index.tsx
-export const meta = { title: "Home" };
-
-export default function Home() {
-  return <h1>Hello from zfb</h1>;
-}
-```
-
-Components, layouts, and content collections live alongside `pages/` in their own directories. The entire authoring surface is TypeScript and JSX — no framework-specific template syntax or custom file formats to learn.
-
-## What the build produces
-
-`zfb build` produces static HTML in `dist/`. Each route becomes an `.html` file. Interactive fragments — [Islands](/concepts/islands) — ship their own small JS bundles and hydrate in the browser. Pages with no interactive components ship zero bytes of JavaScript.
-
-The engine rebuilds only the pages affected by each file change, not the whole site, so dev-loop latency stays in the tens of milliseconds even for large sites. See [Build engine](/architecture/build-engine) for the full picture of how the crates fit together.
-
-## What problems it solves
-
-**Build speed.** zfb's orchestration is a tight Rust loop over a dependency graph. A shared header change in a 2,000-page site touches only the pages that import it.
-
-**Distribution.** The framework ships as a single binary. No `node_modules` for zfb itself, no transitive package tree to audit. Your project's own dependencies are still managed via pnpm — zfb just isn't one of them.
-
-**Authoring simplicity.** TSX is the only authoring surface. Content collections work the same whether a file is `.md`, `.mdx`, or `.tsx`. There is no framework-specific config layer or plugin API to learn before you can ship a page.
-
-**Clear scope.** zfb is an [engine, not a framework](/concepts/engine-vs-framework). It commits to six primitives — frontmatter, content collections, dynamic routes, MDX components, non-HTML pages, and the content-query bridge — and stops there. Sidebars, search, theming, and i18n are your project's responsibility, which means they're under your control.
-
-## What to read next
-
-Start with [Installation](/getting-started/installation) to build and install the CLI. Then work through [Your first site](/getting-started/your-first-site) to scaffold a project and see an end-to-end build. For a deeper understanding of the system, read [Engine vs Framework](/concepts/engine-vs-framework) to understand zfb's scope, [Build engine](/architecture/build-engine) for how the Rust crates fit together, and [Islands](/concepts/islands) for how interactive components work. If you are moving an existing site, [Migrating from Astro](/guides/migrating-from-astro) maps concepts side by side.
+<CategoryNav category="getting-started" />

--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -1,19 +1,18 @@
 ---
 title: Installation
-description: Install the zfb CLI from source while v0 is still in development.
+description: Build and install the zfb CLI from source.
 sidebar_position: 2
 ---
 
-zfb (zudo-front-builder) is shipped as a single Rust binary. While the project is in v0, there are no published releases on crates.io and no prebuilt binaries — you build the CLI yourself from this repository.
+zfb (zudo-front-builder) ships as a single Rust binary. Build it from this repository and install it into your Cargo bin directory.
 
 ## Prerequisites
 
 You will need:
 
-- **Rust toolchain** — install via [rustup](https://rustup.rs/). A recent stable toolchain (1.75 or newer) is fine.
+- **Rust toolchain** — install via [rustup](https://rustup.rs/). Stable 1.75 or newer is fine.
+- **Node.js ≥ 20** — the config loader and some build steps invoke Node. See [BUILDING.md](https://github.com/Takazudo/zudo-front-builder/blob/main/BUILDING.md) for the full requirement list.
 - **pnpm** — install via the [official installer](https://pnpm.io/installation). zfb scaffolds projects that use pnpm and will run `pnpm install` for you when it can find pnpm on your `PATH`.
-
-You **do** need Node.js for `zfb dev` and `zfb preview`. The dev / preview path renders pages through a Node-hosted miniflare worker (see [ADR-005 (SSG-first)](https://github.com/Takazudo/zudo-front-builder/blob/main/docs/architecture/adr-005-ssg-first.md)). Production-built static output (`dist/`) does not require Node at deploy time — only the build/dev tooling does.
 
 ## Build and install the CLI
 
@@ -48,9 +47,3 @@ You should see four subcommands:
 - `zfb preview` — serve the build output
 
 If `zfb --help` prints all four, you're ready to move on to [Your first site](/getting-started/your-first-site).
-
-<Info title="v0 distribution">
-
-  This source-build flow is the only supported install path right now. Released crates and prebuilt binaries will land once the framework reaches a stable surface.
-
-</Info>

--- a/docs/src/content/docs/getting-started/introduction.mdx
+++ b/docs/src/content/docs/getting-started/introduction.mdx
@@ -1,0 +1,62 @@
+---
+title: Introduction
+description: What zfb is, who it is for, and how it compares to Astro and Next.js.
+sidebar_position: 1
+---
+
+zfb is a Rust-built static-site engine for people who already know Astro or Next.js and want millisecond rebuilds, a single-binary toolchain, and an opt-in island model.
+
+If you can read a `pages/` directory tree and write a TSX component, you already know 90 percent of what zfb requires.
+
+## What zfb provides
+
+- **Embedded V8 worker** — pages render through a Rust-embedded V8 runtime (ADR-007). No separate Node process is required at build time.
+- **Atomic writes** — the build never leaves the output directory in a partially-written state. Each `zfb build` run either completes fully or leaves `dist/` unchanged.
+- **Per-page incremental rebuild** — changing a shared layout touches only the pages that import it, not the whole site. Dev-loop latency stays in the tens of milliseconds even on large sites.
+- **Opt-in islands** — components are server-rendered by default. Add `"use client"` to a component file to opt into client-side hydration. Pages with no islands ship zero JavaScript.
+- **Frontmatter and content collections** — Markdown, MDX, and TypeScript data files in a named directory become a typed collection, queryable from pages via `getCollection()`.
+- **Dynamic routes** — `pages/blog/[slug].tsx` exports a `paths()` function; zfb evaluates it at build time to expand the route into one HTML file per slug.
+- **MDX components** — import any TSX component into `.mdx` content and use it as JSX.
+- **Non-HTML pages** — a page file can export a `contentType` to produce JSON, XML, RSS, or any other text format instead of HTML.
+- **Content-query bridge** — `getCollection()` is available inside MDX files and inside `paths()`, not only in page components.
+- **Single-binary distribution** — zfb ships as one Rust binary. No `node_modules` for the framework itself, no plugin registry to audit.
+
+## Familiar from Astro
+
+| Astro concept | zfb equivalent |
+| --- | --- |
+| `src/pages/` file-system routing | `pages/` directory, same naming conventions |
+| `.astro` components with a frontmatter fence | TSX page files with a `getStaticProps` export |
+| Content Collections with typed schemas | `getCollection()` + schema declared in `zfb.config.ts` |
+| `<slot />` in layouts | React `children` prop — plain TSX composition |
+| `client:load` directive | `"use client"` directive at the top of a component file |
+| `public/` for static assets | `public/` — same semantics |
+| `astro.config.mjs` | `zfb.config.ts` (TypeScript, loaded directly) |
+
+What is different: zfb has no component syntax of its own — everything is TSX. There is no `.astro` file format to learn. The trade-off is that you lose Astro's per-component fence syntax and gain a single consistent authoring surface for pages, layouts, and components.
+
+## Familiar from Next.js
+
+| Next.js concept | zfb equivalent |
+| --- | --- |
+| `pages/` directory routing (Pages Router) | `pages/` — same file naming and nesting rules |
+| `getStaticProps` / `getStaticPaths` | `getStaticProps` + `paths()` export, same two-function pattern |
+| Dynamic routes `[slug].tsx` | `[slug].tsx` — identical syntax |
+| Catch-all routes `[...slug].tsx` | `[...slug].tsx` — identical syntax |
+| `public/` for static assets | `public/` — same semantics |
+| Layout components wrapping pages | Layout components wrapping pages — plain TSX composition |
+
+What is different: zfb produces only static HTML — there is no server runtime, no API routes, and no SSR at request time. Think of it as Next.js with `output: "export"` only, but with a faster build engine and no Node.js required in the build environment. The App Router, server components, and middleware are outside zfb's scope.
+
+## Client router and view transitions
+
+The `@takazudo/zfb-runtime` package ships a `<ClientRouter />` component that intercepts same-origin navigations and replaces page content without a full reload, with optional View Transitions API support. Opt in by mounting it in your root layout — pages that do not mount it get normal link behavior.
+
+## Migration guides
+
+- [Migrating from Astro](/guides/migrating-from-astro) — concept-by-concept map for moving an existing Astro static site to zfb.
+
+## What to read next
+
+[Installation](/getting-started/installation) covers building and installing the CLI.
+[Your first site](/getting-started/your-first-site) walks through scaffolding a project and running a build end to end.

--- a/docs/src/content/docs/getting-started/project-structure.mdx
+++ b/docs/src/content/docs/getting-started/project-structure.mdx
@@ -4,7 +4,7 @@ description: A tour of every file and directory the default template lays down.
 sidebar_position: 4
 ---
 
-When you run `zfb new my-site`, the `default` template lays down a small but complete project. Knowing what each directory is for makes the rest of the docs much easier to skim.
+When you run `zfb new my-site`, the `basic-blog` template lays down a small but complete project. Knowing what each directory is for makes the rest of the docs much easier to skim.
 
 ```text
 my-site/
@@ -15,14 +15,15 @@ my-site/
 ├── layouts/
 │   └── default.tsx
 ├── components/
-│   └── counter.tsx
+│   ├── note.tsx
+│   └── theme-toggle.tsx
 ├── content/
 │   └── blog/
-│       └── welcome.md
+│       └── hello-zfb.mdx
 ├── styles/
 │   └── global.css
 ├── public/
-├── zfb.config.ts
+├── zfb.config.json
 ├── package.json
 ├── tsconfig.json
 └── .gitignore
@@ -37,7 +38,7 @@ File-system routing lives here. Every `.tsx` file under `pages/` becomes a route
 - `pages/blog/[slug].tsx` → `/blog/:slug` (dynamic route — one HTML file per resolved slug)
 - `pages/docs/[...slug].tsx` → catchall, matches any depth
 
-The default template ships an index page and one dynamic blog route. Dynamic and catchall routes are recognized by the router today, but per-instance expansion (the `paths()` evaluation that turns `[slug]` into concrete files at build time) lands with the JS runtime — see [JS runtime architecture](/architecture/js-runtime).
+The default template ships an index page and one dynamic blog route. A dynamic route file exports a `paths()` function; zfb calls it at build time to expand `[slug]` into one HTML file per resolved slug. See [Dynamic routes](/concepts/dynamic-routes) for the full API.
 
 ## layouts/
 
@@ -45,11 +46,11 @@ Reusable page wrappers. `layouts/default.tsx` is the shell every page imports �
 
 ## components/
 
-Plain components and **islands**. `components/counter.tsx` opens with a `"use client"` directive — that's the marker that turns it into an island, hydrated in the browser. Components without `"use client"` render only on the server. The full mental model is on the [islands page](/concepts/islands).
+Plain components and **islands**. The template ships `components/note.tsx` (a server-rendered callout) and `components/theme-toggle.tsx` (a `"use client"` island for toggling dark mode). The `"use client"` directive at the top of a file is what turns a component into a client-side island — components without it render only on the server and ship zero JavaScript. The full mental model is on the [islands page](/concepts/islands).
 
 ## content/
 
-Content collections. `content/blog/welcome.md` is the seed entry of a `blog` collection: Markdown (or MDX) files in a directory, queried from your pages via `getCollection("blog")`. Collection schemas are declared in `zfb.config.{json,ts}` under `collections`.
+Content collections. `content/blog/` holds the seed entries of a `blog` collection: Markdown and MDX files in a named directory, queryable from pages via `getCollection("blog")`. Collection schemas are declared in `zfb.config.ts` under `collections`.
 
 ## styles/
 
@@ -59,15 +60,11 @@ Global CSS. `styles/global.css` is the entry point — import it from your root 
 
 Static assets served as-is from the site root. Put `favicon.ico`, robots.txt, and any image you want to reference by absolute URL here. zfb's dev server and `zfb preview` both serve `public/` directly.
 
-## zfb.config — JSON today, TS later
+## zfb.config.json
 
 The config file uses a camelCase schema with these keys: `outDir` (default `"dist"`), `publicDir` (default `"public"`), `host` (default `"localhost"`), `port` (default `3000`), `framework` (`"preact"` or `"react"`, default `"preact"`), `collections`, `tailwind`, and `plugins`.
 
-<Info title="zfb.config.ts is not loaded yet">
-
-  The template writes a `zfb.config.ts` so your editor gets type hints, but zfb only loads `zfb.config.json` today — TS config support lands with the JS runtime. For now, write your runtime configuration in `zfb.config.json` (same schema) and treat the `.ts` file as a typed reference.
-
-</Info>
+The template scaffolds `zfb.config.json`. If you rename it to `zfb.config.ts`, zfb loads it via the bundled esbuild binary and you get full TypeScript types and IDE completion — the schema is identical in both formats.
 
 ## package.json, tsconfig.json, .gitignore
 

--- a/docs/src/content/docs/getting-started/your-first-site.mdx
+++ b/docs/src/content/docs/getting-started/your-first-site.mdx
@@ -4,12 +4,6 @@ description: Scaffold, run, and build a zfb project in about five minutes.
 sidebar_position: 3
 ---
 
-<Warning title="Superseded by ADR-005">
-
-The `dev_404` / `DenoCoreHost` status note below predates [ADR-005 (SSG-first)](https://github.com/Takazudo/zudo-front-builder/blob/main/docs/architecture/adr-005-ssg-first.md). The current architecture renders pages through a Node-hosted miniflare worker rather than an in-process `deno_core` runtime, so the "blocked on ADR-001" framing no longer reflects how zfb dev works today.
-
-</Warning>
-
 This walkthrough takes you from an empty directory to a running dev server and a built site. It assumes you already [installed the zfb CLI](/getting-started/installation).
 
 ## Scaffold a new project
@@ -19,9 +13,13 @@ zfb new my-site
 cd my-site
 ```
 
-`zfb new` copies the `default` template into `my-site/`. If pnpm is on your `PATH`, zfb runs `pnpm install` automatically right after copying the template; otherwise it prints a short note telling you to run it yourself.
+`zfb new` copies the `basic-blog` template into `my-site/`. If pnpm is on your `PATH`, zfb runs `pnpm install` automatically right after copying the template; otherwise it prints a short note telling you to run it yourself.
 
-The `--template` flag is reserved for future templates — only `default` ships today.
+Pass `--template` to select a different template if additional ones are available:
+
+```bash
+zfb new my-site --template basic-blog
+```
 
 ## Start the dev server
 
@@ -31,17 +29,11 @@ zfb dev
 
 You'll see a "ready" banner with the host and port (defaults: `http://localhost:3000`). zfb watches the project directory; saving any file in `pages/`, `layouts/`, `components/`, `content/`, or `styles/` triggers a live-reload broadcast to connected browsers. The server also serves anything you drop into `public/`.
 
-You can override host and port from the CLI — they always win over `zfb.config.json`:
+You can override host and port from the CLI — they always win over `zfb.config.ts`:
 
 ```bash
 zfb dev --port 4000 --host 0.0.0.0
 ```
-
-<Warning title="v0 status — renderer pending">
-
-  Today `zfb dev` boots, watches files, and broadcasts live-reload events on save — but every page request currently falls through to a `dev_404` placeholder body. Per-route rendering is blocked on **ADR-001**: the JS runtime host (`DenoCoreHost`) is still a skeleton (`execute_module` returns a placeholder, `call_default` returns "not yet implemented"). The watcher, router, dev server, and live-reload pipeline are all real and exercisable; the actual page output lands once the runtime decision in [JS runtime architecture](/architecture/js-runtime) is implemented.
-
-</Warning>
 
 ## Build and preview
 
@@ -54,14 +46,9 @@ zfb preview
 
 `zfb build` resolves the output directory (defaulting to `dist/`), enumerates routes via the file-system router, and writes one HTML file per static route. `zfb preview` then serves that directory over HTTP on port `4321` by default. CLI flags (`--outdir`, `--port`) win over the config file in both commands.
 
-<Warning title="v0 status — build output is a placeholder">
-
-  Same caveat as `zfb dev`: `zfb build` already validates the project, loads config, and walks the route table — but each generated HTML file currently contains a stub noting the route template, not the rendered page. Real per-route SSR turns on the day ADR-001 lands. See [JS runtime architecture](/architecture/js-runtime).
-
-</Warning>
-
 ## What to read next
 
 - [Project structure](/getting-started/project-structure) — what every directory the template created actually does.
 - [Routing](/concepts/routing) — how `pages/` becomes URLs, including dynamic and catchall routes.
-- [JS runtime architecture](/architecture/js-runtime) — the in-progress decision behind the rendering placeholder.
+- [Islands](/concepts/islands) — how to opt individual components into client-side hydration.
+- [Build engine](/architecture/build-engine) — how the Rust crates fit together under the hood.


### PR DESCRIPTION
## Summary

- Add `introduction.mdx` (sidebar_position 1) — new canonical first read targeting Astro/Next.js users; From Astro / From Next.js comparison tables; ClientRouter note; migration guide link.
- Rewrite `index.mdx` to a `Getting Started` landing page with `<CategoryNav category="getting-started" />` (sidebar_position 0), mirroring zudo-doc pattern.
- Update `installation.mdx`: drop `<Info title="v0 distribution">` block; remove miniflare/ADR-005 Node note; add Node >= 20 prerequisite.
- Rewrite `your-first-site.mdx`: remove two `<Warning title="v0 status — renderer pending">` blocks and the leading `<Warning title="Superseded by ADR-005">` block; correct template name to `basic-blog`; clean up "What to read next".
- Update `project-structure.mdx`: remove `<Info title="zfb.config.ts is not loaded yet">` block; correct template tree to match actual `basic-blog` files; fix config section heading; update dynamic routes prose (no ADR-001 reference).
- Sync `docs-ja/getting-started/index.mdx` structurally with new English `index.mdx`.

## Acceptance criteria verification

- Stale-text grep returns zero hits (all v0/WIP patterns cleaned).
- `pnpm --filter docs build` exits clean (105 pages built).
- All internal links verified against existing content files.
- Sidebar order: index (0), introduction (1), installation (2), your-first-site (3), project-structure (4).
- Shared-truth aligned: embedded V8 / ADR-007, `zfb.config.ts` loading, `syntect` highlighting, full render pipeline.

## Notes

- No Next.js migration guide exists yet (`/guides/migrating-from-astro` is the only one available); the introduction links only to Astro. Adding a Next.js guide is a follow-up recommendation.
- Template tree in `project-structure.mdx` was corrected to match actual `basic-blog` template files (prior doc had placeholder `counter.tsx` that doesn't exist in the template).

Closes: #237