### PR TITLE
Route nested markdown in MDX JSX bodies through _components

### DIFF
--- a/crates/zfb-content/src/mdx_jsx_emit.rs
+++ b/crates/zfb-content/src/mdx_jsx_emit.rs
@@ -1170,10 +1170,15 @@ fn jsx_element_text(
 ///
 /// Mirrors the coverage of [`mdast_to_hast`](crate::pipeline::mdast_to_hast)
 /// — every node kind that has a meaningful HTML rendering produces a
-/// matching plain-HTML JSX tag. Inside an MDX JSX block we cannot
-/// route through `_components.<tag>` (the children live inside a
-/// JsxRaw string, not a `JsxEmitter` invocation), so plain
-/// `<p>`/`<strong>`/etc. ship to JSX as regular HTML elements.
+/// matching JSX tag. Markdown nodes living inside an MDX JSX block (e.g.
+/// a `## heading` or a list inside `<Outro>…</Outro>`) route through
+/// `_components.<tag>` so callers can override `<p>`/`<h2>`/etc. via the
+/// `components` prop, matching `JsxEmitter::emit_jsx`'s contract on the
+/// non-pipeline path. These tags are emitted into a JsxRaw payload; the
+/// bridge's `collect_components_tag_names` scan (see `emit_node` for the
+/// `HastNode::JsxRaw` arm) harvests the `<_components.<tag>` references
+/// afterwards so the module preamble registers each tag's default
+/// fallback in the `_components` map.
 fn jsx_render_child(node: &MdastNode) -> String {
     match node {
         MdastNode::Text(t) => jsx_text_escape(&t.value),
@@ -1194,14 +1199,17 @@ fn jsx_render_child(node: &MdastNode) -> String {
         MdastNode::Emphasis(e) => jsx_wrap_children("em", "", &e.children),
         MdastNode::Strong(s) => jsx_wrap_children("strong", "", &s.children),
         MdastNode::Delete(d) => jsx_wrap_children("del", "", &d.children),
-        MdastNode::InlineCode(c) => format!("<code>{}</code>", jsx_text_escape(&c.value)),
+        MdastNode::InlineCode(c) => format!(
+            "<_components.code>{}</_components.code>",
+            jsx_text_escape(&c.value),
+        ),
         MdastNode::Code(c) => {
             let mut attrs = String::new();
             if let Some(lang) = &c.lang {
                 attrs.push_str(&format!(" class=\"language-{}\"", jsx_attr_escape(lang)));
             }
             format!(
-                "<pre><code{attrs}>{}</code></pre>",
+                "<_components.pre><_components.code{attrs}>{}</_components.code></_components.pre>",
                 jsx_text_escape(&c.value),
             )
         }
@@ -1211,7 +1219,7 @@ fn jsx_render_child(node: &MdastNode) -> String {
                 attrs.push_str(&format!(" title=\"{}\"", jsx_attr_escape(title)));
             }
             format!(
-                "<a{attrs}>{}</a>",
+                "<_components.a{attrs}>{}</_components.a>",
                 l.children.iter().map(jsx_render_child).collect::<String>(),
             )
         }
@@ -1224,7 +1232,7 @@ fn jsx_render_child(node: &MdastNode) -> String {
             if let Some(title) = &i.title {
                 attrs.push_str(&format!(" title=\"{}\"", jsx_attr_escape(title)));
             }
-            format!("<img{attrs} />")
+            format!("<_components.img{attrs} />")
         }
         MdastNode::List(l) => {
             let tag = if l.ordered { "ol" } else { "ul" };
@@ -1237,26 +1245,25 @@ fn jsx_render_child(node: &MdastNode) -> String {
                 }
             }
             format!(
-                "<{tag}{attrs}>{}</{tag}>",
+                "<_components.{tag}{attrs}>{}</_components.{tag}>",
                 l.children.iter().map(jsx_render_child).collect::<String>(),
             )
         }
         MdastNode::ListItem(li) => jsx_wrap_children("li", "", &li.children),
         MdastNode::Blockquote(b) => jsx_wrap_children("blockquote", "", &b.children),
-        MdastNode::ThematicBreak(_) => "<hr />".to_string(),
-        MdastNode::Break(_) => "<br />".to_string(),
+        MdastNode::ThematicBreak(_) => "<_components.hr />".to_string(),
+        MdastNode::Break(_) => "<_components.br />".to_string(),
         MdastNode::Math(m) => format!(
-            "<pre><code class=\"language-math math-display\">{}</code></pre>",
+            "<_components.pre><_components.code class=\"language-math math-display\">{}</_components.code></_components.pre>",
             jsx_text_escape(&m.value),
         ),
         MdastNode::InlineMath(m) => format!(
-            "<code class=\"language-math math-inline\">{}</code>",
+            "<_components.code class=\"language-math math-inline\">{}</_components.code>",
             jsx_text_escape(&m.value),
         ),
         MdastNode::Root(r) => r.children.iter().map(jsx_render_child).collect(),
-        // GFM pipe-table inside MDX JSX body — emit plain HTML table tags
-        // (no _components routing here; jsx_render_child produces JsxRaw
-        // payloads that the bridge embeds verbatim, so plain HTML tags work).
+        // GFM pipe-table inside MDX JSX body — routes table tags through
+        // `_components.<tag>`, matching the non-pipeline `emit_table_jsx`.
         MdastNode::Table(t) => jsx_render_table(t),
         // Footnotes, references, ESM, frontmatter, etc. drop silently here
         // — better than leaking a `Debug` repr.
@@ -1264,11 +1271,13 @@ fn jsx_render_child(node: &MdastNode) -> String {
     }
 }
 
-/// Render a GFM pipe-table as plain HTML inside a JSX-shaped string.
+/// Render a GFM pipe-table as `_components.<tag>`-routed JSX.
 ///
 /// Used by [`jsx_render_child`] for tables that appear inside MDX JSX
-/// element bodies (where `_components.*` routing is not available).
-/// The resulting string is embedded as a [`HastNode::JsxRaw`] payload.
+/// element bodies. Table tags route through `_components.<tag>` so
+/// callers can override them, matching the non-pipeline `emit_table_jsx`.
+/// The resulting string is embedded as a [`HastNode::JsxRaw`] payload;
+/// the bridge's `collect_components_tag_names` scan registers each tag.
 fn jsx_render_table(t: &markdown::mdast::Table) -> String {
     let style_attr = |col: usize| -> String {
         t.align
@@ -1282,24 +1291,26 @@ fn jsx_render_table(t: &markdown::mdast::Table) -> String {
         let MdastNode::TableRow(tr) = row else {
             return String::new();
         };
-        let mut out = String::from("<tr>");
+        let mut out = String::from("<_components.tr>");
         for (col, cell) in tr.children.iter().enumerate() {
             let MdastNode::TableCell(tc) = cell else {
                 continue;
             };
             let style = style_attr(col);
             let inner: String = tc.children.iter().map(jsx_render_child).collect();
-            out.push_str(&format!("<{cell_tag}{style}>{inner}</{cell_tag}>"));
+            out.push_str(&format!(
+                "<_components.{cell_tag}{style}>{inner}</_components.{cell_tag}>"
+            ));
         }
-        out.push_str("</tr>");
+        out.push_str("</_components.tr>");
         out
     };
 
-    let mut out = String::from("<table>");
+    let mut out = String::from("<_components.table>");
     if let Some(head_row) = t.children.first() {
-        out.push_str("<thead>");
+        out.push_str("<_components.thead>");
         out.push_str(&emit_row(head_row, "th"));
-        out.push_str("</thead>");
+        out.push_str("</_components.thead>");
     }
     let body_rows = if t.children.len() > 1 {
         &t.children[1..]
@@ -1307,19 +1318,19 @@ fn jsx_render_table(t: &markdown::mdast::Table) -> String {
         &[]
     };
     if !body_rows.is_empty() {
-        out.push_str("<tbody>");
+        out.push_str("<_components.tbody>");
         for row in body_rows {
             out.push_str(&emit_row(row, "td"));
         }
-        out.push_str("</tbody>");
+        out.push_str("</_components.tbody>");
     }
-    out.push_str("</table>");
+    out.push_str("</_components.table>");
     out
 }
 
 fn jsx_wrap_children(tag: &str, attrs: &str, children: &[MdastNode]) -> String {
     format!(
-        "<{tag}{attrs}>{}</{tag}>",
+        "<_components.{tag}{attrs}>{}</_components.{tag}>",
         children.iter().map(jsx_render_child).collect::<String>(),
     )
 }

--- a/crates/zfb-content/tests/mdx_jsx_emit_hast.rs
+++ b/crates/zfb-content/tests/mdx_jsx_emit_hast.rs
@@ -441,3 +441,58 @@ fn empty_mdx_fragment_emits_valid_jsx() {
         .compile(&out, &opts)
         .unwrap_or_else(|e| panic!("SWC rejected empty-fragment output: {e}\n--- src ---\n{out}"));
 }
+
+/// Regression for #286 (epic #285): markdown block nodes nested inside
+/// an MDX JSX element body — a heading, a paragraph, AND a list — must
+/// route through `_components.<tag>` so consumers can override `<h2>` /
+/// `<p>` / `<ul>` / `<li>` via the `components` prop, matching
+/// `JsxEmitter::emit_jsx`'s contract. Before the fix `jsx_render_child`
+/// / `jsx_wrap_children` emitted bare `<h2>`/`<p>`/`<ul>`/`<li>` tags,
+/// which missed the consumer `_components` map (no styled heading) and
+/// were never registered in the preamble.
+#[test]
+fn nested_markdown_in_mdx_jsx_routes_through_components() {
+    let out = emit_with_defaults(
+        "<Outro>\n\n## Wrap up\n\nA closing paragraph.\n\n- first\n- second\n\n</Outro>\n",
+    );
+    // The PascalCase wrapper still routes correctly (unchanged behavior).
+    assert!(
+        out.contains("const Outro = _components.Outro ?? components.Outro;"),
+        "PascalCase wrapper preamble must be emitted for <Outro>:\n{out}",
+    );
+    // Nested markdown tags route through `_components.<tag>`.
+    for needle in [
+        "<_components.h2",
+        "<_components.p>",
+        "<_components.ul>",
+        "<_components.li>",
+    ] {
+        assert!(
+            out.contains(needle),
+            "nested markdown must route through `{needle}`:\n{out}",
+        );
+    }
+    // Bare HTML tags must NOT leak through alongside the routed forms —
+    // this negative assertion is what catches a future regression.
+    for bare in ["<h2>", "<h2 ", "<p>", "<ul>", "<li>", "</h2>", "</p>", "</ul>", "</li>"] {
+        assert!(
+            !out.contains(bare),
+            "bare `{bare}` must not leak alongside the `_components` route:\n{out}",
+        );
+    }
+    // The preamble must register each tag's default fallback so the
+    // route works even without an explicit `components` override —
+    // this proves `collect_components_tag_names` harvested the tags.
+    for tag in ["h2", "p", "ul", "li"] {
+        let needle = format!("{tag}: \"{tag}\",");
+        assert!(
+            out.contains(&needle),
+            "`_components` default must register `{needle}`:\n{out}",
+        );
+    }
+    // SWC must accept the emitted module.
+    let opts = CompileOptions::default().with_filename("nested-md.tsx".to_string());
+    SwcPipeline::new()
+        .compile(&out, &opts)
+        .unwrap_or_else(|e| panic!("SWC rejected nested-markdown output: {e}\n--- src ---\n{out}"));
+}


### PR DESCRIPTION
## Problem

Markdown block nodes living **inside** an MDX JSX element body — e.g. a `## heading`, a paragraph, or a list inside `<Outro>…</Outro>` — were rendered by `jsx_render_child` / `jsx_wrap_children` / `jsx_render_table` as **bare HTML tags** (`<p>`, `<h2>`, `<ul>`, `<table>`).

On the production hast-detour path (`take_hast_detour = pipeline_mut.is_some()`), this bypassed the consumer `_components` map entirely. Consumers that override `<h2>` etc. via the `components` prop (e.g. a styled heading accent bar) had those overrides silently dropped for any markdown nested inside an MDX JSX wrapper. The non-pipeline `JsxEmitter::emit_jsx` path already routed nested markdown through `_components.<tag>` — this brings the JSX-path child renderer to parity.

## Fix

Route every markdown-derived tag emitted by `jsx_render_child`, `jsx_wrap_children`, and `jsx_render_table` through `_components.<tag>`:

- `p`, `h1`–`h6`, `em`, `strong`, `del`, `li`, `blockquote` (via `jsx_wrap_children`)
- `ul`/`ol`, `code`, `pre`, `a`, `img`, `hr`, `br`, math `pre`/`code`
- table: `table`/`thead`/`tbody`/`tr`/`th`/`td`

The bridge's existing `collect_components_tag_names` scan over the `JsxRaw` payload harvests the `<_components.<tag>` references afterwards, so the module preamble registers each tag's default fallback automatically — no manual `html_tags` threading needed.

**Unchanged:** PascalCase component names, `_Fragment`, and user-written raw HTML (`MdastNode::Html`) stay verbatim.

## Tests

Adds `nested_markdown_in_mdx_jsx_routes_through_components` to `mdx_jsx_emit_hast.rs`: nests a `## heading`, a paragraph, AND a list inside `<Outro>`, asserting:
- presence of `<_components.h2`, `<_components.p>`, `<_components.ul>`, `<_components.li>`
- **absence** of bare `<h2>`/`<p>`/`<ul>`/`<li>` (the negative assertion catches future regressions)
- preamble registers each tag's default fallback (proves `collect_components_tag_names` harvested them)
- SWC accepts the emitted module

`cargo test -p zfb-content` — all pass; HTML-serializer-path and non-pipeline-path snapshots remain **byte-stable**.

## Note: rehype-slug / TOC not addressed here

Routing through `_components.h2` fixes the styling/override gap. It does **not** restore `rehype-slug` ids / TOC entries for these nested headings — `rehype-slug` runs over the hast tree and `JsxRaw` payloads stay opaque to hast plugins. That is a separate concern, out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)