### PR TITLE
feat(bundler): trim runtime bundle to SSR-only routes for deploy adapters

### DIFF
--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -490,6 +490,44 @@ pub struct BundlerInput {
     ///
     /// Mirrors `zfb_islands::EsbuildSubprocessConfig::virtual_modules`.
     pub plugin_virtual_modules: Vec<(String, String)>,
+
+    /// When `Some(set)`, the synthetic `entry.mjs` only imports + registers
+    /// the routes whose [`RouteEntry::entry_key`] appears in the set. All
+    /// other discovered routes are still visible to `BundlerOutput::manifest`
+    /// (so build-time bookkeeping continues to know about them) but they
+    /// are unreachable from the entry — esbuild's tree-shaker drops them
+    /// and their transitive deps from the final bundle.
+    ///
+    /// Intended for "runtime-only" bundle passes consumed by deploy
+    /// adapters whose dispatch path serves prerendered routes from a
+    /// separate static-asset server (e.g. Cloudflare Pages' `ASSETS first,
+    /// inner on 404` shape). Pass the set of routes with `prerender =
+    /// false`; the resulting bundle ships only the SSR code path.
+    ///
+    /// `None` (the default) preserves the existing single-bundle behavior:
+    /// every discovered route is imported into the entry. SSG render
+    /// pipelines must keep this `None` because the embedded V8 host walks
+    /// every route to write static HTML.
+    ///
+    /// Additional side-effects when `Some`:
+    /// - `content_imports` is emptied for the entry — getCollection()
+    ///   bridge entries do not reach the runtime bundle. Combined with
+    ///   the content snapshot suppression below, this drops MDX-derived
+    ///   data (incl. inline image / blurhash data URIs) from the worker.
+    /// - [`Self::content_snapshot_json`] is treated as if it were `None`,
+    ///   so `getCollection(...)` inside SSR routes resolves against an
+    ///   empty snapshot. Refine if a real consumer needs SSR-time content
+    ///   access.
+    pub worker_only_routes: Option<std::collections::BTreeSet<String>>,
+
+    /// Filename (not full path) of the emitted bundle inside [`Self::outdir`].
+    /// `None` defaults to `"bundle.mjs"` for backward compatibility.
+    ///
+    /// Allows two consecutive `bundle()` calls in the same `outdir` to
+    /// produce distinct artifacts — e.g. a full `bundle.mjs` for SSG
+    /// render and a `bundle-runtime.mjs` for the deploy adapter. The
+    /// sourcemap suffix `.map` is appended automatically.
+    pub bundle_basename: Option<String>,
 }
 
 impl BundlerInput {
@@ -544,6 +582,8 @@ impl BundlerInput {
             cjk_friendly: true,
             plugin_alias_entries: Vec::new(),
             plugin_virtual_modules: Vec::new(),
+            worker_only_routes: None,
+            bundle_basename: None,
         }
     }
 }
@@ -992,12 +1032,45 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
     .context("bundler: failed writing synthetic tsconfig.json")?;
 
     // 5. Synthetic entry.mjs.
