### PR TITLE
release: local-build escape hatch for macOS-x64 (closes #437)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -379,18 +379,61 @@ jobs:
           path: artifacts
           merge-multiple: false
 
-      - name: Place binaries in platform packages
+      # Escape-hatch gate (issue #437): when the macOS-x64 leg was skipped, the
+      # binary was built locally and uploaded to the GH Release. Verify both the
+      # archive and its .sha256 are present (fail loud if not), then download and
+      # extract the binary so @takazudo/zfb-darwin-x64 can be published.
+      - name: Verify + fetch pre-built macOS-x64 archive from GH Release
+        if: ${{ inputs.skip_macos_x64 == true && inputs.dry_run != true }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          ZFB_SEMVER=$(node -p "require('./packages/zfb/package.json').version")
+          ARCHIVE="zfb-${ZFB_SEMVER}-x86_64-apple-darwin.tar.gz"
+          echo "Expecting pre-built asset on Release ${TAG}: ${ARCHIVE} (+ .sha256)"
+
+          ASSETS=$(gh release view "$TAG" --json assets --jq '.assets[].name')
+          for f in "$ARCHIVE" "${ARCHIVE}.sha256"; do
+            if ! grep -Fxq "$f" <<<"$ASSETS"; then
+              echo "::error::skip_macos_x64=true but '${f}' is not attached to GH Release ${TAG}."
+              echo "::error::Run ./scripts/build-macos-x64-local.sh --upload ${TAG} on a Mac first."
+              echo "Assets currently on the release:"; echo "$ASSETS"
+              exit 1
+            fi
+          done
+          echo "Both macOS-x64 assets present on the release."
+
+          gh release download "$TAG" --pattern "$ARCHIVE" --dir prebuilt-macos-x64 --clobber
+          tar -C prebuilt-macos-x64 -xzf "prebuilt-macos-x64/${ARCHIVE}"
+          if [[ ! -f prebuilt-macos-x64/zfb ]]; then
+            echo "::error::Archive ${ARCHIVE} did not contain a 'zfb' binary at its root."
+            exit 1
+          fi
+          cp prebuilt-macos-x64/zfb packages/zfb-darwin-x64/zfb
+          chmod +x packages/zfb-darwin-x64/zfb
+          echo "Placed locally-built macOS-x64 binary into packages/zfb-darwin-x64/zfb"
+
+      - name: Place CI-built binaries in platform packages
         shell: bash
         run: |
           cp artifacts/binary-aarch64-apple-darwin/zfb packages/zfb-darwin-arm64/zfb
-          cp artifacts/binary-x86_64-apple-darwin/zfb packages/zfb-darwin-x64/zfb
           cp artifacts/binary-aarch64-unknown-linux-gnu/zfb packages/zfb-linux-arm64-gnu/zfb
           cp artifacts/binary-x86_64-unknown-linux-gnu/zfb packages/zfb-linux-x64-gnu/zfb
           cp artifacts/binary-x86_64-pc-windows-msvc/zfb.exe packages/zfb-win32-x64-msvc/zfb.exe
           chmod +x packages/zfb-darwin-arm64/zfb
-          chmod +x packages/zfb-darwin-x64/zfb
           chmod +x packages/zfb-linux-arm64-gnu/zfb
           chmod +x packages/zfb-linux-x64-gnu/zfb
+
+      # When NOT skipping, the macOS-x64 binary comes from the CI build artifact.
+      # When skipping, it was placed by the "Verify + fetch" step above instead.
+      - name: Place CI-built macOS-x64 binary
+        if: ${{ inputs.skip_macos_x64 != true }}
+        shell: bash
+        run: |
+          cp artifacts/binary-x86_64-apple-darwin/zfb packages/zfb-darwin-x64/zfb
+          chmod +x packages/zfb-darwin-x64/zfb
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -434,8 +477,21 @@ jobs:
             exit 1
           fi
 
+      # Normal path: every package published with OIDC-attested --provenance.
       - name: Publish to npm
-        if: ${{ inputs.dry_run != true }}
+        if: ${{ inputs.dry_run != true && inputs.skip_macos_x64 != true }}
         run: pnpm -r publish --tag "$DIST_TAG" --no-git-checks --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      # Escape-hatch path (issue #437): the macOS-x64 binary was built locally,
+      # outside this GHA job, so it cannot carry OIDC provenance. Publish that one
+      # package WITHOUT --provenance and every other package WITH --provenance
+      # (option B — mixed provenance). See RELEASE_DAY_CHECKLIST.md.
+      - name: Publish to npm (mixed provenance — local macOS-x64)
+        if: ${{ inputs.dry_run != true && inputs.skip_macos_x64 == true }}
+        run: |
+          pnpm -r --filter '@takazudo/zfb-darwin-x64' publish --tag "$DIST_TAG" --no-git-checks --access public
+          pnpm -r --filter '!@takazudo/zfb-darwin-x64' publish --tag "$DIST_TAG" --no-git-checks --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -405,7 +405,15 @@ jobs:
           done
           echo "Both macOS-x64 assets present on the release."
 
-          gh release download "$TAG" --pattern "$ARCHIVE" --dir prebuilt-macos-x64 --clobber
+          gh release download "$TAG" \
+            --pattern "$ARCHIVE" --pattern "${ARCHIVE}.sha256" \
+            --dir prebuilt-macos-x64 --clobber
+
+          # Validate the archive against its published checksum before trusting
+          # it — guards against a corrupted/interrupted upload or an independent
+          # clobber putting a mismatched binary on the Release.
+          ( cd prebuilt-macos-x64 && sha256sum -c "${ARCHIVE}.sha256" )
+
           tar -C prebuilt-macos-x64 -xzf "prebuilt-macos-x64/${ARCHIVE}"
           if [[ ! -f prebuilt-macos-x64/zfb ]]; then
             echo "::error::Archive ${ARCHIVE} did not contain a 'zfb' binary at its root."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,42 +62,62 @@ on:
         description: "Skip publish + GH Release upload steps (build + tarball + sha256 only)"
         type: boolean
         default: false
+      skip_macos_x64:
+        # Escape hatch for the queue-starved macos-13 runner (issue #437).
+        # When true: the darwin-x64 build leg is dropped from the matrix, the
+        # publish job verifies a locally-built macOS-x64 archive + .sha256 are
+        # already attached to the GH Release, downloads that binary, and
+        # publishes @takazudo/zfb-darwin-x64 WITHOUT --provenance (it was not
+        # built inside this GHA job). See RELEASE_DAY_CHECKLIST.md.
+        description: "Skip the macOS-x64 build leg; use the locally-built archive already on the GH Release"
+        type: boolean
+        default: false
 
 jobs:
+  # Emits the build matrix as JSON so the darwin-x64 leg can be conditionally
+  # dropped (GitHub's static `matrix.exclude` cannot reference inputs). The full
+  # matrix lives here as the single source of truth; jq removes the x86_64-apple-
+  # darwin entry when skip_macos_x64 is set.
+  prepare-matrix:
+    name: Prepare build matrix
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      settings: ${{ steps.set.outputs.settings }}
+    steps:
+      - id: set
+        shell: bash
+        env:
+          SKIP_MACOS_X64: ${{ inputs.skip_macos_x64 }}
+        run: |
+          ALL='[
+            {"host":"macos-latest","target":"aarch64-apple-darwin","platform":"darwin-arm64","binary":"zfb","archive_ext":"tar.gz"},
+            {"host":"macos-13","target":"x86_64-apple-darwin","platform":"darwin-x64","binary":"zfb","archive_ext":"tar.gz"},
+            {"host":"ubuntu-22.04","target":"x86_64-unknown-linux-gnu","platform":"linux-x64-gnu","binary":"zfb","archive_ext":"tar.gz"},
+            {"host":"ubuntu-latest","target":"aarch64-unknown-linux-gnu","platform":"linux-arm64-gnu","binary":"zfb","archive_ext":"tar.gz","use_cross":true},
+            {"host":"windows-latest","target":"x86_64-pc-windows-msvc","platform":"win32-x64-msvc","binary":"zfb.exe","archive_ext":"zip"}
+          ]'
+          # TODO when ubuntu-22.04 GitHub Actions runner is deprecated: switch to a
+          # manylinux_2_28 container or zig-cc cross-compile to maintain the GLIBC 2.35 floor.
+          if [[ "$SKIP_MACOS_X64" == "true" ]]; then
+            SETTINGS="$(echo "$ALL" | jq -c '[.[] | select(.target != "x86_64-apple-darwin")]')"
+            echo "skip_macos_x64=true → dropping the x86_64-apple-darwin (macos-13) build leg"
+          else
+            SETTINGS="$(echo "$ALL" | jq -c '.')"
+          fi
+          echo "Resolved build matrix:"
+          echo "$SETTINGS" | jq '.'
+          echo "settings=$SETTINGS" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: prepare-matrix
     name: Build ${{ matrix.settings.target }}
     strategy:
       fail-fast: false
       matrix:
-        settings:
-          - host: macos-latest
-            target: aarch64-apple-darwin
-            platform: darwin-arm64
-            binary: zfb
-            archive_ext: tar.gz
-          - host: macos-13
-            target: x86_64-apple-darwin
-            platform: darwin-x64
-            binary: zfb
-            archive_ext: tar.gz
-          # TODO when ubuntu-22.04 GitHub Actions runner is deprecated: switch to a
-          # manylinux_2_28 container or zig-cc cross-compile to maintain the GLIBC 2.35 floor.
-          - host: ubuntu-22.04
-            target: x86_64-unknown-linux-gnu
-            platform: linux-x64-gnu
-            binary: zfb
-            archive_ext: tar.gz
-          - host: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-            platform: linux-arm64-gnu
-            binary: zfb
-            archive_ext: tar.gz
-            use_cross: true
-          - host: windows-latest
-            target: x86_64-pc-windows-msvc
-            platform: win32-x64-msvc
-            binary: zfb.exe
-            archive_ext: zip
+        # Dynamic matrix from prepare-matrix — the darwin-x64 leg is dropped when
+        # skip_macos_x64 is set (issue #437). See the prepare-matrix job above.
+        settings: ${{ fromJSON(needs.prepare-matrix.outputs.settings) }}
     runs-on: ${{ matrix.settings.host }}
     timeout-minutes: 45
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,9 @@ __inbox/
 # miniflare subprocess is killed before NamedTempFile drop runs
 # (e.g. SIGKILL). See crates/zfb-build/src/renderer.rs.
 /zfb-renderer-bootstrap-*.mjs
+
+# Release archives + checksums produced locally by
+# scripts/build-macos-x64-local.sh (issue #437 escape hatch). Uploaded to the
+# GH Release, never committed.
+/zfb-*.tar.gz
+/zfb-*.tar.gz.sha256

--- a/RELEASE_DAY_CHECKLIST.md
+++ b/RELEASE_DAY_CHECKLIST.md
@@ -55,6 +55,69 @@ Run `workflow_dispatch` with `dry_run: true` to exercise all build, tarball,
 and sha256 steps without uploading to a GH Release or publishing to npm.
 The `release-assets` job will list the collected files instead of uploading.
 
+## macOS-x64 local-build escape hatch (added by issue #437)
+
+The GHA `macos-13` (legacy Intel) runner is chronically queue-starved — GitHub
+is throttling its capacity to push users toward Apple Silicon images. It is the
+single point of failure for releases: the other 4 platforms build in 5–15 min,
+while `darwin-x64` has repeatedly stalled for hours. This escape hatch lets a
+Mac dev host build that one artifact locally and skip the runner entirely.
+
+### Default path (no escape hatch)
+
+Push a `v*` tag and wait for the full 5-platform GHA matrix. Use this whenever
+`macos-13` is behaving — it keeps full npm `--provenance` on every package.
+
+### Escape-hatch path (when `macos-13` is stuck)
+
+1. **Push the `vX.Y.Z` tag as usual.** The Release workflow starts.
+2. **If the `darwin-x64` (macos-13) leg stalls**, cancel that workflow run. The
+   GH Release for the tag has already been created (or will be — if not, the
+   other platforms' run created it).
+3. **On a Mac, build + upload the macOS-x64 asset:**
+
+   ```sh
+   ./scripts/build-macos-x64-local.sh --upload vX.Y.Z
+   ```
+
+   This runs `pnpm install`, builds `x86_64-apple-darwin` in release mode, and
+   uploads `zfb-{semver}-x86_64-apple-darwin.tar.gz` + `.sha256` to the GH
+   Release for `vX.Y.Z` (`gh release upload --clobber`, so re-runs are safe).
+   The archive + checksum are byte-format-identical to what the runner produces
+   (same name, same one-file-at-root layout, same GNU two-space sha256 line).
+4. **Re-dispatch `release.yml` against the tag with the escape hatch on:**
+   - Actions → Release → "Run workflow"
+   - **Use workflow from:** select the **tag** `vX.Y.Z` (not a branch — the
+     publish/upload guards require a `refs/tags/v*` ref)
+   - `dry_run`: `false`
+   - `skip_macos_x64`: `true`
+
+   With `skip_macos_x64=true` the workflow:
+
+   - drops the `darwin-x64` build leg from the matrix (no `macos-13` wait),
+   - verifies the macOS-x64 archive + `.sha256` are already on the GH Release
+     before the publish job proceeds (fails loud if missing),
+   - uploads the other 4 archives to the Release (the pre-uploaded macOS-x64
+     asset stays in place),
+   - publishes all npm packages, splitting the publish so
+     `@takazudo/zfb-darwin-x64` is published **without** `--provenance` while
+     every other package keeps `--provenance` (see "Provenance trade-off"
+     below).
+
+### Provenance trade-off (option B — mixed provenance)
+
+npm `--provenance` (added in #425 / PR #436) requires OIDC attestation from the
+GHA job that built the code. A locally-built `darwin-x64` binary did **not** run
+inside the GHA job, so it cannot carry provenance. When `skip_macos_x64=true`
+the publish step therefore splits:
+
+- `@takazudo/zfb-darwin-x64` → published **without** `--provenance`
+- all other packages → published **with** `--provenance`
+
+This is the "mixed-provenance" option B from issue #437. Prefer the default path
+(option C: only use the escape hatch when `macos-13` is actually stuck) so most
+releases keep full provenance across every package.
+
 ## Homebrew tap update (added by issue #383)
 
 After the GitHub Release assets are published, regenerate and push the Homebrew

--- a/scripts/build-macos-x64-local.sh
+++ b/scripts/build-macos-x64-local.sh
@@ -148,6 +148,25 @@ echo "    ${archive_path}.sha256"
 # ── Optional upload to the GH Release ─────────────────────────────────────────
 
 if [[ -n "$upload_tag" ]]; then
+  # In the documented recovery flow the user cancels the stalled tag run, so the
+  # release-assets job (which creates the GH Release) never ran — the Release may
+  # not exist yet. `gh release upload` requires an existing Release, so create a
+  # minimal one first. The re-dispatched release.yml release-assets job later
+  # updates this same Release with the other 4 archives and the final prerelease
+  # flag (softprops/action-gh-release updates an existing release in place).
+  if ! gh release view "$upload_tag" >/dev/null 2>&1; then
+    echo "==> GH Release ${upload_tag} does not exist yet — creating it"
+    # Match the channel policy: *-next.* / *-beta.* / *-rc.* tags are prereleases.
+    prerelease_flag=""
+    if [[ "$upload_tag" =~ -next\. ]] || [[ "$upload_tag" =~ -beta\. ]] || [[ "$upload_tag" =~ -rc\. ]]; then
+      prerelease_flag="--prerelease"
+    fi
+    gh release create "$upload_tag" \
+      --title "$upload_tag" \
+      --notes "Release ${upload_tag} (macOS-x64 built locally via escape hatch — issue #437; remaining assets uploaded by release.yml)" \
+      $prerelease_flag
+  fi
+
   echo "==> Uploading to GitHub Release ${upload_tag} (--clobber)"
   # --clobber makes re-runs idempotent (overwrites an existing asset of the
   # same name instead of erroring).

--- a/scripts/build-macos-x64-local.sh
+++ b/scripts/build-macos-x64-local.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# build-macos-x64-local.sh
+#
+# Escape hatch for the chronically queue-starved GHA `macos-13` (legacy Intel)
+# runner (issue #437). Builds the macOS-x64 (`x86_64-apple-darwin`) release
+# binary locally on a Mac and produces the GH Release archive + sha256 in the
+# EXACT format release.yml would have produced on the runner.
+#
+# Usage:
+#   ./scripts/build-macos-x64-local.sh [--upload <tag>] [--out-dir DIR]
+#
+# --upload <tag>  After building, upload the archive + .sha256 to the GitHub
+#                 Release for <tag> via `gh release upload --clobber`. The tag
+#                 (e.g. v0.1.0-next.1) must already have a Release. Without this
+#                 flag the files are only written locally and the upload command
+#                 is printed for you to run manually.
+#
+# --out-dir DIR   Where to write the archive + .sha256. Default: repo root.
+#
+# Prerequisites (matches release.yml's build job):
+#   - Rust toolchain (rustup); the script runs `rustup target add
+#     x86_64-apple-darwin` itself (idempotent — needed on Apple Silicon hosts).
+#   - node_modules present. build.rs (embed_framework_packages) reads
+#     node_modules/.pnpm/preact@*/... at compile time, so the script runs
+#     `pnpm install --frozen-lockfile` before cargo build — skipping it yields a
+#     binary missing embedded framework assets that only fails at the user's
+#     install time. (release.yml installs deps before cargo build for the same
+#     reason.)
+#
+# Archive / checksum contract (LOCKED — must match release.yml exactly, see the
+# header of .github/workflows/release.yml and RELEASE_DAY_CHECKLIST.md):
+#   Archive name:  zfb-{semver}-x86_64-apple-darwin.tar.gz
+#     {semver} = packages/zfb/package.json .version, no leading "v"
+#   Contents:      exactly one file at the archive root — "zfb" (no nested dir),
+#                  produced by `tar -C packages/zfb-darwin-x64 -czf <archive> zfb`
+#   Checksum file: {archive-name}.sha256, one line
+#                  "<64-hex-lowercase>  <archive-basename>" (two spaces, GNU
+#                  sha256sum format; S4/S5/S6 installers parse field 1).
+set -euo pipefail
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+
+upload_tag=""
+out_dir=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --upload)
+      upload_tag="$2"
+      shift 2
+      ;;
+    --out-dir)
+      out_dir="$2"
+      shift 2
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+    *)
+      echo "Unexpected positional argument: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ── Locate repo root ──────────────────────────────────────────────────────────
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+if [[ -z "$out_dir" ]]; then
+  out_dir="$repo_root"
+fi
+mkdir -p "$out_dir"
+
+# ── Platform sanity check ─────────────────────────────────────────────────────
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "ERROR: this script must run on macOS — cross-compiling to" >&2
+  echo "       x86_64-apple-darwin from Linux/Windows needs significant SDK" >&2
+  echo "       setup and is out of scope (issue #437)." >&2
+  exit 1
+fi
+
+target="x86_64-apple-darwin"
+platform_pkg="packages/zfb-darwin-x64"
+
+# ── Resolve semver (single source of truth, matches release.yml) ──────────────
+
+semver="$(node -p "require('./packages/zfb/package.json').version")"
+archive="zfb-${semver}-${target}.tar.gz"
+echo "==> Building zfb ${semver} for ${target}"
+
+# ── Toolchain target (idempotent — Apple Silicon hosts need this once) ────────
+
+echo "==> Ensuring rust target ${target} is installed"
+rustup target add "$target"
+
+# ── Install node deps before cargo build ──────────────────────────────────────
+# build.rs embeds framework packages from node_modules at compile time.
+
+echo "==> Installing node dependencies (pnpm install --frozen-lockfile)"
+pnpm install --frozen-lockfile
+
+# ── Build ─────────────────────────────────────────────────────────────────────
+
+echo "==> cargo build -p zfb --release --target ${target}"
+cargo build -p zfb --release --target "$target"
+
+built_binary="target/${target}/release/zfb"
+if [[ ! -f "$built_binary" ]]; then
+  echo "ERROR: expected binary not found: ${built_binary}" >&2
+  exit 1
+fi
+
+# ── Place binary in the platform package (mirrors release.yml) ────────────────
+# The archive is created with `-C <platform_pkg>` so its single root entry is
+# exactly "zfb" with no nested directory.
+
+cp "$built_binary" "${platform_pkg}/zfb"
+chmod +x "${platform_pkg}/zfb"
+
+# ── Create archive (Unix tar.gz, contract format) ─────────────────────────────
+
+archive_path="${out_dir}/${archive}"
+echo "==> Creating archive ${archive_path}"
+tar -C "$platform_pkg" -czf "$archive_path" zfb
+
+# ── Generate sha256 checksum (GNU two-space format) ───────────────────────────
+# Prefer coreutils sha256sum; fall back to the always-present macOS `shasum`.
+# Both emit "<hash>  <basename>" (two spaces). Run from out_dir so the file
+# records only the basename (installers rely on basename-only).
+
+echo "==> Generating ${archive}.sha256"
+if command -v sha256sum >/dev/null 2>&1; then
+  ( cd "$out_dir" && sha256sum "$archive" > "${archive}.sha256" )
+else
+  ( cd "$out_dir" && shasum -a 256 "$archive" > "${archive}.sha256" )
+fi
+echo "--- checksum file contents ---"
+cat "${archive_path}.sha256"
+
+echo "==> Built:"
+echo "    ${archive_path}"
+echo "    ${archive_path}.sha256"
+
+# ── Optional upload to the GH Release ─────────────────────────────────────────
+
+if [[ -n "$upload_tag" ]]; then
+  echo "==> Uploading to GitHub Release ${upload_tag} (--clobber)"
+  # --clobber makes re-runs idempotent (overwrites an existing asset of the
+  # same name instead of erroring).
+  gh release upload "$upload_tag" \
+    "$archive_path" \
+    "${archive_path}.sha256" \
+    --clobber
+  echo "==> Uploaded. Now re-dispatch release.yml against tag ${upload_tag} with skip_macos_x64=true."
+else
+  echo ""
+  echo "Not uploaded. To attach these to the GH Release for <tag>, run:"
+  echo "  gh release upload <tag> \\"
+  echo "    \"${archive_path}\" \\"
+  echo "    \"${archive_path}.sha256\" --clobber"
+  echo "Then re-dispatch release.yml against <tag> with skip_macos_x64=true."
+fi


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/437

