### PR TITLE
feat(content): CollectionDef include / exclude / idStripSuffix filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,6 +317,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1333,6 +1343,19 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "gzip-header"
@@ -4900,6 +4923,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "fs2",
+ "globset",
  "hex",
  "lol_html",
  "reqwest",
@@ -4928,6 +4952,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "garde",
+ "globset",
  "hex",
  "markdown",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ garde = { version = "0.22", features = ["derive"] }
 tempfile = "3"
 walkdir = "2"
 async-trait = "0.1"
+# Glob pattern matching for content-collection include/exclude filters.
+# `globset` is the BurntSushi crate used by ripgrep — single GlobSet
+# compiles many patterns into one matcher.
+globset = "0.4"
 
 # SWC umbrella crate. Pinning the major version here is the project's
 # single source of truth — both `zfb-render` (TSX→JS pipeline) and

--- a/crates/zfb-build/Cargo.toml
+++ b/crates/zfb-build/Cargo.toml
@@ -39,6 +39,11 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 walkdir = { workspace = true }
+# Glob filter for the bundler's parallel collection walk. MUST match the
+# zfb-content walker's filter shape byte-for-byte so the snapshot's
+# `module_specifier` and the bridge map key agree on which files were
+# kept (and on what slug each one got, post `idStripSuffix`).
+globset = { workspace = true }
 # Sub 3 / #108: `process` + `io-util` + `fs` add the long-lived plugin
 # host subprocess with newline-delimited JSON over stdio. `process`
 # brings `tokio::process::Command`, `io-util` brings `AsyncBufReadExt`

--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -157,14 +157,29 @@ pub struct ContentCollectionSpec {
     pub name: String,
     /// Source directory (project-relative or absolute).
     pub root: PathBuf,
+    /// Optional include globs (Astro-style). MUST match
+    /// `zfb_content::CollectionConfig::include` exactly so the snapshot ↔
+    /// bridge keys agree on which files survive.
+    pub include: Option<Vec<String>>,
+    /// Optional exclude globs. MUST match the snapshot side.
+    pub exclude: Option<Vec<String>>,
+    /// Optional suffix to strip from the `<slug>` segment of the
+    /// `mdx://` / `tsx://` specifier the bridge installer emits for
+    /// each kept entry. MUST match the snapshot side — otherwise
+    /// every `globalThis.__zfb.content.get(spec)` misses.
+    pub id_strip_suffix: Option<String>,
 }
 
 impl ContentCollectionSpec {
-    /// Convenience constructor.
+    /// Convenience constructor (no filters). Use struct-init shorthand
+    /// to set the filter fields directly when needed.
     pub fn new(name: impl Into<String>, root: impl Into<PathBuf>) -> Self {
         Self {
             name: name.into(),
             root: root.into(),
+            include: None,
+            exclude: None,
+            id_strip_suffix: None,
         }
     }
 }
@@ -801,6 +816,9 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
                 input.toc.clone(),
                 input.external_links.as_ref(),
                 input.cjk_friendly,
