### PR TITLE
fix(jsx-types): widen VNode.type to accept class components

### DIFF
--- a/packages/zfb/src/jsx-types.ts
+++ b/packages/zfb/src/jsx-types.ts
@@ -17,9 +17,17 @@
  * HTML attribute values (strings, numbers, booleans). All fields are widened
  * to `unknown` so the type stays opaque to callers that don't know which
  * framework produced the value.
+ *
+ * `type` accepts BOTH function components (call signature) AND class
+ * components (construct signature). Preact and React both expose
+ * `ComponentType = FunctionComponent | ComponentClass`, and the JSX runtime
+ * stores either on `.type`. Without the construct signature, valid Preact
+ * `<MyComponent />` expressions fail to assign to `VNode` at the framework
+ * boundary (e.g. inside `<Island>` children) — even though class components
+ * are rare in modern Preact, the `ComponentType` union includes them.
  */
 export type VNodeObject = {
-  readonly type: string | ((...args: unknown[]) => unknown);
+  readonly type: string | ((...args: unknown[]) => unknown) | (new (...args: unknown[]) => unknown);
   readonly props: Readonly<Record<string, unknown>>;
   readonly key: unknown;
 };


### PR DESCRIPTION
## Summary

Widen `VNodeObject.type` (in `packages/zfb/src/jsx-types.ts`) to accept the construct signature `new (...) => unknown` in addition to the existing call signature. This makes `<Island when="..."><PreactComponent /></Island>` typecheck under Preact's standard JSX types.

## Why

`IslandProps.children: VNode` only accepted function components. Preact's `JSX.Element` widens `.type` to `ComponentType<any>`, which is `FunctionComponent | ComponentClass`. The class side has a construct signature, not a call signature, so the structural assignment fails:

```
error TS2322: Type 'Element' is not assignable to type 'VNode'.
  Type 'VNode<any>' is not assignable to type 'VNodeObject'.
    Types of property 'type' are incompatible.
      Type 'ComponentClass<any, {}>' is not assignable to
      type 'string | ((...args: unknown[]) => unknown)'.
```

Runtime is unchanged — both Preact and React store either function or class on `.type` and the SSR/hydrate path handles both. This is purely a TypeScript declaration mismatch at the framework boundary.

## Discovered in

zzmod's Wave 2 of the Astro → zfb migration. See [zudolab/zzmod#97](https://github.com/zudolab/zzmod/issues/97) for the consumer-side context and the workaround cast that lands in zzmod's `base/zfb` while this PR is in flight.

## Test plan

- [x] `cargo build -p zfb --release` succeeds.
- [x] Consumer zzmod's `pnpm typecheck` (= `astro check`) goes from red (1 Wave-2 error) to green once `framework-pins.json` bumps to this commit.
- [x] No runtime behavior change — `dist/_worker.js`, `dist/_zfb_inner.mjs`, `dist/assets/islands.js` unchanged byte-for-byte (the type widening is erased at compile time).