---

## Summary

- The GHA `macos-13` (legacy Intel) runner is chronically queue-starved and is the single point of failure for releases (other 4 platforms build in 5–15 min; macOS-x64 has stalled for hours). This adds a documented local-build escape hatch so a release is no longer blocked on that runner.
- A Mac dev host builds the `x86_64-apple-darwin` artifact locally and uploads it to the GH Release; `release.yml` is then re-dispatched with `skip_macos_x64: true` to finish the release without scheduling the macos-13 leg.
- Provenance: **option B (mixed provenance)** — only `@takazudo/zfb-darwin-x64` is published without `--provenance` (it was built outside the GHA OIDC chain); every other package keeps `--provenance`.

## Changes

**`scripts/build-macos-x64-local.sh` (new)**
- `rustup target add x86_64-apple-darwin` (idempotent) → `pnpm install --frozen-lockfile` (so `build.rs` can embed framework packages) → `cargo build -p zfb --release`.
- Produces `zfb-{semver}-x86_64-apple-darwin.tar.gz` + `.sha256` in the exact contract-locked format `release.yml` produces (same archive name, one-file-at-root layout, GNU two-space sha256 line). Prefers `sha256sum`, falls back to macOS `shasum -a 256`.
- `--upload <tag>` attaches both assets to the GH Release (`--clobber` for idempotent re-runs); **creates the Release if it doesn't exist yet** (the recovery flow cancels the stalled run before `release-assets` created it).

