### PR TITLE
feat(config): flexible markdown.gfm with snapshot/bundler parity

### DIFF
--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -384,6 +384,21 @@ pub struct BundlerInput {
     /// Mirrors `zfb::config::Config::resolve_markdown_links`. Default: `None`
     /// (pass-through — links are not rewritten).
     pub resolve_markdown_links: Option<ResolveMarkdownLinksSpec>,
+
+    /// Resolved per-construct GFM flags. Threaded into the hoisted MDX
+    /// pre-compile pipeline at every `materialise_*` call site so the
+    /// JSX `content_hash` baked into each compiled module agrees with
+    /// what the snapshot walker (`zfb_content::build_snapshot_with_config`)
+    /// produces. Divergence here is the snapshot ↔ bundler hash
+    /// land mine documented at
+    /// `crates/zfb-content/src/content_bridge.rs:118-153`.
+    ///
+    /// Mirrors `zfb::config::resolve_gfm_constructs(config.markdown)`.
+    /// `Default` is [`ResolvedGfmConstructs::CONSERVATIVE`] so call
+    /// sites that don't construct this struct manually (the test
+    /// builders in `crates/zfb-build/tests/` etc.) keep the same
+    /// effective parser behaviour.
+    pub gfm_constructs: zfb_content::ResolvedGfmConstructs,
 }
 
 impl BundlerInput {
@@ -429,6 +444,7 @@ impl BundlerInput {
             strip_md_ext: false,
             code_highlight_theme: None,
             resolve_markdown_links: None,
+            gfm_constructs: zfb_content::ResolvedGfmConstructs::default(),
         }
     }
 }
@@ -604,6 +620,7 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
             input.strip_md_ext,
             input.code_highlight_theme.as_deref(),
             if resolve_links_enabled { Some(&resolve_source_map) } else { None },
+            input.gfm_constructs,
             &mut broken,
         )
         .with_context(|| format!("bundler: failed materialising pages from {}", pages_dir.display()))?;
@@ -636,6 +653,7 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
                 input.strip_md_ext,
                 input.code_highlight_theme.as_deref(),
                 if resolve_links_enabled { Some(&resolve_source_map) } else { None },
+                input.gfm_constructs,
                 &mut broken,
             )
             .with_context(|| {
@@ -661,6 +679,7 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
             input.strip_md_ext,
             input.code_highlight_theme.as_deref(),
             if resolve_links_enabled { Some(&resolve_source_map) } else { None },
+            input.gfm_constructs,
             &mut broken,
         )
         .with_context(|| {
@@ -682,6 +701,7 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
             input.strip_md_ext,
             input.code_highlight_theme.as_deref(),
             if resolve_links_enabled { Some(&resolve_source_map) } else { None },
+            input.gfm_constructs,
             &mut broken,
         )
         .with_context(|| {
@@ -702,6 +722,7 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
             input.strip_md_ext,
             input.code_highlight_theme.as_deref(),
             if resolve_links_enabled { Some(&resolve_source_map) } else { None },
+            input.gfm_constructs,
             &mut broken,
         )
         .with_context(|| {
@@ -756,6 +777,7 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
                     input.strip_md_ext,
                     input.code_highlight_theme.as_deref(),
                     if resolve_links_enabled { Some(&resolve_source_map) } else { None },
+                    input.gfm_constructs,
                     &mut broken,
                 )
                 .with_context(|| {
@@ -933,6 +955,7 @@ fn materialise_shadow(
     strip_md_ext: bool,
     code_highlight_theme: Option<&str>,
     resolve_source_map: Option<&HashMap<std::path::PathBuf, String>>,
+    gfm_constructs: zfb_content::ResolvedGfmConstructs,
     broken_links_out: &mut Vec<(String, String)>,
 ) -> Result<()> {
     if !src.exists() {
@@ -977,7 +1000,10 @@ fn materialise_shadow(
     // also wired into the mdast phase after `AdmonitionsPlugin` so
     // author-written `[label](./other.mdx)` links rewrite to the
     // rendered route URL. The `source_dir` is updated per-file below.
-    let mut pipeline = zfb_content::pipeline::Pipeline::with_defaults_and_theme(code_highlight_theme);
+    let mut pipeline = zfb_content::pipeline::Pipeline::with_defaults_and_theme_and_gfm(
+        code_highlight_theme,
+        gfm_constructs,
+    );
     if strip_md_ext {
         pipeline.add_strip_md_ext();
     }
@@ -1218,6 +1244,7 @@ fn materialise_collection(
     strip_md_ext: bool,
     code_highlight_theme: Option<&str>,
     resolve_source_map: Option<&HashMap<std::path::PathBuf, String>>,
+    gfm_constructs: zfb_content::ResolvedGfmConstructs,
     broken_links_out: &mut Vec<(String, String)>,
 ) -> Result<()> {
     if !src.exists() {
@@ -1240,7 +1267,10 @@ fn materialise_collection(
     // When `resolve_source_map` is `Some`, the `ResolveLinksPlugin` is
     // also wired after `AdmonitionsPlugin` in the mdast phase. The
     // `source_dir` is updated per-file inside the walk loop.
-    let mut pipeline = zfb_content::pipeline::Pipeline::with_defaults_and_theme(code_highlight_theme);
+    let mut pipeline = zfb_content::pipeline::Pipeline::with_defaults_and_theme_and_gfm(
+        code_highlight_theme,
+        gfm_constructs,
+    );
     if strip_md_ext {
         pipeline.add_strip_md_ext();
     }
@@ -2108,6 +2138,7 @@ mod tests {
             strip_md_ext: false,
             code_highlight_theme: None,
             resolve_markdown_links: None,
+            gfm_constructs: zfb_content::ResolvedGfmConstructs::default(),
         }
     }
 
@@ -2332,7 +2363,18 @@ mod tests {
 
         let dest = tmp.path().join("shadow_content").join("docs");
         let mut imports: Vec<ContentImport> = Vec::new();
-        materialise_collection(&src, &dest, "docs", &mut imports, false, None, None, &mut Vec::new()).unwrap();
+        materialise_collection(
+            &src,
+            &dest,
+            "docs",
+            &mut imports,
+            false,
+            None,
+            None,
+            zfb_content::ResolvedGfmConstructs::default(),
+            &mut Vec::new(),
+        )
+        .unwrap();
 
         // Two MDX files → two ContentImport records, with stable
         // forward-slash shadow_rel_paths under `content/docs/...`.
@@ -2460,6 +2502,7 @@ mod tests {
             false,
             None,
             None,
+            zfb_content::ResolvedGfmConstructs::default(),
             &mut Vec::new(),
         )
         .unwrap();
@@ -2663,6 +2706,7 @@ mod tests {
             strip_md_ext: false,
             code_highlight_theme: None,
             resolve_markdown_links: None,
+            gfm_constructs: zfb_content::ResolvedGfmConstructs::default(),
         };
 
         let out = bundle(input).expect("real esbuild bundle should succeed");
@@ -2771,7 +2815,18 @@ mod tests {
         let mut routes = Vec::new();
         // dest must be named "pages" for is_pages_dir detection in materialise_shadow
         let shadow_pages_dest = root.join("shadow").join("pages");
-        materialise_shadow(&pages, &shadow_pages_dest, &mut routes, &root, false, None, None, &mut Vec::new()).unwrap();
+        materialise_shadow(
+            &pages,
+            &shadow_pages_dest,
+            &mut routes,
+            &root,
+            false,
+            None,
+            None,
+            zfb_content::ResolvedGfmConstructs::default(),
+            &mut Vec::new(),
+        )
+        .unwrap();
 
         // Map route → registration index.
         let order: BTreeMap<&str, usize> = routes

--- a/crates/zfb-build/tests/bundler_default_plugins.rs
+++ b/crates/zfb-build/tests/bundler_default_plugins.rs
@@ -313,6 +313,7 @@ fn make_input(
         strip_md_ext: false,
         code_highlight_theme: None,
         resolve_markdown_links: None,
+        gfm_constructs: zfb_content::ResolvedGfmConstructs::default(),
     }
 }
 

--- a/crates/zfb-build/tests/bundler_integration.rs
+++ b/crates/zfb-build/tests/bundler_integration.rs
@@ -194,6 +194,7 @@ fn end_to_end_bundles_aliases_mdx_islands_and_define() {
         strip_md_ext: false,
         code_highlight_theme: None,
         resolve_markdown_links: None,
+        gfm_constructs: zfb_content::ResolvedGfmConstructs::default(),
     };
 
     let out = bundle(input).expect("end-to-end bundle should succeed");

--- a/crates/zfb-build/tests/bundler_resolve_links.rs
+++ b/crates/zfb-build/tests/bundler_resolve_links.rs
@@ -153,6 +153,7 @@ fn make_input_with_resolve(
             }],
             on_broken_links,
         }),
+        gfm_constructs: zfb_content::ResolvedGfmConstructs::default(),
     }
 }
 
@@ -191,6 +192,7 @@ fn make_input_without_resolve(
         code_highlight_theme: None,
         // Feature disabled: links pass through unchanged.
         resolve_markdown_links: None,
+        gfm_constructs: zfb_content::ResolvedGfmConstructs::default(),
     }
 }
 

--- a/crates/zfb-build/tests/bundler_strip_md_ext.rs
+++ b/crates/zfb-build/tests/bundler_strip_md_ext.rs
@@ -130,6 +130,7 @@ fn make_input(
         strip_md_ext,
         code_highlight_theme: None,
         resolve_markdown_links: None,
+        gfm_constructs: zfb_content::ResolvedGfmConstructs::default(),
     }
 }
 

--- a/crates/zfb-build/tests/embedded_v8_snapshot_e2e.rs
+++ b/crates/zfb-build/tests/embedded_v8_snapshot_e2e.rs
@@ -97,6 +97,7 @@ fn make_mock_input(tmp: &tempfile::TempDir, snapshot_json: Option<String>) -> Bu
         strip_md_ext: false,
         code_highlight_theme: None,
         resolve_markdown_links: None,
+        gfm_constructs: zfb_content::ResolvedGfmConstructs::default(),
     }
 }
 

--- a/crates/zfb-build/tests/integration_e2e_routing_rendering.rs
+++ b/crates/zfb-build/tests/integration_e2e_routing_rendering.rs
@@ -315,6 +315,7 @@ fn build_bundle(
         strip_md_ext: false,
         code_highlight_theme: None,
         resolve_markdown_links: None,
+        gfm_constructs: zfb_content::ResolvedGfmConstructs::default(),
     };
 
     let output = bundle(input).expect("bundle should succeed for fixture project");

--- a/crates/zfb-build/tests/migration_fixes_integration_confirm.rs
+++ b/crates/zfb-build/tests/migration_fixes_integration_confirm.rs
@@ -421,6 +421,7 @@ fn make_full_fixture_input(
             }],
             on_broken_links: OnBrokenLinks::Warn,
         }),