+    //
+    // When `worker_only_routes` is set, narrow the entry's static-import
+    // set to that subset and drop `content_imports` + the content snapshot
+    // (see `BundlerInput::worker_only_routes` for the contract). This
+    // makes prerendered-only routes unreachable from the entry so esbuild's
+    // tree-shaker can drop them and their transitive deps (page modules,
+    // MDX namespaces, inline data URIs) from the final bundle. The full
+    // `routes` vec is preserved for `BundlerOutput::manifest.routes` —
+    // build-time bookkeeping (route table, post-build manifest) must keep
+    // seeing every discovered route regardless of this filter.
+    let entry_routes_filtered_storage: Vec<RouteEntry>;
+    let entry_routes_for_write: &[RouteEntry];
+    let entry_content_imports_for_write: &[ContentImport];
+    let entry_snapshot_for_write: Option<&str>;
+    if let Some(filter) = input.worker_only_routes.as_ref() {
+        entry_routes_filtered_storage = routes
+            .iter()
+            .filter(|r| filter.contains(&r.entry_key))
+            .cloned()
+            .collect();
+        entry_routes_for_write = &entry_routes_filtered_storage;
+        // Content imports + snapshot are intentionally dropped from the
+        // runtime bundle slice; see field docs for the rationale and the
+        // listed follow-up if/when an SSR route legitimately needs
+        // getCollection(...).
+        entry_content_imports_for_write = &[];
+        entry_snapshot_for_write = None;
+    } else {
+        // No filter — preserve the existing single-bundle behavior verbatim.
+        entry_routes_for_write = &routes;
+        entry_content_imports_for_write = &content_imports;
+        entry_snapshot_for_write = input.content_snapshot_json.as_deref();
+    }
     write_entry_module(
         shadow,
-        &routes,
+        entry_routes_for_write,
         adapter.render_to_string_module(),
-        input.content_snapshot_json.as_deref(),
-        &content_imports,
+        entry_snapshot_for_write,
+        entry_content_imports_for_write,
         input.site.as_deref(),
         input.prefetch_disabled,
     )
@@ -1006,8 +1079,14 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
     // 6. Resolve and run esbuild (or the mock).
     fs::create_dir_all(&outdir)
         .with_context(|| format!("bundler: failed to create outdir {}", outdir.display()))?;
