### PR TITLE
feat(runtime): zfb:navigation-aborted event in prep-aborted branch (#275)

### DIFF
--- a/packages/zfb-runtime/src/__tests__/client-router/events.test.ts
+++ b/packages/zfb-runtime/src/__tests__/client-router/events.test.ts
@@ -23,6 +23,7 @@ import {
   TRANSITION_AFTER_SWAP,
   TRANSITION_BEFORE_PREPARATION,
   TRANSITION_BEFORE_SWAP,
+  TRANSITION_NAVIGATION_ABORTED,
   TRANSITION_PAGE_LOAD,
   TransitionBeforePreparationEvent,
   TransitionBeforeSwapEvent,
@@ -48,6 +49,7 @@ describe("event constants", () => {
     expect(TRANSITION_BEFORE_SWAP).toBe("zfb:before-swap");
     expect(TRANSITION_AFTER_SWAP).toBe("zfb:after-swap");
     expect(TRANSITION_PAGE_LOAD).toBe("zfb:page-load");
+    expect(TRANSITION_NAVIGATION_ABORTED).toBe("zfb:navigation-aborted");
   });
 });
 

--- a/packages/zfb-runtime/src/__tests__/client-router/router.test.ts
+++ b/packages/zfb-runtime/src/__tests__/client-router/router.test.ts
@@ -166,6 +166,90 @@ describe("navigate() — happy path with mocked fetch", () => {
   });
 });
 
