### PR TITLE
fix(dev-server): serve public/ at site root, not /public/*

### DIFF
--- a/.github/workflows/health.yml
+++ b/.github/workflows/health.yml
@@ -39,8 +39,13 @@ jobs:
       # Sub 2).
       - uses: Swatinem/rust-cache@v2
         with:
-          # Prefix so future workspace-member additions don't share a stale cache.
-          prefix-key: "v1-zfb"
+          # Prefix so future workspace-member additions don't share a stale
+          # cache. Bumped v1 → v2 in PR #250 after the cached target/ snapshot
+          # started failing to link `v8` (rusty_v8 native static lib not found
+          # in OUT_DIR after partial rebuild). The first build on this key
+          # will take 15-30 min for V8 first-compile; subsequent runs hit the
+          # restored cache and are fast.
+          prefix-key: "v2-zfb"
 
       - run: pnpm install --frozen-lockfile
 

--- a/crates/zfb-server/src/lib.rs
+++ b/crates/zfb-server/src/lib.rs
@@ -1,8 +1,11 @@
 //! `zfb-server` — the dev-mode HTTP server for `zudo-front-builder`.
 //!
 //! This crate runs an [`axum`] server that serves the in-memory
-//! page-cache HTML produced by [`zfb_build`]'s rebuild loop, plus the
-//! built `dist/assets/` and `public/` directories. Every served HTML
+//! page-cache HTML produced by [`zfb_build`]'s rebuild loop, the built
+//! `dist/assets/` tree, and per-request on-disk fallbacks for the
+//! project's `dist/` and `public/` directories so static files in
+//! `public/` are reachable at the site root (e.g.
+//! `public/logo.svg` → `/logo.svg`). Every served HTML
 //! response has a small `<script src="/__zfb/livereload.js"></script>`
 //! injected before `</body>`. That script opens an SSE connection to
 //! `/__zfb/reload` and listens for two event types:
@@ -80,8 +83,11 @@ pub struct ServeOpts {
     /// `<dist_root>/assets/`.
     pub dist_root: PathBuf,
 
-    /// Project public-static directory. `/public/*` is served from
-    /// here verbatim.
+    /// Project public-static directory. Files here are served at the
+    /// site root via a per-request on-disk fallback inside the page
+    /// handler — `public/logo.svg` → `GET /logo.svg`. The same shape
+    /// `zfb build` produces (it copies `public/*` straight into
+    /// `dist/`), so dev and prod URLs match.
     pub public_root: PathBuf,
 
     /// Address to bind. Defaults to `127.0.0.1:3000`.
@@ -192,10 +198,11 @@ where
         broadcast: opts.broadcast,
         plugins: opts.plugins,
         dist_root: opts.dist_root.clone(),
+        public_root: opts.public_root.clone(),
         base_prefix,
         trailing_slash: opts.trailing_slash,
     };
-    let router = build_router(state, opts.public_root.clone());
+    let router = build_router(state);
 
     let actual = listener.local_addr().unwrap_or(opts.addr);
     info!(

--- a/crates/zfb-server/src/routes.rs
+++ b/crates/zfb-server/src/routes.rs
@@ -4,19 +4,22 @@
 //!
 //! - `GET /assets/*path` — static files from `<dist_root>/assets/`,
 //!   served via [`tower_http::services::ServeDir`].
-//! - `GET /public/*path` — static files from `<public_root>/`,
-//!   served via [`tower_http::services::ServeDir`].
 //! - `GET /__zfb/livereload.js` — bundled JS that opens an SSE
 //!   connection back to this server. Always served with
 //!   `Cache-Control: no-store`.
 //! - `GET /__zfb/reload` — SSE event stream. See
 //!   [`crate::livereload::sse_response`].
 //! - `GET /` and `GET /*path` — render HTML out of the in-memory page
-//!   cache. See [`PageCache`] for keying conventions.
+//!   cache, then fall back to `<dist_root>/...` and finally to
+//!   `<public_root>/...` on disk before returning the dev 404. The
+//!   `public/` directory has NO URL prefix — `public/logo.svg` is
+//!   reachable at `/logo.svg`, matching the production layout
+//!   `zfb build` produces (`copy_public_dir` copies straight into
+//!   `dist/`).
 //!
-//! ## Page key resolution
+//! ## Page key / static-file resolution
 //!
-//! For a request to `/blog/foo` we look up the cache in this order:
+//! For a request to `/blog/foo` we look up the page cache in this order:
 //!
 //! 1. `/blog/foo`
 //! 2. `/blog/foo/index.html`
@@ -24,8 +27,14 @@
 //!    directory-style path)
 //!
 //! For a request to `/` we look up `/` and then `/index.html`. First
-//! hit wins. Misses respond with the dev-mode 404 body
-//! ([`DEV_404_BODY`]).
+//! hit wins. If the cache misses, we then try `<dist_root>/<path>` and
+//! `<dist_root>/<path>/index.html` on disk, then `<public_root>/<path>`
+//! as a verbatim static-file read. Only after all three layers miss do
+//! we return [`DEV_404_BODY`].
+//!
+//! Precedence (highest first): plugin dev-middleware → page cache →
+//! dist directory → public directory → 404. A `pages/foo.tsx` route
+//! therefore always wins over a same-named `public/foo` file.
 //!
 //! All HTML responses (including 404) go through
 //! [`crate::inject::inject_livereload_with_prefix`] before being
@@ -38,9 +47,11 @@
 //! When the project's `zfb.config.ts` declares `base: "/foo/"`, the
 //! whole route table moves under `/foo`:
 //!
-//! - `GET /foo/` and `GET /foo/<route>` serve the rendered page,
-//! - `GET /foo/assets/<file>`, `GET /foo/public/<file>` serve static
-//!   assets,
+//! - `GET /foo/` and `GET /foo/<route>` serve the rendered page (with
+//!   the same `dist/` + `public/` disk fallback chain described above,
+//!   so `public/logo.svg` is reachable at `/foo/logo.svg`),
+//! - `GET /foo/assets/<file>` serves built static assets from
+//!   `<dist_root>/assets/`,
 //! - `GET /foo/__zfb/livereload.js` and `GET /foo/__zfb/reload` serve
 //!   live-reload (and the injected `<script src>` matches),
 //! - plugin-registered dev-middleware paths are auto-prefixed too
@@ -333,6 +344,13 @@ pub struct AppState {
     /// not yet in the in-memory cache. `serve_page` reads
     /// `<dist_root>/<path>/index.html` when the cache misses.
     pub dist_root: std::path::PathBuf,
+    /// Project public-static directory. Used as a final on-disk fallback
+    /// after the page cache and dist directory miss, so that user files
+    /// in `public/` are reachable at the site root (e.g.
+    /// `public/logo.svg` → `/logo.svg`). Matches the production layout
+    /// that `zfb build` produces by copying `public/*` straight into
+    /// `dist/`.
+    pub public_root: std::path::PathBuf,
     /// Canonical mount prefix from `zfb.config.ts`'s `base` field, as
     /// returned by [`zfb_types::dev_mount_prefix`]. `None` means the
     /// dev server mounts everything at root (the no-base case);
@@ -350,51 +368,57 @@ pub struct AppState {
 
 /// Build the axum router for the dev server.
 ///
-/// `dist_root` is the build output directory (used for `/assets/*`).
-/// `public_root` is the project's static assets directory (used for
-/// `/public/*`). Both are served via [`ServeDir`]; missing files fall
-/// back to a plain 404.
+/// `state.dist_root` is the build output directory (used for
+/// `/assets/*` and as the first on-disk fallback for page misses).
+/// `state.public_root` is the project's static assets directory; it
+/// is consulted as a per-request on-disk fallback inside [`serve_page`]
+/// (no top-level `/public/*` mount — files there appear at the site
+/// root, mirroring `zfb build`'s `public/` → `dist/` copy).
 ///
 /// ## Method policy (issue #230)
 ///
 /// Built-in routes keep their existing GET-only semantics:
 ///
 /// - `<base>/__zfb/livereload.js`, `<base>/__zfb/reload`,
-///   `<base>/assets/*`, `<base>/public/*` are all registered with
-///   `get(...)` or via [`ServeDir`] (which is GET/HEAD-only). A non-GET
-///   request to any of these surfaces gets a `405 Method Not Allowed`
-///   from axum / tower-http directly — those routes are dev-server
-///   infrastructure, not user code, and CSRF posture for them must
-///   stay tight.
+///   `<base>/assets/*` are all registered with `get(...)` or via
+///   [`ServeDir`] (which is GET/HEAD-only). A non-GET request to any
+///   of these surfaces gets a `405 Method Not Allowed` from axum /
+///   tower-http directly — those routes are dev-server infrastructure,
+///   not user code, and CSRF posture for them must stay tight.
 /// - The page-renderer mounts accept ALL methods so user-registered
 ///   `devMiddleware` handlers can serve `POST`, `PUT`, `DELETE`,
 ///   `PATCH`, etc. on prefixes they claim. The handler itself in
 ///   [`serve_page`] still returns `405 Allow: GET, HEAD` if a non-GET
 ///   request slips through to the page-cache fallback (i.e. no plugin
-///   claimed the URL or a plugin returned `Passthrough`).
+///   claimed the URL or a plugin returned `Passthrough`). The
+///   `public/` on-disk fallback inside `serve_page` is also reached
+///   only on the GET/HEAD path, so `POST /favicon.ico` 405s the same
+///   way it always did.
 ///
 /// ## Base prefix mounting (issue #229)
 ///
 /// When `state.base_prefix` is `Some(prefix)`, every route is
 /// registered at `<prefix>/<route>` directly (livereload, SSE,
-/// `/assets/*`, `/public/*`, page cache, plugin middleware). A bare
-/// `GET /` request is redirected to `<prefix>/`, and any other
-/// unprefixed path falls through to a 404 with a one-line hint at the
-/// configured base. See the module docs for the complete contract.
+/// `/assets/*`, page cache, plugin middleware). A bare `GET /` request
+/// is redirected to `<prefix>/`, and any other unprefixed path falls
+/// through to a 404 with a one-line hint at the configured base. See
+/// the module docs for the complete contract. The `public/` on-disk
+/// fallback inside `serve_page` is reached after the page-cache miss,
+/// so `public/logo.svg` is served at `<prefix>/logo.svg` just like the
+/// production build emits.
 ///
 /// Routes are registered with explicit prefix substitution rather than
 /// [`Router::nest`] because the latter has subtle 0.8.x trailing-slash
 /// quirks when the inner router contains both a literal `/` route and
 /// a `/{*path}` catch-all (the very shape we use). Manual prefix
 /// registration is verbose but uniquely well-defined.
-pub fn build_router(state: AppState, public_root: std::path::PathBuf) -> Router {
+pub fn build_router(state: AppState) -> Router {
     let prefix = state.base_prefix.clone();
 
     let Some(prefix) = prefix else {
         // No base prefix configured — keep the byte-for-byte
         // pre-`base` route table at the root.
-        return build_core_router(state, public_root, "")
-            .layer(TraceLayer::new_for_http());
+        return build_core_router(state, "").layer(TraceLayer::new_for_http());
     };
 
     // Prefix is canonical: leading slash, no trailing slash (e.g.
@@ -404,7 +428,7 @@ pub fn build_router(state: AppState, public_root: std::path::PathBuf) -> Router 
     let redirect_target = format!("{prefix}/");
     let prefix_for_404 = prefix.clone();
 
-    build_core_router(state, public_root, &prefix)
+    build_core_router(state, &prefix)
         // Bare `/` lands the developer on the home page — but only `/`
         // exactly, never `<prefix>/...`, because the prefixed routes
         // above already catch those and a redirect there would loop.
@@ -435,19 +459,13 @@ pub fn build_router(state: AppState, public_root: std::path::PathBuf) -> Router 
 /// at `<prefix>/api/echo` but the handler still sees `req.url =
 /// /api/echo`). The page handlers below strip the prefix from the
 /// captured wildcard / URI before forwarding into [`serve_page`].
-fn build_core_router(
-    state: AppState,
-    public_root: std::path::PathBuf,
-    prefix: &str,
-) -> Router {
+fn build_core_router(state: AppState, prefix: &str) -> Router {
     let assets_dir = state.dist_root.join("assets");
     let assets_service = ServeDir::new(&assets_dir);
-    let public_service = ServeDir::new(&public_root);
 
     let livereload_path = format!("{prefix}/__zfb/livereload.js");
     let sse_path = format!("{prefix}/__zfb/reload");
     let assets_mount = format!("{prefix}/assets");
-    let public_mount = format!("{prefix}/public");
     let root_path = format!("{prefix}/");
     let wild_path = format!("{prefix}/{{*path}}");
 
@@ -455,7 +473,6 @@ fn build_core_router(
         .route(&livereload_path, get(livereload_js))
         .route(&sse_path, get(sse_handler))
         .nest_service(&assets_mount, assets_service)
-        .nest_service(&public_mount, public_service)
         // `any` (vs `get`) on the page-renderer mounts so user-registered
         // devMiddleware handlers can serve every HTTP method (zfb#230).
         // `serve_page` enforces GET/HEAD-only for the page-cache fallback
@@ -581,9 +598,10 @@ async fn serve_page(
     //
     // Issue #230: every HTTP method (including POST/PUT/DELETE/PATCH)
     // is forwarded; the plugin handler decides whether to accept or
-    // reject the method. Built-in routes (`/__zfb/...`, `/assets/*`,
-    // `/public/*`) are unaffected — those are routed by axum directly
-    // and stay GET-only.
+    // reject the method. Built-in routes (`/__zfb/...`, `/assets/*`)
+    // are unaffected — those are routed by axum directly and stay
+    // GET-only. The `public/` on-disk fallback further down only
+    // runs on the GET/HEAD path, so `POST /favicon.ico` still 405s.
     //
     // Issue #229 contract: plugins register UNPREFIXED paths
     // (`ctx.register("/api/echo")`); the dev server registers the
@@ -676,6 +694,36 @@ async fn serve_page(
         );
     }
 
+    // Final on-disk fallback: project `public/` directory. The
+    // production build copies `public/*` straight into `dist/` (see
+    // `crates/zfb/src/commands/build.rs::copy_public_dir`), so files
+    // there must also appear at the site root in dev — otherwise
+    // `<img src="/logo.svg">` referencing `public/logo.svg` 404s in
+    // dev but works after `zfb build`, which is the bug this lookup
+    // is designed to prevent. Page cache and dist take precedence
+    // (above), so a same-named `pages/foo.tsx` route always wins over
+    // `public/foo`.
+    if !trimmed.is_empty() {
+        if let Some(bytes) = read_from_public(&state.public_root, trimmed) {
+            let basename = trimmed.rsplit('/').next().unwrap_or(trimmed);
+            let ext = basename.rsplit_once('.').map(|(_, e)| e).unwrap_or("");
+            let content_type = if ext.is_empty() {
+                "application/octet-stream".to_string()
+            } else {
+                content_type_for_extension(ext)
+            };
+            let is_html = content_type.to_ascii_lowercase().starts_with("text/html");
+            return page_response_bytes(
+                StatusCode::OK,
+                bytes,
+                &content_type,
+                is_html,
+                lr_prefix,
+                state.trailing_slash,
+            );
+        }
+    }
+
     // 404 is always the dev HTML body so the page is replaced once
     // a real one lands. The live-reload script gets injected.
     page_response_bytes(
@@ -751,6 +799,33 @@ fn read_from_dist(dist_root: &std::path::Path, trimmed: &str) -> Option<Vec<u8>>
         }
     }
     None
+}
+
+/// Try to read a file from the project's `public/` directory on disk.
+///
+/// Unlike [`read_from_dist`] this does NOT probe an `index.html`
+/// candidate — `public/` is a verbatim static-file mirror, so a
+/// request to `/foo` resolves to `<public_root>/foo` only. Returns
+/// `None` on any read failure (including the file simply not existing).
+///
+/// `trimmed` comes from a percent-decoded URL, so we reject any path
+/// that contains `..`, NUL, backslash, or absolute components before
+/// joining onto `public_root` — same threat model as [`read_from_dist`].
+/// Empty `trimmed` (a bare `/` request) is also rejected because we
+/// never want to serve the directory itself.
+fn read_from_public(public_root: &std::path::Path, trimmed: &str) -> Option<Vec<u8>> {
+    if trimmed.is_empty() || !is_safe_url_path(trimmed) {
+        return None;
+    }
+    let path = public_root.join(trimmed);
+    // Reject directory reads explicitly — `std::fs::read` on a directory
+    // returns an EISDIR error on Unix and would surface as a None here
+    // anyway, but on Windows the behaviour is platform-dependent. Being
+    // explicit also documents the intent.
+    if path.is_dir() {
+        return None;
+    }
+    std::fs::read(&path).ok()
 }
 
 /// Reject URL paths that would escape the dist root once joined.
@@ -1060,6 +1135,7 @@ mod tests {
             broadcast: tx,
             plugins: None,
             dist_root: std::env::temp_dir().join("zfb-test-dist"),
+            public_root: std::env::temp_dir().join("zfb-test-public"),
             base_prefix: None,
             trailing_slash: false,
         }
@@ -1072,17 +1148,20 @@ mod tests {
             broadcast: tx,
             plugins: None,
             dist_root: std::env::temp_dir().join("zfb-test-dist"),
+            public_root: std::env::temp_dir().join("zfb-test-public"),
             base_prefix: Some(prefix.to_string()),
             trailing_slash: false,
         }
     }
 
     fn test_router(state: AppState) -> Router {
-        // Use bogus dist/public roots — ServeDir will simply 404, which
-        // is fine: these tests don't exercise asset routing (Sub 6
-        // covers integration with a real fixture project).
-        let tmp = std::env::temp_dir();
-        build_router(state, tmp.join("zfb-test-public"))
+        // The dist/public roots on the state are bogus paths that
+        // don't exist on disk, so the dist + public on-disk fallbacks
+        // inside `serve_page` simply return None — which is fine: these
+        // tests exercise the routing logic, not asset I/O. Tests that
+        // need real on-disk fixtures override `dist_root` / `public_root`
+        // on the AppState before calling `test_router`.
+        build_router(state)
     }
 
     async fn body_string(resp: Response) -> String {
@@ -1508,6 +1587,7 @@ mod tests {
             broadcast: tx,
             plugins: Some(set),
             dist_root: std::env::temp_dir().join("zfb-test-dist"),
+            public_root: std::env::temp_dir().join("zfb-test-public"),
             base_prefix: None,
             trailing_slash: false,
         }
@@ -1767,8 +1847,7 @@ mod tests {
     // base-aware 404 hint.
 
     fn test_router_with_base(state: AppState) -> Router {
-        let tmp = std::env::temp_dir();
-        build_router(state, tmp.join("zfb-test-public"))
+        build_router(state)
     }
 
     #[tokio::test]

--- a/crates/zfb-server/src/routes.rs
+++ b/crates/zfb-server/src/routes.rs
@@ -2178,4 +2178,71 @@ mod tests {
             "opt-out href should not be prefixed: {body}"
         );
     }
+
+    /// A public file must remain reachable when the dev server runs
+    /// under a `base` prefix. `GET /foo/logo.svg` with `base: "/foo"`
+    /// resolves to `<public_root>/logo.svg` — the prefix is stripped
+    /// before the on-disk fallback runs, matching the production
+    /// `copy_public_dir` layout where `public/*` lands under the same
+    /// `<base-segment>/` in `dist/`.
+    #[tokio::test]
+    async fn base_prefix_serves_public_file_at_prefixed_root() {
+        // Stage a real public_root with a fixture file. The default
+        // test_state_with_base uses a bogus path; override it here so
+        // the on-disk read actually finds something.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let public_root = tmp.path().to_path_buf();
+        std::fs::write(public_root.join("logo.svg"), b"<svg/>").unwrap();
+
+        let mut state = test_state_with_base("/foo");
+        state.public_root = public_root;
+        let router = test_router_with_base(state);
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/foo/logo.svg")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let bytes = to_bytes(resp.into_body(), 1_000_000).await.unwrap();
+        assert_eq!(bytes.as_ref(), b"<svg/>");
+    }
+
+    /// Sibling check: under a `base` prefix, requesting the same file
+    /// WITHOUT the prefix must 404 (lands in the outside-base 404
+    /// handler), not silently serve the public file from the root.
+    /// This locks in that the public on-disk fallback is gated by the
+    /// prefix-stripping in `serve_page` and not reachable via a bare
+    /// unprefixed URL.
+    #[tokio::test]
+    async fn base_prefix_unprefixed_public_path_is_not_served() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let public_root = tmp.path().to_path_buf();
+        std::fs::write(public_root.join("logo.svg"), b"<svg/>").unwrap();
+
+        let mut state = test_state_with_base("/foo");
+        state.public_root = public_root;
+        let router = test_router_with_base(state);
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/logo.svg")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::NOT_FOUND,
+            "bare unprefixed asset URL must not bypass the base prefix"
+        );
+    }
 }

--- a/crates/zfb-server/tests/integration.rs
+++ b/crates/zfb-server/tests/integration.rs
@@ -207,6 +207,54 @@ async fn page_cache_wins_over_public_file() {
     );
 }
 
+/// When a file exists in both `dist/` and `public/`, the dist copy
+/// wins. The on-disk fallback chain in `serve_page` consults
+/// `<dist_root>/<path>` before `<public_root>/<path>`, so any artefact
+/// the build pipeline materialised into `dist/` (rendered HTML, hashed
+/// assets, etc.) shadows a same-named user file in `public/`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dist_wins_over_public_file() {
+    let h = Harness::start().await;
+    // The dist_root for the harness is `<tmp>/dist`. Drop a file in
+    // there that collides with a public/ file of the same name.
+    let dist_root = h.tmp_path().join("dist");
+    std::fs::write(dist_root.join("collide.txt"), b"FROM DIST").unwrap();
+    std::fs::write(h.public_root().join("collide.txt"), b"FROM PUBLIC").unwrap();
+
+    let resp = reqwest::get(h.url("/collide.txt")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert_eq!(
+        body, "FROM DIST",
+        "dist/ must win over public/ when both have the same path"
+    );
+}
+
+/// Requesting a subdirectory of `public/` (e.g. `/img/`) must NOT
+/// produce a directory listing — `read_from_public` rejects directory
+/// reads explicitly. Returns the dev 404.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn public_directory_request_does_not_list() {
+    let h = Harness::start().await;
+    std::fs::create_dir_all(h.public_root().join("img")).unwrap();
+    std::fs::write(h.public_root().join("img/inside.png"), b"PNG").unwrap();
+
+    // `/img/inside.png` works — it's a real file.
+    let ok = reqwest::get(h.url("/img/inside.png")).await.unwrap();
+    assert_eq!(ok.status(), 200);
+
+    // `/img` as a directory must 404 — neither the page cache nor the
+    // public fallback should serve it. (read_from_public explicitly
+    // rejects directory reads; read_from_dist would also miss because
+    // we're under the harness's empty dist/.)
+    let dir = reqwest::get(h.url("/img")).await.unwrap();
+    assert_eq!(
+        dir.status(),
+        404,
+        "directory request should fall through to dev 404"
+    );
+}
+
 /// Path traversal must not escape `public_root`. The `is_safe_url_path`
 /// gate (shared with the dist fallback) rejects `..` and absolute
 /// segments before any disk read.

--- a/crates/zfb-server/tests/integration.rs
+++ b/crates/zfb-server/tests/integration.rs
@@ -30,6 +30,10 @@ struct Harness {
     pages: PageCache,
     tx: broadcast::Sender<ReloadEvent>,
     server: tokio::task::JoinHandle<anyhow::Result<()>>,
+    /// Project public-static directory inside the tempdir — exposed so
+    /// tests can stage fixture files at runtime (e.g. for precedence
+    /// and path-safety checks). `_tmp` keeps the directory alive.
+    public_root: PathBuf,
     _tmp: TempDir,
 }
 
@@ -63,7 +67,7 @@ impl Harness {
         let opts = ServeOpts {
             project_root: root.clone(),
             dist_root,
-            public_root,
+            public_root: public_root.clone(),
             addr,
             pages: pages.clone(),
             broadcast: tx.clone(),
@@ -87,12 +91,21 @@ impl Harness {
             pages,
             tx,
             server,
+            public_root,
             _tmp: tmp,
         }
     }
 
     fn url(&self, path: &str) -> String {
         format!("http://{}{}", self.addr, path)
+    }
+
+    fn public_root(&self) -> &std::path::Path {
+        &self.public_root
+    }
+
+    fn tmp_path(&self) -> &std::path::Path {
+        self._tmp.path()
     }
 }
 
@@ -142,13 +155,77 @@ async fn asset_route_serves_static_files() {
     assert_eq!(body, "body { color: red; }");
 }
 
+/// `public/favicon.ico` must be reachable at the site root (`/favicon.ico`),
+/// NOT under a `/public/` URL prefix. This mirrors the production build
+/// (`copy_public_dir` copies straight into `dist/`) so a single
+/// `<link rel="icon" href="/favicon.ico">` works in both dev and prod.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn public_route_serves_user_files() {
+async fn public_files_serve_at_site_root() {
     let h = Harness::start().await;
-    let resp = reqwest::get(h.url("/public/favicon.ico")).await.unwrap();
-    assert_eq!(resp.status(), 200);
+    let resp = reqwest::get(h.url("/favicon.ico")).await.unwrap();
+    assert_eq!(resp.status(), 200, "public file should be reachable at root");
     let body = resp.bytes().await.unwrap();
     assert_eq!(body.as_ref(), b"\x00FAVICON\x00");
+}
+
+/// Files in `public/` should NOT be reachable under a `/public/...` URL
+/// prefix — that was the pre-fix dev URL space, and it doesn't exist in
+/// production (where `public/*` is copied to `dist/` root). Keeping the
+/// old URL alive would let developers ship code that works in dev but
+/// 404s in prod.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn public_files_not_reachable_under_public_prefix() {
+    let h = Harness::start().await;
+    let resp = reqwest::get(h.url("/public/favicon.ico")).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        404,
+        "the legacy /public/* mount must be gone — files appear at site root"
+    );
+}
+
+/// When a `pages/foo.tsx` route and a `public/foo` file collide, the
+/// rendered page wins. This is a precedence guarantee: the public-disk
+/// fallback runs AFTER the page cache, so the page handler always sees
+/// the rendered HTML first.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn page_cache_wins_over_public_file() {
+    let h = Harness::start().await;
+    // Stage a "page" at /robots.txt in the cache while a same-named
+    // file exists in public/ (we add one via the harness's tempdir).
+    std::fs::write(h.public_root().join("robots.txt"), b"FROM PUBLIC").unwrap();
+    h.pages
+        .insert("/robots.txt", "FROM PAGE CACHE")
+        .await;
+
+    let resp = reqwest::get(h.url("/robots.txt")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("FROM PAGE CACHE"),
+        "page cache must win over public/ file, got: {body}"
+    );
+}
+
+/// Path traversal must not escape `public_root`. The `is_safe_url_path`
+/// gate (shared with the dist fallback) rejects `..` and absolute
+/// segments before any disk read.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn public_fallback_rejects_path_traversal() {
+    let h = Harness::start().await;
+    // Place a secret file OUTSIDE public/ but inside the harness tmp,
+    // so a successful traversal would surface it.
+    std::fs::write(h.tmp_path().join("secret.txt"), b"top secret").unwrap();
+
+    // `/%2e%2e/secret.txt` decodes to `/../secret.txt`. Must 404, not
+    // 200 with the secret bytes.
+    let resp = reqwest::get(h.url("/%2e%2e/secret.txt")).await.unwrap();
+    assert_eq!(resp.status(), 404);
+    let body = resp.text().await.unwrap();
+    assert!(
+        !body.contains("top secret"),
+        "secret file must not leak through traversal, body: {body}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/docs/src/content/docs/concepts/static-assets.mdx
+++ b/docs/src/content/docs/concepts/static-assets.mdx
@@ -1,0 +1,148 @@
+---
+title: Static Assets
+description: "How to ship images, SVGs, fonts, favicons, robots.txt, and any other byte-for-byte file through zfb's public/ directory."
+sidebar_position: 4.5
+category: Concepts
+---
+
+<Info title="What this page covers">
+
+How to ship static files — images, SVGs, fonts, favicons, `robots.txt`,
+JSON manifests, anything binary — through the `public/` directory.
+Covers the URL convention, the dev/prod parity guarantee, the
+precedence rule when filenames collide with pages, the interaction
+with the `base` mount prefix, and when to reach for a TSX `import`
+instead.
+
+</Info>
+
+zfb handles non-code assets through a single directory: `public/`. Drop a file in, reference it by absolute URL, and the same URL works in `zfb dev`, `zfb preview`, and the static `dist/` your build emits. There's no plugin to install, no `import` to write, no bundler step you can break.
+
+## The convention
+
+Anything inside `public/` is served verbatim at the site root. The `public` segment does **not** appear in the URL.
+
+```text
+public/favicon.ico       →  /favicon.ico
+public/logo.svg          →  /logo.svg
+public/robots.txt        →  /robots.txt
+public/img/hero.png      →  /img/hero.png
+public/fonts/Inter.woff2 →  /fonts/Inter.woff2
+```
+
+Subdirectories are preserved, but the top-level `public/` name is stripped. A request to `/img/hero.png` resolves to `<project_root>/public/img/hero.png` in dev and to `dist/img/hero.png` after `zfb build`.
+
+## Referencing assets
+
+Use absolute URLs. The asset path mirrors what shows up in the rendered HTML:
+
+```tsx
+// pages/index.tsx
+export default function Home() {
+  return (
+    <main>
+      <img src="/logo.svg" alt="Site logo" width={128} height={32} />
+      <link rel="icon" href="/favicon.ico" />
+    </main>
+  );
+}
+```
+
+CSS works the same way — the URL is what the browser ultimately requests:
+
+```css
+/* styles/global.css */
+.hero {
+  background-image: url("/img/hero.png");
+}
+
+@font-face {
+  font-family: "Inter";
+  src: url("/fonts/Inter.woff2") format("woff2");
+}
+```
+
+## Do not import static assets as modules
+
+zfb does **not** run a bundler over `public/`. Patterns like the ones below — common in Vite, webpack, and similar toolchains — do not work here:
+
+```tsx
+// ❌ Do not do this for static files.
+import logoUrl from "../public/logo.svg";
+import heroImg from "./hero.png";
+```
+
+There is no asset pipeline that turns those imports into URLs. Use the absolute-URL form (`src="/logo.svg"`) instead. Imports are still the right answer for **code** — `.ts`, `.tsx`, `.css` modules used by islands — but not for binary files like images, fonts, or SVGs you want the browser to fetch as-is.
+
+If you genuinely need to inline an SVG as JSX (so CSS can style strokes, fills, etc.), copy the SVG markup into a TSX component. That's a code path; `public/` is the byte-for-byte path.
+
+## Dev / prod parity
+
+The dev server and the production build agree on URL shape. This is a guarantee, not a coincidence:
+
+- **`zfb dev`** — the page handler falls back to reading from `<public_root>/<path>` after a page-cache miss and a `dist/` miss. The `public/` directory has no URL prefix and no top-level `nest_service` mount; files appear at the site root directly.
+- **`zfb build`** — `copy_public_dir` (in `crates/zfb/src/commands/build.rs`) copies every file under `public/` into `dist/<rel>`, recursively. The static `dist/` tree your edge CDN serves is the same shape your browser saw in dev.
+
+That means `<img src="/logo.svg">` written once in your page works in both modes without conditional logic, environment checks, or a `withBase`-style helper.
+
+## Precedence: pages win over public files
+
+It is possible — though usually unintentional — to have a `pages/foo.tsx` route and a `public/foo` file with the same URL. zfb resolves this deterministically:
+
+1. **Plugin dev-middleware** that claims `/foo` runs first.
+2. **Page cache** — the rendered output of `pages/foo.tsx` wins next.
+3. **`dist/` directory** — files written by the build pipeline are served next.
+4. **`public/` directory** — only consulted if all three of the above miss.
+5. **404** otherwise.
+
+So a same-named TSX page always shadows a public file. The reverse is not possible — `public/foo` cannot override a route. If you need a static file at a URL that a page also claims, rename one of them.
+
+## Interaction with `base`
+
+When `zfb.config.ts` sets a `base` prefix (e.g. `base: "/pj/site/"` for a deploy under a sub-path), files in `public/` move under that prefix too:
+
+```text
+config: base: "/pj/site/"
+
+public/logo.svg  →  /pj/site/logo.svg   (dev and prod)
+```
+
+Both the dev server's `serve_page` fallback and the build-time `copy_public_dir` honour the prefix. As long as you write asset URLs in HTML the same way the rest of your project does — typically by going through the link rewriter that the markdown / TSX pipeline already runs — the prefix is applied for free.
+
+## Configuration
+
+The directory is configurable. Add `publicDir` to `zfb.config.ts` to point somewhere other than the default:
+
+```ts
+// zfb.config.ts
+import { defineConfig } from "@takazudo/zfb/config";
+
+export default defineConfig({
+  publicDir: "static",
+});
+```
+
+Default: `"public"`. The path is resolved relative to the project root. A missing directory is a silent no-op — not every project needs one.
+
+## What does NOT go in `public/`
+
+`public/` is the right home for:
+
+- Site-wide icons and favicons (`favicon.ico`, `apple-touch-icon.png`)
+- Open Graph / social-share images
+- `robots.txt`, `humans.txt`, security.txt
+- Web app manifests (`manifest.webmanifest`)
+- Fonts you self-host
+- Decorative imagery referenced by absolute URL from many pages
+
+It is the wrong home for:
+
+- **Source images you transform** (resize, optimise, convert to AVIF/WebP). zfb has no built-in image pipeline; if you need transforms, run them out-of-band (e.g. via a `prebuild` script) and check the optimised outputs into `public/`, or reach for a separate tool entirely.
+- **Code dependencies of islands**. TSX / JSX / TS / CSS imported by a `"use client"` island should live alongside the island and be bundled. Putting code in `public/` skips the bundler entirely — the browser will fetch raw source the runtime cannot execute.
+- **Files that need a different `Content-Type` than the extension implies**. zfb derives the Content-Type from the file extension. If you need an override, render the file through a TSX page instead (see [Non-HTML Pages](/concepts/non-html-pages)).
+
+## See also
+
+- [Project structure: `public/`](/getting-started/project-structure) — the directory layout at a glance.
+- [Non-HTML Pages](/concepts/non-html-pages) — render `.xml`, `.json`, or `.txt` through a TSX page when you need control over headers or want the page to depend on collection data.
+- [Islands](/concepts/islands) — the path for client-side JS, distinct from the static-asset path described here.

--- a/docs/src/content/docs/getting-started/project-structure.mdx
+++ b/docs/src/content/docs/getting-started/project-structure.mdx
@@ -58,7 +58,20 @@ Global CSS. `styles/global.css` is the entry point — import it from your root 
 
 ## public/
 
-Static assets served as-is from the site root. Put `favicon.ico`, robots.txt, and any image you want to reference by absolute URL here. zfb's dev server and `zfb preview` both serve `public/` directly.
+Static assets served as-is from the site root. Put `favicon.ico`, `robots.txt`, SVGs, raster images, fonts, manifest files, or any binary you want to reference by absolute URL here. The directory does NOT appear in the URL — `public/logo.svg` is reachable at `/logo.svg`, both in `zfb dev` and after `zfb build`.
+
+Reference these files by URL from your TSX, MDX, or CSS:
+
+```tsx
+<img src="/logo.svg" alt="" width={128} height={32} />
+<link rel="icon" href="/favicon.ico" />
+```
+
+Do NOT use bundler-style imports (`import logo from "./logo.svg"`) for static assets — zfb does not run an asset pipeline over `public/`. The directory is a verbatim mirror; files come out at the URL that matches their relative path.
+
+When `base` is set in `zfb.config.ts` (e.g. `base: "/pj/site/"`), files in `public/` are served under that prefix too — `public/logo.svg` → `/pj/site/logo.svg`. The same prepend happens at build time, so the prefix is consistent between dev and prod.
+
+See [Static Assets](/concepts/static-assets) for the full reference, including when to use `public/` vs a TSX import for islands.
 
 ## zfb.config.json
 


### PR DESCRIPTION
## Summary

- Replaces the dev server's `/public/*` `nest_service` mount with a per-request on-disk fallback inside `serve_page`, so static files in `public/` now appear at the site root in both `zfb dev` and the production `dist/` (matching what the docs always promised).
- Adds a dedicated `concepts/static-assets.mdx` page covering the URL convention, dev/prod parity, precedence, `base` interaction, and the "do not use bundler-style imports" rule — plus a beefed-up `getting-started/project-structure.mdx` `public/` section with a worked example.
- Tightens the regression net with new integration and unit tests covering page-cache → dist → public precedence, directory-request safety, base-prefix + public-file interaction, and path-traversal rejection.
- Bumps the `Swatinem/rust-cache` prefix-key (v1 → v2) in `.github/workflows/health.yml` to drop a stale cached `target/` snapshot that was failing to link `v8` during partial rebuilds. Follow-up #251 tracks committing `Cargo.lock` to stop the underlying re-resolution drift.

## Changes

### Dev server (`crates/zfb-server/`)

- `routes.rs`
  - Drops the top-level `nest_service("/public", ServeDir(public_root))` mount.
  - Adds `read_from_public(public_root, trimmed)` that reads `<public_root>/<path>` verbatim (no `index.html` probing, gated by the existing `is_safe_url_path` check, rejects directory reads).
  - Wires it into `serve_page` after the dist-on-disk fallback so the resolution chain is now: plugin dev-middleware → page cache → dist directory → public directory → 404.
  - Adds `public_root` to `AppState`; `build_router` no longer takes `public_root` as a separate parameter.
  - Updates the module-level doc, the `AppState` field docs, and inline comments to reflect the new layout (no more `/public/*` URL space).
- `lib.rs` — populates `AppState.public_root` and updates the doc comment / `ServeOpts.public_root` field doc.

### Tests (`crates/zfb-server/tests/integration.rs` + `routes.rs` test module)

Integration:

- `public_files_serve_at_site_root` — favicon reachable at `/favicon.ico` (renamed from `public_route_serves_user_files`).
- `public_files_not_reachable_under_public_prefix` — locks in that the legacy `/public/*` URL is gone (returns 404).
- `page_cache_wins_over_public_file` — page-cache entry shadows a same-named `public/` file.
- `dist_wins_over_public_file` — `<dist_root>/foo` shadows `<public_root>/foo` (locks in dist > public precedence).
- `public_directory_request_does_not_list` — requesting a subdirectory returns 404, not a directory listing.
- `public_fallback_rejects_path_traversal` — `%2e%2e` decodes are gated before the disk read.

Unit (under `base` prefix):

- `base_prefix_serves_public_file_at_prefixed_root` — `GET /foo/logo.svg` with `base: "/foo"` reads `<public_root>/logo.svg`.
- `base_prefix_unprefixed_public_path_is_not_served` — bare `GET /logo.svg` correctly 404s through the outside-base handler.

### Docs (`docs/src/content/docs/`)

- `getting-started/project-structure.mdx` — beefed up `## public/` with a worked TSX example, the "no bundler-imports" note, the `base`-prefix mention, and a link to the new concepts page.
- `concepts/static-assets.mdx` *(new)* — dedicated reference: URL convention, referencing assets from TSX/CSS, what NOT to import as modules, dev/prod parity guarantee, precedence rules, `base` interaction, `publicDir` config, and a "what goes / does not go in `public/`" rubric.

### CI (`.github/workflows/health.yml`)

- `Swatinem/rust-cache@v2` `prefix-key` bumped `v1-zfb` → `v2-zfb`. The cached `target/` under the old key was causing `v8 v147.4.0` to enter the partial-rebuild path with a stale fingerprint, and the link step failed with `could not find native static library 'rusty_v8'`. The first run on the new key absorbs the V8 first-compile cost (~3-15 min in practice); subsequent runs rehydrate normally. See #251 for the follow-up (commit `Cargo.lock`).

## Behavior break (narrow)

Code that hard-coded `/public/...` URLs against the **dev server only** will need to drop the `/public` prefix. The docs never told users to use that URL space, and `zfb build` always emitted at the site root, so the old dev URL was broken-by-convention. The new test `public_files_not_reachable_under_public_prefix` deliberately asserts the legacy URL is gone.

## Test Plan

- [x] `cargo test -p zfb-server` — 89 tests pass locally (69 unit + 13 integration + 7 plugin). All new tests included.
- [x] `cargo build --workspace --all-targets` clean (workspace warnings are pre-existing in `crates/zfb/src/output.rs`, unrelated).
- [x] `pnpm check` in `docs/` — 0 errors, 0 warnings on the new `static-assets.mdx`.
- [x] Health CI green on commit `9dcae3f` after the cache prefix-key bump.
- [ ] Manual `zfb dev` exercising a `<img src="/foo.svg">` against `public/foo.svg` — NOT exercised. The `examples/basic-blog` fixture has no static-asset images, so this would have required adding test fixtures. The integration tests above already cover the routing behavior end-to-end (real `tempfile`-backed `public_root`, real HTTP requests via `reqwest`), so the gap is small.

## Follow-up

- #251 — Commit `Cargo.lock` so dep re-resolution doesn't silently drift between CI runs (root cause of the v8 cache hiccup, only worked-around here).