+                col.include.as_deref(),
+                col.exclude.as_deref(),
+                col.id_strip_suffix.as_deref(),
                 &mut broken,
             )
             .with_context(|| {
@@ -1466,6 +1484,7 @@ struct ContentImport {
 /// A missing source root is non-fatal — the caller may have a stale
 /// config entry pointing at a deleted directory; the build should
 /// proceed with zero entries from that collection rather than aborting.
+#[allow(clippy::too_many_arguments)]
 fn materialise_collection(
     src: &Path,
     dest: &Path,
@@ -1479,6 +1498,9 @@ fn materialise_collection(
     toc: Option<zfb_content::TocConfig>,
     external_links: Option<&(zfb_content::ExternalLinksConfig, Option<String>)>,
     cjk_friendly: bool,
+    include: Option<&[String]>,
+    exclude: Option<&[String]>,
+    id_strip_suffix: Option<&str>,
     broken_links_out: &mut Vec<(String, String)>,
 ) -> Result<()> {
     if !src.exists() {
@@ -1486,6 +1508,33 @@ fn materialise_collection(
     }
     fs::create_dir_all(dest)
         .with_context(|| format!("create dir {}", dest.display()))?;
+
+    // Compile the include / exclude globs once per collection. The
+    // shared `CollectionFilter` MUST match `CollectionConfig::*` on the
+    // snapshot side byte-for-byte — both surfaces feed the same JSON
+    // bridge, so any divergence in which files survive (or which slug
+    // each gets) silently turns every consumer-side `getCollection` /
+    // `<Content />` lookup into a `<pre data-zfb-content-fallback>`
+    // block.
+    let filter = zfb_content::collection::CollectionFilter::new(
+        include,
+        exclude,
+        id_strip_suffix,
+    )
+    .with_context(|| {
+        format!(
+            "bundler: failed to compile collection filter for `{}`",
+            collection_name
+        )
+    })?;
+    let has_glob_filter = include.map(|p| !p.is_empty()).unwrap_or(false)
+        || exclude.map(|p| !p.is_empty()).unwrap_or(false);
+    // Re-derive the same suffix `CollectionFilter` would have stored
+    // (empty / whitespace → None) so the bundler's specifier rewrite
+    // and the walker's rewrite agree on whether to strip.
+    let strip_suffix = id_strip_suffix
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
 
     // Hoist a single `Pipeline::with_defaults_and_theme()` outside the
     // walk loop so the seven default plugins fire on every collection
@@ -1557,6 +1606,28 @@ fn materialise_collection(
         }
         if !entry.file_type().is_file() {
             continue;
+        }
+
+        // Apply include / exclude globs to recognised content extensions
+        // only (md / mdx / tsx). Non-content siblings (images, css,
+        // json, …) pass through unchanged — they live in the shadow
+        // tree purely for esbuild's resolver and never reach the
+        // snapshot or bridge map, so filtering them would just diverge
+        // from the walker's coverage.
+        let is_content_ext = matches!(
+            from.extension().and_then(|s| s.to_str()),
+            Some("md") | Some("mdx") | Some("tsx")
+        );
+        if is_content_ext && has_glob_filter {
+            let rel_posix = path_to_posix_string(rel);
+            if !filter.matches_relative(&rel_posix) {
+                // Filtered out — neither materialise the shadow file
+                // nor record a bridge import. The walker on the
+                // snapshot side reaches the identical decision via
+                // `CollectionFilter::matches`, keeping the two
+                // surfaces in lock-step.
+                continue;
+            }
         }
 
         let is_mdx = from.extension().and_then(|s| s.to_str()) == Some("mdx");
@@ -1644,8 +1715,19 @@ fn materialise_collection(
 
             let rel_str = path_to_posix_string(rel);
             let shadow_rel_path = format!("content/{}/{}", collection_name, rel_str);
+            // Apply `idStripSuffix` to the specifier's slug segment
+            // so the bundler's bridge-map key matches the snapshot's
+            // `EntrySnapshot::module_specifier` after stripping. The
+            // shared helper lives in `zfb-content` so both surfaces
+            // share one implementation — divergence here is what the
+            // snapshot↔bridge byte-for-byte invariant exists to
+            // prevent.
+            let specifier = zfb_content::collection::maybe_strip_specifier_suffix(
+                &compiled.specifier,
+                strip_suffix,
+            );
             imports.push(ContentImport {
-                specifier: compiled.specifier.clone(),
+                specifier,
                 shadow_rel_path,
             });
         } else {
@@ -2857,6 +2939,9 @@ mod tests {
             None,
             None,
             true,
+            None,
+            None,
+            None,
             &mut Vec::new(),
         )
         .unwrap();
@@ -2992,6 +3077,9 @@ mod tests {
             None,
             None,
             true,
+            None,
+            None,
+            None,
             &mut Vec::new(),
         )
         .unwrap();

--- a/crates/zfb-content/Cargo.toml
+++ b/crates/zfb-content/Cargo.toml
@@ -17,6 +17,11 @@ thiserror = { workspace = true }
 syntect = { workspace = true }
 garde = { workspace = true }
 
+# Glob matcher for the collection walker's include/exclude filters
+# (zzmod Wave 13 + CollectionDef filters). Same crate ripgrep uses;
+# one GlobSet compiles many patterns into one matcher.
+globset = { workspace = true }
+
 # Hashing for the per-module content hash that drives `mdx://` specifiers
 # and the in-memory compile cache. Same crate+version pair used by
 # `zfb-css::pipeline::hash_8` so the project speaks one hashing dialect.

--- a/crates/zfb-content/src/collection.rs
+++ b/crates/zfb-content/src/collection.rs
@@ -10,6 +10,7 @@ use std::fs;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
 
+use globset::{Glob, GlobSet, GlobSetBuilder};
 use serde::de::DeserializeOwned;
 use serde_json::Value as JsonValue;
 use sha2::{Digest, Sha256};
@@ -129,11 +130,205 @@ pub enum CollectionError {
     Schema { path: PathBuf, report: String },
     #[error("MDX compile error in {path}: {message}", path = path.display())]
     Mdx { path: PathBuf, message: String },
+    #[error("invalid collection filter glob {pattern:?}: {message}")]
+    BadGlob { pattern: String, message: String },
     #[error("multiple errors:\n{summary}")]
     Multiple {
         summary: String,
         errors: Vec<CollectionError>,
     },
+}
+
+/// Optional per-collection filter applied during the walk.
+///
+/// All three fields are independent and optional:
+///
+/// - `include`: keep an entry only if its path (relative to the
+///   collection root, forward-slash-normalised) matches at least one
+///   glob. `None` / empty means no include filtering.
+/// - `exclude`: drop an entry whose relative path matches any glob.
+///   Evaluated AFTER include.
+/// - `id_strip_suffix`: when an entry's derived slug ends with this
+///   string, strip the suffix from both [`Entry::slug`] and
+///   [`Entry::module_specifier`]. Other entries pass through unchanged.
+///
+/// Globs use the `globset` dialect (Unix-style, with `**` for
+/// recursive segment matching). Patterns are evaluated against the
+/// posix-style relative path, so a pattern like `subdir/*.mdx` works
+/// portably on Windows too.
+///
+/// A [`CollectionFilter::default`] / `Filter::none` value applies no
+/// filtering — equivalent to today's pre-filter walker behaviour.
+#[derive(Debug, Clone, Default)]
+pub struct CollectionFilter {
+    /// Pre-compiled `globset` matcher for include patterns. `None`
+    /// means "no include filter" (every entry passes the include
+    /// stage). An empty matcher should be expressed by passing `None`,
+    /// not an empty `GlobSet`.
+    include: Option<GlobSet>,
+    /// Pre-compiled `globset` matcher for exclude patterns.
+    exclude: Option<GlobSet>,
+    /// Suffix stripped from each kept entry's slug + module specifier.
+    id_strip_suffix: Option<String>,
+}
+
+impl CollectionFilter {
+    /// Construct a filter from raw inputs. Empty input vectors are
+    /// treated as `None` (no filtering at that stage). An empty
+    /// `id_strip_suffix` (after trimming) is treated as `None`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CollectionError::BadGlob`] when any pattern fails to
+    /// compile through `globset::Glob::new` (e.g. unbalanced brackets).
+    pub fn new(
+        include: Option<&[String]>,
+        exclude: Option<&[String]>,
+        id_strip_suffix: Option<&str>,
+    ) -> Result<Self, CollectionError> {
+        let include = compile_globset(include)?;
+        let exclude = compile_globset(exclude)?;
+        // Treat an empty / whitespace suffix as None — a stray empty
+        // string from a JSON config would otherwise no-op-strip every
+        // entry (since "foo".ends_with("") is true), which is a foot
+        // gun even though the resulting slug is unchanged.
+        let id_strip_suffix = id_strip_suffix
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned);
+        Ok(Self {
+            include,
+            exclude,
+            id_strip_suffix,
+        })
+    }
+
+    /// A no-op filter — `Default::default()` with an inherent name for
+    /// readability at call sites that mean "no filter".
+    #[must_use]
+    pub fn none() -> Self {
+        Self::default()
+    }
+
+    /// `true` when no filtering happens (every entry passes, no slug
+    /// rewriting). Lets fast paths skip the per-entry filter check.
+    #[must_use]
+    pub fn is_noop(&self) -> bool {
+        self.include.is_none() && self.exclude.is_none() && self.id_strip_suffix.is_none()
+    }
+
+    /// `true` when the relative path passes the include + exclude
+    /// stages. Paths must already be normalised to forward slashes.
+    fn matches(&self, rel_posix: &str) -> bool {
+        if let Some(inc) = &self.include {
+            if !inc.is_match(rel_posix) {
+                return false;
+            }
+        }
+        if let Some(exc) = &self.exclude {
+            if exc.is_match(rel_posix) {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Public flavour of [`Self::matches`] for the bundler's parallel
+    /// shadow-tree walk. Pass a POSIX-style (forward-slash) relative
+    /// path. The two surfaces share one matcher so the include /
+    /// exclude verdict per file is byte-identical on both sides.
+    #[must_use]
+    pub fn matches_relative(&self, rel_posix: &str) -> bool {
+        self.matches(rel_posix)
+    }
+
+    /// Borrow the suffix-strip rule for use by [`parse_entry`].
+    fn id_strip_suffix(&self) -> Option<&str> {
+        self.id_strip_suffix.as_deref()
+    }
+}
+
+fn compile_globset(patterns: Option<&[String]>) -> Result<Option<GlobSet>, CollectionError> {
+    let patterns = match patterns {
+        Some(p) if !p.is_empty() => p,
+        _ => return Ok(None),
+    };
+    let mut builder = GlobSetBuilder::new();
+    for pat in patterns {
+        let glob = Glob::new(pat).map_err(|e| CollectionError::BadGlob {
+            pattern: pat.clone(),
+            message: e.to_string(),
+        })?;
+        builder.add(glob);
+    }
+    let set = builder.build().map_err(|e| CollectionError::BadGlob {
+        pattern: patterns.join(","),
+        message: e.to_string(),
+    })?;
+    Ok(Some(set))
+}
+
+/// Render a relative path as a forward-slash POSIX string. The walker
+/// emits paths in `std::path::PathBuf` shape; globset patterns are
+/// authored against POSIX-style relative paths so a single pattern
+/// like `subdir/*.mdx` works portably across operating systems.
+fn rel_to_posix(rel: &Path) -> String {
+    let lossy = rel.to_string_lossy();
+    if std::path::MAIN_SEPARATOR == '/' {
+        lossy.into_owned()
+    } else {
+        lossy.replace(std::path::MAIN_SEPARATOR, "/")
+    }
+}
+
+/// Apply [`CollectionFilter::id_strip_suffix`] to a slug, returning the
+/// stripped slug when the suffix matches and the original otherwise.
+/// Pure helper — shared between the walker and the bundler's parallel
+/// shadow-tree pass so the two surfaces stay in lock-step.
+#[must_use]
+pub fn maybe_strip_slug_suffix<'a>(slug: &'a str, suffix: Option<&str>) -> &'a str {
+    match suffix {
+        Some(s) if !s.is_empty() => slug.strip_suffix(s).unwrap_or(slug),
+        _ => slug,
+    }
+}
+
+/// Apply [`CollectionFilter::id_strip_suffix`] to a `<scheme>://<col>/<slug>#<hash>`
+/// specifier, leaving the scheme, collection, and hash untouched.
+///
+/// Pure helper — shared with the bundler's bridge-import construction
+/// in `crates/zfb-build/src/bundler.rs` so the snapshot specifier and
+/// the bundler's bridge map key stay byte-identical after suffix
+/// stripping. The MDX/TSX `compile_mdx_to_jsx_module_cached` call site
+/// hashes JSX (not slug), so rewriting the slug segment is safe — the
+/// `#<hash8>` fragment stays stable.
+#[must_use]
+pub fn maybe_strip_specifier_suffix(specifier: &str, suffix: Option<&str>) -> String {
+    let suffix = match suffix {
+        Some(s) if !s.is_empty() => s,
+        _ => return specifier.to_string(),
+    };
+    // Format: `<scheme>://<col>/<slug>#<hash>`. We rewrite just the
+    // `<slug>` segment. Anything that doesn't parse to that shape is
+    // returned verbatim — defensive belt-and-braces.
+    let (scheme_and_path, hash) = match specifier.split_once('#') {
+        Some(pair) => pair,
+        None => return specifier.to_string(),
+    };
+    let (scheme, rest) = match scheme_and_path.split_once("://") {
+        Some(pair) => pair,
+        None => return specifier.to_string(),
+    };
+    let (col, slug) = match rest.split_once('/') {
+        Some(pair) => pair,
+        None => return specifier.to_string(),
+    };
+    let stripped_slug = slug.strip_suffix(suffix).unwrap_or(slug);
+    if stripped_slug.as_ptr() == slug.as_ptr() && stripped_slug.len() == slug.len() {
+        // No change — return the original string to avoid allocating.
+        return specifier.to_string();
+    }
+    format!("{scheme}://{col}/{stripped_slug}#{hash}")
 }
 
 /// Walk a collection directory, parsing + validating each `.md`, `.mdx`,
@@ -162,7 +357,7 @@ pub fn walk_collection<T>(
 where
     T: DeserializeOwned + garde::Validate<Context = ()>,
 {
-    walk_collection_with_cache(dir, None, pipeline)
+    walk_collection_with_cache_and_filter(dir, None, pipeline, &CollectionFilter::none())
 }
 
 /// Walk a collection directory like [`walk_collection`], reusing `cache`
@@ -190,7 +385,37 @@ where
 pub fn walk_collection_with_cache<T>(
     dir: &Path,
     cache: Option<&MdxModuleCache>,
+    pipeline: Option<&mut Pipeline>,
+) -> Result<Vec<Entry<T>>, CollectionError>
+where
+    T: DeserializeOwned + garde::Validate<Context = ()>,
+{
+    walk_collection_with_cache_and_filter(dir, cache, pipeline, &CollectionFilter::none())
+}
+
+/// Walk a collection like [`walk_collection_with_cache`], but apply the
+/// supplied [`CollectionFilter`] to the candidate file list AND to the
+/// per-entry slug + module specifier.
+///
+/// The filter is applied at two distinct moments:
+///
+/// 1. After [`collect_collection_files`] returns its candidate list and
+///    BEFORE `parse_entry` runs. Files whose POSIX-style relative path
+///    fails the include / exclude check are dropped without being read
+///    from disk.
+/// 2. Inside `parse_entry`, after the slug is derived from the relative
+///    path, the configured `id_strip_suffix` is applied to both
+///    [`Entry::slug`] and the `<scheme>://<col>/<slug>#<hash>` segment
+///    of [`Entry::module_specifier`].
+///
+/// Pass `CollectionFilter::none()` (or use the legacy
+/// [`walk_collection_with_cache`] helper) to get the pre-filter walker
+/// behaviour byte-for-byte.
+pub fn walk_collection_with_cache_and_filter<T>(
+    dir: &Path,
+    cache: Option<&MdxModuleCache>,
     mut pipeline: Option<&mut Pipeline>,
+    filter: &CollectionFilter,
 ) -> Result<Vec<Entry<T>>, CollectionError>
 where
     T: DeserializeOwned + garde::Validate<Context = ()>,
@@ -201,6 +426,17 @@ where
         source: e,
     })?;
     files.sort();
+
+    // Apply include + exclude globs against POSIX-normalised relative
+    // paths. The fast-path skips the per-entry check entirely when no
+    // filtering is configured so today's byte-for-byte behaviour is
+    // preserved for every existing call site.
+    if filter.include.is_some() || filter.exclude.is_some() {
+        files.retain(|p| {
+            let rel = p.strip_prefix(dir).unwrap_or(p);
+            filter.matches(&rel_to_posix(rel))
+        });
+    }
 
     let mut entries: Vec<Entry<T>> = Vec::new();
     let mut errors: Vec<CollectionError> = Vec::new();
@@ -232,7 +468,7 @@ where
                 p.set_resolve_links_source_dir(parent.to_path_buf());
             }
         }
-        match parse_entry::<T>(dir, &path, cache, pipeline.as_deref_mut()) {
+        match parse_entry::<T>(dir, &path, cache, pipeline.as_deref_mut(), filter) {
             Ok(entry) => entries.push(entry),
             Err(e) => errors.push(e),
         }
@@ -466,6 +702,7 @@ fn parse_entry<T>(
     path: &Path,
     cache: Option<&MdxModuleCache>,
     pipeline: Option<&mut Pipeline>,
+    filter: &CollectionFilter,
 ) -> Result<Entry<T>, CollectionError>
 where
     T: DeserializeOwned + garde::Validate<Context = ()>,
@@ -534,6 +771,15 @@ where
     } = uf;
 
     let (collection_seg, slug_seg) = collection_and_slug_from_path(path);
+    // Apply `idStripSuffix` to BOTH the user-facing slug (the long
+    // posix relative path with extension stripped) AND the specifier's
+    // <slug> segment (the bare file stem). The two are independent
+    // derivations from different roots — strip both so a call like
+    // `getEntry('notes-en', 'col003-mixers')` and a bridge lookup of
+    // `mdx://notes-en/col003-mixers#hash` both resolve.
+    let strip = filter.id_strip_suffix();
+    let slug = maybe_strip_slug_suffix(&slug, strip).to_string();
+    let slug_seg = maybe_strip_slug_suffix(&slug_seg, strip).to_string();
 
     let kind = entry_kind_from_path(path);
     let (body, compiled_jsx_source, module_specifier) = match kind {
@@ -940,6 +1186,7 @@ mod tests {
                         CollectionError::Schema { .. } => "schema",
                         CollectionError::Io { .. } => "io",
                         CollectionError::Mdx { .. } => "mdx",
+                        CollectionError::BadGlob { .. } => "bad-glob",
                         CollectionError::Multiple { .. } => "multiple",
                     })
                     .collect();
@@ -1156,6 +1403,193 @@ declare module \"zfb/content\" {\n\
                 "blog: { slug: string; data: {\n      date: string;\n      tags?: string[];\n      title: string;\n    }; body: string };"
             ),
             "blog interface drifted:\n{actual}",
+        );
+    }
+
+    // -------------------------------------------------------------------
+    // CollectionFilter (include / exclude / idStripSuffix) tests
+    // -------------------------------------------------------------------
+
+    fn filter(
+        include: Option<&[&str]>,
+        exclude: Option<&[&str]>,
+        id_strip: Option<&str>,
+    ) -> CollectionFilter {
+        let inc = include.map(|v| v.iter().map(|s| (*s).to_owned()).collect::<Vec<_>>());
+        let exc = exclude.map(|v| v.iter().map(|s| (*s).to_owned()).collect::<Vec<_>>());
+        CollectionFilter::new(inc.as_deref(), exc.as_deref(), id_strip).expect("compile globs")
+    }
+
+    /// `include` keeps only entries matching at least one pattern.
+    /// Mirrors zzmod's `notes-en` collection (only `.en.mdx` siblings).
+    #[test]
+    fn walk_with_include_keeps_only_matching_entries() {
+        let tmp = TmpDir::new("inc");
+        tmp.write("a.mdx", &valid_md("A"));
+        tmp.write("a.en.mdx", &valid_md("AEn"));
+        tmp.write("b.mdx", &valid_md("B"));
+        tmp.write("b.en.mdx", &valid_md("BEn"));
+        let filter = filter(Some(&["*.en.mdx"]), None, None);
+        let out: Vec<Entry<TestSchema>> =
+            walk_collection_with_cache_and_filter(tmp.path(), None, None, &filter).unwrap();
+        let slugs: Vec<&str> = out.iter().map(|e| e.slug.as_str()).collect();
+        assert_eq!(slugs, vec!["a.en", "b.en"]);
+    }
+
+    /// `exclude` drops entries matching any pattern. Mirrors zzmod's
+    /// JA collections (everything *except* the `.en.mdx` siblings).
+    #[test]
+    fn walk_with_exclude_drops_matching_entries() {
+        let tmp = TmpDir::new("exc");
+        tmp.write("a.mdx", &valid_md("A"));
+        tmp.write("a.en.mdx", &valid_md("AEn"));
+        tmp.write("b.mdx", &valid_md("B"));
+        tmp.write("b.en.mdx", &valid_md("BEn"));
+        let filter = filter(None, Some(&["*.en.mdx"]), None);
+        let out: Vec<Entry<TestSchema>> =
+            walk_collection_with_cache_and_filter(tmp.path(), None, None, &filter).unwrap();
+        let slugs: Vec<&str> = out.iter().map(|e| e.slug.as_str()).collect();
+        assert_eq!(slugs, vec!["a", "b"]);
+    }
+
+    /// `include` runs first, then `exclude` removes from the included
+    /// set. With `include=['*.mdx']` + `exclude=['*.en.mdx']` we keep
+    /// only the JA `.mdx` files (the `.en.mdx` ones are included by
+    /// the first pattern but kicked out by the second).
+    #[test]
+    fn walk_with_include_and_exclude_chains() {
+        let tmp = TmpDir::new("inc-exc");
+        tmp.write("a.mdx", &valid_md("A"));
+        tmp.write("a.en.mdx", &valid_md("AEn"));
+        tmp.write("b.md", &valid_md("B"));
+        tmp.write("notes.txt", "skipped by extension already");
+        let filter = filter(Some(&["*.mdx"]), Some(&["*.en.mdx"]), None);
+        let out: Vec<Entry<TestSchema>> =
+            walk_collection_with_cache_and_filter(tmp.path(), None, None, &filter).unwrap();
+        let slugs: Vec<&str> = out.iter().map(|e| e.slug.as_str()).collect();
+        assert_eq!(slugs, vec!["a"], "only `a.mdx` survives include∩¬exclude");
+    }
+
+    /// `idStripSuffix` rewrites both `Entry::slug` and the `<slug>`
+    /// segment of `Entry::module_specifier`. Non-matching entries are
+    /// untouched.
+    #[test]
+    fn walk_with_id_strip_suffix_rewrites_slug_and_specifier() {
+        let tmp = TmpDir::new("strip");
+        tmp.write("col003-mixers.en.mdx", &valid_md("Mixers EN"));
+        tmp.write("col004-osc.mdx", &valid_md("Osc"));
+        let filter = filter(None, None, Some(".en"));
+        let out: Vec<Entry<TestSchema>> =
+            walk_collection_with_cache_and_filter(tmp.path(), None, None, &filter).unwrap();
+        let by_slug: std::collections::HashMap<&str, &Entry<TestSchema>> =
+            out.iter().map(|e| (e.slug.as_str(), e)).collect();
+
+        // EN file's `.en` suffix is stripped from BOTH slug + specifier.
+        let mixers = by_slug.get("col003-mixers").expect("mixers entry");
+        assert!(
+            mixers.module_specifier.contains("/col003-mixers#"),
+            "specifier slug not stripped: {}",
+            mixers.module_specifier,
+        );
+        assert!(
+            !mixers.module_specifier.contains("col003-mixers.en"),
+            "specifier still contains pre-strip slug: {}",
+            mixers.module_specifier,
+        );
+
+        // Non-matching file's slug is untouched.
+        let osc = by_slug.get("col004-osc").expect("osc entry");
+        assert!(
+            osc.module_specifier.contains("/col004-osc#"),
+            "specifier slug accidentally rewritten: {}",
+            osc.module_specifier,
+        );
+    }
+
+    /// `CollectionFilter::none()` is the no-op default — same number of
+    /// entries, same slugs as the legacy unfiltered walker.
+    #[test]
+    fn walk_with_noop_filter_matches_unfiltered_walker() {
+        let tmp = TmpDir::new("noop");
+        tmp.write("a.mdx", &valid_md("A"));
+        tmp.write("nested/b.md", &valid_md("B"));
+        let baseline: Vec<Entry<TestSchema>> = walk_collection(tmp.path(), None).unwrap();
+        let filtered: Vec<Entry<TestSchema>> = walk_collection_with_cache_and_filter(
+            tmp.path(),
+            None,
+            None,
+            &CollectionFilter::none(),
+        )
+        .unwrap();
+        let baseline_slugs: Vec<&str> = baseline.iter().map(|e| e.slug.as_str()).collect();
+        let filtered_slugs: Vec<&str> = filtered.iter().map(|e| e.slug.as_str()).collect();
+        assert_eq!(baseline_slugs, filtered_slugs);
+        assert_eq!(baseline.len(), 2);
+    }
+
+    /// Globs are evaluated against the RELATIVE path (POSIX-form), not
+    /// the absolute path. A pattern like `nested/*.mdx` matches a file
+    /// that lives under a subdirectory regardless of where the
+    /// collection root sits on disk.
+    #[test]
+    fn walk_filter_uses_relative_posix_paths() {
+        let tmp = TmpDir::new("rel");
+        tmp.write("nested/a.mdx", &valid_md("A"));
+        tmp.write("nested/b.mdx", &valid_md("B"));
+        tmp.write("other/c.mdx", &valid_md("C"));
+        let filter = filter(Some(&["nested/*.mdx"]), None, None);
+        let out: Vec<Entry<TestSchema>> =
+            walk_collection_with_cache_and_filter(tmp.path(), None, None, &filter).unwrap();
+        let mut slugs: Vec<String> = out.iter().map(|e| e.slug.clone()).collect();
+        slugs.sort();
+        assert_eq!(slugs, vec!["nested/a".to_string(), "nested/b".to_string()]);
+    }
+
+    /// Invalid glob patterns surface as `CollectionError::BadGlob` at
+    /// filter-build time (before any file IO).
+    #[test]
+    fn collection_filter_rejects_invalid_glob() {
+        let err = CollectionFilter::new(Some(&["[unbalanced".to_string()]), None, None)
+            .expect_err("unbalanced bracket should fail");
+        match err {
+            CollectionError::BadGlob { pattern, .. } => {
+                assert_eq!(pattern, "[unbalanced");
+            }
+            other => panic!("expected BadGlob, got {other:?}"),
+        }
+    }
+
+    /// `maybe_strip_specifier_suffix` is the pure helper shared with
+    /// the bundler's bridge-import code path. It rewrites only the
+    /// `<slug>` segment of `<scheme>://<col>/<slug>#<hash>` and leaves
+    /// scheme + collection + hash bytes untouched.
+    #[test]
+    fn maybe_strip_specifier_suffix_rewrites_slug_only() {
+        let stripped = maybe_strip_specifier_suffix(
+            "mdx://notes-en/col003-mixers.en#deadbeef",
+            Some(".en"),
+        );
+        assert_eq!(stripped, "mdx://notes-en/col003-mixers#deadbeef");
+
+        // Non-matching suffix → returned unchanged.
+        let unchanged =
+            maybe_strip_specifier_suffix("mdx://notes/col004-osc#cafebabe", Some(".en"));
+        assert_eq!(unchanged, "mdx://notes/col004-osc#cafebabe");
+
+        // `None` / empty suffix → no-op.
+        assert_eq!(
+            maybe_strip_specifier_suffix("mdx://a/b#01234567", None),
+            "mdx://a/b#01234567",
+        );
+        assert_eq!(
+            maybe_strip_specifier_suffix("mdx://a/b#01234567", Some("")),
+            "mdx://a/b#01234567",
+        );
+
+        // TSX scheme works identically.
+        assert_eq!(
+            maybe_strip_specifier_suffix("tsx://feeds/a.en#11111111", Some(".en")),
+            "tsx://feeds/a#11111111",
         );
     }
 }

