### PR TITLE
docs(concepts): add Dev mode lifecycle + SSR on a Worker pages (#399)

### DIFF
--- a/docs/src/content/docs/concepts/architecture-overview.mdx
+++ b/docs/src/content/docs/concepts/architecture-overview.mdx
@@ -115,7 +115,9 @@ embedded V8 isolate. The production host is workerd. The contract —
 
 `packages/zfb-adapter-cloudflare` is the deployment adapter for Cloudflare
 Workers. It takes the bundle produced by `zfb build --target=cloudflare` and
-wraps it in the thin shell that `wrangler deploy` expects.
+wraps it in the thin shell that `wrangler deploy` expects. For a deep dive into
+the two-file worker output and how requests are dispatched at runtime, see
+[SSR on a Worker (adapter mode)](/concepts/ssr-on-a-worker).
 
 The full rationale for this design is in [JS Runtime](/architecture/js-runtime):
 the embedded V8 host design and why the bundle contract is engine-agnostic.

--- a/docs/src/content/docs/concepts/build-pipeline.mdx
+++ b/docs/src/content/docs/concepts/build-pipeline.mdx
@@ -17,7 +17,7 @@ zfb is built as a set of small Rust crates that each own one job. This page is a
 6. **Renderer** — `crates/zfb-render`. Compiles TSX to JS with SWC, evaluates the resulting ES module via the JS runtime host, and calls the page's `default()` export to produce an HTML string. Content collection entries (`.md` / `.mdx`) are compiled through the same pipeline as JSX modules — the renderer resolves `mdx://<collection>/<slug>` specifiers and surfaces them to user pages as `entry.Content` (see [MDX Components](/concepts/mdx-components)).
 7. **CSS pipeline** — `crates/zfb-css`. Runs Tailwind v4 and PostCSS as needed. See [Styling](/concepts/styling).
 8. **Islands pipeline** — `crates/zfb-islands`. Bundles each `"use client"` component as a separate ESM module via esbuild. See [Islands](/concepts/islands).
-9. **Server** — `crates/zfb-server`. Dev mode only. An axum-based HTTP server that serves the page cache as static files, plus an SSE channel at `/__zfb/livereload` for browser reload events.
+9. **Server** — `crates/zfb-server`. Dev mode only. An axum-based HTTP server that serves the page cache as static files, plus an SSE channel at `/__zfb/reload` for browser reload events (see [Dev mode lifecycle](/concepts/dev-mode-lifecycle) for the full event-type breakdown).
 
 ## Production: `zfb build`
 
@@ -25,7 +25,7 @@ zfb is built as a set of small Rust crates that each own one job. This page is a
 
 CLI → Router → Graph → Build orchestrator → Renderer → CSS pipeline → Islands pipeline.
 
-The watcher and dev server are not involved. Every page is rendered, every CSS bundle is produced, every island is bundled, and the result lands in `dist/` (or wherever `outDir` points). Atomic writes mean an interrupted build leaves the previous `dist/` intact rather than a partially overwritten mess.
+The watcher and dev server are not involved. Every page is rendered, every CSS bundle is produced, every island is bundled, and the result lands in `dist/` (or wherever `outDir` points). Atomic writes mean an interrupted build leaves the previous `dist/` intact rather than a partially overwritten mess. For `prerender = false` routes, the adapter emits a worker bundle instead of static HTML — see [SSR on a Worker (adapter mode)](/concepts/ssr-on-a-worker) for how that output is structured.
 
 ## Development: `zfb dev`
 

--- a/docs/src/content/docs/concepts/dev-mode-lifecycle.mdx
+++ b/docs/src/content/docs/concepts/dev-mode-lifecycle.mdx
@@ -15,7 +15,9 @@ rebuilds to affected pages read [Incremental rebuild](/concepts/incremental-rebu
 
 This page describes the **SSG / static-HTML dev loop only**. For `prerender = false`
 SSR routes, source edits during a `zfb dev` session do **not** hot-reload — the V8
-SSR bundle is restart-only. See
+SSR bundle is bound to the boot-time JS bundle and is restart-only. The per-tick
+rebuild described below does **not** reload the SSR renderer; it re-renders the
+SSG output that the renderer was bootstrapped with. See
 [No live reload of the SSR bundle](/guides/ssr-and-cloudflare-bindings#dev-prod-parity-for-prerender--false)
 in the SSR guide.
 
@@ -25,8 +27,10 @@ in the SSR guide.
 
 The moment you save, the operating system fires a filesystem event on the file's
 path. `crates/zfb-watcher` is watching every relevant directory — `pages/`,
-`components/`, `content/`, `layouts/`, `styles/`, `data/`, `public/`, and
-`zfb.config.ts` — via the [`notify`](https://crates.io/crates/notify) crate.
+`components/`, `content/`, `layouts/`, `styles/`, `data/`, `public/`, and the two
+config files `zfb.config.json` and `zfb.config.ts` — via the
+[`notify`](https://crates.io/crates/notify) crate. (See `DEFAULT_WATCH_ROOTS` in
+`crates/zfb/src/commands/dev.rs` for the canonical list.)
 
 Editor saves are rarely a single clean event. vim renames a swap file over the
 original; VS Code emits several metadata-then-data events in quick succession; a
@@ -48,24 +52,24 @@ is inside an islands root (e.g. `components/`), the plan's `rerun_islands` flag 
 set. If a CSS source changed, `rerun_css` is set. Then the
 `DevAssetPipeline::apply()` method runs, in this order:
 
-1. **Islands re-bundle.** When `rerun_islands` is true, the esbuild Go binary
+1. **Pages re-rendered.** The orchestrator calls the renderer for each page in
+   the dirty set, driving SSG output through the embedded V8 host that was booted
+   when `zfb dev` started. Each rendered `RenderedPage.html` is compared
+   byte-for-byte against the last-known output. If the bytes are identical (a
+   pure refactor that produced no semantic HTML change), no file is written and
+   no reload signal is sent for that page. The V8 host itself is **not** reloaded
+   per tick — `BuildContext::reload_renderer` is `None` in dev today (see
+   `crates/zfb/src/commands/dev.rs`), so the renderer stays bound to the
+   boot-time bundle for the whole session.
+2. **CSS pipeline.** When `rerun_css` is true, Tailwind v4 + PostCSS run. If the
+   CSS output is byte-identical to the previous tick, no `Css` event is emitted.
+3. **Islands re-bundle.** When `rerun_islands` is true, the esbuild Go binary
    subprocess is invoked. It bundles every `"use client"` component and writes a
    single combined module to a **stable filename** — `dist/assets/islands.js` (the
-   `STABLE_ISLANDS_FILENAME` constant in `crates/zfb-islands/src/bundler.rs`). No
-   content hash in the filename; see [Why filenames stay stable in dev](#why-filenames-stay-stable-in-dev).
-2. **SSR renderer reload.** Before pages are rendered, the embedded V8 host
-   (`deno_core`) is reloaded with the freshly-emitted bundle. This step runs
-   whenever the dirty page set is non-empty. It is constant-cost — one isolate
-   boot regardless of how many pages will be rendered — and is the main per-tick
-   overhead for small dirty sets.
-3. **Pages re-rendered.** The orchestrator calls the renderer for each page in the
-   dirty set. Each rendered `RenderedPage.html` is compared byte-for-byte against
-   the last-known output. If the bytes are identical (a pure refactor that produced
-   no semantic HTML change), no file is written and no reload signal is sent for
-   that page.
-4. **CSS pipeline.** When `rerun_css` is true, Tailwind v4 + PostCSS run. If the
-   CSS output is byte-identical to the previous tick, no `Css` event is emitted.
-5. **Build outcome broadcast.** The pipeline returns a `BuildOutcome` struct.
+   `STABLE_ISLANDS_FILENAME` constant in `crates/zfb-types/src/asset_urls.rs`,
+   re-exported and consumed by the islands bundler). No content hash in the
+   filename; see [Why filenames stay stable in dev](#why-filenames-stay-stable-in-dev).
+4. **Build outcome broadcast.** The pipeline returns a `BuildOutcome` struct.
    `outcome_to_events()` in `crates/zfb-server/src/livereload.rs` inspects the
    outcome and maps it to `ReloadEvent` values that are broadcast over the SSE
    channel at `/__zfb/reload`. Every browser tab that has your site open is
@@ -77,23 +81,33 @@ set. If a CSS source changed, `rerun_css` is set. Then the
 |---|---|---|
 | `pages_written.len() > 0` | `Page` | Full `location.reload()` |
 | `css_changed` | `Css` | Hot-swap every `<link rel="stylesheet">` — appends `?v=<timestamp>` to bust the browser cache without reloading the document |
-| `islands_bundle.is_some()` | `Islands { component, bundle_url }` | Dynamic `import()` of the new bundle URL (with a cache-busting `?v=<timestamp>`) and re-hydration of just that component — no document reload |
+| `islands_bundle.is_some()` | `Islands { component, bundle_url }` | Dynamic `import()` of the new bundle URL (with a cache-busting `?v=<timestamp>`). The newly-imported module runs its hydration, which by default re-mounts **every** `[data-zfb-island]` element on the current page — no document reload |
 
-When multiple events fire in the same tick, the server emits every applicable event.
-The browser processes them in the order they arrive. On receiving a `Page` event,
-the browser calls `location.reload()`, which discards the current document —
-this makes the in-place `Css` or `Islands` swaps moot for that tab. **But other
-tabs subscribed to the same SSE channel still benefit from the `Css` and `Islands`
-hot-swaps** — they receive those events independently and update without reloading.
+When multiple events fire in the same tick, the server emits every applicable event,
+and **every connected tab is subscribed to the same SSE channel and receives all of
+them.** The browser processes events in arrival order. On receiving a `Page` event,
+each tab calls `location.reload()`, which discards the current document — this
+makes any `Css` or `Islands` events emitted in the same tick moot for that tab. The
+"only this tab gets a full reload" pattern does not exist here; **the in-place
+`Css` and `Islands` swaps are moot for every subscribed tab in that tick**, not
+just the active one.
 
-One detail on `Islands`: the server emits **one `Islands` event per re-bundled
-component**. If a save touches a shared utility consumed by two islands components,
-`outcome_to_events()` emits two separate events — one for each entry in
-`info.components`. Both events carry the same `bundle_url` (`/assets/islands.js`)
-because the output is a single combined bundle. The client script at
-`/__zfb/livereload.js` appends a fresh timestamp (`?v=<timestamp>`) to that URL
-before each `import()` call so the module cache is busted even though the URL is
-otherwise stable.
+One detail on `Islands`: in dev mode today, `BuildContext::run_islands` reports
+`components: Vec::new()` to `outcome_to_events()` because the build-side payload
+does not currently surface per-island names. The server therefore emits a
+**single** `Islands` event with `component: ""` and the stable bundle URL
+(`/assets/islands.js`). The client script at `/__zfb/livereload.js` reads only
+`bundleUrl`, appends a fresh timestamp (`?v=<timestamp>`), and dynamic-imports the
+result. The imported bundle's top-level hydration code then runs and walks every
+`[data-zfb-island]` on the page — so a single islands tick re-hydrates the whole
+page, not a single component, by default.
+
+**Targeted re-hydration is opt-in.** When the client detects a user-provided
+`window.__zfbIslandsReload(component, swapUrl)` function, it delegates the
+import to that hook instead of doing a plain dynamic import. Applications that
+want to preserve scroll position or component state across an islands hot-swap
+install this hook and decide for themselves which components to remount. Without
+the hook, the default page-wide re-hydration is what runs.
 
 ## Why filenames stay stable in dev
 
@@ -117,12 +131,14 @@ is correct by design, not an oversight.
 Three typical edit scenarios, and which event fires:
 
 **Edit a `.tsx` island component body only.** The watcher fires on the component
-file. The dependency graph marks pages that consume it dirty; islands re-bundle runs;
-the SSR renderer reloads; affected pages re-render. If the rendered HTML changed, a
-`Page` event fires and the browser reloads. If the HTML is byte-identical (e.g. you
-only changed client-side state logic that never reaches the server render), only an
-`Islands` event fires — the component re-hydrates in place, your neighbour
-components' scroll position and state are untouched.
+file. The dependency graph marks pages that consume it dirty; the orchestrator
+re-renders affected pages first, then re-bundles islands. If the rendered HTML
+changed, a `Page` event fires and the browser reloads. If the HTML is
+byte-identical (e.g. you only changed client-side state logic that never reaches
+the server render), only an `Islands` event fires — the new bundle is
+dynamic-imported and its hydration runs, re-mounting every island on the page. To
+preserve scroll position or per-component state across that swap, install a
+`window.__zfbIslandsReload` hook (see [The three SSE event types](#the-three-sse-event-types)).
 
 **Edit a page file that consumes an island.** Both page and island are dirty. The
 orchestrator re-renders the page; the HTML almost certainly changed; a `Page` event

--- a/docs/src/content/docs/concepts/dev-mode-lifecycle.mdx
+++ b/docs/src/content/docs/concepts/dev-mode-lifecycle.mdx
@@ -1,0 +1,146 @@
+---
+title: Dev mode lifecycle
+description: What happens between hitting save on a .tsx file and seeing the change in the browser — watcher, rebundle, SSR refresh, and the three SSE event types.
+sidebar_position: 7.5
+category: Concepts
+---
+
+<Info title="What this page covers">
+
+The save-to-pixel loop for `zfb dev`: how the watcher detects your change, how the
+orchestrator decides what to rebuild, and how three SSE event types let the browser
+react without an unnecessary full page reload. For the overall build step order read
+[Build pipeline](/concepts/build-pipeline); for how the dependency graph limits
+rebuilds to affected pages read [Incremental rebuild](/concepts/incremental-rebuild).
+
+This page describes the **SSG / static-HTML dev loop only**. For `prerender = false`
+SSR routes, source edits during a `zfb dev` session do **not** hot-reload — the V8
+SSR bundle is restart-only. See
+[No live reload of the SSR bundle](/guides/ssr-and-cloudflare-bindings#dev-prod-parity-for-prerender--false)
+in the SSR guide.
+
+</Info>
+
+## You save a `.tsx` file. Then what?
+
+The moment you save, the operating system fires a filesystem event on the file's
+path. `crates/zfb-watcher` is watching every relevant directory — `pages/`,
+`components/`, `content/`, `layouts/`, `styles/`, `data/`, `public/`, and
+`zfb.config.ts` — via the [`notify`](https://crates.io/crates/notify) crate.
+
+Editor saves are rarely a single clean event. vim renames a swap file over the
+original; VS Code emits several metadata-then-data events in quick succession; a
+`git checkout` fires hundreds at once. The watcher's debouncer coalesces everything
+within a 50ms quiet window into a single `Change { path, kind }` value. The `kind`
+field is one of `ChangeKind::Created`, `ChangeKind::Modified`, or
+`ChangeKind::Removed`; any event kind the OS cannot classify collapses to `Modified`
+so that a real change is never silently dropped.
+
+Once the burst settles and the debounce window closes, the build orchestrator
+(`crates/zfb-build`) receives the change. It calls into `crates/zfb-graph` with the
+changed path and gets back a `DirtySet` — either `All` (global files like
+`zfb.config.ts`) or `Specific(set_of_page_ids)` for the pages that actually import
+the changed file. Pages outside the dirty set are not touched. (The full dependency
+tracking story lives in [Incremental rebuild](/concepts/incremental-rebuild).)
+
+The orchestrator assembles a `RebuildPlan` from the dirty set. If the changed path
+is inside an islands root (e.g. `components/`), the plan's `rerun_islands` flag is
+set. If a CSS source changed, `rerun_css` is set. Then the
+`DevAssetPipeline::apply()` method runs, in this order:
+
+1. **Islands re-bundle.** When `rerun_islands` is true, the esbuild Go binary
+   subprocess is invoked. It bundles every `"use client"` component and writes a
+   single combined module to a **stable filename** — `dist/assets/islands.js` (the
+   `STABLE_ISLANDS_FILENAME` constant in `crates/zfb-islands/src/bundler.rs`). No
+   content hash in the filename; see [Why filenames stay stable in dev](#why-filenames-stay-stable-in-dev).
+2. **SSR renderer reload.** Before pages are rendered, the embedded V8 host
+   (`deno_core`) is reloaded with the freshly-emitted bundle. This step runs
+   whenever the dirty page set is non-empty. It is constant-cost — one isolate
+   boot regardless of how many pages will be rendered — and is the main per-tick
+   overhead for small dirty sets.
+3. **Pages re-rendered.** The orchestrator calls the renderer for each page in the
+   dirty set. Each rendered `RenderedPage.html` is compared byte-for-byte against
+   the last-known output. If the bytes are identical (a pure refactor that produced
+   no semantic HTML change), no file is written and no reload signal is sent for
+   that page.
+4. **CSS pipeline.** When `rerun_css` is true, Tailwind v4 + PostCSS run. If the
+   CSS output is byte-identical to the previous tick, no `Css` event is emitted.
+5. **Build outcome broadcast.** The pipeline returns a `BuildOutcome` struct.
+   `outcome_to_events()` in `crates/zfb-server/src/livereload.rs` inspects the
+   outcome and maps it to `ReloadEvent` values that are broadcast over the SSE
+   channel at `/__zfb/reload`. Every browser tab that has your site open is
+   subscribed to that channel and reacts immediately.
+
+## The three SSE event types
+
+| Outcome trigger | Event | Browser behaviour |
+|---|---|---|
+| `pages_written.len() > 0` | `Page` | Full `location.reload()` |
+| `css_changed` | `Css` | Hot-swap every `<link rel="stylesheet">` — appends `?v=<timestamp>` to bust the browser cache without reloading the document |
+| `islands_bundle.is_some()` | `Islands { component, bundle_url }` | Dynamic `import()` of the new bundle URL (with a cache-busting `?v=<timestamp>`) and re-hydration of just that component — no document reload |
+
+When multiple events fire in the same tick, the server emits every applicable event.
+The browser processes them in the order they arrive. On receiving a `Page` event,
+the browser calls `location.reload()`, which discards the current document —
+this makes the in-place `Css` or `Islands` swaps moot for that tab. **But other
+tabs subscribed to the same SSE channel still benefit from the `Css` and `Islands`
+hot-swaps** — they receive those events independently and update without reloading.
+
+One detail on `Islands`: the server emits **one `Islands` event per re-bundled
+component**. If a save touches a shared utility consumed by two islands components,
+`outcome_to_events()` emits two separate events — one for each entry in
+`info.components`. Both events carry the same `bundle_url` (`/assets/islands.js`)
+because the output is a single combined bundle. The client script at
+`/__zfb/livereload.js` appends a fresh timestamp (`?v=<timestamp>`) to that URL
+before each `import()` call so the module cache is busted even though the URL is
+otherwise stable.
+
+## Why filenames stay stable in dev
+
+Production builds use content-hashed asset URLs (`/assets/islands-abc12345.js`) so
+that deployed CDN responses can be cached indefinitely and a new deploy's changed
+assets get fresh URLs. The hash is determined by file content; it changes every time
+the bundle changes.
+
+Dev mode deliberately skips the content hash. The output lands at
+`dist/assets/islands.js` — the same URL every tick. This is the URL-contract
+guarantee that makes SSE-driven hot-swap work: when the browser receives an
+`Islands` event, it knows the new bundle is always reachable at the same base URL.
+Changing the URL on every rebuild would force a full page reload because the browser
+would have no cached reference to swap from.
+
+Content hashing is the production pipeline's responsibility. In dev the stable name
+is correct by design, not an oversight.
+
+## What this means in practice
+
+Three typical edit scenarios, and which event fires:
+
+**Edit a `.tsx` island component body only.** The watcher fires on the component
+file. The dependency graph marks pages that consume it dirty; islands re-bundle runs;
+the SSR renderer reloads; affected pages re-render. If the rendered HTML changed, a
+`Page` event fires and the browser reloads. If the HTML is byte-identical (e.g. you
+only changed client-side state logic that never reaches the server render), only an
+`Islands` event fires — the component re-hydrates in place, your neighbour
+components' scroll position and state are untouched.
+
+**Edit a page file that consumes an island.** Both page and island are dirty. The
+orchestrator re-renders the page; the HTML almost certainly changed; a `Page` event
+fires. The browser gets a fresh full-page load with up-to-date server-rendered HTML.
+Any concurrent `Islands` events for that tab are mooted by the reload.
+
+**Edit a CSS file only.** No pages are dirty, no islands re-bundle. The CSS pipeline
+runs; if the output changed, a `Css` event fires. The browser swaps the stylesheet
+in place — no document reload, your scroll position and any client-side state are
+preserved.
+
+## Related
+
+- [Build pipeline](/concepts/build-pipeline) — the full pipeline from CLI to
+  `dist/`, and how dev mode layers on top of it
+- [Incremental rebuild](/concepts/incremental-rebuild) — the dependency graph and
+  `DirtySet` that limit rebuilds to affected pages
+- [Islands](/concepts/islands) — how `"use client"` opts a component into the
+  islands bundle
+- [SSR and Cloudflare Bindings](/guides/ssr-and-cloudflare-bindings) — including
+  the restart-only limitation for `prerender = false` routes in dev

--- a/docs/src/content/docs/concepts/incremental-rebuild.mdx
+++ b/docs/src/content/docs/concepts/incremental-rebuild.mdx
@@ -72,7 +72,7 @@ The orchestrator (`crates/zfb-build`) receives the `DirtySet` and feeds it into 
 3. **Re-bundle islands only when consuming pages changed.** The islands sub-pipeline runs only when the plan's `rerun_islands` flag is set — which the orchestrator sets only when a changed file is inside an islands root (e.g. `components/`). A content-only change does not trigger an islands re-bundle.
 4. **Keep filenames stable.** Dev-mode output files use stable names (no content hashes). The browser cache contract does not change between watcher ticks. Content hashing is the production pipeline's job.
 
-The combined effect: a content edit that touches two pages produces two HTML writes, one live-reload event, and no island bundling. A header component edit produces writes for every page that imports the header, but still only those pages.
+The combined effect: a content edit that touches two pages produces two HTML writes, one live-reload event, and no island bundling. A header component edit produces writes for every page that imports the header, but still only those pages. For the full breakdown of SSE event types (`Page`, `Css`, `Islands`) and how the browser reacts to each, see [Dev mode lifecycle](/concepts/dev-mode-lifecycle).
 
 For a deeper look at the orchestrator design, see [Build engine](/architecture/build-engine).
 

--- a/docs/src/content/docs/concepts/ssr-on-a-worker.mdx
+++ b/docs/src/content/docs/concepts/ssr-on-a-worker.mdx
@@ -23,7 +23,11 @@ external Workers you deploy separately with wrangler.
 ## Your page is just a function
 
 Strip away the framework vocabulary and a `prerender = false` zfb page is a plain
-`async function` that returns a `Response`:
+`async function` that returns a `Response`. In the snippet below, `renderToString`,
+`getUser`, `updateProfile`, and `AccountLayout` are placeholder identifiers
+representing app-side code — they are not exports of zfb or
+`@takazudo/zfb-adapter-cloudflare`. The only framework-provided symbol the example
+uses is `getCloudflareContext`.
 
 ```tsx
 // pages/account.tsx
@@ -93,16 +97,24 @@ applies a static-first, dynamic-second rule:
 
 | Request method | Dispatch order |
 |---|---|
-| GET, HEAD | Probe `env.ASSETS` first. Status 200 returns the static asset directly. Status 404 falls through to the inner worker. |
+| GET, HEAD | Probe `env.ASSETS` first. The inner worker is invoked only if the asset server returns 404. Any other status — 200, 308, etc. — is returned to the client directly. |
 | POST, PUT, PATCH, DELETE | Skip `env.ASSETS` entirely. Go straight to the inner worker. |
 
-**Why static-first for GET/HEAD:** Cloudflare Pages' asset server handles the
-trailing-slash canonicalisation for prerendered routes (e.g. `/docs/account` →
-308 → `/docs/account/` → `dist/docs/account/index.html`). It also serves the
-build-time head injection (`<link rel="stylesheet">`, `<script type="module"
-src="/islands/...">`) that makes island hydration work. If the inner Hono router
-handled prerendered routes first, it would re-render them at request time
-without those injected assets, and islands would not hydrate.
+The fall-through rule is "404 only", not "non-200 only". This matters because
+Cloudflare Pages' asset server emits 308 redirects to canonicalise trailing
+slashes for prerendered routes (e.g. `/docs/account` →
+308 → `/docs/account/` → `dist/docs/account/index.html`), and the wrapper has to
+let those 308s reach the client so the browser can follow them to the index.html.
+Inspecting `worker-wrapper.mjs`: the wrapper calls `await env.ASSETS.fetch(request)`
+and returns the response untouched whenever `assetResponse.status !== 404`.
+
+**Why static-first for GET/HEAD:** the asset server is responsible for the
+trailing-slash canonicalisation described above, and it also serves the
+build-time head injection (`<link rel="stylesheet">`,
+`<script type="module" src="/assets/islands-<hash>.js">`) that makes island
+hydration work. If the inner Hono router handled prerendered routes first, it
+would re-render them at request time without those injected assets, and islands
+would not hydrate.
 
 **Why POST/PUT/PATCH/DELETE go straight through:** The asset server is read-only
 by definition. Probing it for a form submission would always return 404 or 405 —
@@ -110,7 +122,11 @@ an unnecessary round-trip with no benefit. Form submissions, JSON API calls, and
 any mutation go directly to the inner worker.
 
 The result: static pages are not paying the SSR cost. A `prerender = true` page
-is served entirely by `env.ASSETS`; the inner bundle is never loaded for it.
+is served entirely by `env.ASSETS`, and the inner worker's `fetch` handler is
+not invoked. (The inner bundle is still loaded and evaluated on worker boot
+because `_worker.js` imports it at module scope — see
+[What is NOT in the worker output](#what-is-not-in-the-worker-output) for the
+precise wording.)
 
 ## The `getCloudflareContext()` trick
 
@@ -184,15 +200,25 @@ Two categories of output are intentionally absent from `dist/_worker.js` and
 `dist/_zfb_inner.mjs`:
 
 **Islands** — components marked with `"use client"` are compiled by a separate
-esbuild step into per-island browser bundles under `dist/islands/`. They are
-browser-shipped JavaScript, not server-executed Worker code. The Worker renders
-their static HTML shell; the browser downloads and hydrates each island
-independently. See [Islands](/concepts/islands).
+esbuild step into a **single combined** browser-shipped bundle. In dev the bundle
+lands at `dist/assets/islands.js` (stable filename, no hash); in production
+`ProductionAssetPipeline` writes it as `dist/assets/islands-<hash>.js` and
+rewrites every reference in the rendered HTML to the hashed URL. The bundle is
+neither part of `dist/_worker.js` nor of `dist/_zfb_inner.mjs` — it is browser-shipped
+JavaScript, not server-executed Worker code. The Worker renders the static HTML
+shell; the browser downloads the islands bundle and its top-level hydration code
+walks every `[data-zfb-island]` element on the page. See
+[Islands](/concepts/islands) for the full mechanism.
 
 **Prerendered pages** — any page that exports `prerender = true` (or omits the
 export, which defaults to true) is rendered to static HTML at build time. At
-request time, Cloudflare Pages serves the `.html` file directly from `env.ASSETS`.
-The inner Worker bundle is never invoked for those routes.
+request time, Cloudflare Pages serves the `.html` file directly from `env.ASSETS`,
+so the inner Worker's `fetch` handler is **not invoked** for those routes. The
+inner bundle is still loaded and evaluated on worker boot, however —
+`_worker.js` does a static `import inner from "./_zfb_inner.mjs"`, so workerd
+pulls the inner module graph into memory regardless of which route the first
+request lands on. The optimisation is "static hits skip `inner.fetch()`", not
+"static-only deploys skip loading the inner bundle".
 
 ## Related
 

--- a/docs/src/content/docs/concepts/ssr-on-a-worker.mdx
+++ b/docs/src/content/docs/concepts/ssr-on-a-worker.mdx
@@ -1,0 +1,206 @@
+---
+title: SSR on a Worker (adapter mode)
+description: How a prerender = false zfb page actually runs in production — the two-layer worker output, the ASSETS-first dispatch, and the AsyncLocalStorage trick behind getCloudflareContext().
+sidebar_position: 8
+category: Concepts
+---
+
+<Info title="What this page covers">
+
+The mental model of what actually runs in production for a `prerender = false` zfb
+page: the two-layer worker output, how requests are dispatched to the right handler,
+and how `getCloudflareContext()` delivers Cloudflare bindings to any page component
+without prop-drilling.
+
+This page is the mental model. For hands-on setup — installing the adapter,
+wiring up `wrangler.toml`, querying D1, and configuring `compatibility_flags` —
+read [SSR and Cloudflare Bindings](/guides/ssr-and-cloudflare-bindings).
+This page is also specifically about zfb's emitted `dist/_worker.js`, not
+external Workers you deploy separately with wrangler.
+
+</Info>
+
+## Your page is just a function
+
+Strip away the framework vocabulary and a `prerender = false` zfb page is a plain
+`async function` that returns a `Response`:
+
+```tsx
+// pages/account.tsx
+import { getCloudflareContext } from "@takazudo/zfb-adapter-cloudflare";
+import AccountLayout from "../layouts/account-layout";
+
+export const prerender = false;
+
+interface Env {
+  DB: D1Database;
+  SESSION_SECRET: string;
+}
+
+export default async function AccountPage(): Promise<Response> {
+  const { env, request } = getCloudflareContext<Env>();
+
+  if (request.method === "POST") {
+    const form = await request.formData();
+    await updateProfile(env, form);
+    return new Response(null, { status: 303, headers: { location: "/account" } });
+  }
+
+  const user = await getUser(env, request);
+  return new Response(
+    renderToString(<AccountLayout user={user} />),
+    { headers: { "content-type": "text/html" } },
+  );
+}
+```
+
+The function receives no arguments. Cloudflare's `(request, env, ctx)` tuple is
+available through `getCloudflareContext()` anywhere in the call tree — layouts,
+helpers, lib modules. A `POST` from a `<form method="post">` on the same page
+reaches the same handler; branching on `request.method` is the mutation path.
+
+Nothing special happens here that does not happen in a hand-written Worker. The
+rest of this page explains how `getCloudflareContext()` actually works, and what
+the build emits to make it possible.
+
+## What the build actually emits
+
+Running `zfb build` with `@takazudo/zfb-adapter-cloudflare` configured produces
+two files under `dist/`:
+
+**`dist/_worker.js`** — a small auto-generated stub written by the adapter. This
+is the Cloudflare Pages advanced-mode entry: the file Cloudflare loads when a
+request arrives. Its job is to set up an `AsyncLocalStorage` scope for
+`(env, ctx, request)` and then dispatch every request — either to the static asset
+server or to the inner bundle. It does not contain your application code.
+
+**`dist/_zfb_inner.mjs`** — the real application bundle: every `pages/*.tsx` file,
+layouts, components, and lib helpers compiled into a single Hono-shaped ESM module.
+This is what actually renders your pages.
+
+The two-file layout avoids a second esbuild pass inside the adapter. Workerd's
+module loader resolves relative ESM imports inside an advanced-mode `_worker.js`
+directory, so `_worker.js` can simply `import inner from "./_zfb_inner.mjs"` and
+both files stay independent.
+
+For the broader two-bundle mental model (worker bundle vs island bundles), read
+[Architecture overview](/concepts/architecture-overview).
+
+## The dispatch flow
+
+Every request to your Cloudflare Pages site hits `_worker.js` first. The stub
+applies a static-first, dynamic-second rule:
+
+| Request method | Dispatch order |
+|---|---|
+| GET, HEAD | Probe `env.ASSETS` first. Status 200 returns the static asset directly. Status 404 falls through to the inner worker. |
+| POST, PUT, PATCH, DELETE | Skip `env.ASSETS` entirely. Go straight to the inner worker. |
+
+**Why static-first for GET/HEAD:** Cloudflare Pages' asset server handles the
+trailing-slash canonicalisation for prerendered routes (e.g. `/docs/account` →
+308 → `/docs/account/` → `dist/docs/account/index.html`). It also serves the
+build-time head injection (`<link rel="stylesheet">`, `<script type="module"
+src="/islands/...">`) that makes island hydration work. If the inner Hono router
+handled prerendered routes first, it would re-render them at request time
+without those injected assets, and islands would not hydrate.
+
+**Why POST/PUT/PATCH/DELETE go straight through:** The asset server is read-only
+by definition. Probing it for a form submission would always return 404 or 405 —
+an unnecessary round-trip with no benefit. Form submissions, JSON API calls, and
+any mutation go directly to the inner worker.
+
+The result: static pages are not paying the SSR cost. A `prerender = true` page
+is served entirely by `env.ASSETS`; the inner bundle is never loaded for it.
+
+## The `getCloudflareContext()` trick
+
+Cloudflare Workers can dispatch multiple requests concurrently inside the same
+V8 isolate. A naïve `globalThis.__env = env` write would race across those
+concurrent requests. The adapter solves this with `AsyncLocalStorage` from
+`node:async_hooks`.
+
+The mechanism in two steps:
+
+**Step 1 — the wrapper stores the context.** Before calling `inner.fetch(request)`,
+the generated `_worker.js` stub runs:
+
+```js
+als.run({ env, ctx, request }, () => inner.fetch(request));
+```
+
+This opens a per-request async scope. Every `await` inside that scope —
+across layouts, helpers, database calls — still sees the same stored value.
+
+**Step 2 — user code reads the context.** `getCloudflareContext<Env>()` calls
+`als.getStore()` on the same `AsyncLocalStorage` instance. Because the adapter
+module registers the storage instance on `globalThis` under a stable key, the
+wrapper file (`_worker.js`) and the user bundle (`_zfb_inner.mjs`) share the
+same instance even though they are separate ESM modules. `getStore()` returns
+the `{ env, ctx, request }` object the wrapper stored for this request, not for
+any other concurrent request.
+
+**Why this means `compatibility_flags = ["nodejs_compat"]` is mandatory.**
+`AsyncLocalStorage` lives in `node:async_hooks`. Workerd does not expose it
+by default — you must opt in with:
+
+```toml
+# wrangler.toml
+compatibility_flags = ["nodejs_compat"]
+```
+
+Without this flag, the Worker fails to boot. The error message names
+`node:async_hooks` as the missing module. See the
+[SSR and Cloudflare Bindings guide](/guides/ssr-and-cloudflare-bindings)
+for the full `wrangler.toml` configuration.
+
+**Why AsyncLocalStorage instead of prop-drilling.** Page handlers compose shared
+layouts and lib helpers freely. Threading `env` as an explicit parameter would
+force every component and helper to accept it — a leaky coupling between
+Cloudflare-specific infrastructure and generic UI code. ALS lets the framework
+boundary stay clean: the adapter owns the storage, user code reads it only where
+it's needed.
+
+<Info title="If you know Next.js or Remix">
+
+The concepts map like this:
+
+| Concept | Next.js App Router | Remix | zfb adapter-mode |
+|---|---|---|---|
+| File-based routing | `app/account/page.tsx` | `routes/account.tsx` | `pages/account.tsx` |
+| Server data fetch | `async function Page()` | `loader` | `async function AccountPage()` |
+| Mutation | Server Actions | `action` | Plain `<form method="post">` |
+| Layouts | `layout.tsx` | Nested route layouts | `layouts/*.tsx` (imported) |
+| Static vs dynamic | `dynamic = 'force-static'` / `'force-dynamic'` | (always dynamic) | `export const prerender = true` / `false` |
+
+Mechanically a Worker; ergonomically App-Router-style SSR; philosophically
+Remix-without-the-Remix-runtime. No RSC streaming, no Server Actions abstraction
+— just one bundle and a Web `fetch` handler.
+
+</Info>
+
+## What is NOT in the worker output
+
+Two categories of output are intentionally absent from `dist/_worker.js` and
+`dist/_zfb_inner.mjs`:
+
+**Islands** — components marked with `"use client"` are compiled by a separate
+esbuild step into per-island browser bundles under `dist/islands/`. They are
+browser-shipped JavaScript, not server-executed Worker code. The Worker renders
+their static HTML shell; the browser downloads and hydrates each island
+independently. See [Islands](/concepts/islands).
+
+**Prerendered pages** — any page that exports `prerender = true` (or omits the
+export, which defaults to true) is rendered to static HTML at build time. At
+request time, Cloudflare Pages serves the `.html` file directly from `env.ASSETS`.
+The inner Worker bundle is never invoked for those routes.
+
+## Related
+
+- [Architecture overview](/concepts/architecture-overview) — the two-bundle model
+  and how the worker bundle shape is the stable contract between build time and
+  production.
+- [Islands](/concepts/islands) — how `"use client"` opts a component into the
+  browser-shipped bundle that lives outside the Worker.
+- [SSR and Cloudflare Bindings](/guides/ssr-and-cloudflare-bindings) — for
+  hands-on setup: `wrangler.toml`, D1 queries, secrets, and local development
+  with `wrangler pages dev`.

--- a/docs/src/content/docs/guides/ssr-and-cloudflare-bindings.mdx
+++ b/docs/src/content/docs/guides/ssr-and-cloudflare-bindings.mdx
@@ -137,6 +137,25 @@ pnpm add -D @takazudo/zfb-adapter-cloudflare
 Deploy `dist/` to Cloudflare Pages as usual. The Worker handles dynamic
 routes; the static asset server handles everything else.
 
+<Warning title="compatibility_flags = ['nodejs_compat'] is mandatory">
+
+The adapter threads the per-request `(env, ctx, request)` context through an
+`AsyncLocalStorage` (from `node:async_hooks`) that `getCloudflareContext()` reads
+from. Workerd does not expose `node:async_hooks` by default — you must opt in
+via `wrangler.toml`:
+
+```toml
+# wrangler.toml
+compatibility_flags = ["nodejs_compat"]
+```
+
+Without this flag the Worker fails to boot with an error naming `node:async_hooks`
+as the missing module. See
+[SSR on a Worker (adapter mode)](/concepts/ssr-on-a-worker#the-getcloudflarecontext-trick)
+for the deeper mechanism.
+
+</Warning>
+
 ## Reading the Worker `env` from an SSR handler
 
 A Cloudflare Worker's `fetch` handler receives `(request, env, ctx)`.

--- a/docs/src/content/docs/guides/ssr-and-cloudflare-bindings.mdx
+++ b/docs/src/content/docs/guides/ssr-and-cloudflare-bindings.mdx
@@ -25,6 +25,8 @@ Why this matters: AI agents and human readers often try to import shared layout 
 
 </Info>
 
+For the conceptual mental model of how the emitted worker actually runs, see [SSR on a Worker (adapter mode)](/concepts/ssr-on-a-worker).
+
 ## SSG vs SSR in zfb
 
 By default every page in zfb is rendered **once at build time** into


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/399

---

## Summary

Adds two new Concepts pages that fill the gap between *what features exist* (existing Concepts) and *deep internals* (Architecture), and audits surrounding pages with the new inbound cross-links. Implements epic #399.

- **Dev mode lifecycle** — what happens between hitting save on a .tsx file and seeing the change in the browser (watcher → orchestrator → Pages re-render → CSS → islands re-bundle → SSE event broadcast). Scoped to the SSG dev loop; the V8 SSR bundle is restart-only and the page calls this out explicitly with a cross-link to the SSR guide.
- **SSR on a Worker (adapter mode)** — the production deploy story for `prerender = false` zfb pages: two-layer `_worker.js` + `_zfb_inner.mjs` output, ASSETS-first dispatch, the `AsyncLocalStorage` mechanism behind `getCloudflareContext()`, and an embedded "If you know Next.js or Remix" comparison callout.
- Wave-2 cross-link audit adds inbound references from build-pipeline, incremental-rebuild, architecture-overview, and the SSR guide; also fixes the existing SSE-endpoint typo in build-pipeline.mdx (`/__zfb/livereload` → `/__zfb/reload`).
- Deep-review pass with 3 Opus reviewers + codex standard + codex adversarial caught 12 factual errors against runtime behavior; all corrected before merge (see the deep-review-fixes commit).

## Changes

### New pages

- `docs/src/content/docs/concepts/dev-mode-lifecycle.mdx` (sidebar 7.5) — describes the actual dev pipeline order (Pages → CSS → Islands), the three SSE event types (Page / Css / Islands), the dev-only stable filename contract, and the SSG-scope note pointing at the SSR-restart-only behavior. Includes the watcher's actual watched roots (`zfb.config.json` + `zfb.config.ts`).
- `docs/src/content/docs/concepts/ssr-on-a-worker.mdx` (sidebar 8) — the runtime mental model of a `prerender = false` Worker deployment: a small auto-generated stub `_worker.js` plus the bundled `_zfb_inner.mjs`, the GET/HEAD-ASSETS-first vs mutations-direct dispatch rule (404 → fall through; any other status returns directly), the `AsyncLocalStorage` storage-key trick for `getCloudflareContext()`, and a Next.js / Remix concept-mapping table.

### Cross-link audit (existing pages augmented, not pruned)

- `concepts/build-pipeline.mdx` — SSE endpoint typo fix (`/__zfb/livereload` → `/__zfb/reload`) + backlinks to Dev mode lifecycle and SSR on a Worker.
- `concepts/incremental-rebuild.mdx` — link to Dev mode lifecycle for the SSE event-types detail.
- `concepts/architecture-overview.mdx` — link to SSR on a Worker where the page mentions adapter mode.
- `guides/ssr-and-cloudflare-bindings.mdx` — link to the SSR on a Worker mental-model page near the top; plus a new Warning admonition documenting the `compatibility_flags = [\"nodejs_compat\"]` requirement (needed so the SSR-on-a-Worker page's cross-link to "the full wrangler.toml configuration" lands on real content).

### Deep-review fixes applied before merge

- Dev mode lifecycle: corrected pipeline step order (Pages → CSS → Islands, not Islands first); removed the never-existed "per-tick SSR renderer reload" step (the V8 SSR bundle is bound to the boot-time bundle in dev — `reload_renderer: None`); fixed multi-tab Page-event behavior wording (every subscribed tab reloads); softened the Islands-event wording from per-component to page-wide re-hydration (default), with the optional `window.__zfbIslandsReload` hook called out as the escape hatch; fixed the watched-directories list; fixed STABLE_ISLANDS_FILENAME source location reference.
- SSR on a Worker: corrected the islands artifact layout (`dist/assets/islands.js` stable in dev, content-hashed in prod — not `dist/islands/`); fixed the dispatch table 200/404 fallthrough wording (404 falls through; any other status, including 308, returns directly); precise wording for "inner bundle never invoked" (it's loaded on worker boot regardless; only `inner.fetch` is skipped on asset hits); added a one-line note that `renderToString` / `getUser` / etc. in the example are app-side placeholders.

## Test Plan

- `pnpm --filter docs check` passes (0 errors, 0 warnings, 3 pre-existing TS hints unrelated)
- `pnpm --filter docs build` passes — 119 pages (up from 117, confirms +2 new Concepts pages)
- All cross-links resolve in the built site
- Sub-issues #400, #401, #402 each had their own pass: Wave 1 wrote the two new pages with /gcoc light-review per agent; Wave 2 did the cross-link audit; deep review (3 Opus + 2 codex + 1 gcoc) caught remaining factual errors and the fix-up subagent corrected them with source-by-source verification

Closes #400, #401, #402.