+        gfm_constructs: zfb_content::ResolvedGfmConstructs::default(),
     }
 }
 

--- a/crates/zfb-content/src/content_bridge.rs
+++ b/crates/zfb-content/src/content_bridge.rs
@@ -150,13 +150,30 @@ pub struct SnapshotPipelineConfig {
     /// the plugin entirely.
     pub resolve_source_map:
         Option<std::collections::HashMap<std::path::PathBuf, String>>,
+    /// Resolved GFM construct flags (output of
+    /// `zfb::config::resolve_gfm_constructs` / `MarkdownConfig::resolve_constructs`).
+    /// MUST match what the bundler threads into its own
+    /// `Pipeline::with_defaults_and_theme_and_gfm` call. Divergence
+    /// here is the snapshot ↔ bundler hash divergence land mine
+    /// documented above — flipping `gfm_strikethrough` on one side and
+    /// off on the other shifts every snapshot's JSX `content_hash`,
+    /// and every `<Content />` lookup falls back to
+    /// `<pre data-zfb-content-fallback>`.
+    ///
+    /// `Default` is [`ResolvedGfmConstructs::CONSERVATIVE`] so existing
+    /// tests + fixtures that don't construct this struct manually keep
+    /// the same effective behaviour as before this field landed.
+    pub gfm_constructs: super::pipeline::ResolvedGfmConstructs,
 }
 
 impl SnapshotPipelineConfig {
     /// Construct a pipeline shaped by this config. Used by
     /// [`build_snapshot_with_config`] once per collection.
     fn build_pipeline(&self) -> Pipeline {
-        let mut p = Pipeline::with_defaults_and_theme(self.code_highlight_theme.as_deref());
+        let mut p = Pipeline::with_defaults_and_theme_and_gfm(
+            self.code_highlight_theme.as_deref(),
+            self.gfm_constructs,
+        );
         if self.strip_md_ext {
             p.add_strip_md_ext();
         }
@@ -730,5 +747,123 @@ mod tests {
         let docs = snap.collections.get("docs").expect("docs present");
         assert_eq!(docs.len(), 1);
         assert_eq!(docs[0].rel_path, "guides/intro.md");
+    }
+
+    /// Sub-issue #61 land-mine guard: GFM resolved-constructs threaded
+    /// through `SnapshotPipelineConfig` must produce the same JSX
+    /// `content_hash` as an independent bundler-shaped compile that
+    /// uses the same constructs. Diverging here is exactly the
+    /// `<pre data-zfb-content-fallback>` failure mode the docstring at
+    /// lines 118-153 warns about.
+    ///
+    /// We exercise BOTH endpoints of the new config surface:
+    /// `gfm: false` (every GFM construct off — strikethrough should
+    /// pass through as raw `~~` text) and `gfm: true` (every GFM
+    /// construct on — strikethrough emits `<del>` and divides the
+    /// `content_hash` from the all-off path).
+    #[test]
+    fn snapshot_specifier_matches_bridge_hash_under_explicit_gfm_choice() {
+        use crate::mdx_jsx_emit::{compile_mdx_to_jsx_module_cached, parse_mdx_specifier};
+        use crate::pipeline::ResolvedGfmConstructs;
+
+        let mdx = "---\ntitle: \"Strike\"\n---\n\nplain ~~gone~~ here\n";
+        let body = "\nplain ~~gone~~ here\n";
+
+        for (label, resolved) in [
+            ("ALL_OFF", ResolvedGfmConstructs::ALL_OFF),
+            ("ALL_ON", ResolvedGfmConstructs::ALL_ON),
+        ] {
+            let tmp = TmpDir::new(&format!("snapshot-gfm-parity-{}", label.to_lowercase()));
+            let path = tmp.write("docs/strike.mdx", mdx);
+
+            let cfg = CollectionConfig::new("docs", tmp.path.join("docs"));
+            let snap = build_snapshot_with_config(
+                &[cfg],
+                &SnapshotPipelineConfig {
+                    gfm_constructs: resolved,
+                    ..Default::default()
+                },
+            )
+            .expect("snapshot must succeed");
+            let entry = snap
+                .collections
+                .get("docs")
+                .expect("docs collection")
+                .iter()
+                .find(|e| e.slug == "strike")
+                .expect("strike entry");
+
+            // Independent bundler-shaped compile with the same
+            // constructs. Hash must agree byte-for-byte.
+            let mut pipeline =
+                crate::pipeline::Pipeline::with_defaults_and_theme_and_gfm(None, resolved);
+            let compiled =
+                compile_mdx_to_jsx_module_cached(body, &path, None, Some(&mut pipeline))
+                    .expect("bundler-style compile must succeed");
+
+            let snap_spec = parse_mdx_specifier(&entry.module_specifier)
+                .expect("snapshot specifier parses");
+            let bridge_spec = parse_mdx_specifier(&compiled.specifier)
+                .expect("bundler specifier parses");
+
+            assert_eq!(
+                snap_spec.content_hash, bridge_spec.content_hash,
+                "snapshot ↔ bundler hash divergence under gfm={label}: \
+                 snapshot={snap}, bundler={bridge} — this is the \
+                 sub-#61 / zfb#132 hazard (see content_bridge.rs:118-153)",
+                snap = snap_spec.content_hash,
+                bridge = bridge_spec.content_hash,
+            );
+            // Sanity — neither output should carry the fallback marker
+            // (the `<pre data-zfb-content-fallback>` shape is emitted
+            // by the bundler entry-module shim, not the compiled JSX
+            // itself; the proxy here is "compiled JSX agrees on both
+            // sides", which is the input the shim sees).
+            assert!(
+                !compiled.jsx_source.contains("zfb-content-fallback"),
+                "unexpected fallback marker in compiled JSX under gfm={label}"
+            );
+        }
+    }
+
+    /// Smoke check that the two extreme GFM choices produce *different*
+    /// `content_hash` values for the same input — otherwise the parity
+    /// assertion above could trivially pass when the resolve path is
+    /// broken (everything would collapse to a single hash).
+    #[test]
+    fn snapshot_specifier_differs_between_gfm_on_and_off() {
+        use crate::pipeline::ResolvedGfmConstructs;
+
+        let mdx = "---\ntitle: \"Strike\"\n---\n\nplain ~~gone~~ here\n";
+
+        let tmp = TmpDir::new("snapshot-gfm-distinct");
+        tmp.write("docs/strike.mdx", mdx);
+        let cfg = || CollectionConfig::new("docs", tmp.path.join("docs"));
+
+        let off = build_snapshot_with_config(
+            &[cfg()],
+            &SnapshotPipelineConfig {
+                gfm_constructs: ResolvedGfmConstructs::ALL_OFF,
+                ..Default::default()
+            },
+        )
+        .expect("snapshot off");
+        let on = build_snapshot_with_config(
+            &[cfg()],
+            &SnapshotPipelineConfig {
+                gfm_constructs: ResolvedGfmConstructs::ALL_ON,
+                ..Default::default()
+            },
+        )
+        .expect("snapshot on");
+
+        let off_spec = off.collections["docs"][0].module_specifier.as_str();
+        let on_spec = on.collections["docs"][0].module_specifier.as_str();
+        assert_ne!(
+            off_spec, on_spec,
+            "snapshot specifier MUST differ between gfm=on and gfm=off — \
+             otherwise the resolve_constructs path is not actually \
+             threading through to the parser"
+        );
     }
 }

--- a/crates/zfb-content/src/lib.rs
+++ b/crates/zfb-content/src/lib.rs
@@ -16,6 +16,10 @@ pub use content_bridge::{
     CollectionConfig, ContentSnapshot, EntrySnapshot, SnapshotPipelineConfig,
 };
 
+pub use pipeline::{
+    constructs_for_jsx_emit, constructs_for_pipeline, ResolvedGfmConstructs,
+};
+
 pub use frontmatter::{FrontmatterError, UnifiedFrontmatter};
 pub use mdx_jsx_emit::{
     compile_mdx_to_jsx_module, compile_mdx_to_jsx_module_cached, mdx_to_jsx_module,

--- a/crates/zfb-content/src/mdx_jsx_emit.rs
+++ b/crates/zfb-content/src/mdx_jsx_emit.rs
@@ -49,7 +49,8 @@ use markdown::mdast::{AlignKind, AttributeContent, AttributeValue, Node as Mdast
 use sha2::{Digest, Sha256};
 
 use crate::pipeline::{
-    mdast_to_hast_with, HastNode, JsxEmitStrategy, Pipeline, PipelineError,
+    constructs_for_jsx_emit, mdast_to_hast_with, HastNode, JsxEmitStrategy, Pipeline,
+    PipelineError, ResolvedGfmConstructs,
 };
 use crate::plugins::heading_links::{next_slug, slugify};
 
@@ -175,16 +176,25 @@ fn mdx_to_jsx_module_inner(
     // of inline math (markdown-rs's `math_text_single_dollar` defaults
     // to true). Authors who want a literal dollar sign must escape it
     // as `\$` — same convention as the upstream remark-math ecosystem.
+    //
+    // The GFM constructs come from the supplied pipeline (the bundler
+    // / dev loader / snapshot bridge resolve them from
+    // `zfb.config.ts#markdown.gfm` and thread them through). Without a
+    // pipeline (the no-`pipeline` legacy entry point) we fall back to
+    // the conservative default — strikethrough + table on, every other
+    // GFM construct off — so the no-pipeline path doesn't silently
+    // strip strikethrough either. Both paths route through
+    // `constructs_for_jsx_emit` so math (`math_flow` / `math_text`)
+    // stays hard-coded ON regardless of the GFM choice; math
+    // constructs are not part of the new `markdown.gfm` config
+    // surface, and the JSX emitter has dedicated arms for them
+    // (zfb#93).
+    let resolved_gfm: ResolvedGfmConstructs = pipeline
+        .as_deref()
+        .map(|p| p.gfm_constructs())
+        .unwrap_or(ResolvedGfmConstructs::CONSERVATIVE);
     let parse_options = markdown::ParseOptions {
-        constructs: markdown::Constructs {
-            math_flow: true,
-            math_text: true,
-            // GFM pipe-table syntax: `| Key | Value |`. Not part of
-            // Constructs::mdx() by default; enabled so MdastNode::Table
-            // reaches the emitter (see zfb#136).
-            gfm_table: true,
-            ..markdown::Constructs::mdx()
-        },
+        constructs: constructs_for_jsx_emit(resolved_gfm),
         mdx_esm_parse: Some(Box::new(|_value: &str| -> markdown::MdxSignal {
             markdown::MdxSignal::Ok
         })),

--- a/crates/zfb-content/src/pipeline.rs
+++ b/crates/zfb-content/src/pipeline.rs
@@ -30,6 +30,115 @@ use crate::plugins::{
 };
 use crate::syntect_highlight::Highlighter;
 
+/// Resolved per-construct GFM flags.
+///
+/// Output of `zfb::config::MarkdownConfig::resolve_constructs` (and the
+/// matching `resolve_gfm_constructs` free function). Threaded into
+/// every site that builds [`markdown::ParseOptions`] so the snapshot
+/// walker, bundler, and dev loader stay in lockstep on the parser
+/// constructs — divergence here is the
+/// `content_bridge.rs:118-153` land mine (snapshot ↔ bundler
+/// `content_hash` divergence → `<pre data-zfb-content-fallback>`).
+///
+/// Defined here in `zfb-content` (the lowest crate that actually
+/// touches `markdown::Constructs`) so consumers can wire it into the
+/// pipeline without an upward dependency on `zfb`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ResolvedGfmConstructs {
+    /// GFM strikethrough (`~~text~~`).
+    pub strikethrough: bool,
+    /// GFM pipe-style tables.
+    pub table: bool,
+    /// GFM autolink literal (bare URLs).
+    pub autolink_literal: bool,
+    /// GFM task list items (`- [x]` / `- [ ]`).
+    pub task_list_item: bool,
+    /// GFM footnote definitions (`[^ref]: …`).
+    pub footnote_definition: bool,
+}
+
+impl ResolvedGfmConstructs {
+    /// Conservative default — strikethrough + table on, every other
+    /// GFM construct off. See
+    /// `zfb::config::ResolvedGfmConstructs::CONSERVATIVE` for the full
+    /// rationale; both constants must stay in sync.
+    pub const CONSERVATIVE: Self = Self {
+        strikethrough: true,
+        table: true,
+        autolink_literal: false,
+        task_list_item: false,
+        footnote_definition: false,
+    };
+
+    /// Every GFM construct ON.
+    pub const ALL_ON: Self = Self {
+        strikethrough: true,
+        table: true,
+        autolink_literal: true,
+        task_list_item: true,
+        footnote_definition: true,
+    };
+
+    /// Every GFM construct OFF.
+    pub const ALL_OFF: Self = Self {
+        strikethrough: false,
+        table: false,
+        autolink_literal: false,
+        task_list_item: false,
+        footnote_definition: false,
+    };
+}
+
+impl Default for ResolvedGfmConstructs {
+    /// `Default` is the conservative default — the only `Default` that
+    /// makes sense without further context.
+    fn default() -> Self {
+        Self::CONSERVATIVE
+    }
+}
+
+/// Build `markdown::Constructs` for the HTML-serializer / collection
+/// walker pipeline (`Pipeline::run`) from a resolved GFM flag set.
+///
+/// Math constructs are deliberately left at their `Constructs::mdx()`
+/// default values here. The HTML serializer path treats math nodes as
+/// passthrough; enabling them here would not change the serializer
+/// output. The JSX-emit path enables `math_flow` / `math_text`
+/// separately, where the JSX emitter has dedicated arms for them.
+#[must_use]
+pub fn constructs_for_pipeline(
+    resolved: ResolvedGfmConstructs,
+) -> markdown::Constructs {
+    markdown::Constructs {
+        gfm_strikethrough: resolved.strikethrough,
+        gfm_table: resolved.table,
+        gfm_autolink_literal: resolved.autolink_literal,
+        gfm_task_list_item: resolved.task_list_item,
+        gfm_footnote_definition: resolved.footnote_definition,
+        // `gfm_label_start_footnote` is the inline-side of footnotes
+        // (`[^ref]` reference markers); markdown-rs treats it as a
+        // pair with `gfm_footnote_definition`, so we mirror the flag.
+        gfm_label_start_footnote: resolved.footnote_definition,
+        ..markdown::Constructs::mdx()
+    }
+}
+
+/// Same as [`constructs_for_pipeline`] but additionally turns on
+/// `math_flow` + `math_text`. Used at the JSX emit site so `$$…$$`
+/// and `$…$` parse into dedicated `Math` / `InlineMath` mdast nodes
+/// (zfb#93).
+#[must_use]
+pub fn constructs_for_jsx_emit(
+    resolved: ResolvedGfmConstructs,
+) -> markdown::Constructs {
+    markdown::Constructs {
+        math_flow: true,
+        math_text: true,
+        ..constructs_for_pipeline(resolved)
+    }
+}
+
+
 /// Lightweight HTML AST node.
 ///
 /// Plugins (mdast and hast visitors) operate on this representation in
@@ -129,6 +238,15 @@ pub struct Pipeline {
     mdast_visitors: Vec<Box<dyn MdastVisitor>>,
     hast_visitors: Vec<Box<dyn HastVisitor>>,
     parse_options: markdown::ParseOptions,
+    /// Resolved GFM constructs the pipeline was constructed with.
+    /// Stored separately from `parse_options.constructs` so the JSX
+    /// emit path can read back the same flags and build its own
+    /// `ParseOptions` (which also enables math constructs) without
+    /// having to round-trip through the markdown-rs `Constructs`
+    /// struct field-by-field. The two MUST stay in sync; the
+    /// constructors enforce this by building both from one
+    /// `ResolvedGfmConstructs` input.
+    gfm_constructs: ResolvedGfmConstructs,
     /// When the `StripMdExtensionPlugin` is wired into the pipeline,
     /// this flag controls whether the plugin appends `/` to internal
     /// hrefs after stripping `.md`/`.mdx` (and to any extensionless
@@ -163,15 +281,68 @@ impl Pipeline {
     }
 
     /// New pipeline using MDX-aware [`markdown::ParseOptions`].
+    ///
+    /// GFM construct flags follow the conservative default
+    /// (`gfm_strikethrough` + `gfm_table` on, every other GFM construct
+    /// off) — matching `ResolvedGfmConstructs::CONSERVATIVE` in
+    /// `crates/zfb/src/config.rs`. Math constructs (`math_flow`,
+    /// `math_text`) stay OFF here because [`Pipeline::run`] consumes
+    /// HTML output and the HTML serializer treats math nodes as
+    /// passthrough; the JSX-emit path enables them separately at
+    /// `mdx_jsx_emit::mdx_to_jsx_module_inner`. Callers wiring this
+    /// pipeline from a project config should prefer
+    /// [`Pipeline::with_resolved_gfm_constructs`] so the user's
+    /// `markdown.gfm` setting flows through.
     #[must_use]
     pub fn with_mdx() -> Self {
+        Self::with_resolved_gfm_constructs(ResolvedGfmConstructs::CONSERVATIVE)
+    }
+
+    /// New pipeline whose [`markdown::ParseOptions::constructs`] is
+    /// built from a project-supplied [`ResolvedGfmConstructs`] (see
+    /// `zfb::config::resolve_gfm_constructs`).
+    ///
+    /// The bundler + dev loader + snapshot bridge all funnel through
+    /// this entry point so every site that materialises MDX content
+    /// agrees on the same parser constructs — which is what keeps the
+    /// snapshot ↔ bundler JSX `content_hash` byte-identical. The
+    /// land-mine comment at
+    /// `crates/zfb-content/src/content_bridge.rs:118-153` calls this
+    /// out explicitly.
+    ///
+    /// `gfm_label_start_footnote` is mirrored to the resolved
+    /// `footnote_definition` flag because the two constructs are
+    /// paired in markdown-rs: enabling the definition without the
+    /// label-start means the parser sees `[^a]: body` but never the
+    /// `[^a]` reference at the use site.
+    #[must_use]
+    pub fn with_resolved_gfm_constructs(
+        resolved: ResolvedGfmConstructs,
+    ) -> Self {
+        let constructs = constructs_for_pipeline(resolved);
         Self {
             mdast_visitors: Vec::new(),
             hast_visitors: Vec::new(),
-            parse_options: markdown::ParseOptions::mdx(),
+            parse_options: markdown::ParseOptions {
+                constructs,
+                ..markdown::ParseOptions::mdx()
+            },
+            gfm_constructs: resolved,
             add_trailing_slash: true,
             resolve_links: None,
         }
+    }
+
+    /// Borrow the resolved GFM construct set this pipeline was built
+    /// with.
+    ///
+    /// The JSX-emit detour reads this to build its own
+    /// `ParseOptions` (which also enables math constructs) so the two
+    /// parse paths agree on every non-math construct. Snapshot ↔
+    /// bundler hash parity depends on this agreement.
+    #[must_use]
+    pub fn gfm_constructs(&self) -> ResolvedGfmConstructs {
+        self.gfm_constructs
     }
 
     /// Set the `add_trailing_slash` option. Affects subsequent
@@ -313,6 +484,17 @@ impl Pipeline {
         Self::with_defaults_and_theme(None)
     }
 
+    /// New pipeline preloaded with the default plugin chain plus an
+    /// explicit GFM construct set.
+    ///
+    /// Forwards to [`Pipeline::with_defaults_and_theme_and_gfm`] with
+    /// the default theme. Use when the project's `zfb.config.ts`
+    /// configures `markdown.gfm` but not `codeHighlight.theme`.
+    #[must_use]
+    pub fn with_defaults_and_gfm(resolved: ResolvedGfmConstructs) -> Self {
+        Self::with_defaults_and_theme_and_gfm(None, resolved)
+    }
+
     /// New pipeline preloaded with the default plugin chain, optionally
     /// overriding the syntect highlight theme.
     ///
@@ -332,8 +514,24 @@ impl Pipeline {
     /// (theme = `base16-ocean.dark`).
     #[must_use]
     pub fn with_defaults_and_theme(theme: Option<&str>) -> Self {
+        Self::with_defaults_and_theme_and_gfm(theme, ResolvedGfmConstructs::CONSERVATIVE)
+    }
+
+    /// Most-explicit constructor: default plugin chain + theme +
+    /// resolved GFM construct set.
+    ///
+    /// The bundler, snapshot walker, and dev loader all funnel through
+    /// this entry point so every site that materialises MDX content
+    /// agrees on the same parser constructs — the snapshot ↔ bundler
+    /// hash parity requirement called out in
+    /// `crates/zfb-content/src/content_bridge.rs:118-153`.
+    #[must_use]
+    pub fn with_defaults_and_theme_and_gfm(
+        theme: Option<&str>,
+        resolved: ResolvedGfmConstructs,
+    ) -> Self {
         let highlighter = Arc::new(Highlighter::new());
-        let mut p = Self::with_mdx();
+        let mut p = Self::with_resolved_gfm_constructs(resolved);
         // mdast phase.
         p.add_mdast_visitor(Box::new(CjkFriendlyPlugin::new()));
         p.add_mdast_visitor(Box::new(AdmonitionsPlugin::new()));
@@ -902,9 +1100,12 @@ mod tests {
 
     // 4. Bold/italic/strikethrough/inline-code.
     //
-    // Strikethrough (`~~x~~`) is a GFM construct; MDX ParseOptions does
-    // not enable it. We test it explicitly with a Delete mdast node fed
-    // through the converter so the mapping is still covered.
+    // Strikethrough is GFM; with the conservative default
+    // (`ResolvedGfmConstructs::CONSERVATIVE`) it is now ON by default,
+    // so `~~x~~` parses into a `Delete` mdast node and the converter
+    // maps it to `<del>`. We exercise both paths: the synthetic
+    // `Delete` arm of `mdast_to_hast` AND the parse-driven path
+    // through `Pipeline::run`.
     #[test]
     fn inline_formatting() {
         // *em* and **strong** and `code` work under MDX parse options.
@@ -921,7 +1122,8 @@ mod tests {
         let (_, code_children, _) = assert_element(&p_children[4], "code");
         assert_eq!(code_children, &[HastNode::Text("c".into())]);
 
-        // Strikethrough: feed a synthetic Delete node directly.
+        // Strikethrough — synthetic Delete node: the mdast→hast arm is
+        // covered regardless of the parser construct flag.
         let del = MdastNode::Delete(markdown::mdast::Delete {
             children: vec![MdastNode::Text(Text {
                 value: "gone".into(),
@@ -932,6 +1134,51 @@ mod tests {
         let hast = mdast_to_hast(&del);
         let (_, del_children, _) = assert_element(&hast, "del");
         assert_eq!(del_children, &[HastNode::Text("gone".into())]);
+    }
+
+    // 4b. Conservative-default parser turns `~~text~~` into a Delete
+    // node. This is the missing-half of `inline_formatting` (the
+    // pre-config-API test only exercised the synthetic-node path).
+    // Sub-issue #61 of zudo-design-token-panel #60.
+    #[test]
+    fn strikethrough_parses_with_conservative_default() {
+        let h = run("a ~~b~~ c");
+        let (_, p_children, _) = assert_element(first_child(&h), "p");
+        // The `<p>` body is: Text("a ") · <del>b</del> · Text(" c").
+        // Find the `<del>` element regardless of how markdown-rs
+        // splits the surrounding text — what matters is that one
+        // exists.
+        let del = p_children
+            .iter()
+            .find(|child| matches!(child, HastNode::Element { tag, .. } if tag == "del"))
+            .expect("expected a <del> element in the parsed paragraph");
+        let (_, del_children, _) = assert_element(del, "del");
+        assert_eq!(del_children, &[HastNode::Text("b".into())]);
+    }
+
+    // 4c. With strikethrough explicitly OFF (`gfm: false` shape), the
+    // parser leaves `~~text~~` as bare text — no `Delete` node.
+    #[test]
+    fn strikethrough_disabled_emits_no_delete_node() {
+        let mut p = Pipeline::with_resolved_gfm_constructs(
+            ResolvedGfmConstructs::ALL_OFF,
+        );
+        let h = p.run("a ~~b~~ c").expect("parse ok");
+        // Walk the tree and assert there is no `<del>` anywhere — the
+        // raw `~~` characters live inside a Text node instead.
+        fn has_del(node: &HastNode) -> bool {
+            match node {
+                HastNode::Element { tag, children, .. } => {
+                    if tag == "del" {
+                        return true;
+                    }
+                    children.iter().any(has_del)
+                }
+                HastNode::Root { children } => children.iter().any(has_del),
+                _ => false,
+            }
+        }
+        assert!(!has_del(&h), "no <del> expected when strikethrough is off");
     }
 
     // 5. Fenced code block preserves lang and meta as attrs.

--- a/crates/zfb-content/tests/large_mdx_fallback_regression.rs
+++ b/crates/zfb-content/tests/large_mdx_fallback_regression.rs
@@ -376,6 +376,7 @@ fn large_mdx_with_inline_code_html_curly_braces_does_not_fall_back() {
         code_highlight_theme: None,
         strip_md_ext: true,
         resolve_source_map: None,
+        gfm_constructs: zfb_content::ResolvedGfmConstructs::default(),
     };
     let snap = build_snapshot_with_config(
         &[CollectionConfig::new("docs", &root)],

--- a/crates/zfb-content/tests/mdx_jsx_emit.rs
+++ b/crates/zfb-content/tests/mdx_jsx_emit.rs
@@ -151,12 +151,28 @@ fn thematic_break_and_break_are_void() {
 
 #[test]
 fn delete_strikethrough_via_synthetic_node() {
-    // GFM strikethrough is not enabled by `ParseOptions::mdx()`, but
-    // `Delete` is a real mdast node. Round-trip a paragraph that
-    // contains a manually wrapped `<del>` MDX-JSX element to confirm
-    // the lowercase JSX-element path still routes through `_components`.
+    // Two ways a `<del>` element can reach the emitter:
+    //
+    // 1. Author-written `<del>` MDX-JSX element — covered here. The
+    //    lowercase JSX-element path routes through `_components.del`
+    //    regardless of the GFM strikethrough flag.
     let out = emit("text with <del>gone</del> here");
     assert!(out.contains("<_components.del>"));
+    assert!(out.contains("</_components.del>"));
+}
+
+#[test]
+fn gfm_strikethrough_parses_with_conservative_default() {
+    // 2. GFM `~~text~~` shorthand — under the conservative default
+    //    (`markdown.gfm` omitted from `zfb.config.ts`), strikethrough
+    //    is ON, so `~~gone~~` parses into a `Delete` mdast node and
+    //    the emitter routes it through `_components.del`. Sub-issue #61
+    //    of zudo-design-token-panel #60.
+    let out = emit("text with ~~gone~~ here");
+    assert!(
+        out.contains("<_components.del>"),
+        "expected <_components.del> in:\n{out}"
+    );
     assert!(out.contains("</_components.del>"));
 }
 

--- a/crates/zfb-render/src/loader.rs
+++ b/crates/zfb-render/src/loader.rs
@@ -196,8 +196,33 @@ impl ModuleLoader {
     /// #129): when the bundler has the flag on, the dev loader must
     /// honour it too or `pnpm dev` and `zfb build` produce different
     /// href shapes for `[link](other.md)` style references.
+    ///
+    /// GFM constructs default to the conservative set
+    /// (`ResolvedGfmConstructs::CONSERVATIVE`). Use
+    /// [`ModuleLoader::with_strip_md_ext_and_gfm`] when the project's
+    /// `zfb.config.ts` configures `markdown.gfm` so dev rendering
+    /// agrees with the bundler.
     pub fn with_strip_md_ext(jsx_runtime: JsxRuntime, strip_md_ext: bool) -> Self {
-        let mut content_pipeline = Pipeline::with_defaults();
+        Self::with_strip_md_ext_and_gfm(
+            jsx_runtime,
+            strip_md_ext,
+            zfb_content::ResolvedGfmConstructs::default(),
+        )
+    }
+
+    /// Most-explicit constructor: takes both the strip-md-ext toggle
+    /// and the resolved GFM construct set so dev rendering and the
+    /// bundler agree on every parser knob.
+    ///
+    /// Mirrors
+    /// [`zfb_content::pipeline::Pipeline::with_defaults_and_theme_and_gfm`]
+    /// — the bundler funnels through the same constructor.
+    pub fn with_strip_md_ext_and_gfm(
+        jsx_runtime: JsxRuntime,
+        strip_md_ext: bool,
+        gfm_constructs: zfb_content::ResolvedGfmConstructs,
+    ) -> Self {
+        let mut content_pipeline = Pipeline::with_defaults_and_gfm(gfm_constructs);
         if strip_md_ext {
             content_pipeline.add_strip_md_ext();
         }

--- a/crates/zfb-render/src/render.rs
+++ b/crates/zfb-render/src/render.rs
@@ -63,10 +63,35 @@ impl<H: RenderHost> Renderer<H> {
     /// #129); the build CLI threads `Config::strip_md_ext` here so
     /// `zfb dev` and `zfb build` produce identical href shapes.
     ///
+    /// GFM constructs default to the conservative set
+    /// (`ResolvedGfmConstructs::CONSERVATIVE`); use
+    /// [`Renderer::with_strip_md_ext_and_gfm`] when the project's
+    /// `zfb.config.ts` configures `markdown.gfm`.
+    ///
     /// [`StripMdExtensionPlugin`]: zfb_content::plugins::StripMdExtensionPlugin
     pub fn with_strip_md_ext(host: H, jsx_runtime: JsxRuntime, strip_md_ext: bool) -> Self {
+        Self::with_strip_md_ext_and_gfm(
+            host,
+            jsx_runtime,
+            strip_md_ext,
+            zfb_content::ResolvedGfmConstructs::default(),
+        )
+    }
+
+    /// Most-explicit constructor: forwards both `strip_md_ext` and the
+    /// resolved GFM construct set through to the loader.
+    pub fn with_strip_md_ext_and_gfm(
+        host: H,
+        jsx_runtime: JsxRuntime,
+        strip_md_ext: bool,
+        gfm_constructs: zfb_content::ResolvedGfmConstructs,
+    ) -> Self {
         Self {
-            loader: ModuleLoader::with_strip_md_ext(jsx_runtime, strip_md_ext),
+            loader: ModuleLoader::with_strip_md_ext_and_gfm(
+                jsx_runtime,
+                strip_md_ext,
+                gfm_constructs,
+            ),
             host,
         }
     }

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -785,6 +785,7 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(args: BuildArgsResolved<'_, R, A>
             code_highlight_theme: config.code_highlight.as_ref().and_then(|c| c.theme.clone()),
             strip_md_ext: config.strip_md_ext,
             resolve_source_map: build_resolve_source_map_for_snapshot(project_root, config),
+            gfm_constructs: crate::config::resolve_gfm_constructs(config.markdown.as_ref()),
         };
         match zfb_content::build_snapshot_with_config(&collections, &snapshot_config) {
             Ok(snap) => match serde_json::to_string(&snap) {
@@ -965,6 +966,14 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(args: BuildArgsResolved<'_, R, A>
     // syntect theme instead of the default `base16-ocean.dark`.
     bundler_input.code_highlight_theme =
         config.code_highlight.as_ref().and_then(|c| c.theme.clone());
+    // Thread the optional `markdown.gfm` config into the bundler so
+    // the hoisted MDX pre-compile pipeline parses the same GFM
+    // constructs the snapshot walker uses. The snapshot wiring above
+    // resolves from the same source, so both `content_hash` inputs
+    // stay byte-identical (the snapshot ↔ bundler land mine called out
+    // at `crates/zfb-content/src/content_bridge.rs:118-153`).
+    bundler_input.gfm_constructs =
+        crate::config::resolve_gfm_constructs(config.markdown.as_ref());
     // Sub #212 follow-up — extend the embedded-binary extraction tier to
     // the bundler step. `crates/zfb-build/src/bundler.rs::resolve_esbuild_binary_with_env`
     // previously walked only `input.esbuild_binary`, then `ZFB_ESBUILD_BIN`,

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -564,6 +564,11 @@ fn boot_dev_renderer(
     // so the hoisted MDX pre-compile pipeline uses the configured
     // syntect theme. Mirrors the `commands/build.rs` wiring.
     bundler_input.code_highlight_theme = cfg.code_highlight.as_ref().and_then(|c| c.theme.clone());
+    // Thread `markdown.gfm` through to the bundler so dev rendering
+    // and the build agree on the parser construct set. Mirrors the
+    // `commands/build.rs` wiring.
+    bundler_input.gfm_constructs =
+        crate::config::resolve_gfm_constructs(cfg.markdown.as_ref());
     // Sub #212 follow-up — same embedded-esbuild wiring as
     // `commands/build.rs`. Without this, dev mode would also blow up on
     // consumer projects without `crates/zfb/binaries/esbuild/`.

--- a/crates/zfb/src/config.rs
+++ b/crates/zfb/src/config.rs
@@ -320,6 +320,16 @@ pub struct Config {
     /// through unchanged.
     #[serde(default)]
     pub trailing_slash: bool,
+
+    /// Markdown / MDX parsing options. Currently the only knob exposed
+    /// is [`MarkdownConfig::gfm`], which toggles GFM constructs
+    /// (strikethrough, table, autolink-literal, task-list-item,
+    /// footnote-definition) on or off.
+    ///
+    /// `#[serde(rename_all = "camelCase")]` on this struct deserialises
+    /// the JSON / TS form `markdown` into this field.
+    #[serde(default)]
+    pub markdown: Option<MarkdownConfig>,
 }
 
 impl Default for Config {
@@ -339,6 +349,7 @@ impl Default for Config {
             code_highlight: None,
             resolve_markdown_links: None,
             trailing_slash: false,
+            markdown: None,
         }
     }
 }
@@ -514,6 +525,143 @@ pub struct PluginConfig {
     /// for JSON-only configs and synthetic test configs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolved_module: Option<String>,
+}
+
+// --- markdown / GFM config -------------------------------------------------
+
+/// Markdown / MDX parsing options.
+///
+/// Mirrors `MarkdownConfig` in `packages/zfb/src/config.ts`. Today the
+/// only knob is [`Self::gfm`]; future markdown-pipeline knobs would
+/// also live here.
+///
+/// `#[serde(rename_all = "camelCase")]` on this struct (and on the
+/// parent [`Config`]) makes the TS shape (`{ gfm: ... }`) round-trip 1:1
+/// with the Rust shape.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct MarkdownConfig {
+    /// Enable GFM constructs. Accepts three shapes — see [`GfmFlag`].
+    /// Absent / `None` defers to the conservative resolved default in
+    /// [`MarkdownConfig::resolve_constructs`] (strikethrough + table on,
+    /// other GFM constructs off).
+    #[serde(default)]
+    pub gfm: Option<GfmFlag>,
+}
+
+/// Either the shorthand boolean form (`true` = all GFM constructs on,
+/// `false` = all off) or a partial [`GfmConstructs`] object that toggles
+/// individual constructs.
+///
+/// `serde(untagged)` plus the `Constructs` variant being listed FIRST
+/// is important: serde tries variants in order, so the object form
+/// must be tried before the boolean form. (`true` / `false` will never
+/// deserialise into the object variant anyway.)
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum GfmFlag {
+    /// Per-construct opt-in / opt-out.
+    Constructs(GfmConstructs),
+    /// Shorthand: `true` = every GFM construct on, `false` = every GFM
+    /// construct off.
+    All(bool),
+}
+
+/// Per-construct opt-in / opt-out for GFM. Every field is optional;
+/// omitted fields fall back to the conservative default
+/// (`strikethrough: Some(true)`, `table: Some(true)`, others
+/// `Some(false)` at resolve time — see
+/// [`MarkdownConfig::resolve_constructs`]).
+///
+/// Wrapping each field in `Option<bool>` (rather than plain `bool`)
+/// lets `resolve_constructs` distinguish "user explicitly said `false`"
+/// from "user did not mention this field" — the latter falls back to
+/// the conservative default; the former is honoured verbatim.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct GfmConstructs {
+    /// GFM strikethrough (`~~text~~` → `<del>text</del>`).
+    #[serde(default)]
+    pub strikethrough: Option<bool>,
+    /// GFM pipe-style tables.
+    #[serde(default)]
+    pub table: Option<bool>,
+    /// GFM autolink literal — bare URLs like `https://example.com`
+    /// become clickable without `<…>` brackets.
+    #[serde(default)]
+    pub autolink_literal: Option<bool>,
+    /// GFM task list items (`- [x]` / `- [ ]`).
+    #[serde(default)]
+    pub task_list_item: Option<bool>,
+    /// GFM footnote definitions (`[^ref]: …`).
+    #[serde(default)]
+    pub footnote_definition: Option<bool>,
+}
+
+/// Resolved per-construct GFM flags.
+///
+/// Re-exported from `zfb_content::ResolvedGfmConstructs` — the type
+/// itself lives in `zfb-content` (the lowest crate that actually
+/// touches `markdown::Constructs`) so the snapshot walker, bundler,
+/// and dev loader can wire it into [`markdown::ParseOptions`] without
+/// an upward dependency on this crate. This re-export keeps the public
+/// `zfb::config` surface self-contained for `zfb.config.ts` consumers.
+pub use zfb_content::ResolvedGfmConstructs;
+
+impl MarkdownConfig {
+    /// Pure function — overlay this config's `gfm` field onto a
+    /// [`ResolvedGfmConstructs`] base.
+    ///
+    /// Resolution rules:
+    ///
+    /// - `gfm: None` (absent) → return the conservative default
+    ///   ([`ResolvedGfmConstructs::CONSERVATIVE`]). The `base` argument
+    ///   is provided so callers that want a different "what fields the
+    ///   user did NOT mention fall back to" can supply it; the default
+    ///   pipeline path always passes [`ResolvedGfmConstructs::CONSERVATIVE`].
+    /// - `gfm: Some(All(true))` → [`ResolvedGfmConstructs::ALL_ON`].
+    /// - `gfm: Some(All(false))` → [`ResolvedGfmConstructs::ALL_OFF`].
+    /// - `gfm: Some(Constructs(partial))` → overlay each `Some(_)`
+    ///   field of `partial` onto `base`; `None` fields keep the `base`
+    ///   value. So `{ strikethrough: true }` only flips strikethrough
+    ///   relative to the conservative default; the other four
+    ///   constructs keep their default values.
+    ///
+    /// Covered by the four-case test matrix in this module's `#[cfg(test)]`
+    /// block.
+    #[must_use]
+    pub fn resolve_constructs(&self, base: ResolvedGfmConstructs) -> ResolvedGfmConstructs {
+        match &self.gfm {
+            None => base,
+            Some(GfmFlag::All(true)) => ResolvedGfmConstructs::ALL_ON,
+            Some(GfmFlag::All(false)) => ResolvedGfmConstructs::ALL_OFF,
+            Some(GfmFlag::Constructs(c)) => ResolvedGfmConstructs {
+                strikethrough: c.strikethrough.unwrap_or(base.strikethrough),
+                table: c.table.unwrap_or(base.table),
+                autolink_literal: c.autolink_literal.unwrap_or(base.autolink_literal),
+                task_list_item: c.task_list_item.unwrap_or(base.task_list_item),
+                footnote_definition: c.footnote_definition.unwrap_or(base.footnote_definition),
+            },
+        }
+    }
+}
+
+/// Convenience helper: resolve `cfg.markdown.as_ref()` — handling both
+/// "the user omitted the whole `markdown` block" and "the user wrote
+/// `markdown: { gfm: …}`" — to a final [`ResolvedGfmConstructs`].
+///
+/// Pure, deterministic, zero-allocation; intended to be called from the
+/// bundler / loader / snapshot-bridge sites that need the resolved
+/// flags. Matching the conservative-default rule everywhere (and only
+/// here) is what keeps snapshot ↔ bundler hashes byte-identical — the
+/// content_bridge land mine in
+/// `crates/zfb-content/src/content_bridge.rs:118-153`.
+#[must_use]
+pub fn resolve_gfm_constructs(markdown: Option<&MarkdownConfig>) -> ResolvedGfmConstructs {
+    match markdown {
+        Some(m) => m.resolve_constructs(ResolvedGfmConstructs::CONSERVATIVE),
+        None => ResolvedGfmConstructs::CONSERVATIVE,
+    }
 }
 
 // --- helpers ----------------------------------------------------------------
@@ -2105,6 +2253,152 @@ mod tests {
         assert_eq!(
             cfg.collections[0].path,
             PathBuf::from("content/blog")
+        );
+    }
+
+    // --- MarkdownConfig / GFM resolution tests ----------------------------
+
+    // Case 1 of the spec's four-case resolution matrix: `markdown`
+    // omitted entirely → conservative default.
+    #[test]
+    fn gfm_resolve_absent_markdown_yields_conservative_default() {
+        let resolved = resolve_gfm_constructs(None);
+        assert_eq!(resolved, ResolvedGfmConstructs::CONSERVATIVE);
+        // Spell it out so future readers can audit the intent at a
+        // glance — strikethrough + table on, everything else off.
+        assert!(resolved.strikethrough);
+        assert!(resolved.table);
+        assert!(!resolved.autolink_literal);
+        assert!(!resolved.task_list_item);
+        assert!(!resolved.footnote_definition);
+    }
+
+    // Same as case 1 but exercising the "user wrote `markdown: {}`"
+    // path — every field of MarkdownConfig is None / default, and the
+    // overlay should reduce to the conservative base verbatim.
+    #[test]
+    fn gfm_resolve_empty_markdown_yields_conservative_default() {
+        let cfg = MarkdownConfig::default();
+        assert_eq!(
+            cfg.resolve_constructs(ResolvedGfmConstructs::CONSERVATIVE),
+            ResolvedGfmConstructs::CONSERVATIVE
+        );
+    }
+
+    // Case 2 of the spec's matrix: `gfm: true` → every GFM construct on.
+    #[test]
+    fn gfm_resolve_shorthand_true_turns_everything_on() {
+        let cfg = MarkdownConfig {
+            gfm: Some(GfmFlag::All(true)),
+        };
+        assert_eq!(
+            cfg.resolve_constructs(ResolvedGfmConstructs::CONSERVATIVE),
+            ResolvedGfmConstructs::ALL_ON
+        );
+    }
+
+    // Case 3 of the spec's matrix: `gfm: false` → every GFM construct off.
+    #[test]
+    fn gfm_resolve_shorthand_false_turns_everything_off() {
+        let cfg = MarkdownConfig {
+            gfm: Some(GfmFlag::All(false)),
+        };
+        assert_eq!(
+            cfg.resolve_constructs(ResolvedGfmConstructs::CONSERVATIVE),
+            ResolvedGfmConstructs::ALL_OFF
+        );
+    }
+
+    // Case 4 of the spec's matrix: partial object —
+    // `{ strikethrough: true, autolinkLiteral: false }` — only those
+    // fields overlay; absent fields fall back to the conservative
+    // default values.
+    #[test]
+    fn gfm_resolve_partial_object_overlays_only_named_fields() {
+        let cfg = MarkdownConfig {
+            gfm: Some(GfmFlag::Constructs(GfmConstructs {
+                strikethrough: Some(true),
+                autolink_literal: Some(false),
+                ..GfmConstructs::default()
+            })),
+        };
+        let resolved = cfg.resolve_constructs(ResolvedGfmConstructs::CONSERVATIVE);
+        // Named explicitly:
+        assert!(resolved.strikethrough);
+        assert!(!resolved.autolink_literal);
+        // Unnamed → conservative defaults:
+        assert!(resolved.table);
+        assert!(!resolved.task_list_item);
+        assert!(!resolved.footnote_definition);
+    }
+
+    // A partial object that flips a single conservative-default field
+    // OFF (e.g. `{ table: false }`) — verifies the overlay can move a
+    // field in either direction.
+    #[test]
+    fn gfm_resolve_partial_object_can_turn_off_conservative_defaults() {
+        let cfg = MarkdownConfig {
+            gfm: Some(GfmFlag::Constructs(GfmConstructs {
+                table: Some(false),
+                ..GfmConstructs::default()
+            })),
+        };
+        let resolved = cfg.resolve_constructs(ResolvedGfmConstructs::CONSERVATIVE);
+        assert!(resolved.strikethrough); // conservative-default stayed
+        assert!(!resolved.table);        // explicit override
+    }
+
+    // Serde round-trip — the TS `gfm: true` shorthand and the
+    // TS `gfm: { strikethrough: true }` partial object must both
+    // deserialise into the right variant.
+    #[test]
+    fn markdown_config_deserialises_from_shorthand_and_partial_object() {
+        // Shorthand boolean form.
+        let cfg: MarkdownConfig = serde_json::from_value(serde_json::json!({
+            "gfm": true
+        }))
+        .expect("shorthand true deserialises");
+        assert_eq!(cfg.gfm, Some(GfmFlag::All(true)));
+
+        let cfg: MarkdownConfig = serde_json::from_value(serde_json::json!({
+            "gfm": false
+        }))
+        .expect("shorthand false deserialises");
+        assert_eq!(cfg.gfm, Some(GfmFlag::All(false)));
+
+        // Partial object form — TS camelCase round-trips into Rust
+        // snake_case via the parent struct's `rename_all = "camelCase"`.
+        let cfg: MarkdownConfig = serde_json::from_value(serde_json::json!({
+            "gfm": {
+                "strikethrough": true,
+                "autolinkLiteral": false
+            }
+        }))
+        .expect("partial object deserialises");
+        assert_eq!(
+            cfg.gfm,
+            Some(GfmFlag::Constructs(GfmConstructs {
+                strikethrough: Some(true),
+                autolink_literal: Some(false),
+                ..GfmConstructs::default()
+            }))
+        );
+    }
+
+    // The top-level `Config` accepts the `markdown` field via the
+    // camelCase rename — confirming integration with the rest of the
+    // config struct.
+    #[test]
+    fn config_top_level_accepts_markdown_field() {
+        let cfg: Config = serde_json::from_value(serde_json::json!({
+            "markdown": { "gfm": true }
+        }))
+        .expect("top-level markdown deserialises");
+        assert_eq!(
+            cfg.markdown,
+            Some(MarkdownConfig {
+                gfm: Some(GfmFlag::All(true))
+            })
         );
     }
 }

--- a/crates/zfb/tests/framework_packages_no_pnpm.rs
+++ b/crates/zfb/tests/framework_packages_no_pnpm.rs
@@ -169,6 +169,7 @@ fn embedded_extraction_resolves_framework_imports_with_no_consumer_node_modules(
         strip_md_ext: false,
         code_highlight_theme: None,
         resolve_markdown_links: None,
+        gfm_constructs: zfb_content::ResolvedGfmConstructs::default(),
     };
 
     let out = bundle(input).expect(

--- a/packages/zfb/README.md
+++ b/packages/zfb/README.md
@@ -124,6 +124,63 @@ for (const el of document.querySelectorAll<HTMLElement>("[data-zfb-island]")) {
 if hydration has not fired yet. After firing, calling `cancel` is a
 no-op.
 
+## Markdown / GFM config
+
+`ZfbConfig.markdown.gfm` controls which GitHub-Flavored-Markdown
+constructs the MDX parser recognises. The field accepts three shapes:
+
+1. **Shorthand boolean** — turn every GFM construct on or off in one
+   step. Use this when you want the full GFM surface.
+
+   ```ts
+   // zfb.config.ts
+   import { defineConfig } from "zfb/config";
+
+   export default defineConfig({
+     markdown: {
+       gfm: true, // strikethrough + table + autolink-literal + task-list-item + footnote-definition
+     },
+   });
+   ```
+
+2. **Partial object** — toggle individual constructs. Fields you omit
+   fall back to the conservative default (`strikethrough: true`,
+   `table: true`, everything else off).
+
+   ```ts
+   // zfb.config.ts
+   import { defineConfig } from "zfb/config";
+
+   export default defineConfig({
+     markdown: {
+       gfm: {
+         strikethrough: true,
+         table: true,
+         autolinkLiteral: false,    // explicit opt-out
+         taskListItem: false,
+         footnoteDefinition: false,
+       },
+     },
+   });
+   ```
+
+3. **Omitted entirely** — the parser uses the conservative default.
+   `~~text~~` parses as `<del>text</del>` and pipe tables render as
+   `<table>`; every other GFM construct stays off.
+
+   ```ts
+   export default defineConfig({
+     // no `markdown` field — strikethrough + table on, everything else off
+   });
+   ```
+
+The five constructs you can toggle are: `strikethrough`, `table`,
+`autolinkLiteral`, `taskListItem`, `footnoteDefinition`.
+
+Projects that previously relied on raw `~~text~~` passing through as
+literal characters should set `markdown: { gfm: { strikethrough: false } }`
+or `markdown: { gfm: false }` to restore the old behaviour.
+
 ## Tests
 
 ```sh

--- a/packages/zfb/src/config.ts
+++ b/packages/zfb/src/config.ts
@@ -173,6 +173,79 @@ export type ZfbConfig = {
    * Mirrors `Config::trailing_slash` in crates/zfb/src/config.rs.
    */
   trailingSlash?: boolean;
+
+  /**
+   * Markdown / MDX parsing options. Currently the only knob exposed is
+   * [`gfm`](MarkdownConfig.gfm), which toggles GFM constructs
+   * (strikethrough, table, autolink-literal, task-list-item,
+   * footnote-definition) on or off.
+   *
+   * Mirrors `Config::markdown` in crates/zfb/src/config.rs.
+   */
+  markdown?: MarkdownConfig;
+};
+
+/**
+ * Markdown / MDX parsing options.
+ *
+ * See [`ZfbConfig.markdown`] for the embed point. Today the only field
+ * is [`gfm`](MarkdownConfig.gfm); future markdown knobs (e.g. CommonMark
+ * variants, custom extensions) would also live here.
+ *
+ * Mirrors `MarkdownConfig` in crates/zfb/src/config.rs.
+ */
+export type MarkdownConfig = {
+  /**
+   * Enable GFM constructs.
+   *
+   * Accepts three shapes:
+   *
+   * - `true` — turn every GFM construct ON (strikethrough, table,
+   *   autolink-literal, task-list-item, footnote-definition).
+   * - `false` — turn every GFM construct OFF.
+   * - partial object — set individual fields explicitly; fields you
+   *   omit fall back to the conservative-default values described
+   *   below.
+   *
+   * When `markdown` itself is omitted entirely, the conservative
+   * default applies: `strikethrough: true`, `table: true`, every other
+   * GFM construct off. This is the smallest behavioural delta from
+   * zfb's historical effective state (table-only). Projects that want
+   * the full GFM surface should opt in with `gfm: true`.
+   */
+  gfm?: GfmFlag;
+};
+
+/**
+ * Either the shorthand boolean form (`true` = all GFM constructs on,
+ * `false` = all off) or a partial object that toggles individual
+ * constructs.
+ *
+ * Mirrors `GfmFlag` in crates/zfb/src/config.rs.
+ */
+export type GfmFlag = boolean | GfmConstructs;
+
+/**
+ * Per-construct opt-in / opt-out for GFM. Every field is optional;
+ * omitted fields fall back to the conservative default
+ * (`strikethrough: true`, `table: true`, others `false`).
+ *
+ * Mirrors `GfmConstructs` in crates/zfb/src/config.rs.
+ */
+export type GfmConstructs = {
+  /** GFM strikethrough (`~~text~~` → `<del>text</del>`). */
+  strikethrough?: boolean;
+  /** GFM pipe-style tables. */
+  table?: boolean;
+  /**
+   * GFM autolink literal — bare URLs like `https://example.com` become
+   * clickable links without `<…>` brackets.
+   */
+  autolinkLiteral?: boolean;
+  /** GFM task list items (`- [x]` / `- [ ]`). */
+  taskListItem?: boolean;
+  /** GFM footnote definitions (`[^ref]: …`). */
+  footnoteDefinition?: boolean;
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds a flexible `markdown.gfm` knob to `zfb.config.ts` that toggles each
GFM construct (strikethrough, table, autolinkLiteral, taskListItem,
footnoteDefinition) independently. Threads the resolved Constructs
through the snapshot walker, bundler, and dev loader so all three sites
agree on a single parser construct set — preventing the
`<pre data-zfb-content-fallback>` divergence land mine documented at
`crates/zfb-content/src/content_bridge.rs:118-153`.

Sub-issue [Takazudo/zudo-design-token-panel#61](https://github.com/Takazudo/zudo-design-token-panel/issues/61) of [#60](https://github.com/Takazudo/zudo-design-token-panel/issues/60).

## API

```ts
// zfb.config.ts
export default defineConfig({
  markdown: {
    gfm: true,                         // (a) shorthand: every GFM construct on
    // gfm: false,                     // (b) shorthand: every GFM construct off
    // gfm: { strikethrough: true,     // (c) partial object; absent fields fall
    //        autolinkLiteral: false } //     back to the conservative default
  },
});
```

## Conservative default (when `markdown.gfm` is omitted)

| construct             | today's effective state | new default | rationale                                       |
| --------------------- | ----------------------- | ----------- | ----------------------------------------------- |
| `strikethrough`       | off                     | **on**     | fixes `~~text~~` regression                     |
| `table`               | on (hard-coded)         | **on**     | unchanged from today                            |
| `autolinkLiteral`     | off                     | off         | emit path OK; left off for behavioural parity   |
| `taskListItem`        | off                     | off         | `<li checked=…>` not yet honored in emit_node   |
| `footnoteDefinition`  | off                     | off         | no `FootnoteDefinition` / `FootnoteReference` arm in emit_node |

Migration recipe: projects that want the full GFM set add
`markdown: { gfm: true }` to `zfb.config.ts`. Projects that want the
exact old behavior (raw `~~` survives) add `markdown: { gfm: false }`
or `markdown: { gfm: { strikethrough: false } }`.

## Emit-path audit (`crates/zfb-content/src/mdx_jsx_emit.rs::emit_node`)

| mdast kind                              | dedicated arm in `emit_node`? | result                                                                                          |
| --------------------------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------- |
| `Delete` (strikethrough)                | yes (line 508)                | `<del>` via `_components.del`. Verified end-to-end.                                             |
| `Table` / `TableRow` / `TableCell`      | yes (line 617, `emit_table_jsx`) | `<table><thead>…</thead><tbody>…</tbody></table>` with per-col `style="text-align:…"`.        |
| `Link` produced by autolink-literal     | yes via the generic `Link` arm (line 535) | Falls through the same path as `[label](url)` — no special handling required.            |
| `ListItem` from task-list-item          | partial — line 564 emits `<li>` ignoring `checked: Some(_)` | A `<li>` is emitted but no checkbox marker — visually identical to a plain bullet today. |
| `FootnoteDefinition` / `FootnoteReference` | no — falls into the catch-all `_ => String::new()` at line 626 | Footnote markup is silently dropped. Construct stays off-by-default.                |

The two emit-incomplete kinds (`taskListItem`, `footnoteDefinition`)
are kept off in the conservative default to avoid silent content
loss. `autolink-literal` is technically emit-complete but left off
in the default for "smallest behavioural delta from today".

## Test plan

- [x] Config-resolution matrix (4 cases) in `zfb::config::tests`.
- [x] Pipeline-level strikethrough on/off test in `zfb_content::pipeline`.
- [x] JSX-emit `~~gone~~` test in `crates/zfb-content/tests/mdx_jsx_emit.rs`.
- [x] Content-bridge parity test — snapshot vs bundler hashes agree under
      both `gfm: true` and `gfm: false`, AND differ between the two
      (smoke check that the threading is not collapsing).
- [x] Pre-existing tests updated:
      - `crates/zfb-content/src/pipeline.rs::inline_formatting` — re-documented; added two new tests for the parse-driven strikethrough path.
      - `crates/zfb-content/tests/mdx_jsx_emit.rs::delete_strikethrough_via_synthetic_node` — re-commented to clarify the two `<del>` reach paths.
- [x] All call sites of the touched struct literals (`BundlerInput`,
      `SnapshotPipelineConfig`) updated across tests.
- [x] `cargo test -p zfb-content -p zfb-build -p zfb-render -p zfb` — green.
- [x] `pnpm -r test` — green (7 vitest projects, 312 tests).
- [x] `pnpm --filter @takazudo/zfb run typecheck` — green.

## Reviewers

- `/gcoc-review` (GPT-4.1) — clean, no findings beyond noting the documented breaking change.
- `/codex-review` — went through the diff but did not write a final report (transient companion-script hiccup); no actionable findings reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)