--- a/crates/zfb-content/src/content_bridge.rs
+++ b/crates/zfb-content/src/content_bridge.rs
@@ -39,7 +39,9 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
 
-use crate::collection::{walk_collection, CollectionError, Entry};
+use crate::collection::{
+    walk_collection_with_cache_and_filter, CollectionError, CollectionFilter, Entry,
+};
 use crate::pipeline::Pipeline;
 
 /// A single content entry, in the shape the JS bridge sees.
@@ -85,21 +87,60 @@ pub struct ContentSnapshot {
 /// [`EntrySnapshot`]. A non-existent `root` is treated as an empty
 /// collection (matches [`walk_collection`] today; documented on
 /// [`build_snapshot`]).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct CollectionConfig {
     /// Public collection name (the key in [`ContentSnapshot::collections`]).
     pub name: String,
     /// Directory containing the collection's source files.
     pub root: PathBuf,
+    /// Optional include globs (Astro-style). When `Some` and non-empty,
+    /// the walker keeps only entries whose relative path matches at
+    /// least one pattern. See [`crate::collection::CollectionFilter`]
+    /// for the full semantics.
+    pub include: Option<Vec<String>>,
+    /// Optional exclude globs. Applied AFTER `include`. See
+    /// [`crate::collection::CollectionFilter`].
+    pub exclude: Option<Vec<String>>,
+    /// Optional suffix to strip from each kept entry's slug + module
+    /// specifier. MUST match the bundler's
+    /// `ContentCollectionSpec::id_strip_suffix` exactly so the snapshot
+    /// specifier and the bundler's bridge-map key stay byte-identical.
+    pub id_strip_suffix: Option<String>,
 }
 
 impl CollectionConfig {
-    /// Convenience constructor.
+    /// Convenience constructor (no filters). Use field-init shorthand
+    /// (`CollectionConfig { name, root, include: Some(..), .. }`) or
+    /// the with_* builders for filtered collections.
     pub fn new(name: impl Into<String>, root: impl Into<PathBuf>) -> Self {
         Self {
             name: name.into(),
             root: root.into(),
+            include: None,
+            exclude: None,
+            id_strip_suffix: None,
         }
+    }
+
+    /// Builder: replace `include` globs.
+    #[must_use]
+    pub fn with_include(mut self, patterns: Option<Vec<String>>) -> Self {
+        self.include = patterns;
+        self
+    }
+
+    /// Builder: replace `exclude` globs.
+    #[must_use]
+    pub fn with_exclude(mut self, patterns: Option<Vec<String>>) -> Self {
+        self.exclude = patterns;
+        self
+    }
+
+    /// Builder: replace `id_strip_suffix`.
+    #[must_use]
+    pub fn with_id_strip_suffix(mut self, suffix: Option<String>) -> Self {
+        self.id_strip_suffix = suffix;
+        self
     }
 }
 
