### PR TITLE
feat(#277): ZfbConfig.prefetch.disabled flag + meta-tag injection

### DIFF
--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -426,6 +426,13 @@ pub struct BundlerInput {
     /// config loader before reaching here. Default: `None`.
     pub site: Option<String>,
 
+    /// When `true`, the bundler emits `globalThis.__zfb.prefetchDisabled = true`
+    /// in the synthetic `entry.mjs` so `<ClientRouter />` renders the disable
+    /// meta tag and the prefetch-core module short-circuits at `init()` time.
+    ///
+    /// Mirrors `zfb::config::Config::prefetch.disabled`. Default: `false`.
+    pub prefetch_disabled: bool,
+
     /// Optional TOC config. When `Some`, a [`TocPlugin`] is appended to
     /// the hast phase immediately after `HeadingLinksPlugin` so it reads
     /// final deduplicated `id` attributes. `None` (the default) leaves
@@ -531,6 +538,7 @@ impl BundlerInput {
             resolve_markdown_links: None,
             gfm_constructs: zfb_content::ResolvedGfmConstructs::default(),
             site: None,
+            prefetch_disabled: false,
             toc: None,
             external_links: None,
             cjk_friendly: true,
@@ -991,6 +999,7 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
         input.content_snapshot_json.as_deref(),
         &content_imports,
         input.site.as_deref(),
+        input.prefetch_disabled,
     )
     .context("bundler: failed writing entry.mjs")?;
 
@@ -1807,6 +1816,7 @@ fn write_entry_module(
     content_snapshot_json: Option<&str>,
     content_imports: &[ContentImport],
     site: Option<&str>,
+    prefetch_disabled: bool,
 ) -> Result<()> {
     use std::fmt::Write as _;
     let mut src = String::new();
@@ -1960,6 +1970,23 @@ fn write_entry_module(
             "globalThis.__zfb.site = {};\n\n",
             json_str(site_url)
         ));
+    }
+
+    // ---------------------------------------------------------------
+    // Prefetch-disabled flag (#277).
+    //
+    // When `prefetch.disabled === true` in `zfb.config.ts`, emit
+    // `globalThis.__zfb.prefetchDisabled = true` so that
+    // `<ClientRouter />` renders `<meta name="zfb-prefetch-disabled"
+    // content="true">` and the runtime's prefetch-core short-circuits
+    // at `init()` time.  The flag is site-wide and static — emitted
+    // once at bundle time, never per-page.  When absent, zero bytes
+    // are added so the build output is byte-for-byte identical to the
+    // pre-`prefetch` build.
+    // ---------------------------------------------------------------
+    if prefetch_disabled {
+        src.push_str("globalThis.__zfb = globalThis.__zfb ?? {};\n");
+        src.push_str("globalThis.__zfb.prefetchDisabled = true;\n\n");
     }
 
     // ---------------------------------------------------------------
@@ -2431,7 +2458,7 @@ mod tests {
                 entry_key: "/about".to_string(),
             },
         ];
-        write_entry_module(shadow, &routes, "preact-render-to-string", None, &[], None).unwrap();
+        write_entry_module(shadow, &routes, "preact-render-to-string", None, &[], None, false).unwrap();
 
         let body = fs::read_to_string(shadow.join(SHADOW_ENTRY_FILENAME)).unwrap();
 
@@ -2504,7 +2531,7 @@ mod tests {
                 shadow_rel_path: "content/docs-ja/intro.mdx".to_string(),
             },
         ];
-        write_entry_module(shadow, &[], "preact-render-to-string", None, &imports, None).unwrap();
+        write_entry_module(shadow, &[], "preact-render-to-string", None, &imports, None, false).unwrap();
 
         let body = fs::read_to_string(shadow.join(SHADOW_ENTRY_FILENAME)).unwrap();
 
