### PR TITLE
fix(zfb-islands): define import.meta.env.{PROD,DEV} in esbuild args

### DIFF
--- a/crates/zfb-islands/src/esbuild.rs
+++ b/crates/zfb-islands/src/esbuild.rs
@@ -846,6 +846,26 @@ pub(crate) fn build_esbuild_args(
             "--define:process.env.NODE_ENV=\"development\"",
         ));
     }
+    // Inline `import.meta.env.{PROD,DEV}` so consumer `'use client'`
+    // code that references either expression (e.g. `if
+    // (import.meta.env.DEV) console.log(…)`) is folded at bundle time
+    // instead of leaving the literal expression in the shipped bundle.
+    // The shared-bundle path (`crates/zfb-build/src/bundler.rs::2395`)
+    // already does this for the SSR/runtime bundle; mirroring here
+    // keeps both pipelines aligned. Without these defines,
+    // `import.meta.env` is `undefined` at module-init time in the
+    // browser and `import.meta.env.DEV` throws
+    // `TypeError: Cannot read properties of undefined (reading 'DEV')`
+    // before any island can hydrate (issue #287).
+    let prod = config.minify;
+    args.push(OsString::from(format!(
+        "--define:import.meta.env.PROD={}",
+        prod
+    )));
+    args.push(OsString::from(format!(
+        "--define:import.meta.env.DEV={}",
+        !prod
+    )));
     for extra in extra_args {
         args.push(extra.clone());
     }
@@ -1801,6 +1821,52 @@ mod tests {
             .expect("--jsx-import-source=preact present");
         assert!(jsx_idx < entry_idx);
         assert!(import_idx < entry_idx);
+    }
+
+    /// Regression for issue #287 (zudolab/zzmod#154).
+    ///
+    /// `--define:import.meta.env.PROD=…` and `--define:import.meta.env.DEV=…`
+    /// MUST appear in the islands esbuild arg list so consumer `'use client'`
+    /// source code referencing either expression (e.g. `if
+    /// (import.meta.env.DEV) console.log(…)`) is folded at bundle time
+    /// rather than shipped to the browser where `import.meta.env` is
+    /// `undefined` and `import.meta.env.DEV` throws at module init.
+    ///
+    /// Production mode (`config.minify == true`) → `PROD=true`,
+    /// `DEV=false`. The values are JS literal booleans, not quoted
+    /// strings, matching the form already used by
+    /// `crates/zfb-build/src/bundler.rs::2395`.
+    #[test]
+    fn build_esbuild_args_defines_import_meta_env_in_prod() {
+        let cfg = BundleConfig::default().with_minify(true);
+        let args = args_as_strings(&cfg);
+        assert!(
+            args.iter().any(|a| a == "--define:import.meta.env.PROD=true"),
+            "missing --define:import.meta.env.PROD=true in args: {args:?}"
+        );
+        assert!(
+            args.iter().any(|a| a == "--define:import.meta.env.DEV=false"),
+            "missing --define:import.meta.env.DEV=false in args: {args:?}"
+        );
+    }
+
+    /// Dev mode (`config.minify == false`) flips both flags so the
+    /// `if (import.meta.env.DEV) …` branch is preserved in unminified
+    /// builds. Mirrors the `bundler.rs` semantics so consumers see the
+    /// same `PROD`/`DEV` substitution in both pipelines.
+    #[test]
+    fn build_esbuild_args_defines_import_meta_env_in_dev() {
+        let cfg = BundleConfig::default();
+        assert!(!cfg.minify, "default BundleConfig must be dev mode");
+        let args = args_as_strings(&cfg);
+        assert!(
+            args.iter().any(|a| a == "--define:import.meta.env.PROD=false"),
+            "missing --define:import.meta.env.PROD=false in args: {args:?}"
+        );
+        assert!(
+            args.iter().any(|a| a == "--define:import.meta.env.DEV=true"),
+            "missing --define:import.meta.env.DEV=true in args: {args:?}"
+        );
     }
 
     /// `BundleConfig::jsx_import_source` is honoured verbatim — the


### PR DESCRIPTION
## Summary

- Mirror the `--define:import.meta.env.PROD=…` / `.DEV=…` flags from `crates/zfb-build/src/bundler.rs:2395` into `crates/zfb-islands/src/esbuild.rs::build_esbuild_args`.
- Without these defines, consumer `'use client'` source code that references `import.meta.env.DEV` (or `.PROD`) is shipped verbatim into `assets/islands.js`. At runtime `import.meta.env` is `undefined` in the browser, so the first access throws `TypeError: Cannot read properties of undefined (reading 'DEV')` at module init — cascading into a hydration failure for whatever island that file is part of.

## Test plan

- [x] `cargo test -p zfb-islands --lib` — 151 tests pass, including two new tests covering prod and dev modes.
- [x] `cargo clippy -p zfb-islands -- -D warnings` — clean.
- [x] `cargo check --workspace` — clean (pre-existing warnings unchanged).

## Verification (downstream)

The fix is for the deployed islands bundle, so the empirical check is post-merge in the consumer. The expected behavior:

```bash
# Before (current state in zzmod PR #92):
curl -sS https://pr-92.zmod-1iv.pages.dev/assets/islands-fb7b3b7f.js \
  | grep -oE "import\.meta\.env[a-zA-Z\.]*" | sort | uniq -c
#       1 import.meta.env.DEV

# After (post pin-bump): zero occurrences — esbuild folds to literal true/false.
```

## Why this is conservative

- `PUBLIC_*`-prefixed env vars (the second block at `bundler.rs:2400–2411`) are intentionally NOT mirrored here — punted unless a downstream consumer asks for it. The two pipelines are now aligned on the `PROD`/`DEV` boolean defines specifically, which is what the reported crash needs.
- `config.minify` already encodes the prod/dev choice, so no plumbing change is required.

Closes #287
Refs zudolab/zzmod#154

🤖 Generated with [Claude Code](https://claude.com/claude-code)