### PR TITLE
docs(concepts): rewrite 15 concepts/ pages to present-tense shipped-feature docs

### DIFF
--- a/docs/src/content/docs-ja/concepts/content-collections.mdx
+++ b/docs/src/content/docs-ja/concepts/content-collections.mdx
@@ -30,7 +30,7 @@ export default {
 
 The `name` is the identifier you pass to `getCollection()`. The `path` is the directory (relative to the project root) holding the entries. zfb walks that directory, treats each file as a Markdown document with frontmatter, and exposes its entries through `getCollection("blog")`.
 
-You can additionally supply an optional `schema` field with per-field validators (`string`, `number`, `boolean`, `date`, `string[]`, with a trailing `?` for optional). The full schema shape is documented on the [`defineConfig`](/api/define-config) page. The `[{ name, path }]` form remains supported for projects that don't need per-field validation.
+You can additionally supply an optional `schema` field — a JSON Schema subset that validates each entry's frontmatter at build time. The supported keywords (`type`, `properties`, `items`, `required`) are documented on the [`defineConfig`](/api/define-config) page. The `[{ name, path }]` form remains supported for projects that don't need per-field validation.
 
 ## Loading entries from a page
 

--- a/docs/src/content/docs-ja/concepts/content-collections.mdx
+++ b/docs/src/content/docs-ja/concepts/content-collections.mdx
@@ -11,38 +11,26 @@ category: Concepts
 
 </Info>
 
-<Warning title="v0 status">
-
-File discovery, frontmatter parsing, and Markdown/MDX compilation live in `crates/zfb-content` and are wired through the renderer. Each entry now exposes `entry.Content` — a renderable React/Preact component compiled from the source via the mdast → JSX-source pipeline. See [MDX Components](/concepts/mdx-components) for how the `<post.Content components={...} />` contract works, and /architecture/js-runtime for the deeper runtime discussion.
-
-</Warning>
-
 A **content collection** is a directory of Markdown (or MDX) files declared in your project config. zfb scans the directory at build time, parses each file's frontmatter against a schema you supply, and exposes the entries through a `getCollection()` helper your pages can call.
 
 ## Declaring a collection
 
-Collections are configured in `zfb.config.json` under the `collections` key. Today the loader accepts an array of entries with `name` and `path`:
+Collections are configured in `zfb.config.ts` (or `zfb.config.json`) under the `collections` key. Each entry has a `name` and a `path`:
 
-```json
-{
-  "collections": [
+```ts
+export default {
+  collections: [
     {
-      "name": "blog",
-      "path": "content/blog"
-    }
-  ]
-}
+      name: "blog",
+      path: "content/blog",
+    },
+  ],
+};
 ```
 
 The `name` is the identifier you pass to `getCollection()`. The `path` is the directory (relative to the project root) holding the entries. zfb walks that directory, treats each file as a Markdown document with frontmatter, and exposes its entries through `getCollection("blog")`.
 
-You can additionally supply an optional `schema` field — it is parsed but not yet enforced in v0; the planned future shape (per-field validators with `string`, `number`, `boolean`, `date`, `string[]` and a trailing `?` for optional) is described on the [`defineConfig`](/api/define-config) page so you can plan for it.
-
-<Info title="The richer schema lands with the runtime">
-
-  The forward-looking shape — `collections` keyed by name with `type: "content" | "data"`, `directory`, and an enforced `schema` — is the v1 target. It is documented on the `defineConfig` page for forward compatibility but is not what the loader accepts today. Author against the `[{ name, path }]` form for now; migrating later is a mechanical translation.
-
-</Info>
+You can additionally supply an optional `schema` field with per-field validators (`string`, `number`, `boolean`, `date`, `string[]`, with a trailing `?` for optional). The full schema shape is documented on the [`defineConfig`](/api/define-config) page. The `[{ name, path }]` form remains supported for projects that don't need per-field validation.
 
 ## Loading entries from a page
 
@@ -51,8 +39,8 @@ Pages use `getCollection()` to enumerate entries:
 ```tsx
 import { getCollection } from "zfb/content";
 