@@ -339,18 +380,31 @@ pub fn build_snapshot_with_config(
         // why the parallel walker is implemented as a `T` substitution
         // rather than a duplicate FS traversal.
         //
-        // `walk_collection_with_cache` resets the pipeline's per-entry
-        // state before each file (zfb#188-followup), so any stateful
-        // plugin in the chain — `HeadingLinksPlugin`'s slug counter
-        // included — starts fresh per document, matching the bundler's
-        // `materialise_*` walk loop.
+        // `walk_collection_with_cache_and_filter` resets the pipeline's
+        // per-entry state before each file (zfb#188-followup), so any
+        // stateful plugin in the chain — `HeadingLinksPlugin`'s slug
+        // counter included — starts fresh per document, matching the
+        // bundler's `materialise_*` walk loop.
+        //
+        // The configured include / exclude / idStripSuffix MUST match
+        // the bundler's `ContentCollectionSpec` exactly — otherwise
+        // the snapshot's `module_specifier` and the bundler's bridge
+        // map key disagree and every `bridge.get(spec)` lookup misses.
+        let filter = CollectionFilter::new(
+            cfg.include.as_deref(),
+            cfg.exclude.as_deref(),
+            cfg.id_strip_suffix.as_deref(),
+        )
+        .map_err(|source| BridgeError::Walk {
+            collection: cfg.name.clone(),
+            source,
+        })?;
         let entries: Vec<Entry<UntypedFrontmatter>> =
-            walk_collection(&cfg.root, Some(&mut pipeline)).map_err(|source| {
-                BridgeError::Walk {
+            walk_collection_with_cache_and_filter(&cfg.root, None, Some(&mut pipeline), &filter)
+                .map_err(|source| BridgeError::Walk {
                     collection: cfg.name.clone(),
                     source,
-                }
-            })?;
+                })?;
 
         let mut snapshots: Vec<EntrySnapshot> = entries
             .into_iter()

--- a/crates/zfb-content/tests/collection_filter_parity.rs
+++ b/crates/zfb-content/tests/collection_filter_parity.rs
@@ -1,0 +1,186 @@
+//! Parity tests for the snapshot-walker ↔ bundler-walker contract
+//! introduced when `CollectionDef.include` / `.exclude` / `.idStripSuffix`
+//! landed.
+//!
+//! The snapshot side (this crate's `walk_collection_with_cache_and_filter`
+//! → `build_snapshot_with_config` → `EntrySnapshot.module_specifier`)
+//! and the bundler side (`crates/zfb-build/src/bundler.rs`'s
+//! `materialise_collection` → `ContentImport.specifier`) MUST agree
+//! on the final specifier byte-for-byte. Any divergence makes every
+//! `globalThis.__zfb.content.get(spec)` lookup miss and dumps the page
+//! into a `<pre data-zfb-content-fallback>` block.
+//!
+//! These tests exercise the SHARED helpers
+//! (`CollectionFilter::matches_relative` and
+//! `maybe_strip_specifier_suffix`) end-to-end against the snapshot
+//! pipeline so the contract is locked at this layer. The bundler's
+//! parallel walk is covered by `crates/zfb-build/tests/bundler_*.rs`
+//! integration tests that gate on esbuild.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use zfb_content::collection::{maybe_strip_specifier_suffix, CollectionFilter};
+use zfb_content::{build_snapshot_with_config, CollectionConfig, SnapshotPipelineConfig};
+use zfb_content::{compile_mdx_to_jsx_module_cached, MdxJsxOptions};
+
+fn tmp_root(label: &str) -> PathBuf {
+    let n = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    let dir = std::env::temp_dir().join(format!(
+        "zfb-content-parity-{label}-{n}-{pid}",
+        pid = std::process::id()
+    ));
+    fs::create_dir_all(&dir).expect("create tmp dir");
+    dir
+}
+
+fn write(root: &Path, rel: &str, contents: &str) {
+    let p = root.join(rel);
+    if let Some(parent) = p.parent() {
+        fs::create_dir_all(parent).expect("create parent");
+    }
+    fs::write(p, contents).expect("write file");
+}
+
+/// `idStripSuffix` rewrites the snapshot's `module_specifier` slug
+/// segment. Pin this so the bundler-side rewrite (which uses the same
+/// shared helper) can be cross-checked against snapshot output even
+/// without running esbuild.
+#[test]
+fn snapshot_module_specifier_has_id_strip_suffix_applied() {
+    let root = tmp_root("strip");
+    let col_dir = root.join("notes-en");
+    write(
+        &col_dir,
+        "col003-mixers.en.mdx",
+        "---\ntitle: Mixers EN\n---\nbody\n",
+    );
+    write(
+        &col_dir,
+        "col004-osc.en.mdx",
+        "---\ntitle: Osc EN\n---\nbody\n",
+    );
+    // Non-EN sibling that should be excluded by the include glob.
+    write(
+        &col_dir,
+        "col003-mixers.mdx",
+        "---\ntitle: Mixers JA\n---\nbody\n",
+    );
+
+    let cfg = CollectionConfig {
+        name: "notes-en".into(),
+        root: col_dir.clone(),
+        include: Some(vec!["*.en.mdx".into()]),
+        exclude: None,
+        id_strip_suffix: Some(".en".into()),
+    };
+    let snap = build_snapshot_with_config(&[cfg], &SnapshotPipelineConfig::default())
+        .expect("snapshot build");
+    let entries = snap.collections.get("notes-en").expect("collection");
+
+    // Two EN entries survive (JA sibling excluded). Snapshot is sorted
+    // by slug ascending, and slugs have the `.en` suffix stripped.
+    assert_eq!(entries.len(), 2, "entries: {entries:?}");
+    assert_eq!(entries[0].slug, "col003-mixers");
+    assert_eq!(entries[1].slug, "col004-osc");
+
+    // Specifier slug segment also has `.en` stripped — the consumer's
+    // bridge map key MUST be in this form for `getEntry('notes-en',
+    // 'col003-mixers')` to resolve.
+    assert!(
+        entries[0]
+            .module_specifier
+            .starts_with("mdx://notes-en/col003-mixers#"),
+        "spec: {}",
+        entries[0].module_specifier,
+    );
+    assert!(
+        !entries[0].module_specifier.contains("col003-mixers.en"),
+        "spec still has pre-strip slug: {}",
+        entries[0].module_specifier,
+    );
+
+    // ----- Bundler-side simulation -------------------------------------
+    //
+    // Reproduce what `materialise_collection` does for the same file:
+    // compile MDX with `compile_mdx_to_jsx_module_cached`, then run
+    // the shared `maybe_strip_specifier_suffix` helper. The result
+    // must equal the snapshot's `module_specifier` byte-for-byte —
+    // that's the invariant the bridge map relies on.
+    let file = col_dir.join("col003-mixers.en.mdx");
+    let raw = fs::read_to_string(&file).unwrap();
+    // Snapshot walker calls `frontmatter::extract` then compiles the
+    // post-frontmatter body. Mirror that here so the JSX hash agrees.
+    let uf = zfb_content::extract_tsx_frontmatter; // unused; just import probe
+    let _ = uf;
+    let body = {
+        // Use the public re-export `zfb_content::FrontmatterError` only
+        // to keep imports tight; we inline the YAML strip here.
+        let after_open = raw.strip_prefix("---\n").unwrap_or(&raw);
+        if let Some(close_idx) = after_open.find("\n---\n") {
+            after_open[(close_idx + 5)..].to_string()
+        } else {
+            raw.clone()
+        }
+    };
+    let compiled = compile_mdx_to_jsx_module_cached(&body, &file, None, None).expect("compile mdx");
+    let bundler_specifier = maybe_strip_specifier_suffix(&compiled.specifier, Some(".en"));
+    assert_eq!(
+        bundler_specifier, entries[0].module_specifier,
+        "snapshot↔bundler specifier mismatch — bridge lookups would miss",
+    );
+
+    // Touch a default-construction helper so the public-API surface
+    // for downstream consumers stays compile-checked.
+    let _ = MdxJsxOptions::default();
+}
+
+/// When `idStripSuffix` is unset, the helper is a no-op and the
+/// snapshot specifier carries the pre-strip slug exactly as before.
+/// Pinned so a future refactor can't accidentally start stripping.
+#[test]
+fn snapshot_specifier_unchanged_when_id_strip_suffix_absent() {
+    let root = tmp_root("nostrip");
+    let col_dir = root.join("notes");
+    write(
+        &col_dir,
+        "col003-mixers.mdx",
+        "---\ntitle: Mixers JA\n---\nbody\n",
+    );
+
+    let cfg = CollectionConfig::new("notes", col_dir.clone());
+    let snap = build_snapshot_with_config(&[cfg], &SnapshotPipelineConfig::default())
+        .expect("snapshot build");
+    let entries = snap.collections.get("notes").expect("collection");
+    assert_eq!(entries.len(), 1);
+    assert!(
+        entries[0]
+            .module_specifier
+            .starts_with("mdx://notes/col003-mixers#"),
+        "spec: {}",
+        entries[0].module_specifier,
+    );
+}
+
+/// `CollectionFilter::matches_relative` is the public surface the
+/// bundler calls. The walker uses the same matcher under the hood, so
+/// any path that the snapshot drops MUST also be the path the bundler
+/// drops (and vice versa).
+#[test]
+fn matcher_verdicts_agree_across_surfaces() {
+    let filter = CollectionFilter::new(
+        Some(&["*.mdx".to_string()]),
+        Some(&["*.en.mdx".to_string()]),
+        None,
+    )
+    .unwrap();
+    assert!(filter.matches_relative("col003-mixers.mdx"));
+    assert!(!filter.matches_relative("col003-mixers.en.mdx"));
+    assert!(
+        !filter.matches_relative("readme.md"),
+        "non-mdx falls through include"
+    );
+}

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -925,7 +925,13 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
         let collections: Vec<zfb_content::CollectionConfig> = config
             .collections
             .iter()
-            .map(|c| zfb_content::CollectionConfig::new(c.name.clone(), project_root.join(&c.path)))
+            .map(|c| zfb_content::CollectionConfig {
+                name: c.name.clone(),
+                root: project_root.join(&c.path),
+                include: c.include.clone(),
+                exclude: c.exclude.clone(),
+                id_strip_suffix: c.id_strip_suffix.clone(),
+            })
             .collect();
         // Mirror the bundler's pipeline shape (theme, strip-md-ext,
         // resolve-links). Every plugin the bundler appends to its
@@ -1105,7 +1111,13 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
     bundler_input.content_collections = config
         .collections
         .iter()
-        .map(|c| zfb_build::ContentCollectionSpec::new(c.name.clone(), c.path.clone()))
+        .map(|c| zfb_build::ContentCollectionSpec {
+            name: c.name.clone(),
+            root: c.path.clone(),
+            include: c.include.clone(),
+            exclude: c.exclude.clone(),
+            id_strip_suffix: c.id_strip_suffix.clone(),
+        })
         .collect();
     // Thread the opt-in `stripMdExt` flag from `zfb.config.ts` into the
     // bundler so the hoisted MDX pre-compile pipeline appends
@@ -1931,7 +1943,13 @@ fn maybe_probe_content_snapshot(project_root: &Path, config: &Config) {
     let collections: Vec<zfb_content::CollectionConfig> = config
         .collections
         .iter()
-        .map(|c| zfb_content::CollectionConfig::new(c.name.clone(), project_root.join(&c.path)))
+        .map(|c| zfb_content::CollectionConfig {
+            name: c.name.clone(),
+            root: project_root.join(&c.path),
+            include: c.include.clone(),
+            exclude: c.exclude.clone(),
+            id_strip_suffix: c.id_strip_suffix.clone(),
+        })
         .collect();
     if let Err(err) = zfb_content::build_snapshot(&collections) {
         output::warn(format!("ZFB_DEBUG_SNAPSHOT: snapshot probe failed: {err}"));

--- a/crates/zfb/src/commands/check.rs
+++ b/crates/zfb/src/commands/check.rs
@@ -122,6 +122,34 @@ fn validate_collection(project_root: &Path, collection: &CollectionDef) -> Resul
     })?;
     files.sort();
 
+    // Honour the same include / exclude filter the walker / bundler
+    // apply so a frontmatter check doesn't fire schema errors against
+    // sibling files that wouldn't have made it into the collection in
+    // the first place (e.g. EN siblings under a JA collection with an
+    // `*.en.mdx` exclude pattern).
+    let filter = zfb_content::collection::CollectionFilter::new(
+        collection.include.as_deref(),
+        collection.exclude.as_deref(),
+        collection.id_strip_suffix.as_deref(),
+    )
+    .with_context(|| {
+        format!("collection {:?}: invalid filter glob", collection.name)
+    })?;
+    if !filter.is_noop() {
+        files.retain(|p| {
+            let rel = p.strip_prefix(&dir).unwrap_or(p);
+            // Render to forward-slash form because the filter
+            // patterns are authored against POSIX paths.
+            let rel_posix = if std::path::MAIN_SEPARATOR == '/' {
+                rel.to_string_lossy().into_owned()
+            } else {
+                rel.to_string_lossy()
+                    .replace(std::path::MAIN_SEPARATOR, "/")
+            };
+            filter.matches_relative(&rel_posix)
+        });
+    }
+
     let mut issues = Vec::new();
     for path in &files {
         let raw = match std::fs::read_to_string(path) {
@@ -329,6 +357,9 @@ mod tests {
                 }))
                 .unwrap(),
             ),
