### PR TITLE
docs: philosophy + how-to-use perspective pass (epic #350)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Rust makes the framework itself fast, memory-safe, and distributable as a single
 
 zfb is the **engine**: router, renderer, content pipeline, and the small set of build-time primitives (frontmatter extraction, content collections, `paths()`, MDX directive registry, non-HTML page emission, and the `PageMeta` head/asset contract) that a framework can build on. Frameworks like a future `zudo-doc-v2` sit on top of these primitives and own the opinionated layer — sidebar generation, search, theming, blog conventions, i18n routing, versioning UI, and so on.
 
+zfb is the engine for content sites whose hard parts live outside page rendering — build-time data pipelines, custom content collections, project-specific glue. For sites whose hard parts are page rendering itself (multi-framework, ISR, RSC, server actions), use Astro or Next. See [`concepts/choosing-zfb.mdx`](./docs/src/content/docs/concepts/choosing-zfb.mdx) for the longer answer.
+
 The full pipeline ships today: embedded V8 host, `zfb.config.ts` config loader, `syntect`-backed syntax highlighting, islands pipeline, client router with view transitions, content-collection bridge, and dev-server are all wired.
 
 ## Docs site

--- a/docs/src/content/docs/architecture/js-runtime.mdx
+++ b/docs/src/content/docs/architecture/js-runtime.mdx
@@ -24,7 +24,7 @@ SWC, oxc, and esbuild all compile JSX to `h(...)` calls — none of them need a 
 
 Once JSX becomes `h(...)`, something must _evaluate_ that code: walk the call tree to produce a VDOM, then invoke `renderToString` to produce HTML. Evaluation needs a JS engine somewhere — but not necessarily V8. Two lightweight alternatives exist:
 
-- **Boa** (pure Rust, ~30 s incremental build) — an ECMA-spec-faithful JS engine written entirely in Rust; no C++ toolchain.
+- **Boa** (pure Rust, ~30 s incremental build) — a JS engine written entirely in Rust with no C++ toolchain; tracks the ECMA spec but trails V8 on coverage of newer features.
 - **rquickjs** (Rust bindings to QuickJS, ~210 KB binary contribution) — fast to compile, minimal footprint.
 
 Both work well for SSR of a simple, self-contained Preact component. The problem is "any frontend dev's TSX with whatever npm packages they imported." The moment a user adds a calendar library, an i18n helper, or a component that uses a Proxy-based state store, Boa's ECMA gaps and QuickJS's limited ES2022+ surface start producing silent wrong output or hard panics — failure modes that are extremely hard to diagnose. V8 is the safe bet for arbitrary ecosystem code because it is the same engine Node.js and Chromium run against.

--- a/docs/src/content/docs/architecture/js-runtime.mdx
+++ b/docs/src/content/docs/architecture/js-runtime.mdx
@@ -12,6 +12,35 @@ The V8 embedding decision came through a measured evaluation of available JS hos
 
 The stable production contract throughout has been the _bundle shape_ (`export default { fetch }`), not the build-time engine. The same bundle that zfb renders at build time deploys unchanged to Cloudflare Workers for runtime SSR.
 
+## Why a JS engine at all — and why V8 specifically
+
+zfb uses a JS engine not because TSX requires one, but because *evaluating* the compiled output does. The distinction matters.
+
+### Layer 1 — JSX is just syntax
+
+SWC, oxc, and esbuild all compile JSX to `h(...)` calls — none of them need a JS engine to do it. Parsing and transforming TSX is a pure syntax operation. So "we support TSX" does not logically imply "we need V8." The question is what happens after the transform.
+
+### Layer 2 — The compiled JS still needs to run
+
+Once JSX becomes `h(...)`, something must _evaluate_ that code: walk the call tree to produce a VDOM, then invoke `renderToString` to produce HTML. Evaluation needs a JS engine somewhere — but not necessarily V8. Two lightweight alternatives exist:
+
+- **Boa** (pure Rust, ~30 s incremental build) — an ECMA-spec-faithful JS engine written entirely in Rust; no C++ toolchain.
+- **rquickjs** (Rust bindings to QuickJS, ~210 KB binary contribution) — fast to compile, minimal footprint.
+
+Both work well for SSR of a simple, self-contained Preact component. The problem is "any frontend dev's TSX with whatever npm packages they imported." The moment a user adds a calendar library, an i18n helper, or a component that uses a Proxy-based state store, Boa's ECMA gaps and QuickJS's limited ES2022+ surface start producing silent wrong output or hard panics — failure modes that are extremely hard to diagnose. V8 is the safe bet for arbitrary ecosystem code because it is the same engine Node.js and Chromium run against.
+
+Research is open on both lighter-engine paths — see [#344 — feature-gated V8 in the production runtime](https://github.com/Takazudo/zudo-front-builder/issues/344) and [#345 — Boa / QuickJS as the SSG-only JS engine](https://github.com/Takazudo/zudo-front-builder/issues/345).
+
+### Layer 3 — Rust templating compiles out the JS entirely
+
+Leptos and Yew take JSX-like syntax (RSX) and compile it to Rust at build time. No JS engine is needed at runtime or build time. The catch: they borrowed the syntax, not the language. There is no `import` for arbitrary npm packages, no JS closures over runtime values, and no drop-in Preact component from GitHub. A Leptos project is a Rust project — you write Rust, you depend on Rust crates. That breaks the core audience promise: a frontend developer's existing TSX and npm knowledge would not transfer.
+
+### The audience tradeoff
+
+zfb's target audience is frontend developers who already know TSX. V8 is the price of admission for that audience — it is what makes "your existing component just works" a true statement rather than a best-effort approximation. The [design philosophy](/concepts/design-philosophy) section explains this audience-first framing in full.
+
+Pure-Rust SSG (Boa/QuickJS) and no-V8-at-runtime (build-time-only V8) are real future directions — see [#344](https://github.com/Takazudo/zudo-front-builder/issues/344) and [#345](https://github.com/Takazudo/zudo-front-builder/issues/345) — but they are optimizations on top of the default, not the default itself.
+
 ## What runs today
 
 At `zfb build` / `zfb dev` / `zfb preview`, the Rust orchestrator creates an in-process V8 isolate via `deno_core`. It loads the workerd-shape bundle that `@takazudo/zfb-runtime` builds with esbuild. Per-route props are passed as JSON; the isolate invokes the bundle's `fetch` entry with a synthetic `Request`, collects the `Response` (HTML), and returns it. The orchestrator writes plain HTML to `dist/`. No subprocess is spawned; no Node.js is required.

--- a/docs/src/content/docs/concepts/architecture-overview.mdx
+++ b/docs/src/content/docs/concepts/architecture-overview.mdx
@@ -38,8 +38,11 @@ The Rust orchestrator loads this bundle into an embedded V8 isolate
 and drives it with synthetic HTTP requests — one request per page
 URL. Each synthetic request produces an HTML `Response`. The orchestrator writes
 those responses to `dist/` as plain `.html` files. When the build finishes, the
-isolate is torn down. The worker bundle never leaves your machine; it is the
-*tool* that produces the static output, not the output itself.
+isolate is torn down. At build time the worker bundle never leaves your machine — it is the
+*tool* the Rust orchestrator drives to produce the static output. (The
+same bundle shape also deploys unchanged to Cloudflare Workers for any
+`prerender = false` routes; that production path is covered later in
+this page and in the [SSR guide](/guides/ssr-and-cloudflare-bindings).)
 
 **Island bundles — shipped to the browser, on-demand.**
 

--- a/docs/src/content/docs/concepts/choosing-zfb.mdx
+++ b/docs/src/content/docs/concepts/choosing-zfb.mdx
@@ -73,11 +73,13 @@ module resolution.
 zfb is the wrong choice in several cases — be honest with yourself
 before committing.
 
-**Your site is primarily server-rendered or driven by dynamic data.**
-zfb is an SSG engine. Every page is computed at build time and written
-to `dist/` as static HTML. There is no per-request rendering, no API
-routes, and no database-query layer. If your pages change per-user or
-on every request, you need a full SSR framework.
+**Most or every page on your site is dynamic.** zfb is SSG-by-default:
+every page is computed at build time into static HTML. Routes that need
+request-time behavior can opt out with `prerender = false` and be served
+by an adapter (see [SSR and Cloudflare bindings](/guides/ssr-and-cloudflare-bindings)).
+That covers a sprinkle of dynamic routes on an otherwise-static site. If
+*every* page is dynamic — per-user, per-request — zfb is the wrong tool,
+and a full SSR framework is the right one.
 
 **You need broad multi-framework support.** Astro's adapter ecosystem
 lets you swap between React, Vue, Svelte, Solid, and others inside the
@@ -137,6 +139,7 @@ lives in the [README scaling note](https://github.com/Takazudo/zudo-front-builde
 ## Where to go next
 
 - [Getting started](/getting-started) — scaffold your first site.
+- [Design philosophy](/concepts/design-philosophy) — the "narrow on purpose" stance and the recipes-over-plugins framing that explain why this set of trade-offs.
 - [Architecture: Build engine](/architecture/build-engine) — how the
   Rust crates, the JS host, and the snapshot fit together.
 - [Engine vs Framework](/concepts/engine-vs-framework) — the six

--- a/docs/src/content/docs/concepts/design-philosophy.mdx
+++ b/docs/src/content/docs/concepts/design-philosophy.mdx
@@ -1,0 +1,114 @@
+---
+title: Design Philosophy
+description: Why zfb stays narrow on purpose, and why the AI era tips the balance further toward recipes over plugins.
+sidebar_position: -0.7
+category: Concepts
+---
+
+<Info title="What this page covers">
+
+Two design principles that run through every decision in zfb: the deliberate
+choice to stay narrow rather than grow the surface area, and why — in an era
+where LLMs are in every workflow — recipes beat plugins for nearly everything
+outside a small universal core.
+
+</Info>
+
+zfb's surface area is intentionally small. That choice has a cost, and it has
+benefits. This page makes both explicit, then explains why the LLM-in-loop
+shift makes the recipe path even more attractive than it was before.
+
+## Narrow on purpose
+
+zfb is the SSG + SSR version of esbuild: a fast, focused engine that does
+exactly what it commits to and stops there. Just as esbuild deliberately
+avoids becoming a full application bundler with its own plugin ecosystem for
+every possible transformation, zfb deliberately avoids growing a thick API
+surface to cover every site-building pattern.
+
+The [six engine primitives](/concepts/engine-vs-framework) are the complete
+public contract of zfb v1. Adding a seventh primitive — even a useful one —
+means a new API to design, document, maintain, and version across future
+releases. It means answering "is this possible?" questions about edge cases
+on the new surface. And it means that framework authors building on top of
+zfb must now reason about one more axis.
+
+**The cost of staying narrow** is real: the consumer carries the glue. When
+zfb does not ship sidebar generation or i18n routing or a built-in search
+hook, the framework author — or the consumer directly — writes that code. In
+a pre-generated ecosystem, that would mean searching for recipes, reading
+through them, and adapting them to the project's shape. That adaptation cost
+was genuine.
+
+**The benefit** is the absence of an uncertainty tax. When the surface is
+narrow and stable, the question "does zfb support this?" has a fast answer:
+look at the six primitives. If the feature maps onto them, it works. If it
+does not, it belongs in a framework sitting on top of zfb, not inside the
+engine. There is no thick API to audit, no plugin point that might break in
+the next minor version, and no dependency on the engine team keeping up with
+every downstream use case.
+
+[Astro](https://astro.build) and [Next.js](https://nextjs.org) make a
+different trade. They offer broad multi-framework support, rich plugin
+ecosystems, and first-party adapters for many patterns. That is the right
+call for a general-purpose framework aimed at the widest possible audience.
+zfb's bet is the opposite: that a narrower, faster engine with a smaller
+stable contract is a better foundation for the specific case of
+content-heavy statically generated sites targeting Cloudflare's edge.
+
+The engine-promotion test captures the boundary precisely: `"if two frameworks
+built on zfb would do this differently, it's not engine."` If there is any
+legitimate reason two downstream frameworks would make different choices, the
+feature does not belong in zfb's surface area. It belongs in the frameworks.
+
+## Recipes over plugins in the AI era
+
+Before LLMs were part of every workflow, the recipe vs. plugin choice had a
+real asymmetry.
+
+**Pre-LLM recipe cost.** Finding a recipe meant a search, a scan through
+Stack Overflow answers or blog posts, a judgment call about whether the
+recipe matched the current project's version and structure, and then manual
+adaptation. Each of those steps took time and attention. A well-packaged
+plugin that solved the same problem was genuinely faster to reach for.
+
+**The LLM-in-loop shift.** With an LLM available, the adaptation cost
+collapses. A recipe that would have taken thirty minutes to understand and
+adapt now takes a prompt. More importantly, the recipe is now *transparent*:
+it runs in the consumer's project, it uses the consumer's imports, it ages
+alongside the consumer's codebase, and it is debuggable without peering into
+a dependency's internals. A plugin, by contrast, hides the implementation
+behind a version-pinned package, requires the plugin author to keep pace with
+the engine, and adds an indirection layer the LLM has to reason around.
+
+This does not mean plugins are obsolete. It means the bar for promoting
+something into a plugin has risen. The right question is no longer "would a
+recipe here be annoying to find and adapt?" — the LLM handles that. The right
+question is "is this something 100% of zfb consumers would use the same way,
+with no legitimate reason to deviate?"
+
+**The narrow plugin API zfb ships today** — the four lifecycle hooks, virtual
+modules, import aliases, and dev-only injected routes documented in
+[Plugins](/concepts/plugins) — is exactly that narrow exception. The `setup`
+hook's virtual module and alias registrations, the `preBuild` / `postBuild`
+file-generation hooks, and the `devMiddleware` handler cover patterns that
+are structurally inseparable from the build pipeline: things a consumer
+cannot implement as a recipe without forking the engine itself. The surface is
+deliberately closed elsewhere — no `addRemarkPlugin`, no `addModuleTransform`,
+no `onModuleLoad` — because those patterns belong in recipes, not in a stable
+engine API.
+
+The plugin-promotion test states the threshold: `"don't extract until the same
+recipe has been written by hand in three different zfb consumer projects."` One
+project's convenience is a recipe. Three independent projects converging on the
+same solution is evidence of a universal need. At that point, and only at that
+point, the extraction into a plugin API earns its maintenance cost.
+
+## Where to go next
+
+- [Engine vs Framework](/concepts/engine-vs-framework) — the six primitives
+  zfb commits to, and the line between engine and framework concerns.
+- [Plugins](/concepts/plugins) — the narrow exception: the four lifecycle hooks
+  and what they do and do not cover.
+- [Choosing zfb](/concepts/choosing-zfb) — when the narrow-on-purpose tradeoff
+  is the right call for your project, and when it is not.

--- a/docs/src/content/docs/concepts/plugins.mdx
+++ b/docs/src/content/docs/concepts/plugins.mdx
@@ -9,6 +9,15 @@ zfb plugins are plain ES modules whose default export is a `ZfbPlugin` object. T
 
 This page documents the contract for plugin authors. The companion API reference is on [`defineConfig.plugins`](/api/define-config).
 
+## When you actually need a plugin
+
+Reach for a plugin when you need one of the four capabilities that `setup` provides — the same four the sections below document. If none of these apply, a plain script is the right tool instead (see [When you don't — write a recipe](#when-you-dont--write-a-recipe) below). For the broader engine-vs-script mental model, see [Design Philosophy](/concepts/design-philosophy).
+
+- **Virtual module backing a synthetic data source.** If your pages need to `import` from a specifier that has no real file on disk — a metadata DB, a content index, a generated config blob — `addVirtualModule` is the only way to inject that source into the module graph. Example: `import metadata from "virtual:metadata-db"` across every page.
+- **Alias rewrite that must apply across all bundlers.** `addAlias` registers an exact-match import rewrite that is honored by all three consumers: the embedded V8 host, the main page/layout bundler, and the islands esbuild bundler. A `tsconfig.json` `paths` entry only reaches the type-checker. If the alias has to work at runtime in all three bundlers, it belongs in a plugin.
+- **Dev-only injected route that lives outside `pages/`.** `injectRoute` registers a TSX/TS file under a URL pattern the dev server recognises — a synthetic page that has no counterpart in the on-disk `pages/` tree, gated on `command === "dev"` so it never escapes into a production build.
+- **Dev middleware HTTP handler.** `devMiddleware` is for responses that aren't pages at all: a JSON API endpoint, a hot-reload bridge, an upload handler. No JSX pipeline, no page renderer — just a function returning `{ status, headers, body }`.
+
 ## The four hooks
 
 ```ts
@@ -179,6 +188,12 @@ export default defineConfig({
 
 The plugin runs after `dist/` is fully written; any file it creates alongside the emitted HTML pages is served as a static asset in production.
 
+<Note title="SSR route over-inclusion gap">
+
+The filter `r.extension === "html"` above will over-include server-rendered (SSR) routes — routes where `prerender` is `false` — once SSR ships. Today `ctx.routes[].prerender` does not exist on `ZfbRouteEntry`. When it does, the correct filter will be `r.extension === "html" && r.prerender !== false`. Do not use that expression yet; the field is not there. Tracked in [zudo-front-builder#347](https://github.com/Takazudo/zudo-front-builder/issues/347).
+
+</Note>
+
 ## `devMiddleware(ctx)`
 
 Unchanged from v1. Register one or more HTTP handlers via `ctx.register(path, handler)`; handlers return `{ status, headers, body }` (or `undefined` to fall through to zfb's built-in dev routes).
@@ -247,6 +262,17 @@ When two plugins clash on a registration, zfb aborts the build/dev with one of t
 - `InjectRouteConflict` — same URL pattern, different plugins.
 
 `InjectRouteInBuildMode` is raised when any plugin calls `injectRoute` during `zfb build` (regardless of who registered first).
+
+## When you don't — write a recipe
+
+Not everything that runs at build time needs a plugin. If your task doesn't require `setup`-level capabilities (no virtual module, no alias, no injected route, no dev middleware), a plain Node.js script in `scripts/` wired into `pnpm build` is simpler, easier to test in isolation, and less coupled to zfb's internals. The [Design Philosophy](/concepts/design-philosophy) and [Engine vs Framework](/concepts/engine-vs-framework) pages explain the broader principle.
+
+Common candidates that do not need a plugin:
+
+- **Sitemap generation.** `postBuild` gives you `ctx.routes` — but you can read the same `dist/` tree from a standalone script. No module graph access needed; wire it into `pnpm build`.
+- **OGP image emission.** Rendering open-graph images from page metadata is a pure data-in / image-out transform. A standalone script that reads built HTML or a JSON manifest and calls a canvas/puppeteer/satori pipeline needs no plugin hook; wire it into `pnpm build`.
+- **Search-index builds.** Tools like Pagefind or Lunr crawl the finished `dist/` tree. They need no access to zfb internals — just a path to the output directory; wire it into `pnpm build`.
+- **Build-end manifests.** If you need a custom JSON manifest (asset list, version map, route catalog) derived from the emitted files, a script that reads `dist/` after the build is self-contained; wire it into `pnpm build`.
 
 ## See also
 

--- a/docs/src/content/docs/getting-started/introduction.mdx
+++ b/docs/src/content/docs/getting-started/introduction.mdx
@@ -10,6 +10,8 @@ If you can read a `pages/` directory tree and write a TSX component, you already
 
 ## What zfb provides
 
+For the "why this shape" answer — narrow scope, recipes-over-plugins, no middleware layer — see [Design philosophy](/concepts/design-philosophy).
+
 - **Embedded V8 worker** — pages render through a Rust-embedded V8 runtime. No separate Node process is required at build time.
 - **Atomic writes** — the build never leaves the output directory in a partially-written state. Each `zfb build` run either completes fully or leaves `dist/` unchanged.
 - **Per-page incremental rebuild** — changing a shared layout touches only the pages that import it, not the whole site. Dev-loop latency stays in the tens of milliseconds even on large sites.
@@ -46,7 +48,7 @@ What is different: zfb has no component syntax of its own — everything is TSX.
 | `public/` for static assets | `public/` — same semantics |
 | Layout components wrapping pages | Layout components wrapping pages — plain TSX composition |
 
-What is different: zfb produces only static HTML — there is no server runtime, no API routes, and no SSR at request time. Think of it as Next.js with `output: "export"` only, but with a faster build engine and no Node.js required in the build environment. The App Router, server components, and middleware are outside zfb's scope.
+What is different: zfb is **SSG by default** — every page is computed at build time into static HTML. Routes that genuinely need request-time behavior opt out with `prerender = false` and are served by a configured adapter (e.g. Cloudflare Pages via [`@takazudo/zfb-adapter-cloudflare`](/guides/ssr-and-cloudflare-bindings)). What zfb does not aim to be is a full app framework — there is no App Router, no React Server Components, no middleware layer, and no per-page automatic ISR. The runtime story is "SSG plus an adapter-shaped escape hatch," not "Next.js with `output: export` only."
 
 ## Client router and view transitions
 

--- a/docs/src/content/docs/guides/desktop-deployment.mdx
+++ b/docs/src/content/docs/guides/desktop-deployment.mdx
@@ -5,17 +5,36 @@ sidebar_position: 6
 ---
 
 This guide covers what is realistic today when you want to embed a zfb site
-inside a desktop app. The short answer is: **the `dist/` output requires no
-Node.js at runtime**, so shipping a pre-built site is straightforward. Enabling
-live content edits inside the app is a different, harder problem.
+inside a desktop app. There are four distinct composition modes between zfb and
+Tauri — each is the right answer for a different project. Choose deliberately:
 
-## The simple case: ship the static output
+- **Mode A** wins when content is authored at build time and bundled with each
+  release.
+- **Mode B** wins when you want zfb's full runtime dynamism with minimal
+  Tauri-side code.
+- **Mode C** wins when the dynamic part of your app is Rust-doable without zfb
+  in the process.
+- **Mode D** is the future mode once the in-process embed API ships.
 
-`zfb build` produces a fully static site in `dist/` — HTML, CSS, and JavaScript
-files with no server-side dependency at runtime. A desktop app can serve that
-directory directly using the framework's built-in asset server.
+The core invariant that governs all four modes:
 
-For **Tauri**, the relevant `tauri.conf.json` keys are:
+> **Build time = Node.js required. Runtime = no Node.js, ever.**
+
+zfb's static output is deliberately runtime-agnostic. The build tooling is not.
+Plan your architecture around that boundary rather than against it.
+
+## Mode A — Ship `dist/` only
+
+**What it is.** `zfb build` produces a fully static site in `dist/` — HTML, CSS,
+and JavaScript files with no server-side dependency at runtime. A desktop app
+can serve that directory directly using the framework's built-in asset server.
+zfb is invisible at runtime; the packaged app is just files on disk.
+
+**When to pick it.** Documentation apps, help systems, and any desktop app where
+the content is authored at build time and bundled with the release. If users do
+not need to edit content inside the running app, Mode A is the right choice.
+
+**What's involved.** For Tauri, the relevant `tauri.conf.json` keys are:
 
 ```json
 {
@@ -28,12 +47,7 @@ For **Tauri**, the relevant `tauri.conf.json` keys are:
 
 Point `distDir` at your `dist/` folder (adjust the relative path to match your
 project layout). Tauri's built-in static file server handles the rest. There is
-no Node.js process and no HTTP server required in the packaged app — just files
-on disk.
-
-This is the **recommended approach** for documentation apps, help systems, and
-any desktop app where the content is authored at build time and bundled with the
-release:
+no Node.js process and no HTTP server required in the packaged app.
 
 1. Run `zfb build` on the developer machine (or in CI).
 2. Include the resulting `dist/` in your Tauri app bundle.
@@ -43,42 +57,107 @@ See the [Tauri `tauri.conf.json` reference](https://tauri.app/v1/api/config/) fo
 the full set of asset-serving options, including custom protocols and security
 policies.
 
+**Tradeoff.** Updating content requires a new app release. There is no mechanism
+for users to see fresh content without a new build.
+
+---
+
+## Mode B — zfb binary as Tauri sidecar
+
+**What it is.** Tauri spawns the `zfb` binary as a child process; the WebView
+points at `localhost:<port>`. zfb handles request-time MDX rendering, resource
+discovery, and so on from inside that child process. The sidecar binary is Rust —
+no Node.js required in the packaged app.
+
+**When to pick it.** You want zfb's full dynamism — `prerender = false` routes,
+MDX rendering at request time, content reloading without a rebuild — but you do
+not need the zfb server to live inside the Tauri process itself.
+
+**What's involved.** Ship the `zfb` binary alongside your Tauri app as a
+[Tauri sidecar](https://tauri.app/v1/guides/building/sidecar/). Write a thin IPC
+bridge so the Tauri frontend can start the sidecar, discover the port, and open
+the WebView to `http://127.0.0.1:<port>`. The boundary between sidecar and Tauri
+is clean; the integration glue is not provided out of the box.
+
+**Tradeoff.** You carry extra moving parts: child process lifecycle management,
+port discovery, and IPC plumbing between Tauri and the sidecar. In exchange you
+get zfb's full render pipeline at runtime with no Node.js dependency.
+
+---
+
+## Mode C — Custom Rust crates that use zfb at build-time only
+
+**What it is.** zfb compiles the Preact shell to `dist/` once, at build time.
+After that, all runtime dynamism — resource discovery, markdown rendering, serving
+— is hand-rolled Rust code, typically an Axum server that reads files from disk
+and substitutes content into the pre-built shell. zfb is not present at runtime
+at all; it is purely a build-time tool.
+
+**When to pick it.** The dynamic part of your app is markdown rendering or
+something else that straightforward Rust libraries already handle well, and you
+would rather write focused Rust server code than carry the full zfb render
+pipeline into your binary. You want the smallest possible runtime footprint.
+
+**What's involved.** Build the Preact shell with `zfb build`. Then write a
+purpose-built Rust server (or add Axum routes to an existing Tauri app) that
+reads markdown files at request time, renders them with a Rust markdown crate,
+and splices the result into the static shell via sentinel substitution or a
+similar pattern. [CCResDoc](https://github.com/Takazudo/ccresdoc) is a concrete,
+working example of this pattern: zfb compiles the Preact shell once and a
+hand-rolled Rust backend delivers content at runtime.
+
+**Tradeoff.** You write more Rust glue code, and you give up TSX-level page
+components at runtime. In exchange you get the smallest possible binary, full
+control over the runtime behaviour, and zero V8 dependency in the packaged app.
+
+---
+
+## Mode D — Embed zfb as a Rust crate inside Tauri (FUTURE)
+
+**What it is.** Tauri's `setup` hook would spawn a zfb server on a Tokio thread
+inside the Tauri process — no child process, no port management, in-process
+Rust-to-Rust handoff for `prerender = false` routes and Tauri IPC calls. The
+WebView would talk directly to the embedded server without a network port.
+
+**When to pick it (once it ships).** You want zfb's full runtime dynamism and
+tight Tauri integration — IPC, filesystem access, hot content reload — without
+the sidecar lifecycle plumbing of Mode B.
+
+**What's involved.** The embed API does not exist yet. When it ships it will
+require depending on `zfb-core` or a similar crate and calling an initialization
+function in the Tauri `setup` hook. The exact surface is still being designed.
+
+**This mode does NOT work today.** Follow the research issue for progress:
+[https://github.com/Takazudo/zudo-front-builder/issues/346](https://github.com/Takazudo/zudo-front-builder/issues/346)
+
+**Tradeoff.** Once it ships: no sidecar plumbing, tighter IPC, cleaner packaging.
+Until it ships: not an option.
+
+---
+
 ## The harder case: rebuild content inside the app
 
-Some desktop apps want to let users edit Markdown files locally and see a live
-preview inside the app — essentially running `zfb dev` from within a packaged
-Tauri or Electron window.
+If you need a user to edit Markdown files locally and see a live preview inside
+the running app — essentially running `zfb dev` from within a packaged window —
+the right approach depends on what you need:
 
-This is where the current constraint surfaces: **zfb's build and dev tooling
-requires Node.js**. The dev CLI (`zfb dev` / `zfb build`) is a Node.js process;
-the embedded V8 worker that evaluates your TSX pages runs inside the Rust binary,
-but the outer toolchain still requires Node.js to be present on the build machine.
+- **Mode B** (sidecar) is the best path today if you need full MDX rendering.
+  The sidecar keeps the file-watch / incremental-rebuild loop running in the
+  background; the WebView reflects changes without an app restart.
+- **Mode D** (in-process embed) will be the preferred path once it ships —
+  no child process, no port, tighter integration with Tauri IPC and the
+  filesystem.
+- **Mode A or C** do not help here: both assume content is static at the point
+  the packaged app runs.
 
-If you need in-app rebuilds today, the realistic options are:
+If you need Node.js in the runtime — for example, to run custom `zfb` plugins
+that have Node.js dependencies — consider Electron instead. **Electron** embeds
+Node.js, so `zfb dev` runs naturally inside the main process; the cost is a
+significant binary size increase and a more complex packaging story. This is not
+a zfb mode per se; it is a framework choice driven by the Node.js-at-runtime
+requirement.
 
-**Bundle Node.js with the app.** Tauri does not officially support shipping a
-Node.js sidecar, but Electron does — the entire framework runs on Node.js, so
-`zfb dev` runs naturally inside an Electron process. The cost is a significant
-binary size increase and a more complex packaging story.
-
-**Bundle the zfb binary as a Tauri sidecar.** Because the render pipeline runs
-inside an embedded V8 host (the `zfb` Rust binary), you can ship the binary as a
-Tauri sidecar and invoke it for incremental rebuilds. This requires writing a
-thin IPC bridge between the sidecar and your Tauri frontend — that integration is
-not provided out of the box, but the boundary is clean.
-
-**Pre-build on the developer machine; embed the result.** Rather than rebuilding
-inside the app, keep the rebuild workflow on developer machines and ship only
-the `dist/` artifacts. The packaged app delivers a snapshot; users who need
-updated content get a new app release. This is the most conservative option and
-the easiest to reason about.
-
-The core invariant to keep in mind:
-
-> **Build time = Node.js required. Runtime = no Node.js, ever.**
-
-zfb's static output is deliberately runtime-agnostic. The build tooling is not.
-Plan your architecture around that boundary rather than against it.
+---
 
 ## What about Electron, Wails, or other desktop frameworks?
 

--- a/docs/src/content/docs/guides/desktop-deployment.mdx
+++ b/docs/src/content/docs/guides/desktop-deployment.mdx
@@ -74,7 +74,7 @@ MDX rendering at request time, content reloading without a rebuild — but you d
 not need the zfb server to live inside the Tauri process itself.
 
 **What's involved.** Ship the `zfb` binary alongside your Tauri app as a
-[Tauri sidecar](https://tauri.app/v1/guides/building/sidecar/). Write a thin IPC
+[Tauri sidecar](https://v2.tauri.app/develop/sidecar/). Write a thin IPC
 bridge so the Tauri frontend can start the sidecar, discover the port, and open
 the WebView to `http://127.0.0.1:<port>`. The boundary between sidecar and Tauri
 is clean; the integration glue is not provided out of the box.

--- a/docs/src/content/docs/guides/ssr-and-cloudflare-bindings.mdx
+++ b/docs/src/content/docs/guides/ssr-and-cloudflare-bindings.mdx
@@ -13,6 +13,18 @@ read Cloudflare Worker bindings — secrets, environment variables, and a
 
 </Info>
 
+<Info title="Two kinds of Worker — disambiguate first">
+
+There are two distinct concepts both called "Worker" in a zfb + Cloudflare project. Blurring them is the most common source of confusion.
+
+**zfb's emitted `dist/_worker.js`** — produced by the Cloudflare adapter for every route that exports `prerender = false`. It runs inside the same TSX pipeline as static pages: shared layouts, components, and MDX virtual modules all work exactly as they do for SSG routes.
+
+**External standalone Workers** — your own wrangler-built Worker bundles deployed separately (e.g. an auth Worker, a photo-upload Worker, a payment-webhook Worker). zfb has no awareness of them. The seam between zfb and an external Worker is always HTTP/JSON: either a `pages/api/*.tsx` proxy route that `fetch()`'s the external Worker, or a `prerender = false` page that calls `fetch()` directly.
+
+Why this matters: AI agents and human readers often try to import shared layout TSX directly into an external Worker. That doesn't work — an external Worker has a different bundler, a different runtime, and no access to zfb's virtual-module layer. If you find yourself trying to `import` a layout into a wrangler project, you are crossing the wrong boundary.
+
+</Info>
+
 ## SSG vs SSR in zfb
 
 By default every page in zfb is rendered **once at build time** into
@@ -35,6 +47,29 @@ to your configured adapter.
 If a route exports `prerender = false` but no adapter is configured,
 the build fails fast with an error naming the offending route — zfb
 will not silently drop a route it cannot deploy.
+
+<Warning title="prerender = false must be a literal export">
+
+zfb detects `prerender` via **static AST inspection at build time**, not runtime evaluation. The export must be a **literal `export const`** declaration:
+
+```tsx
+export const prerender = false;  // ✅ detected correctly
+```
+
+These forms are **not** detected and silently fall back to SSG:
+
+```tsx
+// ❌ indirect assignment — not a literal export const
+const flags = { prerender: false };
+export const prerender = flags.prerender;
+
+// ❌ function call — not a literal export const
+export const prerender = computeFlag();
+```
+
+The same restriction applies to the `frontmatter` export — see [Frontmatter](/concepts/frontmatter) for the literal-only contract.
+
+</Warning>
 
 ## Configuring the Cloudflare adapter
 


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/350

---

## Summary

Epic root PR for #350 (Docs Philosophy & Research Topics) — six parallel doc sub-issues that collectively articulate zfb's identity and surface the practical landmines that existing docs missed:

- **Philosophy** — narrow-on-purpose engine identity, recipes-over-plugins in the AI era.
- **How-to-use perspective** — two-Worker disambiguation, prerender AST detection gotcha, Tauri composition modes, audience-fit reasoning for V8, and SSG/SSR positioning consistency across front-door docs.

## Sub-issues merged

| # | Sub-issue | Files | Commit |
|---|---|---|---|
| 1 | #351 — concepts/design-philosophy.mdx | NEW: concepts/design-philosophy.mdx | ef66c1a |
| 2 | #352 — Reconcile plugins.mdx with recipes-first framing | concepts/plugins.mdx | 064362b |
| 3 | #353 — Two-worker + prerender AST callouts in SSR guide | guides/ssr-and-cloudflare-bindings.mdx | 06e757d |
| 4 | #354 — Four Tauri composition modes in desktop-deployment | guides/desktop-deployment.mdx | 6bd1a4a |
| 5 | #355 — 'Why V8 (and not Rust templating)' framing in js-runtime | architecture/js-runtime.mdx | 79ec540 |
| 6 | #356 — Front-door consistency pass | README.md + introduction.mdx + choosing-zfb.mdx + architecture-overview.mdx | a131520 |

Plus one post-review fix commit (a30c986) addressing combined-reviewer findings:

- Boa wording in js-runtime.mdx (resolve internal contradiction with later \"ECMA gaps\" note).
- Tauri v2 sidecar URL in desktop-deployment.mdx Mode B (replaced v1 link).

## Changes by file

- **README.md**: engine-not-framework stance paragraph after \"What zfb is\" (engine for content sites; for page-rendering-as-hard-part use Astro/Next).
- **docs/src/content/docs/architecture/js-runtime.mdx**: NEW \"Why a JS engine at all — and why V8 specifically\" section between existing \"How the runtime choice was reached\" and \"What runs today\" sections. Three layers (JSX-as-syntax, evaluation-needs-engine, Rust-templating-breaks-audience) + audience-tradeoff closing. Links to research issues #344, #345.
- **docs/src/content/docs/concepts/architecture-overview.mdx**: softened \"never leaves your machine\" so it acknowledges both build-time and production Cloudflare Workers destinations.
- **docs/src/content/docs/concepts/choosing-zfb.mdx**: SSG-by-default + adapter-escape-hatch framing replaces stale \"no SSR at request time\" wording. Added \"Design philosophy\" link in \"Where to go next\".
- **docs/src/content/docs/concepts/design-philosophy.mdx** (NEW): narrow-on-purpose framing using esbuild analogy, recipes-over-plugins framing for the AI era, locked engine-promotion and plugin-promotion test phrases.
- **docs/src/content/docs/concepts/plugins.mdx**: new \"When you actually need a plugin\" and \"When you don't — write a recipe\" framing sections, plus inline note about the ctx.routes[].prerender gap with link to research issue #347.
- **docs/src/content/docs/getting-started/introduction.mdx**: design-philosophy pointer + SSG-by-default framing replaces stale \"only static HTML\" sentence.
- **docs/src/content/docs/guides/desktop-deployment.mdx**: restructured into four explicit Tauri composition modes (A: ship dist/, B: zfb-binary-as-sidecar, C: minimal-zfb-with-custom-Rust-glue à la CCResDoc, D: embed-as-Rust-crate — future, links to research issue #346).
- **docs/src/content/docs/guides/ssr-and-cloudflare-bindings.mdx**: two new callouts — Info on disambiguating zfb's emitted Worker from external standalone Workers, and Warning that prerender = false must be a literal export const (static AST detection at build time).

## Quality coverage

- Pre-merge per-worktree builds: pass across all 6 sub-issue worktrees (Astro onBrokenMarkdownLinks=warn, so cross-link warnings on not-yet-merged files were expected).
- Post-merge integration build: 107 pages built, no broken cross-link warnings.
- Combined reviewer pass (Step 9): /deep-review at Opus (3 reviewers in parallel) + /gcoc-review (gpt-4.1). Codex review backend failed with a model-auth error and was treated as covered per the silent-fallback policy. Findings: 1 HIGH (Boa wording) + 1 MEDIUM (Tauri v1 URL) — both fixed in commit a30c986. All LOW-priority findings were aesthetic and left as-is.

## Test plan

- [ ] CI green on this PR (pnpm audit + Build docs site + Deploy PR preview to Cloudflare Pages + health).
- [ ] Verify rendered preview shows the four new structures cleanly:
    - New /concepts/design-philosophy page in sidebar between architecture-overview and choosing-zfb.
    - Four Mode sections in /guides/desktop-deployment.
    - New \"Why a JS engine at all\" section in /architecture/js-runtime.
    - Two new callouts at the top of and inline in /guides/ssr-and-cloudflare-bindings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)