-    let bundle_path = outdir.join("bundle.mjs");
-    let sourcemap_path = outdir.join("bundle.mjs.map");
+    // Bundle filename — `bundle_basename` lets callers run two bundle()
+    // passes in the same outdir (full SSG vs runtime-only) without clobber.
+    let bundle_filename: &str = input
+        .bundle_basename
+        .as_deref()
+        .unwrap_or("bundle.mjs");
+    let bundle_path = outdir.join(bundle_filename);
+    let sourcemap_path = outdir.join(format!("{bundle_filename}.map"));
 
     if let Some(mock) = input.mock_subprocess_output.as_ref() {
         fs::write(&bundle_path, mock).with_context(|| {
@@ -2414,6 +2493,8 @@ mod tests {
             cjk_friendly: true,
             plugin_alias_entries: Vec::new(),
             plugin_virtual_modules: Vec::new(),
+            worker_only_routes: None,
+            bundle_basename: None,
         }
     }
 
@@ -3026,6 +3107,116 @@ mod tests {
     }
 
     #[test]
+    fn for_project_defaults_worker_only_routes_and_bundle_basename_to_none() {
+        // Defaults for the runtime-trim fields (zfb#283). `None` keeps
+        // legacy single-bundle behavior — write_entry_module imports every
+        // discovered route, and the bundle filename stays `bundle.mjs`.
+        let input = BundlerInput::for_project(
+            PathBuf::from("/tmp/dummy"),
+            Framework::Preact,
+            BundleMode::Production,
+            PathBuf::from("/tmp/dummy/dist"),
+            None,
+        );
+        assert!(
+            input.worker_only_routes.is_none(),
+            "worker_only_routes should default to None"
+        );
+        assert!(
+            input.bundle_basename.is_none(),
+            "bundle_basename should default to None (so callers see legacy bundle.mjs filename)"
+        );
+    }
+
+    #[test]
+    fn bundle_basename_override_changes_emitted_filename() {
+        // The bundle filename is selectable so two passes (full SSG +
+        // runtime-only) can coexist in the same outdir without clobber.
+        let tmp = tempfile::tempdir().unwrap();
+        let mut input = make_minimal_input(&tmp);
+        input.bundle_basename = Some("bundle-runtime.mjs".to_string());
+
+        let out = bundle(input).expect("mock bundle with custom basename should succeed");
+
+        assert_eq!(
+            out.bundle_path.file_name().and_then(|s| s.to_str()),
+            Some("bundle-runtime.mjs"),
+            "bundle_path should honor bundle_basename"
+        );
+        assert!(out.bundle_path.exists(), "renamed bundle should be on disk");
+        assert_eq!(
+            out.sourcemap_path.file_name().and_then(|s| s.to_str()),
+            Some("bundle-runtime.mjs.map"),
+            "sourcemap suffix should track the renamed bundle"
+        );
+        // Manifest's bundle_basename is derived from the on-disk filename
+        // — it must reflect the override too.
+        assert_eq!(out.manifest.bundle_basename, "bundle-runtime.mjs");
+    }
+
+    #[test]
+    fn worker_only_routes_preserves_full_manifest_routes() {
+        // The filter only narrows what `write_entry_module` imports into
+        // the synthetic entry — `BundlerOutput.manifest.routes` continues
+        // to report every discovered route so build-time bookkeeping
+        // (post-build manifest, route-table dumps) sees the full picture.
+        // This is the documented contract on the field.
+        let tmp = tempfile::tempdir().unwrap();
+        // Fixture: two pages. `pages/index.tsx` (SSG) + `pages/api.tsx`
+        // (SSR-only, by intent in this test).
+        let root = tmp.path().to_path_buf();
+        fs::create_dir_all(root.join("pages")).unwrap();
+        fs::write(
+            root.join("pages/index.tsx"),
+            "export default function Home() { return null; }\n",
+        )
+        .unwrap();
+        fs::write(
+            root.join("pages/api.tsx"),
+            "export const prerender = false;\n\
+             export default function Api() { return null; }\n",
+        )
+        .unwrap();
+        fs::create_dir_all(root.join("content")).unwrap();
+        fs::create_dir_all(root.join("components")).unwrap();
+        fs::create_dir_all(root.join("layouts")).unwrap();
+
+        let mut input = make_minimal_input(&tmp);
+        // make_minimal_input only created pages/index.tsx; re-point the
+        // input at our two-page tree above.
+        input.project_root = root.clone();
+        input.outdir = root.join("dist");
+        let mut filter: std::collections::BTreeSet<String> =
+            std::collections::BTreeSet::new();
+        filter.insert("/api".to_string());
+        input.worker_only_routes = Some(filter);
+
+        let out = bundle(input).expect("mock bundle with filter should succeed");
+
+        let route_keys: Vec<&str> = out
+            .manifest
+            .routes
+            .iter()
+            .map(|r| r.route.as_str())
+            .collect();
+        assert!(
+            route_keys.contains(&"/"),
+            "manifest.routes must still include the prerendered route, got {:?}",
+            route_keys
+        );
+        assert!(
+            route_keys.contains(&"/api"),
+            "manifest.routes must still include the SSR route, got {:?}",
+            route_keys
+        );
+        assert_eq!(
+            route_keys.len(),
+            2,
+            "manifest.routes should report every discovered route regardless of worker_only_routes"
+        );
+    }
+
+    #[test]
     fn server_secrets_are_not_bundled() {
         // Real esbuild test (gated). Verifies a SECRET_ env var never
         // appears in the output, while a PUBLIC_ var does.
@@ -3123,6 +3314,8 @@ mod tests {
             cjk_friendly: true,
             plugin_alias_entries: Vec::new(),
             plugin_virtual_modules: Vec::new(),
+            worker_only_routes: None,
+            bundle_basename: None,
         };
 
         let out = bundle(input).expect("real esbuild bundle should succeed");

--- a/crates/zfb-build/tests/bundler_default_plugins.rs
+++ b/crates/zfb-build/tests/bundler_default_plugins.rs
@@ -322,6 +322,8 @@ fn make_input(
             cjk_friendly: true,
         plugin_alias_entries: Vec::new(),
         plugin_virtual_modules: Vec::new(),
+        worker_only_routes: None,
+        bundle_basename: None,
     }
 }
 

--- a/crates/zfb-build/tests/bundler_exact_match_resolution.rs
+++ b/crates/zfb-build/tests/bundler_exact_match_resolution.rs
@@ -132,6 +132,8 @@ fn make_input(
         cjk_friendly: true,
         plugin_alias_entries,
         plugin_virtual_modules,
+        worker_only_routes: None,
+        bundle_basename: None,
     }
 }
 

--- a/crates/zfb-build/tests/bundler_integration.rs
+++ b/crates/zfb-build/tests/bundler_integration.rs
@@ -203,6 +203,8 @@ fn end_to_end_bundles_aliases_mdx_islands_and_define() {
             cjk_friendly: true,
         plugin_alias_entries: Vec::new(),
         plugin_virtual_modules: Vec::new(),
+        worker_only_routes: None,
+        bundle_basename: None,
     };
 
     let out = bundle(input).expect("end-to-end bundle should succeed");

--- a/crates/zfb-build/tests/bundler_resolve_links.rs
+++ b/crates/zfb-build/tests/bundler_resolve_links.rs
@@ -162,6 +162,8 @@ fn make_input_with_resolve(
         cjk_friendly: true,
         plugin_alias_entries: Vec::new(),
         plugin_virtual_modules: Vec::new(),
+        worker_only_routes: None,
+        bundle_basename: None,
     }
 }
 
