### PR TITLE
feat(plugins): expose prerender on postBuild route manifest

### DIFF
--- a/crates/zfb-build/src/plugin_runner.rs
+++ b/crates/zfb-build/src/plugin_runner.rs
@@ -112,6 +112,13 @@ pub struct PluginSpec {
 /// For static routes `params` is absent. For dynamic / catchall routes
 /// `params` contains the bound parameter values: scalar strings for
 /// `[slug]` segments, string arrays for `[...rest]` segments.
+///
+/// `prerender` mirrors the page module's `export const prerender = ...`:
+/// `true` for SSG routes that produced an on-disk HTML/asset under
+/// `outDir`, `false` for SSR routes whose response is computed by the
+/// runtime adapter and has no on-disk artifact. Plugins that emit
+/// indexes of "URLs the build wrote to disk" (sitemap.xml,
+/// search-index.json, etc.) should filter `r.prerender !== false`.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct PostBuildRouteEntry {
@@ -124,6 +131,11 @@ pub struct PostBuildRouteEntry {
     /// Source page module, relative to the project root,
     /// e.g. `pages/blog/[slug].tsx`.
     pub source: String,
+    /// True when the page is prerendered to disk (default / SSG);
+    /// false when the page exports `prerender = false` and is served
+    /// by the runtime adapter (SSR). Populated for both static and
+    /// dynamic routes.
+    pub prerender: bool,
     /// Bound route params. `None` for static routes. Dynamic params are
     /// `String` scalars; catchall params are `Vec<String>`.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1422,6 +1434,7 @@ mod tests {
                 output: "index.html".to_string(),
                 extension: "html".to_string(),
                 source: "pages/index.tsx".to_string(),
+                prerender: true,
                 params: None,
             }],
         };
