### PR TITLE
ci(release): add npm --provenance + id-token: write (closes #425)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -334,6 +334,9 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+      # id-token: write enables npm OIDC-attested provenance via --provenance below.
+      # Each published tarball carries a signed attestation linking to the GHA run + commit SHA.
+      id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
@@ -413,6 +416,6 @@ jobs:
 
       - name: Publish to npm
         if: ${{ inputs.dry_run != true }}
-        run: pnpm -r publish --tag "$DIST_TAG" --no-git-checks --access public
+        run: pnpm -r publish --tag "$DIST_TAG" --no-git-checks --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `--provenance` to the `pnpm -r publish` step in `release.yml`
- Adds `id-token: write` to the `publish` job's permissions block (required for OIDC attestation)
- Closes #425

Embeds [OIDC-attested provenance](https://docs.npmjs.com/generating-provenance-statements) in each published tarball, linking it back to the exact GHA run + commit SHA that produced it. Surfaces as a "Provenance" badge on the package's npmjs.com landing page.

## Why land before the first publish

#425's body originally deferred this to a follow-up after the first publish proved the basic path works. We're folding it in now so the inaugural `v0.1.0-next.1` ships with provenance from day 1.

The dry-run on commit 79ac239 (run [26344415316](https://github.com/Takazudo/zudo-front-builder/actions/runs/26344415316), cancelled at 8h queue starvation on macOS-x64) already proved 4/5 platforms green end-to-end. This PR only adds two lines and a permission — no risk of regressing the proven path.

## Test plan

- [ ] CI green on this PR (build + check; no publish on a non-tag ref)
- [ ] After merge, version bump → tag `v0.1.0-next.1` → push triggers release.yml on the tagged main commit
- [ ] First publish lands with provenance badge on https://www.npmjs.com/package/@takazudo/zfb

🤖 Generated with [Claude Code](https://claude.com/claude-code)