@@ -209,6 +211,8 @@ fn make_input_without_resolve(
             cjk_friendly: true,
         plugin_alias_entries: Vec::new(),
         plugin_virtual_modules: Vec::new(),
+        worker_only_routes: None,
+        bundle_basename: None,
     }
 }
 

--- a/crates/zfb-build/tests/bundler_strip_md_ext.rs
+++ b/crates/zfb-build/tests/bundler_strip_md_ext.rs
@@ -139,6 +139,8 @@ fn make_input(
             cjk_friendly: true,
         plugin_alias_entries: Vec::new(),
         plugin_virtual_modules: Vec::new(),
+        worker_only_routes: None,
+        bundle_basename: None,
     }
 }
 

--- a/crates/zfb-build/tests/embedded_v8_snapshot_e2e.rs
+++ b/crates/zfb-build/tests/embedded_v8_snapshot_e2e.rs
@@ -106,6 +106,8 @@ fn make_mock_input(tmp: &tempfile::TempDir, snapshot_json: Option<String>) -> Bu
         cjk_friendly: true,
         plugin_alias_entries: Vec::new(),
         plugin_virtual_modules: Vec::new(),
+        worker_only_routes: None,
+        bundle_basename: None,
     }
 }
 

--- a/crates/zfb-build/tests/integration_e2e_routing_rendering.rs
+++ b/crates/zfb-build/tests/integration_e2e_routing_rendering.rs
@@ -324,6 +324,8 @@ fn build_bundle(
             cjk_friendly: true,
         plugin_alias_entries: Vec::new(),
         plugin_virtual_modules: Vec::new(),
+        worker_only_routes: None,
+        bundle_basename: None,
     };
 
     let output = bundle(input).expect("bundle should succeed for fixture project");

--- a/crates/zfb-build/tests/migration_fixes_integration_confirm.rs
+++ b/crates/zfb-build/tests/migration_fixes_integration_confirm.rs
@@ -430,6 +430,8 @@ fn make_full_fixture_input(
         cjk_friendly: true,
         plugin_alias_entries: Vec::new(),
         plugin_virtual_modules: Vec::new(),
+        worker_only_routes: None,
+        bundle_basename: None,
     }
 }
 

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -1006,6 +1006,20 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
         .collect();
     ensure_no_ssr_without_adapter(&adapter, &ssr_route_refs)?;
 
+    // Capture the SSR route key set for the deploy-adapter's runtime-only
+    // bundle pass (zfb#283). The set is computed from the same source as
+    // `ssr_route_refs` above; keeping it as an owned `BTreeSet` lets the
+    // borrow above end before the runtime bundle (built much later in the
+    // function) consumes the data. The set is keyed by the same
+    // `RouteUniverseEntry::route_key` that `BundlerInput::worker_only_routes`
+    // filters against (`RouteEntry::entry_key`); both are the route
+    // template string, so the filter matches by exact key.
+    let ssr_route_keys_for_runtime_bundle: std::collections::BTreeSet<String> = static_routes
+        .iter()
+        .filter(|entry| !prerender_map.get(&entry.route_key).copied().unwrap_or(true))
+        .map(|entry| entry.route_key.clone())
+        .collect();
+
     // Fail fast if the runtime npm package isn't on disk — the renderer
     // will fail later anyway, but we can give the user an actionable
     // hint right at build start.