@@ -1505,6 +1518,7 @@ mod tests {
                     output: "blog/hello-world/index.html".to_string(),
                     extension: "html".to_string(),
                     source: "pages/blog/[slug].tsx".to_string(),
+                    prerender: true,
                     params: Some(dyn_params),
                 },
                 PostBuildRouteEntry {
@@ -1512,6 +1526,7 @@ mod tests {
                     output: "docs/a/b/index.html".to_string(),
                     extension: "html".to_string(),
                     source: "pages/docs/[...rest].tsx".to_string(),
+                    prerender: true,
                     params: Some(catchall_params),
                 },
                 PostBuildRouteEntry {
@@ -1519,6 +1534,7 @@ mod tests {
                     output: "sitemap.xml".to_string(),
                     extension: "xml".to_string(),
                     source: "pages/sitemap.xml.tsx".to_string(),
+                    prerender: true,
                     params: None,
                 },
             ],
@@ -1553,5 +1569,94 @@ mod tests {
         assert_eq!(xml_r["output"], "sitemap.xml");
         assert!(xml_r.get("params").is_none() || xml_r["params"].is_null(),
             "non-HTML static route must not carry params, got: {}", xml_r);
+
+        // prerender field is present on all routes and serialises as a
+        // boolean (not omitted, not null).
+        for r in routes {
+            assert!(r["prerender"].is_boolean(),
+                "prerender must be a boolean, got: {}", r);
+        }
+    }
+
+    /// Mixed SSG + SSR routes round-trip through the JS plugin boundary
+    /// with the `prerender` field preserved on each entry. Locks the new
+    /// contract: SSG (`prerender = true`) and SSR (`prerender = false`)
+    /// stay distinguishable end-to-end so consumer plugins can filter
+    /// `r.prerender !== false` to enumerate only on-disk URLs.
+    #[tokio::test]
+    async fn post_build_route_manifest_preserves_prerender_field() {
+        if !host_node_available() {
+            eprintln!("skipping: node not on PATH");
+            return;
+        }
+        let tmp = tempfile::tempdir().unwrap();
+        let plugin_path = tmp.path().join("prerender-probe.mjs");
+        let marker = tmp.path().join("routes.json");
+        let plugin_src = format!(
+            r#"
+            import {{ writeFileSync }} from "node:fs";
+            export default {{
+              name: "prerender-probe",
+              postBuild(ctx) {{
+                writeFileSync({marker:?}, JSON.stringify(ctx.routes));
+              }},
+            }};
+            "#,
+            marker = marker.to_string_lossy().to_string(),
+        );
+        tokio::fs::write(&plugin_path, plugin_src).await.unwrap();
+        let module_url = file_url_for_test(&plugin_path);
+        let host = PluginHost::spawn(
+            vec![PluginSpec {
+                name: "prerender-probe".into(),
+                module: module_url,
+                options: serde_json::json!({}),
+            }],
+            None,
+        )
+        .await
+        .expect("host spawns");
+
+        let manifest = PostBuildRouteManifest {
+            routes: vec![
+                PostBuildRouteEntry {
+                    url: "/".to_string(),
+                    output: "index.html".to_string(),
+                    extension: "html".to_string(),
+                    source: "pages/index.tsx".to_string(),
+                    prerender: true,
+                    params: None,
+                },
+                PostBuildRouteEntry {
+                    url: "/api/search".to_string(),
+                    output: "api/search/index.html".to_string(),
+                    extension: "html".to_string(),
+                    source: "pages/api/search.tsx".to_string(),
+                    prerender: false,
+                    params: None,
+                },
+            ],
+        };
+        let ctx = BuildHookContext {
+            project_root: tmp.path().to_path_buf(),
+            out_dir: tmp.path().join("dist"),
+            config: serde_json::json!({}),
+            routes: Some(manifest),
+        };
+        host.run_post_build(&ctx).await.expect("postBuild ok");
+        host.shutdown().await.ok();
+
+        let json: serde_json::Value =
+            serde_json::from_str(&tokio::fs::read_to_string(&marker).await.unwrap()).unwrap();
+        let routes = json["routes"].as_array().unwrap();
+        assert_eq!(routes.len(), 2);
+
+        let ssg = routes.iter().find(|r| r["url"] == "/").unwrap();
+        assert_eq!(ssg["prerender"], serde_json::json!(true),
+            "SSG route must have prerender=true, got: {}", ssg);
+
+        let ssr = routes.iter().find(|r| r["url"] == "/api/search").unwrap();
+        assert_eq!(ssr["prerender"], serde_json::json!(false),
+            "SSR route must have prerender=false, got: {}", ssr);
     }
 }

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -1300,7 +1300,7 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
         manifest: bundler_out.manifest.clone(),
         dist_dir: outdir.to_path_buf(),
         route_universe: static_routes,
-        prerender_map,
+        prerender_map: prerender_map.clone(),
         backend,
         request_timeout: None,
         // S4: inject the stable URLs for any asset slot that produced
@@ -1431,13 +1431,19 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
     // - statically-expanded dynamic routes (params from `expansion`),
     // - runtime-expanded dynamic routes (params from `runtime_expansion`).
     //
-    // Only routes that actually appear in the renderer's ssg_files_written
-    // (i.e. emitted to disk) are included, to avoid surfacing SSR-only pages.
+    // The manifest now includes BOTH prerendered (SSG) routes — which
+    // appear in `render_out.ssg_files_written` — AND SSR routes (those
+    // with `export const prerender = false`), which have no on-disk
+    // artifact but ARE valid runtime URLs. Each entry carries a
+    // `prerender` boolean derived from the build-time `prerender_map` so
+    // plugins that should only enumerate on-disk URLs (sitemap.xml,
+    // search-index.json) can filter `r.prerender !== false`.
     let manifest = build_post_build_manifest(
         routes,
         project_root,
         &expansion.resolved_with_params,
         &runtime_expansion.resolved_with_params,
+        &prerender_map,
     );
 
     Ok((render_out.ssg_files_written.len(), manifest))
@@ -1448,11 +1454,18 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
 /// output path is a plain HTML or non-HTML page are included (adapter-specific
 /// artefacts like `_worker.js` are not). The manifest is sorted by `url` for
 /// byte-stable output across runs (#262 AC: "Manifest byte-stable across runs").