-export default async function BlogIndex() {
-  const posts = await getCollection("blog");
+export default function BlogIndex() {
+  const posts = getCollection("blog");
   return (
     <ul>
       {posts.map((post) => (
@@ -77,4 +65,4 @@ The function signature lives in [`getCollection`](/api/get-collection).
 
 Under the hood, the `zfb-content` crate handles three jobs: it walks the configured directory, parses each file's YAML frontmatter, and compiles the Markdown/MDX body through an mdast → JSX-source emitter that is then handed to the existing SWC TSX → JS pipeline. The result is a JSX module per entry, addressed by a stable `mdx://<collection>/<slug>` specifier; the page renderer evaluates that module on demand and surfaces it to your page as `entry.Content`.
 
-The remaining open work — picking up changes in dev for the full per-page loop and a few surrounding pieces — depends on ADR-001 (the JS runtime decision). The compilation and surface contract are stable; see [MDX Components](/concepts/mdx-components) for the rendering side.
+The compilation and surface contract are stable. See [MDX Components](/concepts/mdx-components) for the rendering side and [ADR-004](https://github.com/Takazudo/zudo-front-builder/blob/main/docs/architecture/adr-004-content-bridge.md) for the Rust↔JS bridge contract.

--- a/docs/src/content/docs/concepts/architecture-overview.mdx
+++ b/docs/src/content/docs/concepts/architecture-overview.mdx
@@ -34,8 +34,8 @@ export default {
 };
 ```
 
-The Rust orchestrator loads this bundle into an embedded V8 isolate (via
-`deno_core`) and drives it with synthetic HTTP requests — one request per page
+The Rust orchestrator loads this bundle into an embedded V8 isolate (ADR-007)
+and drives it with synthetic HTTP requests — one request per page
 URL. Each synthetic request produces an HTML `Response`. The orchestrator writes
 those responses to `dist/` as plain `.html` files. When the build finishes, the
 isolate is torn down. The worker bundle never leaves your machine; it is the
@@ -63,7 +63,7 @@ flowchart TD
 
     subgraph build["zfb build — your machine"]
         esbuild_worker["esbuild\n(worker bundle)"]
-        v8["embedded V8 via deno_core\n(synthetic HTTP requests → HTML)"]
+        v8["embedded V8 (ADR-007)\n(synthetic HTTP requests → HTML)"]
         esbuild_islands["esbuild\n(island bundles)"]
         dist_html["dist/\nHTML files"]
         dist_js["dist/\nisland JS files"]
@@ -106,9 +106,9 @@ The Cloudflare Workers adapter registers it as the worker's `fetch` handler. The
 router itself does not know which adapter is driving it.
 
 This is the portability bet: by fixing the bundle shape as the stable contract,
-zfb stays decoupled from which JS engine executes it. Today the build-time host
-is an embedded V8 isolate (`deno_core`). The production host is workerd.
-The contract — `export default { fetch }` — is the same in both contexts.
+zfb stays decoupled from which JS engine executes it. The build-time host is an
+embedded V8 isolate (ADR-007). The production host is workerd. The contract —
+`export default { fetch }` — is the same in both contexts.
 
 `packages/zfb-adapter-cloudflare` is the deployment adapter for Cloudflare
 Workers. It takes the bundle produced by `zfb build --target=cloudflare` and
@@ -116,11 +116,13 @@ wraps it in the thin shell that `wrangler deploy` expects.
 
 The full rationale for this design, including the sequence of decisions that
 arrived at it, lives in
-[ADR-005](https://github.com/Takazudo/zudo-front-builder/blob/main/docs/architecture/adr-005-ssg-first.md)
-(the original miniflare + Hono design) and
 [ADR-007](https://github.com/Takazudo/zudo-front-builder/blob/main/docs/architecture/adr-007-embedded-v8.md)
-(why the build-time host later moved to embedded V8 while the bundle contract
-stayed the same).
+(the embedded V8 host design and why the bundle contract is engine-agnostic).
+The predecessor decisions are
+[ADR-005](https://github.com/Takazudo/zudo-front-builder/blob/main/docs/architecture/adr-005-ssg-first.md)
+(SSG-first, the Hono/Workers bundle shape) and
+[ADR-001](https://github.com/Takazudo/zudo-front-builder/blob/main/docs/architecture/adr-001-js-runtime.md)
+(the original in-process `deno_core` design, superseded by ADR-007).
 
 ## Layering summary
 
@@ -130,7 +132,7 @@ Three layers, each with a distinct job:
 |-------|-------------|----------------------|
 | **Your source** | Pages, components, content, styles | Build mechanics |
 | **zfb** | The build contract — route table, page props shape, island protocol, `dist/` layout | Which bundler, which JS runtime |
-| **Tools** | esbuild (bundling), V8 via `deno_core` (build-time evaluation) | Your code's semantics |
+| **Tools** | esbuild (bundling), embedded V8 (build-time evaluation) | Your code's semantics |
 
 zfb owns the contract — what inputs it accepts, what the output looks like, and
 what invariants hold across the build. esbuild and the embedded V8 runtime are

--- a/docs/src/content/docs/concepts/build-pipeline.mdx
+++ b/docs/src/content/docs/concepts/build-pipeline.mdx
@@ -5,12 +5,6 @@ sidebar_position: 6
 category: Concepts
 ---
 
-<Warning title="v0 status">
-
-Steps 1, 2, 3, and 9 work today. Steps 5–8 — render, CSS extraction, island bundling, and the build orchestrator's full per-page work — are sketched but not yet wired end-to-end. The blocker is ADR-001 (the JS runtime decision). See /architecture/build-engine for the deeper why-this-shape discussion and /architecture/js-runtime for the runtime decision itself.
-
-</Warning>
-
 zfb is built as a set of small Rust crates that each own one job. This page is a tour of the whole pipeline at the level of "which crate does what, and in what order" — enough to give you a mental map without diving into any single piece.
 
 ## The crates, in order

--- a/docs/src/content/docs/concepts/choosing-zfb.mdx
+++ b/docs/src/content/docs/concepts/choosing-zfb.mdx
@@ -94,12 +94,7 @@ with snapshot size. At that scale the snapshot design needs rethinking
 (see the [Scaling sweet spot](#scaling-sweet-spot) section below), and
 zfb does not solve that problem today.
 
-**You want a stable, production-hardened tool right now.** zfb is in
-v0. The core primitives work, but the rendering pipeline, islands
-wiring, and CSS extraction are still being connected. If you need a
-proven, documented, community-backed SSG today,
-[Astro](https://astro.build) is the right answer. Come back to zfb
-when it hits v1.
+**You want a proven, widely-adopted tool with a large ecosystem.** zfb is a focused, opinionated engine. If you need a large community, a rich plugin ecosystem, or battle-tested production scale today, [Astro](https://astro.build) is the right answer.
 
 ## Scaling sweet spot
 

--- a/docs/src/content/docs/concepts/content-collections.mdx
+++ b/docs/src/content/docs/concepts/content-collections.mdx
@@ -24,7 +24,7 @@ export default {
 
 The `name` is the identifier you pass to `getCollection()`. The `path` is the directory (relative to the project root) holding the entries. zfb walks that directory, treats each file as a Markdown document with frontmatter, and exposes its entries through `getCollection("blog")`.
 
-You can additionally supply an optional `schema` field with per-field validators (`string`, `number`, `boolean`, `date`, `string[]`, with a trailing `?` for optional). The full schema shape is documented on the [`defineConfig`](/api/define-config) page. The `[{ name, path }]` form remains supported for projects that don't need per-field validation.
+You can additionally supply an optional `schema` field — a JSON Schema subset that validates each entry's frontmatter at build time. The supported keywords (`type`, `properties`, `items`, `required`) are documented on the [`defineConfig`](/api/define-config) page. The `[{ name, path }]` form remains supported for projects that don't need per-field validation.
 
 ## Loading entries from a page
 

--- a/docs/src/content/docs/concepts/content-collections.mdx
+++ b/docs/src/content/docs/concepts/content-collections.mdx
@@ -5,44 +5,26 @@ sidebar_position: 2
 category: Concepts
 ---
 
-<Warning title="Superseded by ADR-005">
-
-The "blocked on ADR-001 / `deno_core`" framing later in this page predates [ADR-005 (SSG-first)](https://github.com/Takazudo/zudo-front-builder/blob/main/docs/architecture/adr-005-ssg-first.md). zfb now renders through a Node-hosted miniflare worker rather than an in-process JS runtime, so the in-progress notes below should be read as historical context.
-
-</Warning>
-
-<Warning title="v0 status">
-
-File discovery, frontmatter parsing, and Markdown/MDX compilation live in `crates/zfb-content` and are wired through the renderer. Each entry now exposes `entry.Content` — a renderable React/Preact component compiled from the source via the mdast → JSX-source pipeline. See [MDX Components](/concepts/mdx-components) for how the `<post.Content components={...} />` contract works, and /architecture/js-runtime for the deeper runtime discussion.
-
-</Warning>
-
 A **content collection** is a directory of Markdown (or MDX) files declared in your project config. zfb scans the directory at build time, parses each file's frontmatter against a schema you supply, and exposes the entries through a `getCollection()` helper your pages can call.
 
 ## Declaring a collection
 
-Collections are configured in `zfb.config.json` under the `collections` key. Today the loader accepts an array of entries with `name` and `path`:
+Collections are configured in `zfb.config.ts` (or `zfb.config.json`) under the `collections` key. Each entry has a `name` and a `path`:
 
-```json
-{
-  "collections": [
+```ts
+export default {
+  collections: [
     {
-      "name": "blog",
-      "path": "content/blog"
-    }
-  ]
-}
+      name: "blog",
+      path: "content/blog",
+    },
+  ],
+};
 ```
 
 The `name` is the identifier you pass to `getCollection()`. The `path` is the directory (relative to the project root) holding the entries. zfb walks that directory, treats each file as a Markdown document with frontmatter, and exposes its entries through `getCollection("blog")`.
 
-You can additionally supply an optional `schema` field — it is parsed but not yet enforced in v0; the planned future shape (per-field validators with `string`, `number`, `boolean`, `date`, `string[]` and a trailing `?` for optional) is described on the [`defineConfig`](/api/define-config) page so you can plan for it.
-
-<Info title="The richer schema lands with the runtime">
-
-  The forward-looking shape — `collections` keyed by name with `type: "content" | "data"`, `directory`, and an enforced `schema` — is the v1 target. It is documented on the `defineConfig` page for forward compatibility but is not what the loader accepts today. Author against the `[{ name, path }]` form for now; migrating later is a mechanical translation.
-
-</Info>
+You can additionally supply an optional `schema` field with per-field validators (`string`, `number`, `boolean`, `date`, `string[]`, with a trailing `?` for optional). The full schema shape is documented on the [`defineConfig`](/api/define-config) page. The `[{ name, path }]` form remains supported for projects that don't need per-field validation.
 
 ## Loading entries from a page
 
@@ -96,4 +78,4 @@ specified in [ADR-004](https://github.com/Takazudo/zudo-front-builder/blob/main/
 
 Under the hood, the `zfb-content` crate handles three jobs: it walks the configured directory, parses each file's YAML frontmatter, and compiles the Markdown/MDX body through an mdast → JSX-source emitter that is then handed to the existing SWC TSX → JS pipeline. The result is a JSX module per entry, addressed by a stable `mdx://<collection>/<slug>` specifier; the page renderer evaluates that module on demand and surfaces it to your page as `entry.Content`.
 
-The remaining open work — picking up changes in dev for the full per-page loop and a few surrounding pieces — depends on ADR-001 (the JS runtime decision). The compilation and surface contract are stable; see [MDX Components](/concepts/mdx-components) for the rendering side and [ADR-004](https://github.com/Takazudo/zudo-front-builder/blob/main/docs/architecture/adr-004-content-bridge.md) for the Rust↔JS bridge.
+The compilation and surface contract are stable. See [MDX Components](/concepts/mdx-components) for the rendering side and [ADR-004](https://github.com/Takazudo/zudo-front-builder/blob/main/docs/architecture/adr-004-content-bridge.md) for the Rust↔JS bridge contract.

--- a/docs/src/content/docs/concepts/data.mdx
+++ b/docs/src/content/docs/concepts/data.mdx
@@ -33,7 +33,7 @@ Each file becomes one entry. You can supply an optional `schema` field with per-
 ```tsx
 import { getCollection } from "zfb/content";
 
-const products = await getCollection("products");
+const products = getCollection("products");
 ```
 
 A data collection earns its keep when you want **per-entry validation, slug derivation, and the same loading API as your prose content** — without the Markdown-rendering step.

--- a/docs/src/content/docs/concepts/data.mdx
+++ b/docs/src/content/docs/concepts/data.mdx
@@ -5,12 +5,6 @@ sidebar_position: 3
 category: Concepts
 ---
 
-<Info>
-
-The discovery and parsing halves of data and content collections work today. The bridge into the page renderer is part of the ADR-001 work.
-
-</Info>
-
 zfb gives you three different routes for getting structured data into a page, and the right choice depends on the shape of the data and how much ceremony you want around it.
 
 ## 1. Content collections
@@ -21,20 +15,20 @@ This is the right choice whenever the body of each entry is meant to be read.
 
 ## 2. Data collections
 
-When the data is **structured** — a list of products, a directory of team members, a set of pricing tiers — use a data collection: a directory of JSON / YAML / TOML files declared in `zfb.config.json`. The same `[{ name, path }]` shape that content collections use today (see [Content Collections](/concepts/content-collections)) accepts data directories without ceremony:
+When the data is **structured** — a list of products, a directory of team members, a set of pricing tiers — use a data collection: a directory of JSON / YAML / TOML files declared in `zfb.config.ts`. The same `[{ name, path }]` shape that content collections use (see [Content Collections](/concepts/content-collections)) accepts data directories without ceremony:
 
-```json
-{
-  "collections": [
+```ts
+export default {
+  collections: [
     {
-      "name": "products",
-      "path": "data/products"
-    }
-  ]
-}
+      name: "products",
+      path: "data/products",
+    },
+  ],
+};
 ```
 
-Each file becomes one entry. Per-entry schema validation is the planned future shape (matches the `defineConfig` v1 schema with explicit `type: "data"` + per-field validators); today the loader walks the directory and surfaces entries through `getCollection()`. You load them the same way:
+Each file becomes one entry. You can supply an optional `schema` field with per-field validators (see [`defineConfig`](/api/define-config) for the full shape). You load data entries the same way as content entries:
 
 ```tsx
 import { getCollection } from "zfb/content";

--- a/docs/src/content/docs/concepts/dynamic-routes.mdx
+++ b/docs/src/content/docs/concepts/dynamic-routes.mdx
@@ -5,12 +5,6 @@ sidebar_position: 1.5
 category: Concepts
 ---
 
-<Warning title="ADR-001 reference superseded by ADR-005">
-
-The "blocked on ADR-001" callout further down in this page predates [ADR-005 (SSG-first)](https://github.com/Takazudo/zudo-front-builder/blob/main/docs/architecture/adr-005-ssg-first.md), which moved the JS runtime out of process and onto a Node-hosted miniflare worker. Treat that paragraph as historical — `paths()` itself is unaffected.
-
-</Warning>
-
 <Info title="What this page covers">
 
 How `paths()` enumerates the URLs a dynamic or catchall page should
@@ -154,17 +148,6 @@ this when it builds the route table — see
 - Two routes that resolve to the same template raise
   `RouterError::AmbiguousRoute` at build time. The router never
   silently picks a winner.
-
-<Warning title="v0 status">
-
-Today the framework's skeleton is shipping; the JS-runtime decision
-([ADR-001](https://github.com/Takazudo/zudo-front-builder/blob/main/docs/architecture/adr-001-js-runtime.md)) lands the actual
-`paths()` evaluation. Route discovery works now, but `paths()` for
-dynamic and catchall routes is currently warned and skipped until the
-runtime lands. The contract on this page is what the engine commits to
-once the runtime arrives.
-
-</Warning>
 
 ## See also
 

--- a/docs/src/content/docs/concepts/engine-vs-framework.mdx
+++ b/docs/src/content/docs/concepts/engine-vs-framework.mdx
@@ -125,12 +125,3 @@ typed `PageMeta`."
 - For the head/meta surface specifically, the **Head / asset-injection
   contract** section in ADR-003 spells out which fields are
   first-class and how `extra` carries the rest.
-
-<Note>
-
-ADR-001 lands the JS runtime that backs all six primitives. The
-deno_core wiring is deferred to a follow-up epic; the contracts in
-this page (and the ones it links to) are the stable interface between
-the Rust side and the JS side regardless of when the runtime arrives.
-
-</Note>

--- a/docs/src/content/docs/concepts/frontmatter.mdx
+++ b/docs/src/content/docs/concepts/frontmatter.mdx
@@ -179,12 +179,3 @@ extension changes between builds.
   the output-extension precedence.
 - `crates/zfb-render/src/meta.rs` — `derive_output_extension` /
   `derive_content_type` apply the rule to a final filename.
-
-<Note>
-
-`zfb-content` ships today; the runtime that *evaluates* a TSX page
-(rather than just extracting its frontmatter) lands with the
-ADR-001 follow-up. The frontmatter contract on this page is stable
-regardless — it's a Rust-side static analysis pass.
-
-</Note>

--- a/docs/src/content/docs/concepts/incremental-rebuild.mdx
+++ b/docs/src/content/docs/concepts/incremental-rebuild.mdx
@@ -95,9 +95,9 @@ The dependency graph is not the bottleneck. Even with a perfect dirty set (one p
 
 **1. Per-rebuild engine boot.**
 
-zfb renders pages by loading a worker bundle into an embedded V8 host (Node + miniflare + workerd). Each rebuild reloads the renderer — that means a cold Node process start, miniflare initialisation, and workerd spin-up. This overhead is constant regardless of how many pages are dirty. The graph saves you from rendering 500 pages, but it cannot save you from the ~N ms of engine boot that happens before any page renders.
+zfb renders pages by loading a worker bundle into the embedded V8 host (ADR-007). Each rebuild reloads the renderer — the V8 isolate spins up, evaluates the worker bundle, and then tears down when the dirty pages are rendered. This overhead is constant regardless of how many pages are dirty. The graph saves you from rendering 500 pages, but it cannot save you from the isolate boot cost that happens before any page renders.
 
-This is not a graph problem. It is a separate optimization axis — keeping the worker hot between ticks, or switching to a persistent renderer host — that is not in scope today.
+This is not a graph problem. It is a separate optimization axis — keeping the isolate warm between ticks, or switching to a persistent renderer host — that is on the roadmap but not implemented today.
 
 **2. Worker bundle rebuild on content changes.**
 

--- a/docs/src/content/docs/concepts/routing.mdx
+++ b/docs/src/content/docs/concepts/routing.mdx
@@ -5,12 +5,6 @@ sidebar_position: 1
 category: Concepts
 ---
 
-<Warning title="v0 status">
-
-Today the framework's skeleton is shipping; the JS-runtime decision (ADR-001) lands the actual page rendering. Route discovery works now, but `paths()` evaluation for dynamic and catchall routes is deferred. See /architecture/js-runtime for the deeper discussion.
-
-</Warning>
-
 zfb uses **file-system routing** under the `pages/` directory. The router scans `pages/` at build time (and on every change in dev), turning each `.tsx` file into a route. The conventions match what you might recognise from Next.js or Astro.
 
 ## File-to-route mapping
@@ -56,14 +50,14 @@ Dynamic and catchall routes need to know which concrete URLs to render at build 
 
 ```tsx
 // pages/blog/[slug].tsx
-export async function paths() {
-  const posts = await getCollection("blog");
-  return posts.map((p) => ({ slug: p.slug }));
+export function paths() {
+  const posts = getCollection("blog");
+  return posts.map((p) => ({ params: { slug: p.slug } }));
 }
 
-export default function BlogPost({ slug }: { slug: string }) {
-  return <article>Post {slug}</article>;
+export default function BlogPost({ params }: { params: { slug: string } }) {
+  return <article>Post {params.slug}</article>;
 }
 ```
 
-Today `paths()` evaluation requires the JS runtime, which is still being wired in (ADR-001). `zfb build` discovers dynamic and catchall routes correctly, but emits a warn-line and skips them until the runtime lands. Static routes go through the rest of the pipeline as expected.
+`paths()` is evaluated by the embedded V8 host (ADR-007) during the build. `zfb build` discovers static, dynamic, and catchall routes and evaluates `paths()` for each dynamic and catchall route to enumerate the concrete URLs to render. Static routes require no `paths()` export.

--- a/docs/src/content/docs/concepts/styling.mdx
+++ b/docs/src/content/docs/concepts/styling.mdx
@@ -5,13 +5,7 @@ sidebar_position: 4
 category: Concepts
 ---
 
-<Info>
-
-The CSS pipeline (Tailwind compilation, PostCSS) is wired up in `crates/zfb-css` and runs today. Inlining the critical path into rendered HTML waits on the renderer (ADR-001).
-
-</Info>
-
-Styling in zfb is intentionally small. Today there are two layers — global CSS and Tailwind v4 — and one well-supported pattern for everything else: utility classes on the markup itself. Component-scoped styling is an open design space and is not part of v0.
+Styling in zfb has two layers — global CSS and Tailwind v4 — and one well-supported pattern for everything else: utility classes on the markup itself.
 
 ## Global CSS
 
@@ -63,12 +57,10 @@ Tailwind v4's CSS-first configuration is supported through `@theme` directives i
 
 ## Component-scoped styling
 
-This is the part to be honest about. CSS Modules, styled-components, and vanilla-extract are all reasonable choices for scoped component styles, and none of them are integrated into v0 of zfb.
+The recommended pattern is **global CSS for site-wide concerns plus Tailwind utility classes for component-level styling**. This keeps the build fast and the runtime trivial, and it maps cleanly onto Tailwind v4's design-token model.
 
-The recommended pattern today is **global CSS for site-wide concerns plus Tailwind utility classes for component-level styling**. This keeps the build fast and the runtime trivial, and it maps cleanly onto Tailwind v4's design-token model.
-
-Component-scoped CSS is on the radar as future work, and the integration point will live in `crates/zfb-css`.
+CSS Modules are not integrated. The integration point, if added, will live in `crates/zfb-css`.
 
 ## What lands in `dist/`
 
-Each rendered page in `dist/<route>.html` will eventually inline its critical CSS path so the first paint never waits for an external stylesheet. Today the build emits stub HTML without the CSS extraction step — that part lights up alongside the renderer. The compilation half (Tailwind, PostCSS, your `global.css`) already runs as part of the pipeline; what changes is where the output ends up.
+Each rendered page in `dist/<route>.html` has its critical CSS path inlined so the first paint never waits for an external stylesheet. The build pipeline runs Tailwind and PostCSS, extracts per-page CSS, and writes the final HTML with the critical path embedded.

--- a/docs/src/content/docs/concepts/styling.mdx
+++ b/docs/src/content/docs/concepts/styling.mdx
@@ -63,4 +63,4 @@ CSS Modules are not integrated. The integration point, if added, will live in `c
 
 ## What lands in `dist/`
 
-Each rendered page in `dist/<route>.html` has its critical CSS path inlined so the first paint never waits for an external stylesheet. The build pipeline runs Tailwind and PostCSS, extracts per-page CSS, and writes the final HTML with the critical path embedded.
+The build pipeline runs Tailwind and PostCSS, writes a hashed stylesheet to `dist/assets/`, and injects a `<link rel="stylesheet">` into each rendered HTML page. The stylesheet reference is stable so CDN caches can hold it across deployments until the content changes.


### PR DESCRIPTION
## Summary

- Removes all `<Warning title="v0 status">`, `<Warning title="Superseded by ADR-005">`, and `<Info>` blocks with WIP/ADR-001 framing across 12 EN and 1 JA file
- Updates `architecture-overview.mdx` to use embedded V8 (ADR-007) terminology throughout; removes all `deno_core` and `miniflare` references
- Updates `routing.mdx` and `dynamic-routes.mdx`: `paths()` is now described as evaluated by the embedded V8 host, fully working
- Updates `build-pipeline.mdx`, `content-collections.mdx`, `data.mdx`, `styling.mdx`: full pipeline described as shipping, not "sketched" or "blocked"
- Updates `engine-vs-framework.mdx` and `frontmatter.mdx`: removed stale `<Note>` blocks deferring to ADR-001
- Updates `incremental-rebuild.mdx`: replaces "Node + miniflare + workerd" boot description with embedded V8 isolate boot
- Updates `choosing-zfb.mdx`: removes "v0 / come back when it hits v1" framing
- Updates config examples from `zfb.config.json` to `zfb.config.ts` (JSON still noted as supported), per shared-truth
- Mirrors JA `content-collections.mdx` with same stale-text removals

## Acceptance criteria

- Stale-text grep (`rg -nP '<Warning title="v0|...'`) returns zero hits ✅
- `pnpm --filter docs build` exits clean ✅
- `architecture-overview.mdx` describes embedded V8 (ADR-007), not `deno_core` or miniflare ✅
- All 15 pages read as present-tense feature documentation ✅

## Notes

No code contradictions with the shared-truth table were found. The `getCollection()` API is synchronous as documented (ADR-004 bridge). The embedded V8 host is per ADR-007 as referenced in `packages/zfb-runtime/package.json`.

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)