@@ -1220,6 +1234,17 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
     } else {
         _embedded_esbuild_handle = None;
     }
+    // Snapshot the bundler input before consuming it so the runtime-only
+    // bundle pass (zfb#283) can run later in this function with the same
+    // shadow setup / esbuild handle / node_modules / plugin wiring, just
+    // narrowed to SSR-only routes via `worker_only_routes`.
+    //
+    // Clones are cheap relative to the bundle step itself; the heavy
+    // tempdir handles (`_embedded_esbuild_handle`, `_embedded_nm_handle`)
+    // live in this function's scope and are NOT cloned — the cloned
+    // `esbuild_binary` / `node_modules_dir` `PathBuf`s reference paths
+    // those handles keep alive.
+    let bundler_input_for_runtime = bundler_input.clone();
     let bundler_out = runner
         .bundle(bundler_input)
         .context("bundler step failed")?;
@@ -1336,19 +1361,34 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
 
     // 3. Adapter dispatch.
     //
-    // When an adapter is configured, hand the same ESM bundle to the
-    // adapter package's CLI so it can wrap it into a deploy-target-
-    // shaped entry (e.g. `dist/_worker.js` for Cloudflare Pages). The
-    // current contract feeds the WHOLE bundle (SSG + SSR routes) to
-    // the adapter — for Cloudflare Pages this is fine because static
-    // assets short-circuit the worker, so SSG routes in the worker
-    // bundle are dead code on the request path. A future optimization
-    // could trim the bundle to SSR-only routes; tracked as a follow-up
-    // (see this module's docs).
+    // When an adapter is configured, run a SECOND bundle pass narrowed to
+    // SSR-only routes (zfb#283) and hand that smaller bundle to the
+    // adapter. Rationale: deploy targets like Cloudflare Pages serve
+    // prerendered routes through a static-asset server (ASSETS first,
+    // inner worker on 404). SSG route code in the inner worker bundle is
+    // dead code on the request path AND counts against the platform's
+    // worker-size cap (CF Pages: 3 MiB free / 10 MiB paid). Trimming the
+    // bundle to SSR-only routes via `BundlerInput::worker_only_routes`
+    // makes prerendered routes unreachable from the synthetic entry; the
+    // resulting esbuild output is much smaller after tree-shake.
+    //
+    // The full SSG bundle from the first pass (`bundler_out.bundle_path`)
+    // is still needed by `render_all` above for SSG render. After this
+    // function returns, both bundles live under `.zfb-build/` but only
+    // the runtime-narrowed one reaches the adapter (and therefore `dist/`).
     if !adapter.is_none() {
+        let mut runtime_bundler_input = bundler_input_for_runtime;
+        runtime_bundler_input.worker_only_routes =
+            Some(ssr_route_keys_for_runtime_bundle);
+        runtime_bundler_input.bundle_basename =
+            Some("bundle-runtime.mjs".to_string());
+        let runtime_bundler_out = runner
+            .bundle(runtime_bundler_input)
+            .context("runtime-only bundler step (for deploy adapter) failed")?;
+
         let adapter_in = AdapterBundleInput {
             project_root: project_root.to_path_buf(),
-            input_bundle: bundler_out.bundle_path.clone(),
+            input_bundle: runtime_bundler_out.bundle_path.clone(),
             outdir: outdir.to_path_buf(),
         };
         let adapter_out: AdapterBundleOutput =

--- a/crates/zfb/tests/framework_packages_no_pnpm.rs
+++ b/crates/zfb/tests/framework_packages_no_pnpm.rs
@@ -178,6 +178,8 @@ fn embedded_extraction_resolves_framework_imports_with_no_consumer_node_modules(
         cjk_friendly: true,
         plugin_alias_entries: Vec::new(),
         plugin_virtual_modules: Vec::new(),
+        worker_only_routes: None,
+        bundle_basename: None,
     };
 
     let out = bundle(input).expect(


### PR DESCRIPTION
## Summary

- Closes #283.
- Trim the runtime bundle shipped to deploy adapters (e.g. Cloudflare Pages `_zfb_inner.mjs`) to SSR-only routes. The full SSG bundle is still produced and consumed by `render_all`; only the deploy artifact is narrowed.
- Opt-in via a new `BundlerInput::worker_only_routes` field. Every existing call site (dev loop, downstream consumers without an adapter, the test suite) is unchanged by passing the default `None`.
- A second `bundle()` call runs at adapter dispatch time with the filter + a `bundle_basename: "bundle-runtime.mjs"` override so both bundles coexist in `.zfb-build/`.

## Why

`crates/zfb/src/commands/build.rs:1342-1347` already documented this as a known follow-up:

> "The current contract feeds the WHOLE bundle (SSG + SSR routes) to the adapter — for Cloudflare Pages this is fine because static assets short-circuit the worker, so SSG routes in the worker bundle are dead code on the request path. A future optimization could trim the bundle to SSR-only routes; tracked as a follow-up."

On a real consumer (zudolab/zzmod, ~310 pages, ~2,000 product images with blurhash data URIs), the unfiltered bundle hits 24 MB. CF Pages rejects with the 3 MiB Worker-size cap.

## What changed

- `crates/zfb-build/src/bundler.rs`:
  - `BundlerInput`: new `worker_only_routes: Option<BTreeSet<String>>` (filter keyed by `RouteEntry::entry_key`) and `bundle_basename: Option<String>` (defaults to `"bundle.mjs"`).
  - `bundle()`: when the filter is set, narrow `routes`/`content_imports` passed to `write_entry_module` and force `content_snapshot_json` to `None`. The full `routes` vec is preserved on `BundlerOutput.manifest.routes` so post-build bookkeeping keeps seeing every discovered route — the filter is local to the entry emission.
  - 3 new unit tests covering defaults, basename override, and manifest preservation under filter.
- `crates/zfb/src/commands/build.rs`:
  - Capture the SSR route key set right after `prerender_map` is built.
  - Clone the `BundlerInput` before the first `bundle()` consumes it.
  - At adapter dispatch, run a second `bundle()` with `worker_only_routes` + `bundle_basename: "bundle-runtime.mjs"` and hand THAT path to `run_adapter_bundle_with`.
- `crates/zfb-build/tests/*.rs` × 8: add `worker_only_routes: None` and `bundle_basename: None` to each manual `BundlerInput { … }` literal. Behavior-neutral.

## Measurement on the consumer that surfaced this

zudolab/zzmod `base/zfb` HEAD `6657e2af`:

| | dist/_zfb_inner.mjs | dist HTML files | wrangler pages deploy |
|---|---:|---:|---|
| before | 24 MB | 314 | fails — 3 MiB cap |
| after | 1.01 MiB | 314 | succeeds |

Inline blurhash `data:image/png;base64,...` occurrences in `_zfb_inner.mjs`: 2,003 → 0. All 10 SSR API routes (`pages/api/*.tsx`) confirmed reachable in the runtime bundle.

## Test plan

- [x] `cargo test -p zfb-build` — 230 tests pass (3 new + 227 existing + 0 ignored without flag-gating).
- [x] `cargo test -p zfb --lib` — 237 tests pass.
- [x] End-to-end on a real consumer: `pnpm zfb:build` clean, `wrangler pages deploy ./dist --branch=expreview/zfb-ja` succeeds.

## Out of scope / follow-ups

- Sharing the shadow tree between SSG + runtime bundle passes (build-perf optimization).
- Per-content `getCollection(...)` static analysis to keep snapshot slices that surviving SSR routes actually use. Initial cut drops the snapshot entirely from the runtime bundle when the filter is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