+///
+/// `prerender_map` is the same build-time map produced by
+/// [`crate::render_pipeline::build_prerender_map`] and keyed by
+/// `route_key` (the route template). Each emitted [`PostBuildRouteEntry`]
+/// carries the resolved `prerender` boolean so consumer plugins can
+/// distinguish SSG (on-disk) and SSR routes.
 fn build_post_build_manifest(
     routes: &[zfb_router::Route],
     project_root: &Path,
     static_expansion_params: &[DynamicResolvedEntry],
     runtime_expansion_params: &[DynamicResolvedEntry],
+    prerender_map: &std::collections::BTreeMap<String, bool>,
 ) -> zfb_build::PostBuildRouteManifest {
     use std::collections::BTreeMap;
     use zfb_build::{PostBuildParamValue, PostBuildRouteEntry, PostBuildRouteManifest};
@@ -1478,11 +1491,16 @@ fn build_post_build_manifest(
             .unwrap_or(&route.source_path)
             .to_string_lossy()
             .into_owned();
+        // Default to SSG (`prerender = true`) when the map has no entry —
+        // matches the rest of the build's interpretation of a missing
+        // `export const prerender` (e.g. lines 1001 / 1019 above).
+        let prerender = prerender_map.get(&template).copied().unwrap_or(true);
         entries.push(PostBuildRouteEntry {
             url: template,
             output: output_path.to_string_lossy().into_owned(),
             extension: ext,
             source,
+            prerender,
             params: None,
         });
     }
@@ -1515,11 +1533,17 @@ fn build_post_build_manifest(
             Some(map)
         };
 
+        let prerender = prerender_map
+            .get(&dyn_entry.route_key)
+            .copied()
+            .unwrap_or(true);
+
         entries.push(PostBuildRouteEntry {
             url: dyn_entry.url_path.clone(),
             output: dyn_entry.output_path.to_string_lossy().into_owned(),
             extension: dyn_entry.extension.clone(),
             source,
+            prerender,
             params,
         });
     }

--- a/crates/zfb/src/render_pipeline.rs
+++ b/crates/zfb/src/render_pipeline.rs
@@ -381,6 +381,11 @@ pub struct DynamicResolvedEntry {
     pub source_path: PathBuf,
     /// Output extension (`html`, `xml`, `rss`, …).
     pub extension: String,
+    /// Route template the resolved URL came from, e.g. `/blog/[slug]`.
+    /// Join key against the build-time `prerender_map` so the postBuild
+    /// manifest builder can populate `PostBuildRouteEntry::prerender`
+    /// for dynamic entries. Mirrors `RouteUniverseEntry::route_key`.
+    pub route_key: String,
     /// Resolved params for the URL.
     pub params: ResolvedRouteParams,
 }
@@ -544,6 +549,7 @@ fn try_expand_one(
             output_path,
             source_path: route.source_path.clone(),
             extension: extension.clone(),
+            route_key: route.template.clone(),
             params: ResolvedRouteParams { scalars, arrays },
         });
     }
@@ -935,6 +941,7 @@ fn resolve_json_paths(
             output_path,
             source_path: route.source_path.clone(),
             extension: extension.clone(),
+            route_key: route.template.clone(),
             params: ResolvedRouteParams { scalars, arrays },
         });
     }