@@ -2568,7 +2595,7 @@ mod tests {
         // `entry.mjs` without the bridge symbols).
         let tmp = tempfile::tempdir().unwrap();
         let shadow = tmp.path();
-        write_entry_module(shadow, &[], "preact-render-to-string", None, &[], None).unwrap();
+        write_entry_module(shadow, &[], "preact-render-to-string", None, &[], None, false).unwrap();
 
         let body = fs::read_to_string(shadow.join(SHADOW_ENTRY_FILENAME)).unwrap();
         assert!(
@@ -2598,6 +2625,7 @@ mod tests {
             None,
             &[],
             Some("https://example.com"),
+            false,
         )
         .unwrap();
 
@@ -2634,12 +2662,74 @@ mod tests {
         // pre-`site` build (sub #254 acceptance criterion).
         let tmp = tempfile::tempdir().unwrap();
         let shadow = tmp.path();
-        write_entry_module(shadow, &[], "preact-render-to-string", None, &[], None).unwrap();
+        write_entry_module(shadow, &[], "preact-render-to-string", None, &[], None, false).unwrap();
 
         let body = fs::read_to_string(shadow.join(SHADOW_ENTRY_FILENAME)).unwrap();
         assert!(
             !body.contains("globalThis.__zfb.site"),
             "site=None → no site setter; got:\n{body}"
+        );
+    }
+
+    // --- prefetch_disabled flag tests (#277) ---------------------------------
+
+    #[test]
+    fn entry_module_emits_prefetch_disabled_when_true() {
+        // When `prefetch_disabled` is `true`, the entry module must emit
+        // `globalThis.__zfb.prefetchDisabled = true` before `createPageRouter`
+        // so `<ClientRouter />` can read it during the first SSR call.
+        let tmp = tempfile::tempdir().unwrap();
+        let shadow = tmp.path();
+        write_entry_module(
+            shadow,
+            &[],
+            "preact-render-to-string",
+            None,
+            &[],
+            None,
+            true,
+        )
+        .unwrap();
+
+        let body = fs::read_to_string(shadow.join(SHADOW_ENTRY_FILENAME)).unwrap();
+
+        assert!(
+            body.contains("globalThis.__zfb = globalThis.__zfb ?? {};"),
+            "prefetch_disabled branch must emit the namespacing guard; got:\n{body}"
+        );
+        assert!(
+            body.contains("globalThis.__zfb.prefetchDisabled = true;"),
+            "prefetch_disabled setter must be present; got:\n{body}"
+        );
+
+        // The flag must precede createPageRouter so SSR code that reads
+        // `globalThis.__zfb.prefetchDisabled` on the first request already
+        // sees the value.
+        let flag_idx = body
+            .find("globalThis.__zfb.prefetchDisabled")
+            .expect("prefetchDisabled setter present");
+        let router_idx = body
+            .find("createPageRouter({")
+            .expect("createPageRouter present");
+        assert!(
+            flag_idx < router_idx,
+            "prefetch_disabled setter must precede createPageRouter; flag at {flag_idx}, router at {router_idx}"
+        );
+    }
+
+    #[test]
+    fn entry_module_omits_prefetch_disabled_when_false() {
+        // When `prefetch_disabled` is `false`, zero bytes related to the
+        // prefetch flag are emitted — preserving byte-for-byte parity with
+        // the pre-`prefetch` build (sub #277 acceptance criterion).
+        let tmp = tempfile::tempdir().unwrap();
+        let shadow = tmp.path();
+        write_entry_module(shadow, &[], "preact-render-to-string", None, &[], None, false).unwrap();
+
+        let body = fs::read_to_string(shadow.join(SHADOW_ENTRY_FILENAME)).unwrap();
+        assert!(
+            !body.contains("globalThis.__zfb.prefetchDisabled"),
+            "prefetch_disabled=false → no prefetch setter; got:\n{body}"
         );
     }
 
@@ -2835,7 +2925,7 @@ mod tests {
         // is the documented zero-routes behaviour.
         let tmp = tempfile::tempdir().unwrap();
         let shadow = tmp.path();
-        write_entry_module(shadow, &[], "react-dom/server", None, &[], None).unwrap();
+        write_entry_module(shadow, &[], "react-dom/server", None, &[], None, false).unwrap();
 
         let body = fs::read_to_string(shadow.join(SHADOW_ENTRY_FILENAME)).unwrap();
         assert!(body.contains("\"react-dom/server\""));
@@ -2850,7 +2940,7 @@ mod tests {
     fn entry_module_snapshot_literal(snapshot: Option<&str>) -> String {
         let tmp = tempfile::tempdir().unwrap();
         let shadow = tmp.path();
-        write_entry_module(shadow, &[], "react-dom/server", snapshot, &[], None).unwrap();
+        write_entry_module(shadow, &[], "react-dom/server", snapshot, &[], None, false).unwrap();
         let body = fs::read_to_string(shadow.join(SHADOW_ENTRY_FILENAME)).unwrap();
         // Pull just the assignment line so the assertion is precise.
         let prefix = "const __zfb_content_snapshot = ";

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -1160,6 +1160,14 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
     // so the bundler emits `globalThis.__zfb.site` in `entry.mjs` for
     // layout-side canonical tag, OG URL, and sitemap construction (sub #254).
     bundler_input.site = config.site.clone();
+    // Thread `prefetch.disabled` so `zfb build` emits
+    // `globalThis.__zfb.prefetchDisabled = true` in `entry.mjs` when the
+    // user sets `prefetch: { disabled: true }` in `zfb.config.ts` (sub #277).
+    bundler_input.prefetch_disabled = config
+        .prefetch
+        .as_ref()
+        .and_then(|p| p.disabled)
+        .unwrap_or(false);
     bundler_input.toc = config.markdown.as_ref().and_then(|m| m.toc.clone());
     // Thread `markdown.externalLinks` into the bundler so the hoisted MDX
     // pre-compile pipeline appends `ExternalLinksPlugin`. MUST mirror

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -696,6 +696,14 @@ fn boot_dev_renderer(
     // `globalThis.__zfb.site` the same way `zfb build` does. Mirrors the
     // `commands/build.rs` wiring (sub #254).
     bundler_input.site = cfg.site.clone();
+    // Thread `prefetch.disabled` so `zfb dev` emits
+    // `globalThis.__zfb.prefetchDisabled = true` the same way `zfb build`
+    // does. Mirrors the `commands/build.rs` wiring (sub #277).
+    bundler_input.prefetch_disabled = cfg
+        .prefetch
+        .as_ref()
+        .and_then(|p| p.disabled)
+        .unwrap_or(false);
     bundler_input.toc = cfg.markdown.as_ref().and_then(|m| m.toc.clone());
     // Thread `markdown.externalLinks` through to the bundler so dev
     // rendering matches the production build. Mirrors `commands/build.rs`.

--- a/crates/zfb/src/config.rs
+++ b/crates/zfb/src/config.rs
@@ -221,6 +221,19 @@ pub struct Config {
     #[serde(default)]
     pub tailwind: Option<TailwindConfig>,
 
+    /// Prefetch options. When `prefetch.disabled` is `true`, the bundler
+    /// emits `globalThis.__zfb.prefetchDisabled = true` in `entry.mjs` and
+    /// `<ClientRouter />` renders `<meta name="zfb-prefetch-disabled"
+    /// content="true">` in `<head>`. The runtime's prefetch-core reads that
+    /// meta tag at `init()` time and short-circuits.
+    ///
+    /// Absent / `None` preserves current behaviour — no prefetch meta tag is
+    /// emitted and no flag is set.
+    ///
+    /// Mirrors `PrefetchConfig` in `packages/zfb/src/config.ts`.
+    #[serde(default)]
+    pub prefetch: Option<PrefetchConfig>,
+
     /// User-supplied plugins.
     #[serde(default)]
     pub plugins: Vec<PluginConfig>,
@@ -364,6 +377,7 @@ impl Default for Config {
             framework: Framework::default(),
             collections: Vec::new(),
             tailwind: None,
+            prefetch: None,
             plugins: Vec::new(),
             adapter: None,
             strip_md_ext: false,
@@ -410,6 +424,21 @@ pub struct CollectionDef {
 pub struct TailwindConfig {
     #[serde(default = "default_true")]
     pub enabled: bool,
+}
+
+/// Prefetch options. Mirrors `PrefetchConfig` in `packages/zfb/src/config.ts`.
+///
+/// When `disabled` is `Some(true)`, the bundler emits
+/// `globalThis.__zfb.prefetchDisabled = true` in `entry.mjs`, and
+/// `<ClientRouter />` renders `<meta name="zfb-prefetch-disabled"
+/// content="true">` in `<head>`. The runtime's prefetch-core reads that meta
+/// tag at `init()` time and short-circuits so no prefetch wiring runs.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct PrefetchConfig {
+    /// Disable prefetch entirely. Default: `None` (equivalent to `false`).
+    #[serde(default)]
+    pub disabled: Option<bool>,
 }
 
 /// Syntect-based code-highlight options.
@@ -2732,6 +2761,39 @@ mod tests {
             msg.contains("site") && msg.contains("ftp"),
             "expected error mentioning 'site' and 'ftp'; got: {msg}"
         );
+    }
+
+    // --- PrefetchConfig field tests (#277) -----------------------------------
+
+    #[tokio::test]
+    async fn prefetch_disabled_true_parses_correctly() {
+        // `{ "prefetch": { "disabled": true } }` must parse to
+        // `Some(PrefetchConfig { disabled: Some(true) })`.
+        let tmp = TempDir::new().unwrap();
+        tokio::fs::write(
+            tmp.path().join("zfb.config.json"),
+            r#"{ "prefetch": { "disabled": true } }"#,
+        )
+        .await
+        .unwrap();
+        let cfg = load_from_dir(tmp.path()).await.expect("load ok");
+        assert_eq!(
+            cfg.prefetch,
+            Some(PrefetchConfig { disabled: Some(true) }),
+        );
+    }
+
+    #[tokio::test]
+    async fn prefetch_defaults_to_none_when_absent() {
+        // Absent `prefetch` block must produce `None` — the build is
+        // byte-for-byte identical to the pre-`prefetch` build (parity
+        // criterion).
+        let tmp = TempDir::new().unwrap();
+        tokio::fs::write(tmp.path().join("zfb.config.json"), "{}")
+            .await
+            .unwrap();
+        let cfg = load_from_dir(tmp.path()).await.expect("load ok");
+        assert_eq!(cfg.prefetch, None);
     }
 
     // --- resolve_cjk_friendly tests ---

--- a/crates/zfb/tests/framework_packages_no_pnpm.rs
+++ b/crates/zfb/tests/framework_packages_no_pnpm.rs
@@ -172,6 +172,7 @@ fn embedded_extraction_resolves_framework_imports_with_no_consumer_node_modules(
         resolve_markdown_links: None,
         gfm_constructs: zfb_content::ResolvedGfmConstructs::default(),
         site: None,
+        prefetch_disabled: false,
         toc: None,
         external_links: None,
         cjk_friendly: true,

--- a/packages/zfb-runtime/src/__tests__/client-router.test.ts
+++ b/packages/zfb-runtime/src/__tests__/client-router.test.ts
@@ -1,0 +1,102 @@
+// Integration tests for <ClientRouter /> meta-tag emission.
+//
+// Verifies that ClientRouter conditionally appends a
+// `<meta name="zfb-prefetch-disabled" content="true">` VNode to its output
+// when `globalThis.__zfb.prefetchDisabled === true`, and does NOT emit the
+// tag when the flag is absent or false.
+//
+// This pins the meta-tag contract with sibling sub-issue #276.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// vi.mock is hoisted to module top by Vitest, which lets us prevent the
+// client-router module's side effect (`init()`) from running during
+// the module-level `if (typeof document !== "undefined")` guard.
+// We mock `./client-router/router.js` so `init` is a no-op spy.
+vi.mock("../client-router/router.js", () => ({ init: vi.fn() }));
+
+import { ClientRouter } from "../client-router.js";
+
+afterEach(() => {
+  // Clean up any globalThis.__zfb mutations between tests.
+  delete (globalThis as { __zfb?: unknown }).__zfb;
+  vi.unstubAllGlobals();
+});
+
+describe("ClientRouter — baseline (no prefetch flag)", () => {
+  it("returns exactly three VNodes when __zfb.prefetchDisabled is absent", () => {
+    const nodes = ClientRouter();
+    expect(nodes).toHaveLength(3);
+  });
+
+  it("does not include a zfb-prefetch-disabled meta when __zfb is undefined", () => {
+    delete (globalThis as { __zfb?: unknown }).__zfb;
+    const nodes = ClientRouter();
+    const prefetchMeta = nodes.find(
+      (n) => n.type === "meta" && n.props["name"] === "zfb-prefetch-disabled",
+    );
+    expect(prefetchMeta).toBeUndefined();
+  });
+
+  it("does not include a zfb-prefetch-disabled meta when __zfb.prefetchDisabled is false", () => {
+    (globalThis as { __zfb?: { prefetchDisabled?: boolean } }).__zfb = { prefetchDisabled: false };
+    const nodes = ClientRouter();
+    const prefetchMeta = nodes.find(
+      (n) => n.type === "meta" && n.props["name"] === "zfb-prefetch-disabled",
+    );
+    expect(prefetchMeta).toBeUndefined();
+  });
+});
+
+describe("ClientRouter — prefetch disabled flag", () => {
+  it("appends a zfb-prefetch-disabled meta VNode when __zfb.prefetchDisabled === true", () => {
+    (globalThis as { __zfb?: { prefetchDisabled?: boolean } }).__zfb = { prefetchDisabled: true };
+    const nodes = ClientRouter();
+    const prefetchMeta = nodes.find(
+      (n) => n.type === "meta" && n.props["name"] === "zfb-prefetch-disabled",
+    );
+    expect(prefetchMeta).toBeDefined();
+    // Pin the exact attribute values — this is the verbatim contract with #276.
+    expect(prefetchMeta?.props["name"]).toBe("zfb-prefetch-disabled");
+    expect(prefetchMeta?.props["content"]).toBe("true");
+  });
+
+  it("returns four VNodes total when the flag is set", () => {
+    (globalThis as { __zfb?: { prefetchDisabled?: boolean } }).__zfb = { prefetchDisabled: true };
+    const nodes = ClientRouter();
+    expect(nodes).toHaveLength(4);
+  });
+
+  it("the zfb-prefetch-disabled meta VNode has constructor === undefined (VNode shape)", () => {
+    (globalThis as { __zfb?: { prefetchDisabled?: boolean } }).__zfb = { prefetchDisabled: true };
+    const nodes = ClientRouter();
+    const prefetchMeta = nodes.find(
+      (n) => n.type === "meta" && n.props["name"] === "zfb-prefetch-disabled",
+    );
+    // constructor: undefined is the sentinel for Preact/React structural VNodes.
+    expect((prefetchMeta as { constructor?: unknown } | undefined)?.constructor).toBeUndefined();
+  });
+});
+
+describe("ClientRouter — baseline nodes are always present", () => {
+  it("always emits a style VNode first", () => {
+    const nodes = ClientRouter();
+    expect(nodes[0]?.type).toBe("style");
+  });
+
+  it("always emits the zfb-view-transitions-enabled meta", () => {
+    const nodes = ClientRouter();
+    const enabled = nodes.find(
+      (n) => n.type === "meta" && n.props["name"] === "zfb-view-transitions-enabled",
+    );
+    expect(enabled?.props["content"]).toBe("true");
+  });
+
+  it("always emits the zfb-view-transitions-fallback meta with default animate", () => {
+    const nodes = ClientRouter();
+    const fallback = nodes.find(
+      (n) => n.type === "meta" && n.props["name"] === "zfb-view-transitions-fallback",
+    );
+    expect(fallback?.props["content"]).toBe("animate");
+  });
+});

--- a/packages/zfb-runtime/src/client-router.ts
+++ b/packages/zfb-runtime/src/client-router.ts
@@ -106,7 +106,7 @@ const announcerCss = `
 export function ClientRouter({
   fallback = "animate",
 }: ClientRouterProps = {}): readonly ClientRouterElement[] {
-  return [
+  const nodes: ClientRouterElement[] = [
     // Global styles for the ARIA route-announcer div injected into <body>.
     makeVNode("style", { dangerouslySetInnerHTML: { __html: announcerCss } }),
     // Opt-in meta tag: router checks for this to decide whether to intercept navigations.
@@ -114,4 +114,22 @@ export function ClientRouter({
     // Fallback strategy meta tag: read by getFallback() in router.ts.
     makeVNode("meta", { name: "zfb-view-transitions-fallback", content: fallback }),
   ];
+
+  // Prefetch-disabled meta tag (#277): emitted when the bundler set
+  // `globalThis.__zfb.prefetchDisabled = true` (from `zfb.config.ts`
+  // `prefetch: { disabled: true }`). The sibling prefetch-core module reads
+  // `document.querySelector('meta[name="zfb-prefetch-disabled"][content="true"]')`
+  // at `init()` time and short-circuits if found.
+  //
+  // The flag is site-wide and static — set once at bundle-emit time, never
+  // per-page. This meta tag appears on every page that mounts `<ClientRouter />`
+  // or not at all.
+  //
+  // Pin the contract verbatim — the attribute names and content value are
+  // shared with the sibling prefetch-core sub-issue (#276).
+  if ((globalThis as { __zfb?: { prefetchDisabled?: boolean } }).__zfb?.prefetchDisabled === true) {
+    nodes.push(makeVNode("meta", { name: "zfb-prefetch-disabled", content: "true" }));
+  }
+
+  return nodes;
 }

--- a/packages/zfb/src/__tests__/config-prefetch.test.ts
+++ b/packages/zfb/src/__tests__/config-prefetch.test.ts
@@ -1,0 +1,50 @@
+// Smoke tests for the `PrefetchConfig` type addition and `defineConfig`
+// round-trip (#277).
+//
+// These tests are mostly compile-time (TypeScript shape) but also pin the
+// runtime identity of `defineConfig` — if the field name is misspelled or the
+// type changes shape, the test fails.
+
+import { describe, expect, it } from "vitest";
+import { defineConfig } from "../config.js";
+import type { PrefetchConfig, ZfbConfig } from "../config.js";
+
+describe("PrefetchConfig type + defineConfig round-trip", () => {
+  it("defineConfig accepts prefetch: { disabled: true } without type error", () => {
+    // TypeScript compile-time check that the field exists in ZfbConfig.
+    // At runtime, defineConfig is the identity function — the returned
+    // value must equal the input object reference.
+    const cfg = defineConfig({ prefetch: { disabled: true } });
+    expect(cfg.prefetch?.disabled).toBe(true);
+  });
+
+  it("defineConfig accepts prefetch: { disabled: false }", () => {
+    const cfg = defineConfig({ prefetch: { disabled: false } });
+    expect(cfg.prefetch?.disabled).toBe(false);
+  });
+
+  it("defineConfig accepts prefetch: {} (disabled omitted)", () => {
+    const cfg = defineConfig({ prefetch: {} });
+    expect(cfg.prefetch).toEqual({});
+    expect(cfg.prefetch?.disabled).toBeUndefined();
+  });
+
+  it("defineConfig accepts absent prefetch field", () => {
+    const cfg = defineConfig({});
+    expect(cfg.prefetch).toBeUndefined();
+  });
+
+  it("PrefetchConfig type is assignable as expected", () => {
+    // Structural type check: an object with only `disabled` is a valid
+    // PrefetchConfig, and ZfbConfig.prefetch is Optional<PrefetchConfig>.
+    const pc: PrefetchConfig = { disabled: true };
+    const zc: ZfbConfig = { prefetch: pc };
+    expect(zc.prefetch?.disabled).toBe(true);
+  });
+
+  it("defineConfig returns the identical object reference (identity helper)", () => {
+    // defineConfig must remain a no-op identity function — no cloning.
+    const input: ZfbConfig = { prefetch: { disabled: true } };
+    expect(defineConfig(input)).toBe(input);
+  });
+});

--- a/packages/zfb/src/config.ts
+++ b/packages/zfb/src/config.ts
@@ -31,6 +31,25 @@ export type TailwindConfig = {
 };
 
 /**
+ * Prefetch options. Mirrors `PrefetchConfig` in `crates/zfb/src/config.rs`.
+ */
+export type PrefetchConfig = {
+  /**
+   * Disable prefetch entirely.
+   *
+   * When `true`, the bundler emits `globalThis.__zfb.prefetchDisabled = true`
+   * in `entry.mjs`, and `<ClientRouter />` renders
+   * `<meta name="zfb-prefetch-disabled" content="true">` in `<head>`.
+   * The sibling prefetch-core module reads that meta tag at `init()` time
+   * and short-circuits — no prefetch wiring runs.
+   *
+   * The flag is site-wide and static — set once at bundle-emit time,
+   * never recomputed per-page. Default: `false`.
+   */
+  disabled?: boolean;
+};
+
+/**
  * One plugin entry in `zfb.config.ts`.
  *
  * `name` MUST be a module reference that Node's resolver can locate from
@@ -70,6 +89,13 @@ export type ZfbConfig = {
   collections?: CollectionDef[];
   /** Tailwind options; absent = defaults. */
   tailwind?: TailwindConfig;
+  /**
+   * Prefetch options. When `disabled: true`, the build emits a meta tag
+   * that the runtime's prefetch-core module reads at init time to skip
+   * all prefetch wiring. Mirrors `Config::prefetch` in
+   * `crates/zfb/src/config.rs`.
+   */
+  prefetch?: PrefetchConfig;
   /** User-supplied plugins. */
   plugins?: PluginConfig[];
   /**


### PR DESCRIPTION
## Summary

- Adds `PrefetchConfig = { disabled?: boolean }` type to `packages/zfb/src/config.ts` and `ZfbConfig.prefetch` field, mirroring the `TailwindConfig` pattern.
- Mirrors as `pub struct PrefetchConfig { pub disabled: Option<bool> }` in `crates/zfb/src/config.rs` with `#[serde(default)]` and `#[serde(rename_all = "camelCase")]`.
- Adds `prefetch_disabled: bool` to `BundlerInput` and threads it through both `zfb build` (`commands/build.rs`) and `zfb dev` (`commands/dev.rs`) from `Config::prefetch.disabled`.
- Extends `write_entry_module()` to emit `globalThis.__zfb.prefetchDisabled = true;` before `createPageRouter` when the flag is set.
- Updates `ClientRouter` to conditionally append `<meta name="zfb-prefetch-disabled" content="true">` VNode when `globalThis.__zfb?.prefetchDisabled === true`.

## Bundler emission sites audit

Grepped all crates/ and packages/ for `globalThis.__zfb` writers. The only writers are both inside `write_entry_module()` in `crates/zfb-build/src/bundler.rs` (the `site` setter at ~1958 and `content` bridge at ~2016). Both `zfb build` and `zfb dev` funnel through `bundle()` -> `write_entry_module()` — no divergent dev/build path exists. The codex-flagged risk of a missed dev-path emission site is confirmed not present.

## Meta-tag contract (pinned verbatim)

`name="zfb-prefetch-disabled"` / `content="true"` — exact attribute names and value per #276 contract.

## Tests

- Rust unit tests in `crates/zfb/src/config.rs`: parse `{ "prefetch": { "disabled": true } }` and default-to-None.
- Rust unit tests in `crates/zfb-build/src/bundler.rs`: `entry_module_emits_prefetch_disabled_when_true` and `entry_module_omits_prefetch_disabled_when_false`.
- TS smoke tests in `packages/zfb/src/__tests__/config-prefetch.test.ts`: `defineConfig({ prefetch: { disabled: true } })` round-trip.
- Integration tests in `packages/zfb-runtime/src/__tests__/client-router.test.ts`: 9 tests covering flag true/false/absent cases and baseline VNode presence.

## Test status

- `cargo test -p zfb`: 237 passed
- `pnpm --filter @takazudo/zfb test`: 126 passed
- `pnpm --filter @takazudo/zfb-runtime test`: 74 passed

Closes #277.

🤖 Generated with [Claude Code](https://claude.com/claude-code)