### PR TITLE
Npm Supply Chain Hardening: engines, audit CI, dep-surface doc

### DIFF
--- a/.github/workflows/health.yml
+++ b/.github/workflows/health.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter docs build
@@ -40,7 +40,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -48,6 +48,39 @@ jobs:
           path: docs/dist/
           retention-days: 1
 
+  audit:
+    name: pnpm audit (prod)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: pnpm audit (production deps)
+        run: |
+          for attempt in 1 2; do
+            if pnpm audit --prod --audit-level=high; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 2 ]; then
+              echo "audit failed, retrying in 30s..."
+              sleep 30
+            fi
+          done
+          exit 1
+
   deploy-preview:
     name: Deploy PR preview to Cloudflare Pages
     needs: build

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies
@@ -96,7 +96,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Download build artifact

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies
@@ -61,7 +61,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Download build artifact

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,50 @@
+# --audit-level=high — moderate/low findings are tracked in SECURITY-DEPS.md but not gated
+# Scope: pnpm audit --prod audits every workspace package's production dependencies,
+# including the private docs/ workspace. The docs site is publicly deployed via
+# Cloudflare Pages, so a compromised dep in docs/ is a real supply-chain risk for
+# site visitors — not just a private-workspace internal concern.
+
+name: Security Audit
+
+on:
+  schedule:
+    # Monday 07:17 UTC — low-traffic window
+    - cron: "17 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: pnpm audit (prod)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: pnpm audit (production deps)
+        run: |
+          for attempt in 1 2; do
+            if pnpm audit --prod --audit-level=high; then
+              exit 0
+            fi
+            if [ "$attempt" -lt 2 ]; then
+              echo "audit failed, retrying in 30s..."
+              sleep 30
+            fi
+          done
+          exit 1

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 auto-install-peers=true
+engine-strict=true

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -7,10 +7,10 @@ This document covers the toolchain and one-time setup needed to build, test, and
 | Tool   | Version            | Notes                                             |
 | ------ | ------------------ | ------------------------------------------------- |
 | Rust   | stable             | `rustup install stable && rustup default stable`  |
-| Node   | ≥ 20 (LTS)         | The fetch script and Node-side glue use ESM + `fetch`. |
+| Node   | ≥ 22 (LTS)         | The fetch script and Node-side glue use ESM + `fetch`; `engine-strict=true` is set, and the docs site's transitive `chevrotain@12` declares `engines.node >=22`. |
 | pnpm   | as pinned          | The repo declares `packageManager` in `package.json`; use Corepack (`corepack enable`) or install the matching pnpm version directly. |
 
-CI uses Node 20 and Rust stable on `ubuntu-latest`.
+CI uses Node 22 and Rust stable on `ubuntu-latest`.
 
 ## First build is slow
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for your interest in `zudo-front-builder`. The full build pipeline is shi
 ## Toolchain
 
 - **Rust**: stable channel, pinned via `rust-toolchain.toml` at the repo root. With `rustup` installed, the correct toolchain is selected automatically.