+describe("zfb:navigation-aborted — positive control (happy path does NOT fire)", () => {
+  it("does not dispatch zfb:navigation-aborted on a successful SPA swap", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => htmlResponse(pageHtml("Success", "success content"))),
+    );
+
+    const seenNavigationAborted = vi.fn();
+    document.addEventListener("zfb:navigation-aborted", seenNavigationAborted);
+
+    await navigate("/success");
+
+    document.removeEventListener("zfb:navigation-aborted", seenNavigationAborted);
+
+    // The happy path completes the swap; navigation-aborted must NOT fire.
+    expect(seenNavigationAborted).not.toHaveBeenCalled();
+    expect(document.querySelector("main")?.textContent).toBe("success content");
+  });
+});
+
+describe("zfb:navigation-aborted — rapid-navigation race (signal-aborted branch)", () => {
+  it("fires navigation-aborted exactly once for the superseded navigation, not for the winner", async () => {
+    // Build a manually-resolvable promise for /page-a so we control when A's
+    // fetch completes. /page-b resolves immediately.
+    let releaseA!: (r: Response) => void;
+    const promiseA = new Promise<Response>((resolve) => {
+      releaseA = resolve;
+    });
+
+    const fetchMock = vi.fn(async (url: RequestInfo, init?: RequestInit) => {
+      const u = String(url);
+      if (u.includes("/page-a")) return promiseA;
+      if (u.includes("/page-b")) return htmlResponse(pageHtml("B", "page b content"));
+      throw new Error(`unexpected fetch: ${u}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const originalHref = location.href;
+    Object.defineProperty(location, "href", {
+      configurable: true,
+      get: () => originalHref,
+      set: (_v: string) => {
+        // capture but don't assign; keeps happy-dom stable
+      },
+    });
+
+    const seenNavigationAborted = vi.fn();
+    const seenAfterSwap = vi.fn();
+    document.addEventListener("zfb:navigation-aborted", seenNavigationAborted);
+    document.addEventListener("zfb:after-swap", seenAfterSwap);
+
+    // Start /page-a navigation without awaiting so it's in-flight.
+    const navAPromise = navigate("/page-a");
+
+    // Immediately start /page-b — this aborts A's AbortController via
+    // abortAndRecreateMostRecentNavigation() inside transition().
+    const navBPromise = navigate("/page-b");
+
+    // Verify A's fetch signal is aborted. The signal was the second argument
+    // (init) passed to fetch for the /page-a call.
+    const aFetchCall = fetchMock.mock.calls.find((c) => String(c[0]).includes("/page-a"));
+    expect(aFetchCall).toBeDefined();
+    const aSignal = (aFetchCall![1] as RequestInit | undefined)?.signal;
+    expect(aSignal?.aborted).toBe(true);
+
+    // Release A's promise with a valid opt-in HTML page. A's loader will
+    // complete normally, but the signal is already aborted so transition()
+    // will take the signal-aborted branch and fire zfb:navigation-aborted.
+    releaseA(htmlResponse(pageHtml("A", "page a content")));
+
+    // Await both navigations.
+    await navAPromise;
+    await navBPromise;
+
+    document.removeEventListener("zfb:navigation-aborted", seenNavigationAborted);
+    document.removeEventListener("zfb:after-swap", seenAfterSwap);
+
+    // A fires navigation-aborted (signal-aborted branch); B fires after-swap.
+    // B must NOT fire navigation-aborted.
+    expect(seenNavigationAborted).toHaveBeenCalledTimes(1);
+    expect(seenAfterSwap).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe("hash-only same-page navigation", () => {
   it("does not call fetch for `#anchor` on the same page", async () => {
     const fetchMock = vi.fn();
@@ -213,7 +297,9 @@ describe("non-opt-in target page degrade", () => {
     );
 
     const seenAfterSwap = vi.fn();
+    const seenNavigationAborted = vi.fn();
     document.addEventListener("zfb:after-swap", seenAfterSwap);
+    document.addEventListener("zfb:navigation-aborted", seenNavigationAborted);
 
     // happy-dom's location.href is read-only by default; capture assignments.
     const originalHref = location.href;
@@ -229,13 +315,16 @@ describe("non-opt-in target page degrade", () => {
     await navigate("/plain-no-clientrouter");
 
     document.removeEventListener("zfb:after-swap", seenAfterSwap);
+    document.removeEventListener("zfb:navigation-aborted", seenNavigationAborted);
 
     // The router's defaultLoader path calls `preventDefault()` on the
     // preparation event when the new page has no opt-in meta, which short-
     // circuits the swap. The before/after-preparation events fire but
     // before-swap/after-swap do NOT, and a full browser load is requested
-    // by setting location.href.
+    // by setting location.href. zfb:navigation-aborted fires in the
+    // prep-aborted branch to signal that the SPA swap will not happen.
     expect(seenAfterSwap).not.toHaveBeenCalled();
+    expect(seenNavigationAborted).toHaveBeenCalledOnce();
     expect(assignedHref).toContain("/plain-no-clientrouter");
   });
 });
@@ -299,7 +388,9 @@ describe("non-HTML response degrade", () => {
     );
 
     const seenAfterSwap = vi.fn();
+    const seenNavigationAborted = vi.fn();
     document.addEventListener("zfb:after-swap", seenAfterSwap);
+    document.addEventListener("zfb:navigation-aborted", seenNavigationAborted);
 
     const originalHref = location.href;
     let assignedHref: string | undefined;
@@ -314,8 +405,12 @@ describe("non-HTML response degrade", () => {
     await navigate("/api/echo");
 
     document.removeEventListener("zfb:after-swap", seenAfterSwap);
+    document.removeEventListener("zfb:navigation-aborted", seenNavigationAborted);
 
+    // When the response is not HTML, the preparation event is prevented and
+    // zfb:navigation-aborted fires in the prep-aborted branch.
     expect(seenAfterSwap).not.toHaveBeenCalled();
+    expect(seenNavigationAborted).toHaveBeenCalledOnce();
     expect(assignedHref).toContain("/api/echo");
   });
 });

--- a/packages/zfb-runtime/src/client-router/events.ts
+++ b/packages/zfb-runtime/src/client-router/events.ts
@@ -7,8 +7,13 @@ export const TRANSITION_AFTER_PREPARATION = "zfb:after-preparation";
 export const TRANSITION_BEFORE_SWAP = "zfb:before-swap";
 export const TRANSITION_AFTER_SWAP = "zfb:after-swap";
 export const TRANSITION_PAGE_LOAD = "zfb:page-load";
+export const TRANSITION_NAVIGATION_ABORTED = "zfb:navigation-aborted";
 
-type Events = "zfb:after-preparation" | "zfb:after-swap" | "zfb:page-load";
+type Events =
+  | "zfb:after-preparation"
+  | "zfb:after-swap"
+  | "zfb:page-load"
+  | "zfb:navigation-aborted";
 export const triggerEvent = (name: Events) => document.dispatchEvent(new Event(name));
 export const onPageLoad = () => triggerEvent("zfb:page-load");
 

--- a/packages/zfb-runtime/src/client-router/index.ts
+++ b/packages/zfb-runtime/src/client-router/index.ts
@@ -11,6 +11,7 @@ export {
   TRANSITION_BEFORE_SWAP,
   TRANSITION_AFTER_SWAP,
   TRANSITION_PAGE_LOAD,
+  TRANSITION_NAVIGATION_ABORTED,
   TransitionBeforePreparationEvent,
   TransitionBeforeSwapEvent,
   isTransitionBeforePreparationEvent,

--- a/packages/zfb-runtime/src/client-router/router.ts
+++ b/packages/zfb-runtime/src/client-router/router.ts
@@ -443,6 +443,7 @@ async function transition(
   );
   if (prepEvent.defaultPrevented || prepEvent.signal.aborted) {
     if (currentNavigation === mostRecentNavigation) mostRecentNavigation = undefined;
+    triggerEvent("zfb:navigation-aborted");
     if (!prepEvent.signal.aborted) {
       // not aborted -> delegate to browser
       location.href = to.href;

--- a/packages/zfb-runtime/src/index.ts
+++ b/packages/zfb-runtime/src/index.ts
@@ -41,6 +41,7 @@ export {
   TRANSITION_BEFORE_SWAP,
   TRANSITION_AFTER_SWAP,
   TRANSITION_PAGE_LOAD,
+  TRANSITION_NAVIGATION_ABORTED,
   TransitionBeforePreparationEvent,
   TransitionBeforeSwapEvent,
   isTransitionBeforePreparationEvent,


### PR DESCRIPTION
## Summary

- Adds `TRANSITION_NAVIGATION_ABORTED = "zfb:navigation-aborted"` constant to `events.ts` and extends the `Events` type union so `triggerEvent` accepts the new event name
- Wires `triggerEvent("zfb:navigation-aborted")` in `router.ts` inside the `if (prepEvent.defaultPrevented || prepEvent.signal.aborted)` branch (after bookkeeping, before optional `location.href` assignment)
- Re-exports `TRANSITION_NAVIGATION_ABORTED` from both `client-router/index.ts` and the top-level `src/index.ts` barrels

## Test plan

- [x] `events.test.ts`: asserts `TRANSITION_NAVIGATION_ABORTED === "zfb:navigation-aborted"`
- [x] `router.test.ts`: adapted "non-opt-in target page degrade" — asserts `zfb:navigation-aborted` was dispatched
- [x] `router.test.ts`: adapted "non-HTML response degrade" — asserts `zfb:navigation-aborted` was dispatched
- [x] `router.test.ts`: added positive-control — happy-path navigation does NOT fire `zfb:navigation-aborted`
- [x] `router.test.ts`: added rapid-navigation race test with manually-resolvable promise for `/page-a`, verifies exactly one `navigation-aborted` (for A) and one `after-swap` (for B)
- [x] `pnpm --filter @takazudo/zfb-runtime test` green (67/67 tests pass)

Closes #275

🤖 Generated with [Claude Code](https://claude.com/claude-code)