### PR TITLE
chore: upgrade pnpm 10.30.0 → 11.3.0 (fixes provenance attestation)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       # pnpm version is read from package.json's "packageManager" field
-      # (pnpm@10.30.0). action-setup@v4 errors out if BOTH "version:" here
+      # (pnpm@11.3.0). action-setup@v4 errors out if BOTH "version:" here
       # and "packageManager:" in package.json are set — pick one. We pick
       # package.json so the version is single-source-of-truth.
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
@@ -361,7 +361,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       # pnpm version is read from package.json's "packageManager" field
-      # (pnpm@10.30.0). action-setup@v4 errors out if BOTH "version:" here
+      # (pnpm@11.3.0). action-setup@v4 errors out if BOTH "version:" here
       # and "packageManager:" in package.json are set — pick one. We pick
       # package.json so the version is single-source-of-truth.
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,2 @@
-auto-install-peers=true
-engine-strict=true
+# pnpm 11 only reads auth/registry from .npmrc. autoInstallPeers + engineStrict
+# moved to pnpm-workspace.yaml. See https://pnpm.io/settings.

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "type": "module",
   "license": "MIT",
   "description": "zudo-front-builder — frontend build orchestrator (private workspace)",
-  "packageManager": "pnpm@10.30.0",
+  "packageManager": "pnpm@11.3.0",
   "engines": {
     "node": ">=22.0.0",
-    "pnpm": ">=10.0.0"
+    "pnpm": ">=11.0.0"
   },
   "scripts": {
     "//// === ROOT ===": "",
@@ -35,14 +35,5 @@
     "lefthook": "^2.1.6",
     "prettier": "^3.8.3",
     "wrangler": "4.85.0"
-  },
-  "pnpm": {
-    "overrides": {
-      "devalue": "^5.8.1"
-    },
-    "onlyBuiltDependencies": [
-      "lefthook",
-      "wrangler"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,3 +7,28 @@ packages:
   # also publishes a tiny npm package for JS-side helpers). None exist today; the
   # glob is reserved so adding one later requires no workspace-config change.
   - "crates/*/npm"
+
+# pnpm 11 only reads auth/registry from .npmrc and ignores pnpm.* in package.json.
+# Everything else (peer-deps policy, engine strictness, supply-chain delays,
+# overrides, build-script allowlist) lives here. See https://pnpm.io/settings.
+autoInstallPeers: true
+engineStrict: true
+
+# pnpm 11 defaults minimumReleaseAge to 1440 (24h), which would block CI
+# `pnpm install --frozen-lockfile` on any dep published in the last day. CI must be
+# deterministic, so disable the delay here.
+minimumReleaseAge: 0
+
+overrides:
+  devalue: "^5.8.1"
+
+# pnpm 11 replaces the legacy `onlyBuiltDependencies` list with `allowBuilds`,
+# a per-package true/false map. Each entry is a deliberate decision to allow
+# (or refuse) the dependency's install/postinstall script. All four below are
+# legitimate native-binary builds — esbuild ships a Go binary, sharp builds
+# libvips bindings, lefthook + workerd ship native binaries — so all approved.
+allowBuilds:
+  esbuild: true
+  lefthook: true
+  sharp: true
+  workerd: true


### PR DESCRIPTION
## Root cause for v0.1.0-next.2's missing provenance

pnpm **10**'s recursive publish preferred a configured static `_authToken` (from `NODE_AUTH_TOKEN` / `actions/setup-node`'s `.npmrc`) over GHA's OIDC token, **silently dropping `--provenance`** even when the flag was on the command line. All 8 attested packages on v0.1.0-next.2 ended up published without OIDC attestations.

pnpm **11.0.7** reversed that precedence and explicitly applies OIDC on every package during recursive publish (changelog). 11.0.9, 11.1.3, 11.2.0 added related fixes. Upgrading to 11.3.0 (latest) is the actual fix — `release.yml` doesn't need any flag changes; the next tag push will produce attested tarballs.

## What changed

| File | Change |
|---|---|
| `package.json` | `packageManager: pnpm@10.30.0` → `pnpm@11.3.0`; `engines.pnpm: >=10.0.0` → `>=11.0.0`; removed `pnpm.overrides` and `pnpm.onlyBuiltDependencies` (pnpm 11 no longer reads `pnpm.*` from package.json — moved). |
| `pnpm-workspace.yaml` | New: `autoInstallPeers: true`, `engineStrict: true`, `minimumReleaseAge: 0`, `overrides`, `allowBuilds` (per-package map replacing the legacy `onlyBuiltDependencies` list). |
| `.npmrc` | Stripped `auto-install-peers` + `engine-strict` (pnpm 11 only reads auth/registry here). |
| `.github/workflows/release.yml` | Updated stale `pnpm@10.30.0` comments to `pnpm@11.3.0`. No behavioral change — `pnpm/action-setup@v4` reads the version from `packageManager` automatically. |

## Critical: `minimumReleaseAge: 0`

pnpm 11 defaults `minimumReleaseAge` to **1440 (24h)**. Without overriding it, `pnpm install --frozen-lockfile` would refuse to install any transitive dep published in the last 24h — every CI workflow that does a frozen install would start failing intermittently. Set explicitly to 0 in `pnpm-workspace.yaml`.

## `allowBuilds` decisions

pnpm 11 replaces the legacy `onlyBuiltDependencies` list with `allowBuilds`, a per-package true/false map. All 4 packages flagged by pnpm 11 are legitimate native-binary builds:

- `esbuild`: Go binary (bundler used by Vite + docs)
- `lefthook`: Go binary (git hook manager — already in our explicit list)
- `sharp`: libvips bindings (image processing — docs/Astro)
- `workerd`: Cloudflare's edge runtime native binary (via wrangler)

All set to `true`.

## Verification

- Local `pnpm install --frozen-lockfile` with pnpm 11.3.0: **green**, all postinstalls ran, no warnings about ignored `pnpm.*` config
- Local `pnpm -r build`: **green** (docs + zfb + zfb-runtime all built)
- `pnpm-lock.yaml` unchanged (lockfileVersion 9.0 supported in both 10 and 11; no `patchedDependencies` migration churn)

## Test plan

- [ ] CI green across PR-checks, build, docs, audit, health, node-free smoke
- [ ] After merge: cut `v0.1.0-next.3` and verify OIDC attestations land on the 8 attested packages

## Source citations

- pnpm 11.0.7 release notes: "Make trusted publishing (OIDC) take precedence over a configured static `_authToken`... This applies on every package during recursive publish."
- pnpm 11.0.9: provenance + semver build metadata fix; restores compatibility with `actions/setup-node` `.npmrc` via `NPM_CONFIG_USERCONFIG`
- pnpm 11.1.3: OIDC + `.npmrc` 404 fix
- pnpm 11.2.0: honors `publishConfig.access`

🤖 Generated with [Claude Code](https://claude.com/claude-code)