### PR TITLE
fix(docs): claude header 404 + Futura/Noto Sans font system

### DIFF
--- a/docs/src/components/content/heading-h2.tsx
+++ b/docs/src/components/content/heading-h2.tsx
@@ -11,7 +11,7 @@ export function HeadingH2({ id, children, className, ...rest }: Props) {
   return (
     <h2
       id={id}
-      className={`text-subheading font-bold leading-tight pt-vsp-sm border-t-[3px] border-transparent${className ? ` ${className}` : ""}`}
+      className={`text-subheading font-futura font-normal leading-tight pt-vsp-sm border-t-[3px] border-transparent${className ? ` ${className}` : ""}`}
       style={
         {
           borderImage: "linear-gradient(to right, var(--color-fg), transparent) 1",

--- a/docs/src/components/content/heading-h3.tsx
+++ b/docs/src/components/content/heading-h3.tsx
@@ -11,7 +11,7 @@ export function HeadingH3({ id, children, className, ...rest }: Props) {
   return (
     <h3
       id={id}
-      className={`text-body font-bold leading-snug pt-vsp-xs border-t-[2px] border-transparent${className ? ` ${className}` : ""}`}
+      className={`text-body font-futura font-normal leading-snug pt-vsp-xs border-t-[2px] border-transparent${className ? ` ${className}` : ""}`}
       style={
         {
           borderImage: "linear-gradient(to right, var(--color-muted), transparent) 1",

--- a/docs/src/components/content/heading-h4.tsx
+++ b/docs/src/components/content/heading-h4.tsx
@@ -11,7 +11,7 @@ export function HeadingH4({ id, children, className, ...rest }: Props) {
   return (
     <h4
       id={id}
-      className={`text-body font-semibold leading-snug pt-vsp-xs border-t border-transparent${className ? ` ${className}` : ""}`}
+      className={`text-body font-futura font-normal leading-snug pt-vsp-xs border-t border-transparent${className ? ` ${className}` : ""}`}
       style={
         {
           borderImage: "linear-gradient(to right, var(--color-muted), transparent) 1",

--- a/docs/src/components/versions-page-content.astro
+++ b/docs/src/components/versions-page-content.astro
@@ -13,13 +13,13 @@ const defaultDocSlug =
   settings.headerNav[0]?.path.replace(/^\/docs\//, "") ?? "getting-started";
 ---
 
-<h1 class="text-heading font-bold mb-vsp-lg">
+<h1 class="text-heading font-futura font-normal mb-vsp-lg">
   {t("version.page.title", lang)}
 </h1>
 
 {/* Latest version */}
 <section class="mb-vsp-xl">
-  <h2 class="text-subheading font-bold mb-vsp-xs">
+  <h2 class="text-subheading font-futura font-normal mb-vsp-xs">
     {t("version.page.latest.title", lang)}
   </h2>
   <p class="text-small text-muted mb-vsp-sm">
@@ -48,7 +48,7 @@ const defaultDocSlug =
 {
   versions.length > 0 && (
     <section>
-      <h2 class="text-subheading font-bold mb-vsp-xs">
+      <h2 class="text-subheading font-futura font-normal mb-vsp-xs">
         {t("version.page.past.title", lang)}
       </h2>
       <p class="text-small text-muted mb-vsp-md">

--- a/docs/src/config/settings.ts
+++ b/docs/src/config/settings.ts
@@ -124,8 +124,8 @@ export const settings = {
     {
       label: "Claude",
       labelKey: "nav.claude",
-      path: "/docs/claude-skills",
-      categoryMatch: "claude-skills",
+      path: "/docs/claude",
+      categoryMatch: "claude",
     },
     {
       label: "Changelog",

--- a/docs/src/pages/404.astro
+++ b/docs/src/pages/404.astro
@@ -20,7 +20,7 @@ import { defaultLocale } from "@/config/i18n";
   <body
     class="min-h-screen antialiased flex flex-col items-center justify-center px-hsp-2xl py-vsp-xl"
   >
-    <h1 class="text-display font-bold mb-vsp-md">404</h1>
+    <h1 class="text-display font-futura font-normal mb-vsp-md">404</h1>
     <p class="text-subheading text-muted mb-vsp-xl">Page not found.</p>
     <a
       href={withBase("/")}

--- a/docs/src/pages/[locale]/docs/[...slug].astro
+++ b/docs/src/pages/[locale]/docs/[...slug].astro
@@ -169,7 +169,7 @@ const slug = autoIndex
   {
     autoIndex ? (
       <Fragment>
-        <h1 class="text-heading font-bold mb-vsp-xs">{autoIndex.label}</h1>
+        <h1 class="text-heading font-futura font-normal mb-vsp-xs">{autoIndex.label}</h1>
         {autoIndex.description && (
           <p class="mt-0 mb-vsp-lg text-subheading text-muted">
             {autoIndex.description}
@@ -197,7 +197,7 @@ const slug = autoIndex
       </Fragment>
     ) : (
       <Fragment>
-        <h1 class="text-heading font-bold mb-vsp-xs">{entry.data.title}</h1>
+        <h1 class="text-heading font-futura font-normal mb-vsp-xs">{entry.data.title}</h1>
         {settings.docMetainfo && (
           <DocMetainfo filePath={`${contentDir}/${entry.id}`} locale={lang} />
         )}

--- a/docs/src/pages/[locale]/docs/tags/[tag].astro
+++ b/docs/src/pages/[locale]/docs/tags/[tag].astro
@@ -61,7 +61,7 @@ const countText =
       { label: tag },
     ]}
   />
-  <h1 class="text-heading font-bold mb-vsp-xs">
+  <h1 class="text-heading font-futura font-normal mb-vsp-xs">
     {t("doc.taggedWith", lang)}: {tag}
   </h1>
   <p class="text-muted mb-vsp-lg">{countText}</p>

--- a/docs/src/pages/[locale]/docs/tags/index.astro
+++ b/docs/src/pages/[locale]/docs/tags/index.astro
@@ -42,7 +42,7 @@ const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));
       { label: t("doc.allTags", lang) },
     ]}
   />
-  <h1 class="text-heading font-bold mb-vsp-lg">{t("doc.allTags", lang)}</h1>
+  <h1 class="text-heading font-futura font-normal mb-vsp-lg">{t("doc.allTags", lang)}</h1>
   {
     tagMap.size === 0 ? (
       <p class="text-muted">{t("doc.noTags", lang)}</p>

--- a/docs/src/pages/[locale]/index.astro
+++ b/docs/src/pages/[locale]/index.astro
@@ -49,7 +49,7 @@ const tagCount = collectTags(
       >
       </div>
       <div>
-        <h1 class="text-heading font-bold mb-vsp-2xs">{settings.siteName}</h1>
+        <h1 class="text-heading font-futura font-normal mb-vsp-2xs">{settings.siteName}</h1>
         <p class="text-muted text-small mb-vsp-sm">
           {settings.siteDescription}
         </p>

--- a/docs/src/pages/[locale]/index.astro
+++ b/docs/src/pages/[locale]/index.astro
@@ -93,7 +93,7 @@ const tagCount = collectTags(
   {
     settings.docTags && tagCount > 0 && (
       <section class="mt-vsp-xl">
-        <h2 class="text-subheading font-bold mb-vsp-md">
+        <h2 class="text-subheading font-futura font-normal mb-vsp-md">
           {t("doc.allTags", lang)}
         </h2>
         <TagNav variant="all" docs={tagDocs} locale={lang} />

--- a/docs/src/pages/docs/[...slug].astro
+++ b/docs/src/pages/docs/[...slug].astro
@@ -151,7 +151,7 @@ const slug = autoIndex
   {
     autoIndex ? (
       <Fragment>
-        <h1 class="text-heading font-bold mb-vsp-xs">{autoIndex.label}</h1>
+        <h1 class="text-heading font-futura font-normal mb-vsp-xs">{autoIndex.label}</h1>
         {autoIndex.description && (
           <p class="mt-0 mb-vsp-lg text-subheading text-muted">
             {autoIndex.description}
@@ -179,7 +179,7 @@ const slug = autoIndex
       </Fragment>
     ) : (
       <Fragment>
-        <h1 class="text-heading font-bold mb-vsp-xs">{entry.data.title}</h1>
+        <h1 class="text-heading font-futura font-normal mb-vsp-xs">{entry.data.title}</h1>
         {settings.docMetainfo && (
           <DocMetainfo
             filePath={`${settings.docsDir}/${entry.id}`}

--- a/docs/src/pages/docs/tags/[tag].astro
+++ b/docs/src/pages/docs/tags/[tag].astro
@@ -43,7 +43,7 @@ const countText =
       { label: tag },
     ]}
   />
-  <h1 class="text-heading font-bold mb-vsp-xs">{t("doc.taggedWith")}: {tag}</h1>
+  <h1 class="text-heading font-futura font-normal mb-vsp-xs">{t("doc.taggedWith")}: {tag}</h1>
   <p class="text-muted mb-vsp-lg">{countText}</p>
 
   <DocCardGrid

--- a/docs/src/pages/docs/tags/index.astro
+++ b/docs/src/pages/docs/tags/index.astro
@@ -28,7 +28,7 @@ const tagMap = collectTags(docs, (id, data) => data.slug ?? toRouteSlug(id));
       { label: t("doc.allTags") },
     ]}
   />
-  <h1 class="text-heading font-bold mb-vsp-lg">{t("doc.allTags")}</h1>
+  <h1 class="text-heading font-futura font-normal mb-vsp-lg">{t("doc.allTags")}</h1>
   {
     tagMap.size === 0 ? (
       <p class="text-muted">{t("doc.noTags")}</p>

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -43,7 +43,7 @@ const tagCount = collectTags(
       >
       </div>
       <div>
-        <h1 class="text-heading font-bold mb-vsp-2xs">{settings.siteName}</h1>
+        <h1 class="text-heading font-futura font-normal mb-vsp-2xs">{settings.siteName}</h1>
         <p class="text-muted text-small mb-vsp-sm">
           {settings.siteDescription}
         </p>

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -98,7 +98,7 @@ const tagCount = collectTags(
   {
     settings.docTags && tagCount > 0 && (
       <section class="mt-vsp-xl">
-        <h2 class="text-subheading font-bold mb-vsp-md">
+        <h2 class="text-subheading font-futura font-normal mb-vsp-md">
           {t("doc.allTags", defaultLocale)}
         </h2>
         <TagNav variant="all" docs={tagDocs} locale={defaultLocale} />

--- a/docs/src/pages/v/[version]/docs/[...slug].astro
+++ b/docs/src/pages/v/[version]/docs/[...slug].astro
@@ -179,7 +179,7 @@ const slug = autoIndex
   {
     autoIndex ? (
       <Fragment>
-        <h1 class="text-heading font-bold mb-vsp-xs">{autoIndex.label}</h1>
+        <h1 class="text-heading font-futura font-normal mb-vsp-xs">{autoIndex.label}</h1>
         {autoIndex.description && (
           <p class="mt-0 mb-vsp-lg text-subheading text-muted">
             {autoIndex.description}
@@ -209,7 +209,7 @@ const slug = autoIndex
       </Fragment>
     ) : (
       <Fragment>
-        <h1 class="text-heading font-bold mb-vsp-xs">{entry.data.title}</h1>
+        <h1 class="text-heading font-futura font-normal mb-vsp-xs">{entry.data.title}</h1>
         {settings.docMetainfo && (
           <DocMetainfo
             filePath={`${versionConfig.docsDir}/${entry.id}`}

--- a/docs/src/pages/v/[version]/ja/docs/[...slug].astro
+++ b/docs/src/pages/v/[version]/ja/docs/[...slug].astro
@@ -236,7 +236,7 @@ const slug = autoIndex
   {
     autoIndex ? (
       <Fragment>
-        <h1 class="text-heading font-bold mb-vsp-xs">{autoIndex.label}</h1>
+        <h1 class="text-heading font-futura font-normal mb-vsp-xs">{autoIndex.label}</h1>
         {autoIndex.description && (
           <p class="mt-0 mb-vsp-lg text-subheading text-muted">
             {autoIndex.description}
@@ -267,7 +267,7 @@ const slug = autoIndex
       </Fragment>
     ) : (
       <Fragment>
-        <h1 class="text-heading font-bold mb-vsp-xs">{entry.data.title}</h1>
+        <h1 class="text-heading font-futura font-normal mb-vsp-xs">{entry.data.title}</h1>
         {settings.docMetainfo && (
           <DocMetainfo filePath={`${contentDir}/${entry.id}`} locale="ja" />
         )}

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -121,8 +121,22 @@
   --text-heading:    var(--text-scale-xl);   /* page headings */
   --text-display:    var(--text-scale-2xl);  /* hero text */
 
-  /* Font families */
-  --font-sans: system-ui, sans-serif;
+  /* Font families
+   *
+   * System-font stacks — no @font-face declarations or webfont downloads.
+   * Futura is the macOS/iOS system geometric sans; Jost is a free fallback
+   * available where Futura is not installed. Noto Sans / Noto Sans JP serve
+   * as the body face (Noto Sans JP covers CJK glyphs gracefully). */
+  --font-noto:
+    "Noto Sans", "Noto Sans JP", ui-sans-serif, system-ui, -apple-system,
+    BlinkMacSystemFont, "Hiragino Sans", "Hiragino Kaku Gothic Pro",
+    "Yu Gothic", Meiryo, sans-serif;
+
+  --font-futura:
+    Futura, Jost, "Century Gothic", system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", "Noto Sans", "Noto Sans JP", "Hiragino Sans", sans-serif;
+
+  --font-sans: var(--font-noto);
   --font-mono: ui-monospace, monospace;
 
   /* Font weights (4 steps) */
@@ -178,6 +192,7 @@
 body {
   background-color: var(--color-bg);
   color: var(--color-fg);
+  font-family: var(--font-sans);
 }
 
 ::selection {
@@ -217,8 +232,9 @@ body {
 /* ── Headings ── */
 
 .zd-content :where(h2) {
+  font-family: var(--font-futura);
   font-size: var(--text-subheading);
-  font-weight: var(--font-weight-bold);
+  font-weight: var(--font-weight-normal);
   line-height: var(--leading-tight);
   margin-top: var(--spacing-vsp-2xl);
   margin-bottom: var(--spacing-vsp-xs);
@@ -228,8 +244,9 @@ body {
 }
 
 .zd-content :where(h3) {
+  font-family: var(--font-futura);
   font-size: var(--text-body);
-  font-weight: var(--font-weight-bold);
+  font-weight: var(--font-weight-normal);
   line-height: var(--leading-snug);
   margin-top: var(--spacing-vsp-xl);
   margin-bottom: var(--spacing-vsp-xs);
@@ -239,8 +256,9 @@ body {
 }
 
 .zd-content :where(h4) {
+  font-family: var(--font-futura);
   font-size: var(--text-body);
-  font-weight: var(--font-weight-semibold);
+  font-weight: var(--font-weight-normal);
   line-height: var(--leading-snug);
   margin-top: var(--spacing-vsp-lg);
   margin-bottom: var(--spacing-vsp-xs);
@@ -250,8 +268,9 @@ body {
 }
 
 .zd-content :where(h5, h6) {
+  font-family: var(--font-futura);
   font-size: var(--text-small);
-  font-weight: var(--font-weight-semibold);
+  font-weight: var(--font-weight-normal);
   line-height: var(--leading-snug);
   margin-top: var(--spacing-vsp-md);
   margin-bottom: var(--spacing-vsp-2xs);


### PR DESCRIPTION
## Summary

- Repoint the **Claude** header tab from the 404'd `/docs/claude-skills` URL to `/docs/claude` (the auto-generated category index) and widen `categoryMatch` to `"claude"` so it covers `claude/`, `claude-md/`, and `claude-skills/` sub-trees.
- Introduce a Futura + Noto Sans font system (system-font stacks, no webfont download) and switch every content/page-title heading to Futura at `font-weight: normal` — visual hierarchy now comes from size + the existing border-image gradients, not bold weight. Matches the language used by the in-house docs design.
- Define the `--font-futura` CSS variable that commit 9d5da23 had to revert to `font-bold` because the token was undefined; restore the hero h1 (and now every page-title h1/h2 outside the chrome) to the intended Futura/normal-weight design.

## Changes

### Fix `/docs/claude` 404 (1 file)

- `docs/src/config/settings.ts` — `path: "/docs/claude-skills"` → `"/docs/claude"`, `categoryMatch: "claude-skills"` → `"claude"`. The `noPage: true` setting on `claude-skills/_category_.json` meant the old URL never rendered an index page; the `claude/` directory does have one (auto-generated by the claude-resources integration). Pattern mirrors zudo-doc's own `headerNav` entry as documented at https://zudo-doc.pages.dev/pj/zudo-doc/docs/guides/claude-resources/.

### Font system (1 file)

- `docs/src/styles/global.css`:
  - Add `--font-noto` (Noto Sans + Noto Sans JP + system fallbacks) and `--font-futura` (Futura + Jost + Century Gothic + system fallbacks) Tailwind v4 theme tokens. No `@font-face`, no Google Fonts, no webfont download — zero CLS impact.
  - Alias `--font-sans` to `var(--font-noto)` and set `body { font-family: var(--font-sans) }` so Noto Sans is the project-wide default body face.
  - Switch every `.zd-content` heading (h2/h3/h4/h5/h6) to `font-family: var(--font-futura)` + `font-weight: var(--font-weight-normal)`.

### Page-title headings (15 files)

Switch from `font-bold` / `font-semibold` to `font-futura font-normal`:

- React content heading components — `docs/src/components/content/heading-h2.tsx`, `heading-h3.tsx`, `heading-h4.tsx` (used for MDX custom renders so they match raw markdown headings).
- Site landing — `docs/src/pages/index.astro` + `docs/src/pages/[locale]/index.astro` (hero h1 + landing h2).
- Doc pages — `docs/src/pages/docs/[...slug].astro` + `[locale]/docs/[...slug].astro` + `v/[version]/docs/[...slug].astro` + `v/[version]/ja/docs/[...slug].astro` (both auto-index branch and entry-title branch).
- Tag pages — `docs/src/pages/docs/tags/[tag].astro` + `tags/index.astro` and the `[locale]/` twins.
- 404 page — `docs/src/pages/404.astro`.
- Versions page — `docs/src/components/versions-page-content.astro` (h1 + the two h2s).

Header brand link, version-switcher list items, footer headings, sidebar items, and the doc-history widget header are intentionally left as-is — they are site chrome / widget UI, not content headings.

## Test Plan

- `pnpm --filter docs build` succeeds with 103 pages built (verified locally).
- `pnpm --filter docs dev`, then:
  - `curl -I http://localhost:4321/pj/zudo-front-builder/docs/claude` returns **200 OK** (was 404 before).
  - The Claude header tab navigates to a working landing page that lists Claude/CLAUDE.md/Skills sub-trees.
  - Doc-page `<h1>` carries class `text-heading font-futura font-normal mb-vsp-xs` and `.zd-content` `<h2>` carries `font-futura font-normal` — confirmed via raw HTML inspection.
  - `--font-futura`, `--font-noto`, and `--font-sans: var(--font-noto)` are present in the rendered CSS.
- CI ("Build docs site" + health) green on the pushed branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)