**`.github/workflows/release.yml`**
- New `skip_macos_x64` `workflow_dispatch` boolean input (default `false`).
- New `prepare-matrix` job emits the build matrix as JSON (single source of truth); `jq` drops the `x86_64-apple-darwin` leg when `skip_macos_x64=true`. The `build` job consumes `fromJSON(needs.prepare-matrix.outputs.settings)` — GitHub's static `matrix.exclude` can't reference inputs.
- Publish job, when skipping: verifies the macOS-x64 archive + `.sha256` are already on the GH Release (fails loud with a pointer to the script if missing), `sha256sum -c` validates the downloaded archive before extracting, then publishes with the **mixed-provenance** split.
- Normal tag-push path is unchanged: full 5-platform matrix, single `pnpm -r publish --provenance`.

**Docs**
- `RELEASE_DAY_CHECKLIST.md` documents the default flow and the escape-hatch flow (build → upload → re-dispatch against the tag with `skip_macos_x64=true`) plus the provenance trade-off.
- `.gitignore` excludes the locally-produced `/zfb-*.tar.gz` + `.sha256`.

## Test Plan

- ✅ Dispatched `release.yml` with `dry_run=true, skip_macos_x64=true` on this branch ([run 26357083133](https://github.com/Takazudo/zudo-front-builder/actions/runs/26357083133)): `prepare-matrix` + exactly **4 build legs (no macos-13)** + dry-run `publish`/`release-assets` all passed — confirms the dynamic-matrix refactor doesn't break the normal downstream jobs.
- ✅ `/codex-review` (2 findings, both fixed) + `/gcoc-review` (no high-priority issues).
- ⏳ **Acceptance criterion 4** ("one full release exercised end-to-end via the escape-hatch path") is a runtime/manual step requiring a real tag + npm publish — **to be verified at the next stalled release**.

Closes #437