+            include: None,
+            exclude: None,
+            id_strip_suffix: None,
         };
 
         let issues = validate_collection(&tmp.path, &collection).unwrap();
@@ -361,6 +392,9 @@ mod tests {
                 }))
                 .unwrap(),
             ),
+            include: None,
+            exclude: None,
+            id_strip_suffix: None,
         };
 
         let issues = validate_collection(&tmp.path, &collection).unwrap();
@@ -394,6 +428,9 @@ mod tests {
                 }))
                 .unwrap(),
             ),
+            include: None,
+            exclude: None,
+            id_strip_suffix: None,
         };
 
         let issues = validate_collection(&tmp.path, &collection).unwrap();
@@ -417,6 +454,9 @@ mod tests {
             name: "blog".into(),
             path: PathBuf::from("content/blog"),
             schema: None,
+            include: None,
+            exclude: None,
+            id_strip_suffix: None,
         };
 
         let issues = validate_collection(&tmp.path, &collection).unwrap();
@@ -439,6 +479,9 @@ mod tests {
             name: "blog".into(),
             path: PathBuf::from("content/blog"),
             schema: None,
+            include: None,
+            exclude: None,
+            id_strip_suffix: None,
         };
 
         let issues = validate_collection(&tmp.path, &collection).unwrap();

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -639,7 +639,13 @@ fn boot_dev_renderer(
     bundler_input.content_collections = cfg
         .collections
         .iter()
-        .map(|c| zfb_build::ContentCollectionSpec::new(c.name.clone(), c.path.clone()))
+        .map(|c| zfb_build::ContentCollectionSpec {
+            name: c.name.clone(),
+            root: c.path.clone(),
+            include: c.include.clone(),
+            exclude: c.exclude.clone(),
+            id_strip_suffix: c.id_strip_suffix.clone(),
+        })
         .collect();
     // Thread the opt-in `stripMdExt` flag through so the dev-mode
     // bundler (which feeds the embedded V8 host) honours the same setting as

--- a/crates/zfb/src/config.rs
+++ b/crates/zfb/src/config.rs
@@ -415,6 +415,42 @@ pub struct CollectionDef {
     /// dialect.
     #[serde(default)]
     pub schema: Option<JsonSchema>,
+    /// Optional glob patterns (evaluated relative to `path`). When set
+    /// and non-empty, an entry is kept only if at least one pattern
+    /// matches its path relative to `path`. When `None` or empty, no
+    /// include-filtering happens (every candidate file is kept).
+    ///
+    /// Mirrors Astro's content-collection `glob({ pattern })` include
+    /// shape. Patterns use the `globset` dialect (Unix-style globs:
+    /// `*`, `**`, `?`, `[…]`).
+    #[serde(default)]
+    pub include: Option<Vec<String>>,
+    /// Optional glob patterns (evaluated relative to `path`). When set
+    /// and non-empty, an entry is dropped if any pattern matches its
+    /// path relative to `path`. Evaluated AFTER `include` — the
+    /// effective set is `(include ∪ all) ∩ ¬exclude`.
+    ///
+    /// Mirrors Astro's `['**/*.mdx', '!**/*.en.mdx']` pattern. zfb
+    /// splits the negative side into its own field.
+    #[serde(default)]
+    pub exclude: Option<Vec<String>>,
+    /// Optional suffix to strip from each kept entry's slug. When the
+    /// slug (filename minus extension) ends with the given suffix, the
+    /// suffix is stripped from both `Entry::slug` and
+    /// `Entry::module_specifier`. Other entries are unchanged.
+    ///
+    /// Example: with `idStripSuffix: ".en"`, `col003-mixers.en.mdx` ->
+    /// slug `col003-mixers`, specifier
+    /// `mdx://notes-en/col003-mixers#<hash>`. Consumer code calls
+    /// `getEntry('notes-en', 'col003-mixers')` without knowing about
+    /// the suffix.
+    ///
+    /// Useful for multi-locale layouts where one source directory
+    /// holds both `foo.mdx` (default locale) and `foo.en.mdx` (locale
+    /// override). Pair with `include` / `exclude` to route each locale
+    /// into its own collection.
+    #[serde(default)]
+    pub id_strip_suffix: Option<String>,
 }
 
 /// Tailwind options. Empty by default (Tailwind enabled); users can flip

--- a/packages/zfb/src/config.ts
+++ b/packages/zfb/src/config.ts
@@ -23,6 +23,29 @@ export type CollectionDef = {
   path: string;
   /** Optional schema. Reserved for v1.1 — accepted but not enforced today. */
   schema?: Record<string, unknown>;
+  /**
+   * Optional include globs (Astro-style, evaluated relative to `path`).
+   * When set and non-empty, an entry is kept only if at least one
+   * pattern matches its relative path. When omitted or empty, no
+   * include-filtering happens. Patterns use the `globset` dialect
+   * (Unix-style: `*`, `**`, `?`, `[…]`).
+   */
+  include?: string[];
+  /**
+   * Optional exclude globs. When set, an entry is dropped if any
+   * pattern matches its relative path. Evaluated AFTER `include`.
+   * Together they mirror Astro's `['**\/*.mdx', '!**\/*.en.mdx']`
+   * convention (zfb splits the negative side into its own field).
+   */
+  exclude?: string[];
+  /**
+   * Optional suffix to strip from each kept entry's slug + module
+   * specifier. Use with multi-locale layouts where one source
+   * directory holds both `foo.mdx` (default locale) and `foo.en.mdx`
+   * (locale override) — set `idStripSuffix: ".en"` so the EN
+   * collection's slugs round-trip as `foo` instead of `foo.en`.
+   */
+  idStripSuffix?: string;
 };
 
 export type TailwindConfig = {


### PR DESCRIPTION
## Why

Closes the consumer-side TODO at [zzmod/zfb.config.ts:80–94](https://github.com/zudolab/zzmod/blob/base/zfb/zfb.config.ts#L80-L94) and unblocks Wave 13 of the zzmod migration epic (zudolab/zzmod#45).

Also fixes a live bug: the consumer's JA collections currently leak EN siblings because today's `collect_collection_files` picks up every `.md` / `.mdx` / `.tsx` under `path` indiscriminately. With this PR, zzmod can write:

```ts
{ name: 'notes', path: 'src/mdx/notes', exclude: ['**/*.en.mdx'] }
{ name: 'notes-en', path: 'src/mdx/notes', include: ['**/*.en.mdx'], idStripSuffix: '.en' }
```

…and get clean JA + EN collections out of the same source directory.

## API additions

Three new optional fields on `CollectionDef` (serde camelCase already in place):

```ts
export type CollectionDef = {
  name: string;
  path: string;
  schema?: Record<string, unknown>;

  // NEW
  include?: string[];        // keep only entries matching at least one glob
  exclude?: string[];        // drop entries matching any glob (after include)
  idStripSuffix?: string;    // strip suffix from slug + module specifier
};
```

Globs use the `globset` dialect (Unix-style, `**` for recursive segment matches). Patterns are evaluated against the POSIX-style relative path, so `subdir/*.mdx` works portably across operating systems.

\`idStripSuffix\` rewrites both \`Entry::slug\` and the \`<slug>\` segment of \`Entry::module_specifier\`. Example: with \`idStripSuffix: '.en'\`, \`col003-mixers.en.mdx\` → slug \`col003-mixers\`, specifier \`mdx://notes-en/col003-mixers#<hash>\`. Consumer code calls \`getEntry('notes-en', 'col003-mixers')\` without knowing about the suffix.

## Backward compatibility

All three fields are \`Option\`-typed with \`#[serde(default)]\`. Existing configs (zudo-doc2, zfb examples) round-trip unchanged. The walker's fast-path skips the per-entry filter check when no filtering is configured, so today's byte-for-byte behaviour is preserved.

## Snapshot ↔ bundler parity

zfb's content bridge maintains a load-bearing invariant: the snapshot's \`EntrySnapshot.module_specifier\` and the bundler's \`ContentImport.specifier\` MUST be byte-identical, or every \`globalThis.__zfb.content.get(spec)\` lookup misses and the page falls back to \`<pre data-zfb-content-fallback>\`. This means the filter has to apply at BOTH walker surfaces:

1. \`walk_collection_with_cache_and_filter\` in \`zfb-content::collection\` (snapshot side, threaded via \`CollectionConfig\`).
2. \`materialise_collection\` in \`zfb-build::bundler\` (parallel \`WalkDir\` traversal, threaded via \`ContentCollectionSpec\`).

Both surfaces share \`CollectionFilter::matches_relative\` (include / exclude verdict) and \`maybe_strip_specifier_suffix\` (post-strip rewrite) so the verdict is byte-identical on both sides. A dedicated parity test (\`crates/zfb-content/tests/collection_filter_parity.rs\`) walks a fixture with \`idStripSuffix\`, builds the snapshot, independently compiles the same file through \`compile_mdx_to_jsx_module_cached\`, and asserts the two specifiers match byte-for-byte.

## Tests

- 7 walker-level unit tests (in \`crates/zfb-content/src/collection.rs\`) cover: \`include\` only, \`exclude\` only, \`include + exclude\` chaining, \`idStripSuffix\` rewriting slug + specifier, no-filter parity with the legacy walker, relative-POSIX-path matching for nested patterns, invalid-glob error surfacing via \`CollectionError::BadGlob\`, and \`maybe_strip_specifier_suffix\` purity.
- 3 integration tests (in \`crates/zfb-content/tests/collection_filter_parity.rs\`) lock the snapshot ↔ bundler invariant.
- Existing \`zfb-content\` / \`zfb-build\` / \`zfb\` test suites pass with the new \`CollectionFilter::none()\` default substituting for the legacy walker.

## Links

- Consumer planning: zudolab/zzmod#82
- Epic: zudolab/zzmod#45

🤖 Generated with [Claude Code](https://claude.com/claude-code)