--- a/packages/zfb/src/plugins.ts
+++ b/packages/zfb/src/plugins.ts
@@ -47,6 +47,16 @@ export type ZfbRouteEntry = {
   /** Source page module relative to the project root, e.g. `pages/blog/[slug].tsx`. */
   source: string;
   /**
+   * `true` when the page is prerendered to disk (default / SSG); `false`
+   * when the page exports `prerender = false` and is served by the
+   * runtime adapter (SSR — no on-disk artifact under `outDir`).
+   *
+   * Indexes that enumerate on-disk URLs (sitemap.xml, search-index.json,
+   * etc.) should filter `r.prerender !== false` to avoid surfacing SSR
+   * routes that have no static output.
+   */
+  prerender: boolean;
+  /**
    * Bound route parameters. Absent for static routes.
    * Dynamic (`[slug]`) params are string scalars; catchall (`[...rest]`)
    * params are string arrays.


### PR DESCRIPTION
- linked downstream issue
  - https://github.com/zudolab/zzmod/issues/111

---

## Summary

\`ctx.routes.routes\` in the postBuild plugin hook (#262) exposes one entry per emitted URL but with no signal indicating whether the entry is **SSG** (prerendered to disk under \`outDir\`) or **SSR** (\`export const prerender = false\`, served by the runtime adapter, no on-disk artifact).

This is fine for plugins that don't care about the partition, but indexes that enumerate *only URLs the build wrote to disk* — sitemap.xml, search-index.json, etc. — have no clean way to filter SSR routes out.

**Downstream symptom (zzmod consumer):** 9 SSR routes (8 \`/api/*\` JSON endpoints + a \`/zfb-hello/\` spike route) wrongly included in \`dist/sitemap.xml\` with a trailing-slash normalisation the runtime router rejected. See zudolab/zzmod#111 for the full surface and the failure-mode trace.

## Change

Additive on both sides of the JS↔Rust boundary:

| Layer | What's added |
|---|---|
| Rust — \`crates/zfb-build/src/plugin_runner.rs\` | \`PostBuildRouteEntry.prerender: bool\` |
| Rust — \`crates/zfb/src/render_pipeline.rs\` | \`DynamicResolvedEntry.route_key: String\` (join key against \`prerender_map\` for dynamic entries) |
| Rust — \`crates/zfb/src/commands/build.rs\` | \`build_post_build_manifest\` now takes \`&prerender_map\` and populates the new field; static routes look up by \`Route::template()\`, dynamic by the new \`route_key\` |
| TS — \`packages/zfb/src/plugins.ts\` | \`ZfbRouteEntry.prerender: boolean\` with a usage hint that plugins enumerating on-disk URLs should filter \`r.prerender !== false\` |

Missing-entry default is \`true\` (SSG) — matches the existing interpretation of a missing \`export const prerender\` (see \`build.rs:1001\` / \`build.rs:1019\`).

## Test plan

- [x] \`cargo test --workspace --lib\` (zfb-build: 196 + 9, zfb: 237, others all clean)
- [x] \`pnpm test\` in \`packages/zfb\` — 130/130 pass
- [x] \`pnpm typecheck\` clean
- [x] \`pnpm format:check:ts\` clean
- [x] New \`plugin_runner.rs\` test \`post_build_route_manifest_preserves_prerender_field\` locks the contract end-to-end through the JS plugin boundary — both \`prerender: true\` and \`prerender: false\` round-trip through \`ctx.routes.routes\` as proper booleans
- [x] Existing \`post_build_route_manifest_dynamic_and_catchall_params\` test extended to assert the new field is a boolean on every emitted route

## Compatibility

- Additive — existing consumers that don't read \`prerender\` see no behaviour change.
- No JSON-shape regression: the field is always serialised (Rust \`bool\`, not \`Option<bool>\`), so a consumer that reads it never has to handle \`undefined\`.
- Default-when-map-missing is \`true\` so an upstream regression in \`prerender_map\` construction would surface as "everything marked SSG" rather than as a panic — defensive in the same way the runtime-bundle SSR-key filter is.

## Why this is needed in-wave

Per the zzmod migration's CLAUDE.md "upstream zfb fixes are in-wave-scope (no external users yet)" policy. The zzmod consumer's \`plugins/sitemap.mjs\` is the postBuild plugin that needs to filter — without this field it can only fall back to whack-a-mole URL-prefix exclusions, which doesn't survive Wave 13 adding more SSR routes.

Closes upstream-side support for zudolab/zzmod#111.

🤖 Generated with [Claude Code](https://claude.com/claude-code)