-- **Node / pnpm**: **Node 20 or later and pnpm 10 or later are required.** pnpm is pinned via [Corepack](https://nodejs.org/api/corepack.html) (the `packageManager` field in `package.json`). Run `corepack enable` once and pnpm will resolve to the pinned version automatically. The repo sets `engine-strict=true` in `.npmrc`, so `pnpm install` will hard-error if your Node or pnpm version is below the minimum — install the correct version before running install.
+- **Node / pnpm**: **Node 22 or later and pnpm 10 or later are required.** pnpm is pinned via [Corepack](https://nodejs.org/api/corepack.html) (the `packageManager` field in `package.json`). Run `corepack enable` once and pnpm will resolve to the pinned version automatically. The repo sets `engine-strict=true` in `.npmrc`, so `pnpm install` will hard-error if your Node or pnpm version is below the minimum — install the correct version before running install. Node 22 is required (not 20) because `@mermaid-js/parser` (transitive dep of the docs site) pulls in `chevrotain@12` which declares `engines.node >=22`.
 
 ## First build expectation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,10 @@ esbuild is shipped as a Go-built standalone CLI binary that release engineering 
 
 The verification gate is implemented in `ensure_binary_verified` in `crates/zfb-islands/src/esbuild.rs` and runs once per binary path per process: it spawns `esbuild --version`, asserts the reported version equals `EXPECTED_ESBUILD_VERSION`, and (when populated) hashes the binary and asserts the SHA-256 equals `EXPECTED_ESBUILD_SHA256`. A mismatch on either gate aborts with a clear, actionable error pointing back at this section.
 
+## Supply chain
+
+Runtime deps on publishable packages are supply-chain liabilities for downstream users. See [SECURITY-DEPS.md](./SECURITY-DEPS.md) for the full policy, the current runtime-dep audit, and the checklist to follow before adding a new runtime dependency.
+
 ## License
 
 By contributing, you agree that your contributions will be licensed under the [MIT License](./LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ Thanks for your interest in `zudo-front-builder`. The full build pipeline is shi
 ## Toolchain
 
 - **Rust**: stable channel, pinned via `rust-toolchain.toml` at the repo root. With `rustup` installed, the correct toolchain is selected automatically.
-- **Node / pnpm**: pnpm is pinned via [Corepack](https://nodejs.org/api/corepack.html) (the `packageManager` field in `package.json`). Run `corepack enable` once and pnpm will resolve to the pinned version automatically.
+- **Node / pnpm**: **Node 20 or later and pnpm 10 or later are required.** pnpm is pinned via [Corepack](https://nodejs.org/api/corepack.html) (the `packageManager` field in `package.json`). Run `corepack enable` once and pnpm will resolve to the pinned version automatically. The repo sets `engine-strict=true` in `.npmrc`, so `pnpm install` will hard-error if your Node or pnpm version is below the minimum — install the correct version before running install.
 
 ## First build expectation
 

--- a/SECURITY-DEPS.md
+++ b/SECURITY-DEPS.md
@@ -52,7 +52,7 @@ issue number._
 
 ## Before adding a runtime dep
 
-- [ ] Can a Node built-in (≥ 20) do this?
+- [ ] Can a Node built-in (≥ 22) do this?
 - [ ] Can this be a `devDependency` instead?
 - [ ] Can this be `pnpm dlx`'d at build time?
 - [ ] Is the dep on the OpenSSF best-practices list / has a recent release / has an active maintainer?

--- a/SECURITY-DEPS.md
+++ b/SECURITY-DEPS.md
@@ -1,0 +1,59 @@
+# SECURITY-DEPS.md — Runtime Dependency Audit
+
+## Policy
+
+Every runtime dep on a publishable package is a supply-chain liability for downstream users.
+Add deps only when a Node built-in cannot do the job, document the reason here, and prefer
+`pnpm dlx` / `npx` for build-time-only tools.
+
+## Intended-public packages and their runtime deps
+
+The three packages intended for publication are `@takazudo/zfb`, `@takazudo/zfb-runtime`,
+and `@takazudo/zfb-adapter-cloudflare`. Their `dependencies` fields (NOT `devDependencies`)
+are audited here.
+
+### `@takazudo/zfb`
+
+**Runtime deps:** none.
+
+`@takazudo/zfb` has no `dependencies` field — only `devDependencies` (TypeScript, Vitest,
+`@types/node`). All of those are build/test tooling that is never installed by downstream
+users of the package.
+
+### `@takazudo/zfb-runtime`
+
+**Runtime deps:**
+
+| Package | Version range | Rationale |
+| ------- | ------------- | --------- |
+| `hono`  | `^4.7.0`      | Hono is the page-router runtime — it is the entire point of this package. `zfb-runtime` wraps Hono's routing primitives to provide file-system-based page routing, content snapshots, and SSR for Cloudflare Workers. A Node built-in cannot replace a full HTTP routing framework. The dep is retained. |
+
+### `@takazudo/zfb-adapter-cloudflare`
+
+**Runtime deps:** none.
+
+`@takazudo/zfb-adapter-cloudflare` has no `dependencies` field. The shipped CLI
+(`bin/cli.mjs`) uses only Node built-ins (`node:fs/promises`, `node:fs`, `node:path`,
+`node:url`) and one project-internal import (`../src/worker-wrapper.mjs`). No external npm
+package is imported at runtime. The file carries an explicit `// invariant: no runtime npm
+deps — see SECURITY-DEPS.md` comment to make this contractual.
+
+## Audit policy
+
+CI runs `pnpm audit --prod --audit-level=high`. `high`+ findings fail PRs. `moderate` and
+`low` findings are intentionally informational — track them here, file issues for real fixes.
+So "CI audit green" means no high/critical CVEs, not zero findings.
+
+## Known moderate / low findings
+
+_None at the time of this audit (2026-05-20). Update this section whenever a non-gated
+finding is observed, with the advisory ID, affected package, severity, and the tracking
+issue number._
+
+## Before adding a runtime dep
+
+- [ ] Can a Node built-in (≥ 20) do this?
+- [ ] Can this be a `devDependency` instead?
+- [ ] Can this be `pnpm dlx`'d at build time?
+- [ ] Is the dep on the OpenSSF best-practices list / has a recent release / has an active maintainer?
+- [ ] Update this doc with the new dep + rationale.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "license": "MIT",
   "description": "zudo-front-builder — frontend build orchestrator (private workspace)",
   "packageManager": "pnpm@10.30.0",
+  "engines": {
+    "node": ">=20.0.0",
+    "pnpm": ">=10.0.0"
+  },
   "scripts": {
     "//// === ROOT ===": "",
     "prepare": "lefthook install --reset-hooks-path && bash scripts/install-git-hooks.sh",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "description": "zudo-front-builder — frontend build orchestrator (private workspace)",
   "packageManager": "pnpm@10.30.0",
   "engines": {
-    "node": ">=20.0.0",
+    "node": ">=22.0.0",
     "pnpm": ">=10.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "wrangler": "4.85.0"
   },
   "pnpm": {
+    "overrides": {
+      "devalue": "^5.8.1"
+    },
     "onlyBuiltDependencies": [
       "lefthook",
       "wrangler"

--- a/packages/zfb-adapter-cloudflare/bin/cli.mjs
+++ b/packages/zfb-adapter-cloudflare/bin/cli.mjs
@@ -13,6 +13,7 @@
 // The CLI is intentionally tiny and dependency-free. It imports the
 // wrapper string from the canonical `src/worker-wrapper.mjs` (plain JS,
 // no TypeScript loader required) so there is a single source of truth.
+// invariant: no runtime npm deps — see SECURITY-DEPS.md
 
 import { copyFile, mkdir, writeFile } from "node:fs/promises";
 import { realpathSync } from "node:fs";

--- a/packages/zfb-adapter-cloudflare/package.json
+++ b/packages/zfb-adapter-cloudflare/package.json
@@ -54,7 +54,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=20.0.0",
+    "node": ">=22.0.0",
     "pnpm": ">=10.0.0"
   },
   "scripts": {

--- a/packages/zfb-adapter-cloudflare/package.json
+++ b/packages/zfb-adapter-cloudflare/package.json
@@ -53,6 +53,10 @@
   "publishConfig": {
     "access": "public"
   },
+  "engines": {
+    "node": ">=20.0.0",
+    "pnpm": ">=10.0.0"
+  },
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/zfb-runtime/package.json
+++ b/packages/zfb-runtime/package.json
@@ -57,7 +57,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=20.0.0",
+    "node": ">=22.0.0",
     "pnpm": ">=10.0.0"
   },
   "scripts": {

--- a/packages/zfb-runtime/package.json
+++ b/packages/zfb-runtime/package.json
@@ -56,6 +56,10 @@
   "publishConfig": {
     "access": "public"
   },
+  "engines": {
+    "node": ">=20.0.0",
+    "pnpm": ">=10.0.0"
+  },
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/zfb/package.json
+++ b/packages/zfb/package.json
@@ -71,7 +71,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=20.0.0",
+    "node": ">=22.0.0",
     "pnpm": ">=10.0.0"
   },
   "scripts": {

--- a/packages/zfb/package.json
+++ b/packages/zfb/package.json
@@ -70,6 +70,10 @@
   "publishConfig": {
     "access": "public"
   },
+  "engines": {
+    "node": ">=20.0.0",
+    "pnpm": ">=10.0.0"
+  },
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  devalue: ^5.8.1
+
 importers:
 
   .:
@@ -2217,8 +2220,8 @@ packages:
     resolution: {integrity: sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==}
     engines: {node: '>=18'}
 
-  devalue@5.7.1:
-    resolution: {integrity: sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==}
+  devalue@5.8.1:
+    resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -5350,7 +5353,7 @@ snapshots:
       cssesc: 3.0.0
       debug: 4.4.3
       deterministic-object-hash: 2.0.2
-      devalue: 5.7.1
+      devalue: 5.8.1
       diff: 8.0.4
       dlv: 1.1.3
       dset: 3.1.4
@@ -5806,7 +5809,7 @@ snapshots:
     dependencies:
       base-64: 1.0.0
 
-  devalue@5.7.1: {}
+  devalue@5.8.1: {}
 
   devlop@1.1.0:
     dependencies:


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/320

---

## Summary

Implements epic #320 — three supply-chain hardenings to the npm side of the workspace, plus a baseline-driven follow-up adjustment surfaced by CI:

- **Sub #321** — `engines.node`/`engines.pnpm` on all four `package.json`s (root + 3 intended-public packages), `engine-strict=true` in `.npmrc`, and a Node/pnpm minimum note in CONTRIBUTING.md.
- **Sub #322** — clear the `docs > astro > devalue` HIGH advisory (GHSA-77vg-94rm-hx3p) via a workspace-root `pnpm.overrides.devalue = "^5.8.1"`. `pnpm audit --prod --audit-level=high` now exits 0.
- **Sub #323** — new `audit` job in `pr-checks.yml` (per PR) and a new `security-audit.yml` (weekly cron + `workflow_dispatch`), both running `pnpm audit --prod --audit-level=high` behind a 2× retry / 30 s sleep wrapper.
- **Sub #324** — new `SECURITY-DEPS.md` at the repo root cataloguing every runtime dep on every intended-public package, the audit-level policy, the "before adding a runtime dep" checklist, and an explicit no-runtime-deps invariant comment in the cloudflare-adapter CLI. Linked from CONTRIBUTING.md.
- **Node 22 baseline (follow-up)** — the sub-#321 spec assumed Node 20 was safe, but enabling `engine-strict=true` hard-enforces every transitive dep's `engines.node`. The docs site's pre-existing `@mermaid-js/parser → langium → chevrotain@12` chain declares `engines.node >=22`, which Node 20 doesn't satisfy. Bumped `engines.node` to `>=22.0.0` in all four package.jsons, `node-version: 22` in all five CI workflows, and updated CONTRIBUTING.md / BUILDING.md / SECURITY-DEPS.md to match.

## Topic PRs (merged locally into base, branches deleted)

- `npm-supply-chain/engines` → sub #321
- `npm-supply-chain/clear-devalue` → sub #322
- `npm-supply-chain/audit-ci` → sub #323
- `npm-supply-chain/security-deps-doc` → sub #324

## Files changed

- `.github/workflows/pr-checks.yml` — new `audit` job + `node-version: 22`
- `.github/workflows/security-audit.yml` — new weekly cron + dispatch trigger
- `.github/workflows/{health,main-deploy,preview-deploy}.yml` — `node-version: 22`
- `.npmrc` — `engine-strict=true`
- `package.json` (root) — `engines` + `pnpm.overrides.devalue`
- `packages/{zfb,zfb-runtime,zfb-adapter-cloudflare}/package.json` — `engines`
- `pnpm-lock.yaml` — regenerated with `devalue@5.8.1`
- `CONTRIBUTING.md` — Node 22 / pnpm 10 prerequisites + Supply chain link
- `BUILDING.md` — Node 22 baseline + rationale
- `SECURITY-DEPS.md` (new, at repo root)
- `packages/zfb-adapter-cloudflare/bin/cli.mjs` — no-runtime-deps invariant comment

## Review

- `/codex-review` flagged one P2: gating `deploy-preview` on the new `audit` job. **Not applied** — the sub-#323 spec explicitly requires the audit be a *separate job* so a registry blip can't block the build or preview deploy. The 2× retry already mitigates transient blips; gating deploy on audit would conflict with the spec's intent and is out of scope for this PR.
- `/gcoc-review` found no actionable issues.

## Follow-up

- #326 — SHA-pin all GitHub Action references repo-wide (spun out of #323 per the spec).

## Test Plan

- `pnpm install --frozen-lockfile` succeeds locally on Node 22 without lockfile changes.
- `pnpm audit --prod --audit-level=high` exits 0 from the repo root (HIGH cleared; 2 low + 10 moderate remain below the gating threshold).
- `pnpm --filter docs build` succeeds (105 pages built).
- All four CI checks green on this PR: build, health, audit, deploy-preview (skipped on this base branch but not failing).
- `actionlint` (via the `docker://rhysd/actionlint:1.7.12` action in `health.yml`) passes on the new YAML files.