### PR TITLE
MDX & Docs Fixes: nested-JSX heading slug ids + formatter-stable generated frontmatter

### DIFF
--- a/crates/zfb-content/src/mdx_jsx_emit.rs
+++ b/crates/zfb-content/src/mdx_jsx_emit.rs
@@ -230,7 +230,10 @@ fn mdx_to_jsx_module_inner(
     // heading text or remove headings would diverge — none ship with
     // `Pipeline::with_defaults()` today; if a future plugin needs to
     // rewrite headings, this collection should move post-hast.
-    let headings = collect_headings(&children);
+    let CollectedHeadings {
+        entries: headings,
+        nested_slugs,
+    } = collect_headings(&children);
 
     let (body, html_tags, component_names) = if take_hast_detour {
         // Wrap children back into a Root so `mdast_to_hast_with` can
@@ -245,8 +248,33 @@ fn mdx_to_jsx_module_inner(
         // `<Note><strong>bold</strong></Note>`). The HTML serializer
         // path keeps using the lossy fallback to preserve its
         // long-standing snapshot output.
-        let strategy = JsxEmitStrategy::JsxPath(&jsx_raw_recursive);
+        //
+        // Slug context: the strategy callback fires once per top-level
+        // MDX JSX node, in document order, with no shared mutable state
+        // (it is a `&dyn Fn`). We give it interior mutability via a
+        // `Cell<usize>` cursor over `nested_slugs` — the document-order
+        // list of slugs `collect_headings` assigned to JSX-nested
+        // headings. `jsx_render_child` pops the next slug each time it
+        // renders a `MdastNode::Heading`, so the `id` it stamps matches
+        // the TOC export exactly. The cursor persists across all
+        // top-level JSX nodes because the closure captures it by ref.
+        let slug_ctx = SlugCtx {
+            nested_slugs: &nested_slugs,
+            cursor: std::cell::Cell::new(0),
+        };
+        let strategy_fn = |node: &MdastNode| -> String { jsx_raw_recursive(node, &slug_ctx) };
+        let strategy = JsxEmitStrategy::JsxPath(&strategy_fn);
         let mut hast = mdast_to_hast_with(&mdast_root, &strategy);
+        // The emitter must have consumed every nested-heading slug in
+        // lockstep with `collect_headings`. A mismatch means the emit
+        // walk order drifted from `walk_collect_headings`' descent set.
+        debug_assert_eq!(
+            slug_ctx.cursor.get(),
+            nested_slugs.len(),
+            "jsx_render_child consumed {} nested-heading slugs but collect_headings recorded {}",
+            slug_ctx.cursor.get(),
+            nested_slugs.len(),
+        );
         if let Some(p) = pipeline_mut {
             p.apply_hast_visitors(&mut hast);
         }
@@ -325,23 +353,69 @@ struct HeadingEntry {
     text: String,
 }
 
+/// Result of the single canonical heading walk.
+///
+/// `entries` drives the `export const headings = […]` TOC array.
+/// `nested_slugs` lists — in document order — the slug assigned to each
+/// heading that lives *inside* an MDX JSX element body. The JSX emitter
+/// (`jsx_render_child`) replays the same document-order walk and pops
+/// these slugs in sequence so the `id` it stamps on a nested
+/// `<_components.hN>` is byte-identical to the slug the TOC recorded.
+///
+/// Both lists come from ONE walk against ONE `seen` dedup map, so the
+/// numbering can never drift between the TOC export and the rendered
+/// nested heading.
+struct CollectedHeadings {
+    entries: Vec<HeadingEntry>,
+    nested_slugs: Vec<String>,
+}
+
 /// Walk the parsed mdast and collect every heading in document order.
 ///
 /// Slugs match what [`crate::plugins::heading_links`] would emit for
 /// the same document: same `slugify`, same `-1`, `-2`, … numbering for
 /// repeats. Per heading_links semantics, only `<h2>`–`<h6>` participate
 /// in the dedup counter; `<h1>` slugs are emitted raw.
-fn collect_headings(children: &[MdastNode]) -> Vec<HeadingEntry> {
-    let mut out = Vec::new();
+///
+/// ## Dedup ordering across the two render passes
+///
+/// On the production hast-detour path, top-level headings stay real
+/// hast `<hN>` elements and get their `id` from `HeadingLinksPlugin`
+/// (its own `seen` map). Headings nested inside an MDX JSX body are
+/// rendered to an opaque JsxRaw string before hast visitors run, so
+/// `HeadingLinksPlugin` never sees them — `jsx_render_child` must stamp
+/// their `id` instead. This walk is the single source of truth that
+/// sees BOTH, in document order, so the TOC export is always internally
+/// consistent and the nested-heading `id`s match the TOC.
+///
+/// Known asymmetry (out of scope for #477): because
+/// `HeadingLinksPlugin` keeps an independent `seen` map, a top-level
+/// heading's rendered `id` reflects a top-level-only count. If a
+/// JSX-nested heading shares its text and appears *earlier* in document
+/// order, this walk's combined count and HeadingLinksPlugin's
+/// top-level-only count can disagree for that top-level heading.
+/// Reconciling it would require seeding HeadingLinksPlugin's `seen` from
+/// this walk through the pipeline/bridge — invasive and not required by
+/// the issue (its acceptance case is top-level-first). The common case
+/// (top-level heading before any same-text nested heading) is exact.
+fn collect_headings(children: &[MdastNode]) -> CollectedHeadings {
+    let mut out = CollectedHeadings {
+        entries: Vec::new(),
+        nested_slugs: Vec::new(),
+    };
     let mut seen: HashMap<String, usize> = HashMap::new();
-    walk_collect_headings(children, &mut out, &mut seen);
+    // `in_jsx == false` at the top level; flips to true once we descend
+    // into an MDX JSX element body so we can route those headings' slugs
+    // into `nested_slugs` for the emitter to replay.
+    walk_collect_headings(children, &mut out, &mut seen, false);
     out
 }
 
 fn walk_collect_headings(
     nodes: &[MdastNode],
-    out: &mut Vec<HeadingEntry>,
+    out: &mut CollectedHeadings,
     seen: &mut HashMap<String, usize>,
+    in_jsx: bool,
 ) {
     for node in nodes {
         match node {
@@ -358,16 +432,38 @@ fn walk_collect_headings(
                 } else {
                     next_slug(seen, &base)
                 };
-                out.push(HeadingEntry { depth, slug, text });
+                // A heading inside an MDX JSX body is emitted by
+                // `jsx_render_child`, not by HeadingLinksPlugin — record
+                // its slug so the emitter can stamp the matching `id`.
+                // Empty-text headings still consume a slot (the emitter
+                // visits them too) but carry an empty slug → no `id`,
+                // mirroring HeadingLinksPlugin's skip-empty behaviour.
+                if in_jsx {
+                    out.nested_slugs.push(slug.clone());
+                }
+                out.entries.push(HeadingEntry { depth, slug, text });
             }
             // Headings can legally nest inside blockquotes / list items,
             // so descend into block-level containers. We deliberately do
             // NOT descend into Paragraph/Heading children themselves —
             // headings cannot appear there.
-            MdastNode::Root(r) => walk_collect_headings(&r.children, out, seen),
-            MdastNode::Blockquote(b) => walk_collect_headings(&b.children, out, seen),
-            MdastNode::List(l) => walk_collect_headings(&l.children, out, seen),
-            MdastNode::ListItem(li) => walk_collect_headings(&li.children, out, seen),
+            MdastNode::Root(r) => walk_collect_headings(&r.children, out, seen, in_jsx),
+            MdastNode::Blockquote(b) => walk_collect_headings(&b.children, out, seen, in_jsx),
+            MdastNode::List(l) => walk_collect_headings(&l.children, out, seen, in_jsx),
+            MdastNode::ListItem(li) => walk_collect_headings(&li.children, out, seen, in_jsx),
+            // Descend into MDX JSX element bodies (e.g. `<Outro>## …`).
+            // Everything below here is rendered by `jsx_render_child`, so
+            // flip `in_jsx` on so the slugs land in `nested_slugs`. The
+            // descent set below MUST stay in lockstep with the container
+            // arms `jsx_render_child` recurses through, or the emitter's
+            // pop order will drift from this walk (debug_assert in
+            // `mdx_to_jsx_module*` guards against that).
+            MdastNode::MdxJsxFlowElement(j) => {
+                walk_collect_headings(&j.children, out, seen, true);
+            }
+            MdastNode::MdxJsxTextElement(j) => {
+                walk_collect_headings(&j.children, out, seen, true);
+            }
             _ => {}
         }
     }
@@ -1109,6 +1205,73 @@ fn collect_components_tag_names(jsx: &str, out: &mut std::collections::BTreeSet<
     }
 }
 
+/// Slug context threaded through the JSX-text recursive renderer.
+///
+/// `nested_slugs` is the document-order list of slugs `collect_headings`
+/// assigned to headings that live inside an MDX JSX element body, and
+/// `cursor` is the running index into it. Each time `jsx_render_child`
+/// renders a `MdastNode::Heading` it pops `nested_slugs[cursor]` and
+/// advances — so the `id` it stamps is byte-identical to the slug the
+/// TOC export recorded. The renderer's heading-visit order matches
+/// `walk_collect_headings`' descent order (both are mdast document-order
+/// walks reaching the same heading set), so the pop sequence aligns.
+///
+/// `Cell` gives interior mutability without `unsafe` / `thread_local`:
+/// the `&dyn Fn` strategy callback cannot carry `&mut` state, but a
+/// `&Cell` captured by the closure can.
+struct SlugCtx<'a> {
+    nested_slugs: &'a [String],
+    cursor: std::cell::Cell<usize>,
+}
+
+impl SlugCtx<'_> {
+    /// Pop the slug for the next nested heading in document order.
+    ///
+    /// Returns `None` once the precomputed list is exhausted — a guard
+    /// against over-walking (the `debug_assert` at the call site checks
+    /// the inverse, that every slug was consumed).
+    fn next_heading_slug(&self) -> Option<&str> {
+        let i = self.cursor.get();
+        let slug = self.nested_slugs.get(i).map(String::as_str);
+        if slug.is_some() {
+            self.cursor.set(i + 1);
+        }
+        slug
+    }
+}
+
+/// Build the `id="…"` attribute plus trailing hash-link anchor for a
+/// nested heading, mirroring [`crate::plugins::heading_links`] so a
+/// JSX-nested `<_components.hN>` renders identically to a top-level one.
+///
+/// `text` is the same plain-text projection `collect_headings` recorded
+/// for the heading (`mdast_inline_text`), so the `aria-label` matches
+/// what HeadingLinksPlugin would emit. An empty slug (empty-text
+/// heading) yields no id / no anchor, mirroring HeadingLinksPlugin's
+/// skip-empty behaviour. Returns `(attrs, anchor_jsx)`.
+fn nested_heading_id_and_anchor(slug: &str, text: &str) -> (String, String) {
+    if slug.is_empty() {
+        return (String::new(), String::new());
+    }
+    // Use `escape_attr_literal` (not `jsx_attr_escape`) and the verbatim
+    // `class` attribute name so a nested anchor is byte-identical to a
+    // top-level one: the top-level path renders the same
+    // `HeadingLinksPlugin::anchor` hast node through `render_hast_attrs`
+    // → `jsx_string_attr` → `escape_attr_literal`, keeping `class` as-is
+    // (see `render_hast_attrs` docs). The lowercase `a` routes through
+    // `_components.a` exactly as the bridge's `emit_element` would.
+    let attrs = format!(" id=\"{}\"", escape_attr_literal(slug));
+    // Empty-body anchor; the `#` glyph is a CSS `::after`. Mirrors
+    // `HeadingLinksPlugin::anchor`'s href / class / aria-label shape and
+    // attribute order.
+    let anchor = format!(
+        "<_components.a href=\"#{}\" class=\"hash-link\" aria-label=\"Direct link to {}\"></_components.a>",
+        escape_attr_literal(slug),
+        escape_attr_literal(text),
+    );
+    (attrs, anchor)
+}
+
 /// JSX-text recursive renderer plugged into `mdast_to_hast_with` via
 /// [`JsxEmitStrategy::JsxPath`]. Produces JSX-shaped source for the
 /// MDX JSX, MDX expression, and remark-math arms while preserving
@@ -1120,13 +1283,13 @@ fn collect_components_tag_names(jsx: &str, out: &mut std::collections::BTreeSet<
 /// recursion only on the JSX path is safe because the bridge already
 /// embeds the resulting JsxRaw payload verbatim — JSX accepts plain
 /// HTML tags inside MDX JSX bodies.
-fn jsx_raw_recursive(node: &MdastNode) -> String {
+fn jsx_raw_recursive(node: &MdastNode, ctx: &SlugCtx) -> String {
     match node {
         MdastNode::MdxJsxFlowElement(j) => {
-            jsx_element_text(j.name.as_deref(), &j.attributes, &j.children)
+            jsx_element_text(j.name.as_deref(), &j.attributes, &j.children, ctx)
         }
         MdastNode::MdxJsxTextElement(j) => {
-            jsx_element_text(j.name.as_deref(), &j.attributes, &j.children)
+            jsx_element_text(j.name.as_deref(), &j.attributes, &j.children, ctx)
         }
         MdastNode::MdxFlowExpression(e) => format!("{{{}}}", e.value),
         MdastNode::MdxTextExpression(e) => format!("{{{}}}", e.value),
@@ -1134,7 +1297,7 @@ fn jsx_raw_recursive(node: &MdastNode) -> String {
         // fires for the JSX-shaped arms above, but if the contract
         // ever changes we fall back to the recursive child renderer
         // rather than dropping the node.
-        other => jsx_render_child(other),
+        other => jsx_render_child(other, ctx),
     }
 }
 
@@ -1142,6 +1305,7 @@ fn jsx_element_text(
     name: Option<&str>,
     attrs: &[AttributeContent],
     children: &[MdastNode],
+    ctx: &SlugCtx,
 ) -> String {
     let attrs_str = render_jsx_attrs(attrs);
     // Choose the open/close JSX tag name. `name == None` is the MDX
@@ -1162,7 +1326,7 @@ fn jsx_element_text(
         // matches `JsxEmitter::emit_jsx`'s output.
         return format!("<{open_name}{attrs_str} />");
     }
-    let inner: String = children.iter().map(jsx_render_child).collect();
+    let inner: String = children.iter().map(|c| jsx_render_child(c, ctx)).collect();
     format!("<{open_name}{attrs_str}>{inner}</{close_name}>")
 }
 
@@ -1179,26 +1343,40 @@ fn jsx_element_text(
 /// `HastNode::JsxRaw` arm) harvests the `<_components.<tag>` references
 /// afterwards so the module preamble registers each tag's default
 /// fallback in the `_components` map.
-fn jsx_render_child(node: &MdastNode) -> String {
+fn jsx_render_child(node: &MdastNode, ctx: &SlugCtx) -> String {
     match node {
         MdastNode::Text(t) => jsx_text_escape(&t.value),
         MdastNode::Html(h) => h.value.clone(),
         MdastNode::MdxFlowExpression(e) => format!("{{{}}}", e.value),
         MdastNode::MdxTextExpression(e) => format!("{{{}}}", e.value),
         MdastNode::MdxJsxFlowElement(j) => {
-            jsx_element_text(j.name.as_deref(), &j.attributes, &j.children)
+            jsx_element_text(j.name.as_deref(), &j.attributes, &j.children, ctx)
         }
         MdastNode::MdxJsxTextElement(j) => {
-            jsx_element_text(j.name.as_deref(), &j.attributes, &j.children)
+            jsx_element_text(j.name.as_deref(), &j.attributes, &j.children, ctx)
         }
-        MdastNode::Paragraph(p) => jsx_wrap_children("p", "", &p.children),
+        MdastNode::Paragraph(p) => jsx_wrap_children("p", "", &p.children, ctx),
         MdastNode::Heading(h) => {
             let depth = h.depth.clamp(1, 6);
-            jsx_wrap_children(&format!("h{depth}"), "", &h.children)
+            // This heading lives inside an MDX JSX body, so
+            // HeadingLinksPlugin (a hast visitor) never sees it — stamp
+            // the slug `id` + hash-link anchor here instead. The slug
+            // comes from `collect_headings`' canonical document-order
+            // walk via the cursor, so it matches the TOC export and the
+            // dedup numbering of any top-level headings. `next_heading_slug`
+            // returns `None` only if the precomputed list is exhausted
+            // (the debug_assert at the strategy call site guards that);
+            // fall back to no id/anchor rather than panicking in release.
+            let slug = ctx.next_heading_slug().unwrap_or("");
+            let text = mdast_inline_text(&h.children);
+            let (id_attr, anchor) = nested_heading_id_and_anchor(slug, &text);
+            let tag = format!("h{depth}");
+            let inner: String = h.children.iter().map(|c| jsx_render_child(c, ctx)).collect();
+            format!("<_components.{tag}{id_attr}>{inner}{anchor}</_components.{tag}>")
         }
-        MdastNode::Emphasis(e) => jsx_wrap_children("em", "", &e.children),
-        MdastNode::Strong(s) => jsx_wrap_children("strong", "", &s.children),
-        MdastNode::Delete(d) => jsx_wrap_children("del", "", &d.children),
+        MdastNode::Emphasis(e) => jsx_wrap_children("em", "", &e.children, ctx),
+        MdastNode::Strong(s) => jsx_wrap_children("strong", "", &s.children, ctx),
+        MdastNode::Delete(d) => jsx_wrap_children("del", "", &d.children, ctx),
         MdastNode::InlineCode(c) => format!(
             "<_components.code>{}</_components.code>",
             jsx_text_escape(&c.value),
@@ -1220,7 +1398,7 @@ fn jsx_render_child(node: &MdastNode) -> String {
             }
             format!(
                 "<_components.a{attrs}>{}</_components.a>",
-                l.children.iter().map(jsx_render_child).collect::<String>(),
+                l.children.iter().map(|c| jsx_render_child(c, ctx)).collect::<String>(),
             )
         }
         MdastNode::Image(i) => {
@@ -1246,11 +1424,11 @@ fn jsx_render_child(node: &MdastNode) -> String {
             }
             format!(
                 "<_components.{tag}{attrs}>{}</_components.{tag}>",
-                l.children.iter().map(jsx_render_child).collect::<String>(),
+                l.children.iter().map(|c| jsx_render_child(c, ctx)).collect::<String>(),
             )
         }
-        MdastNode::ListItem(li) => jsx_wrap_children("li", "", &li.children),
-        MdastNode::Blockquote(b) => jsx_wrap_children("blockquote", "", &b.children),
+        MdastNode::ListItem(li) => jsx_wrap_children("li", "", &li.children, ctx),
+        MdastNode::Blockquote(b) => jsx_wrap_children("blockquote", "", &b.children, ctx),
         MdastNode::ThematicBreak(_) => "<_components.hr />".to_string(),
         MdastNode::Break(_) => "<_components.br />".to_string(),
         MdastNode::Math(m) => format!(
@@ -1261,10 +1439,10 @@ fn jsx_render_child(node: &MdastNode) -> String {
             "<_components.code class=\"language-math math-inline\">{}</_components.code>",
             jsx_text_escape(&m.value),
         ),
-        MdastNode::Root(r) => r.children.iter().map(jsx_render_child).collect(),
+        MdastNode::Root(r) => r.children.iter().map(|c| jsx_render_child(c, ctx)).collect(),
         // GFM pipe-table inside MDX JSX body — routes table tags through
         // `_components.<tag>`, matching the non-pipeline `emit_table_jsx`.
-        MdastNode::Table(t) => jsx_render_table(t),
+        MdastNode::Table(t) => jsx_render_table(t, ctx),
         // Footnotes, references, ESM, frontmatter, etc. drop silently here
         // — better than leaking a `Debug` repr.
         _ => String::new(),
@@ -1278,7 +1456,7 @@ fn jsx_render_child(node: &MdastNode) -> String {
 /// callers can override them, matching the non-pipeline `emit_table_jsx`.
 /// The resulting string is embedded as a [`HastNode::JsxRaw`] payload;
 /// the bridge's `collect_components_tag_names` scan registers each tag.
-fn jsx_render_table(t: &markdown::mdast::Table) -> String {
+fn jsx_render_table(t: &markdown::mdast::Table, ctx: &SlugCtx) -> String {
     let style_attr = |col: usize| -> String {
         t.align
             .get(col)
@@ -1297,7 +1475,7 @@ fn jsx_render_table(t: &markdown::mdast::Table) -> String {
                 continue;
             };
             let style = style_attr(col);
-            let inner: String = tc.children.iter().map(jsx_render_child).collect();
+            let inner: String = tc.children.iter().map(|c| jsx_render_child(c, ctx)).collect();
             out.push_str(&format!(
                 "<_components.{cell_tag}{style}>{inner}</_components.{cell_tag}>"
             ));
@@ -1328,10 +1506,10 @@ fn jsx_render_table(t: &markdown::mdast::Table) -> String {
     out
 }
 
-fn jsx_wrap_children(tag: &str, attrs: &str, children: &[MdastNode]) -> String {
+fn jsx_wrap_children(tag: &str, attrs: &str, children: &[MdastNode], ctx: &SlugCtx) -> String {
     format!(
         "<_components.{tag}{attrs}>{}</_components.{tag}>",
-        children.iter().map(jsx_render_child).collect::<String>(),
+        children.iter().map(|c| jsx_render_child(c, ctx)).collect::<String>(),
     )
 }
 

--- a/crates/zfb-content/tests/mdx_jsx_emit_hast.rs
+++ b/crates/zfb-content/tests/mdx_jsx_emit_hast.rs
@@ -583,3 +583,39 @@ fn nested_and_top_level_same_text_share_dedup_numbering() {
         .compile(&out, &opts)
         .unwrap_or_else(|e| panic!("SWC rejected dedup output: {e}\n--- src ---\n{out}"));
 }
+
+/// Multiple headings — including a deeply-nested one inside a list —
+/// in a single MDX JSX body must each pop the right slug from the
+/// document-order cursor (no off-by-one, no slug bleed between
+/// headings). Also confirms the `in_jsx` flag propagates through a
+/// list/list-item nested under the JSX element.
+#[test]
+fn multiple_and_deeply_nested_headings_in_one_jsx_pop_correct_slugs() {
+    let out = emit_with_defaults(
+        "<Outro>\n\n## Alpha\n\n### Beta\n\n- item\n\n  #### Gamma\n\n</Outro>\n",
+    );
+
+    // Each heading gets its own slug id at the correct depth.
+    for (depth, slug) in [(2, "alpha"), (3, "beta"), (4, "gamma")] {
+        assert!(
+            out.contains(&format!("<_components.h{depth} id=\"{slug}\">")),
+            "nested h{depth} must get id=\"{slug}\":\n{out}",
+        );
+        // …and a TOC entry.
+        assert!(
+            out.contains(&format!("depth: {depth}, slug: \"{slug}\"")),
+            "TOC must include h{depth} `{slug}`:\n{out}",
+        );
+    }
+
+    // Slugs appear in document order in the TOC (alpha < beta < gamma).
+    let a = out.find("slug: \"alpha\"").unwrap();
+    let b = out.find("slug: \"beta\"").unwrap();
+    let g = out.find("slug: \"gamma\"").unwrap();
+    assert!(a < b && b < g, "TOC headings must be in document order:\n{out}");
+
+    let opts = CompileOptions::default().with_filename("multi-nested.tsx".to_string());
+    SwcPipeline::new()
+        .compile(&out, &opts)
+        .unwrap_or_else(|e| panic!("SWC rejected multi-nested output: {e}\n--- src ---\n{out}"));
+}

--- a/crates/zfb-content/tests/mdx_jsx_emit_hast.rs
+++ b/crates/zfb-content/tests/mdx_jsx_emit_hast.rs
@@ -496,3 +496,90 @@ fn nested_markdown_in_mdx_jsx_routes_through_components() {
         .compile(&out, &opts)
         .unwrap_or_else(|e| panic!("SWC rejected nested-markdown output: {e}\n--- src ---\n{out}"));
 }
+
+/// Regression for #477 (upstream zudolab/zzmod#292): a markdown
+/// `## heading` nested inside an MDX JSX element body must get a
+/// rehype-slug `id`, a hash-link anchor, AND a TOC (`headings`) entry —
+/// matching what `HeadingLinksPlugin` gives a top-level heading.
+///
+/// Before this fix the nested heading routed through `_components.h2`
+/// for styling (#286 / PR #439) but carried NO `id`, NO anchor, and was
+/// dropped from `export const headings`, because it lives in an opaque
+/// JsxRaw payload that hast visitors never traverse.
+#[test]
+fn nested_heading_in_mdx_jsx_gets_slug_id_anchor_and_toc_entry() {
+    let out = emit_with_defaults("<Outro>\n\n## Wrap Up\n\n</Outro>\n");
+
+    // (1) The nested `<_components.h2>` carries `id="wrap-up"` — the
+    // exact `slugify("Wrap Up")` output.
+    assert!(
+        out.contains("<_components.h2 id=\"wrap-up\">"),
+        "nested heading must get id from slugify:\n{out}",
+    );
+
+    // (2) The TOC export includes the nested heading (depth, slug, text).
+    assert!(
+        out.contains("{ depth: 2, slug: \"wrap-up\", text: \"Wrap Up\" }"),
+        "headings export must include the nested heading:\n{out}",
+    );
+
+    // (4) The nested heading carries a hash-link anchor with the SAME
+    // shape `HeadingLinksPlugin` stamps on a top-level heading:
+    // `<_components.a href="#slug" class="hash-link" aria-label="…">`.
+    assert!(
+        out.contains(
+            "<_components.a href=\"#wrap-up\" class=\"hash-link\" aria-label=\"Direct link to Wrap Up\"></_components.a>"
+        ),
+        "nested heading must carry a hash-link anchor identical to a top-level one:\n{out}",
+    );
+
+    // SWC must accept the emitted module.
+    let opts = CompileOptions::default().with_filename("nested-slug.tsx".to_string());
+    SwcPipeline::new()
+        .compile(&out, &opts)
+        .unwrap_or_else(|e| panic!("SWC rejected nested-slug output: {e}\n--- src ---\n{out}"));
+}
+
+/// (3) Slug dedup numbering stays consistent when a same-text heading
+/// appears BOTH top-level and nested-in-JSX. Both passes draw from the
+/// single document-order `seen` map in `collect_headings`, so in
+/// document order the top-level `## Foo` wins `foo` and the later
+/// nested `## Foo` gets `foo-1` — and the rendered ids match the TOC.
+#[test]
+fn nested_and_top_level_same_text_share_dedup_numbering() {
+    // Top-level `## Foo` first (gets `foo`), then nested `## Foo` inside
+    // `<Outro>` second (must get `foo-1`).
+    let out = emit_with_defaults("## Foo\n\n<Outro>\n\n## Foo\n\n</Outro>\n");
+
+    // Top-level heading keeps the un-numbered slug (HeadingLinksPlugin).
+    assert!(
+        out.contains("id=\"foo\""),
+        "top-level heading should keep the base slug `foo`:\n{out}",
+    );
+    // Nested heading gets the deduped `foo-1`, NOT a colliding `foo`.
+    assert!(
+        out.contains("<_components.h2 id=\"foo-1\">"),
+        "nested same-text heading must dedup to `foo-1`:\n{out}",
+    );
+    assert!(
+        out.contains("href=\"#foo-1\""),
+        "nested heading anchor must point at the deduped slug:\n{out}",
+    );
+
+    // TOC export carries BOTH in document order with consistent slugs.
+    let foo_idx = out
+        .find("slug: \"foo\"")
+        .expect("TOC must list top-level `foo`");
+    let foo1_idx = out
+        .find("slug: \"foo-1\"")
+        .expect("TOC must list nested `foo-1`");
+    assert!(
+        foo_idx < foo1_idx,
+        "TOC must list `foo` before `foo-1` (document order):\n{out}",
+    );
+
+    let opts = CompileOptions::default().with_filename("dedup.tsx".to_string());
+    SwcPipeline::new()
+        .compile(&out, &opts)
+        .unwrap_or_else(|e| panic!("SWC rejected dedup output: {e}\n--- src ---\n{out}"));
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,9 @@
     "build": "astro build",
     "preview": "astro preview",
     "check": "astro check",
-    "setup:doc-skill": "bash scripts/setup-doc-skill.sh"
+    "setup:doc-skill": "bash scripts/setup-doc-skill.sh",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@astrojs/mdx": "^4.3.0",
@@ -31,12 +33,14 @@
   "devDependencies": {
     "@astrojs/check": "^0.9.0",
     "@tailwindcss/vite": "^4.2.0",
+    "@takazudo/mdx-formatter": "^1.0.1",
     "@types/hast": "^3.0.4",
     "@types/mdast": "^4.0.4",
     "@types/node": "^22.0.0",
     "@types/react": "^19.2.0",
     "pagefind": "^1.4.0",
     "tailwindcss": "^4.2.0",
-    "typescript": "^5.9.0"
+    "typescript": "^5.9.0",
+    "vitest": "^2.1.9"
   }
 }

--- a/docs/src/integrations/claude-resources/__tests__/generate.test.ts
+++ b/docs/src/integrations/claude-resources/__tests__/generate.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import matter from "gray-matter";
+import { format as mdxFormat } from "@takazudo/mdx-formatter";
 import { generateClaudeResourcesDocs } from "../generate";
 
 let tmpDir: string;
@@ -65,8 +66,8 @@ describe("generateClaudeResourcesDocs", () => {
   // ---------------------------------------------------------------------------
 
   describe("file structure", () => {
-    it("generates correct directory structure", () => {
-      generateClaudeResourcesDocs({
+    it("generates correct directory structure", async () => {
+      await generateClaudeResourcesDocs({
         claudeDir,
         projectRoot: tmpDir,
         docsDir,
@@ -79,8 +80,8 @@ describe("generateClaudeResourcesDocs", () => {
       expect(fs.existsSync(path.join(docsDir, "claude-agents"))).toBe(true);
     });
 
-    it("generates _category_.json with noPage for sub-categories", () => {
-      generateClaudeResourcesDocs({
+    it("generates _category_.json with noPage for sub-categories", async () => {
+      await generateClaudeResourcesDocs({
         claudeDir,
         projectRoot: tmpDir,
         docsDir,
@@ -99,8 +100,8 @@ describe("generateClaudeResourcesDocs", () => {
       }
     });
 
-    it("generates skill as flat .mdx file", () => {
-      generateClaudeResourcesDocs({
+    it("generates skill as flat .mdx file", async () => {
+      await generateClaudeResourcesDocs({
         claudeDir,
         projectRoot: tmpDir,
         docsDir,
@@ -116,8 +117,8 @@ describe("generateClaudeResourcesDocs", () => {
   // ---------------------------------------------------------------------------
 
   describe("content", () => {
-    it("generates overview page with CategoryTreeNav", () => {
-      generateClaudeResourcesDocs({
+    it("generates overview page with CategoryTreeNav", async () => {
+      await generateClaudeResourcesDocs({
         claudeDir,
         projectRoot: tmpDir,
         docsDir,
@@ -127,8 +128,8 @@ describe("generateClaudeResourcesDocs", () => {
       expect(overview).toContain('<CategoryTreeNav category="claude" />');
     });
 
-    it("skill page has correct frontmatter", () => {
-      generateClaudeResourcesDocs({
+    it("skill page has correct frontmatter", async () => {
+      await generateClaudeResourcesDocs({
         claudeDir,
         projectRoot: tmpDir,
         docsDir,
@@ -145,8 +146,8 @@ describe("generateClaudeResourcesDocs", () => {
       expect(parsed.data.sidebar_label).toBe("test-skill");
     });
 
-    it("skill page has file tree", () => {
-      generateClaudeResourcesDocs({
+    it("skill page has file tree", async () => {
+      await generateClaudeResourcesDocs({
         claudeDir,
         projectRoot: tmpDir,
         docsDir,
@@ -164,8 +165,8 @@ describe("generateClaudeResourcesDocs", () => {
       expect(skillPage).toContain("SKILL.md");
     });
 
-    it("skill page has links to sub-files that resolve correctly from the page URL", () => {
-      generateClaudeResourcesDocs({
+    it("skill page has links to sub-files that resolve correctly from the page URL", async () => {
+      await generateClaudeResourcesDocs({
         claudeDir,
         projectRoot: tmpDir,
         docsDir,
@@ -199,8 +200,8 @@ describe("generateClaudeResourcesDocs", () => {
       }
     });
 
-    it("skill body references/scripts/assets links are rewritten to doc site format", () => {
-      generateClaudeResourcesDocs({
+    it("skill body references/scripts/assets links are rewritten to doc site format", async () => {
+      await generateClaudeResourcesDocs({
         claudeDir,
         projectRoot: tmpDir,
         docsDir,
@@ -216,8 +217,8 @@ describe("generateClaudeResourcesDocs", () => {
       expect(skillPage).not.toContain("](references/guide.md)");
     });
 
-    it("agent page has model badge", () => {
-      generateClaudeResourcesDocs({
+    it("agent page has model badge", async () => {
+      await generateClaudeResourcesDocs({
         claudeDir,
         projectRoot: tmpDir,
         docsDir,
@@ -236,8 +237,8 @@ describe("generateClaudeResourcesDocs", () => {
   // ---------------------------------------------------------------------------
 
   describe("sub-file pages", () => {
-    it("generates unlisted reference page", () => {
-      generateClaudeResourcesDocs({
+    it("generates unlisted reference page", async () => {
+      await generateClaudeResourcesDocs({
         claudeDir,
         projectRoot: tmpDir,
         docsDir,
@@ -250,8 +251,8 @@ describe("generateClaudeResourcesDocs", () => {
       expect(parsed.data.unlisted).toBe(true);
     });
 
-    it("generates unlisted asset page for .md files", () => {
-      generateClaudeResourcesDocs({
+    it("generates unlisted asset page for .md files", async () => {
+      await generateClaudeResourcesDocs({
         claudeDir,
         projectRoot: tmpDir,
         docsDir,
@@ -264,8 +265,8 @@ describe("generateClaudeResourcesDocs", () => {
       expect(parsed.data.unlisted).toBe(true);
     });
 
-    it("does NOT generate page for non-.md scripts", () => {
-      generateClaudeResourcesDocs({
+    it("does NOT generate page for non-.md scripts", async () => {
+      await generateClaudeResourcesDocs({
         claudeDir,
         projectRoot: tmpDir,
         docsDir,
@@ -275,8 +276,8 @@ describe("generateClaudeResourcesDocs", () => {
       expect(fs.existsSync(scriptPage)).toBe(false);
     });
 
-    it("sub-pages have custom slug for nested breadcrumbs", () => {
-      generateClaudeResourcesDocs({
+    it("sub-pages have custom slug for nested breadcrumbs", async () => {
+      await generateClaudeResourcesDocs({
         claudeDir,
         projectRoot: tmpDir,
         docsDir,
@@ -290,8 +291,8 @@ describe("generateClaudeResourcesDocs", () => {
       expect(parsed.data.slug).toBe("claude-skills/test-skill/ref-guide");
     });
 
-    it("reference page content is correct", () => {
-      generateClaudeResourcesDocs({
+    it("reference page content is correct", async () => {
+      await generateClaudeResourcesDocs({
         claudeDir,
         projectRoot: tmpDir,
         docsDir,
@@ -313,8 +314,8 @@ describe("generateClaudeResourcesDocs", () => {
   // ---------------------------------------------------------------------------
 
   describe("category metadata", () => {
-    it("_category_.json positions are ordered correctly", () => {
-      generateClaudeResourcesDocs({
+    it("_category_.json positions are ordered correctly", async () => {
+      await generateClaudeResourcesDocs({
         claudeDir,
         projectRoot: tmpDir,
         docsDir,
@@ -337,8 +338,8 @@ describe("generateClaudeResourcesDocs", () => {
   // ---------------------------------------------------------------------------
 
   describe("return value", () => {
-    it("returns correct counts", () => {
-      const result = generateClaudeResourcesDocs({
+    it("returns correct counts", async () => {
+      const result = await generateClaudeResourcesDocs({
         claudeDir,
         projectRoot: tmpDir,
         docsDir,
@@ -350,6 +351,84 @@ describe("generateClaudeResourcesDocs", () => {
         skills: 1,
         agents: 1,
       });
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Formatter stability tests
+  // ---------------------------------------------------------------------------
+
+  describe("formatter stability", () => {
+    it("all generated .mdx files are stable under mdx-formatter (no changes after re-format)", async () => {
+      await generateClaudeResourcesDocs({
+        claudeDir,
+        projectRoot: tmpDir,
+        docsDir,
+      });
+
+      // Collect all generated .mdx files
+      const generatedDirs = [
+        "claude",
+        "claude-md",
+        "claude-commands",
+        "claude-skills",
+        "claude-agents",
+      ];
+      const mdxFiles: string[] = [];
+      for (const dir of generatedDirs) {
+        const dirPath = path.join(docsDir, dir);
+        if (!fs.existsSync(dirPath)) continue;
+        for (const file of fs.readdirSync(dirPath)) {
+          if (file.endsWith(".mdx")) {
+            mdxFiles.push(path.join(dirPath, file));
+          }
+        }
+      }
+
+      expect(mdxFiles.length).toBeGreaterThan(0);
+
+      // Each file must be unchanged after running through mdx-formatter
+      for (const filePath of mdxFiles) {
+        const content = fs.readFileSync(filePath, "utf8");
+        const reformatted = await mdxFormat(content);
+        expect(reformatted, `${path.basename(filePath)} is not formatter-stable`).toBe(content);
+      }
+    });
+
+    it("generated frontmatter uses bare scalars for simple values and quoted for colon-space values", async () => {
+      // Add a skill with a description containing ': ' (colon-space), which requires quoting
+      const specialSkillDir = path.join(claudeDir, "skills", "colon-skill");
+      fs.mkdirSync(specialSkillDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(specialSkillDir, "SKILL.md"),
+        '---\nname: colon-skill\ndescription: "Use when: (1) foo (2) bar"\n---\n\nSkill body.',
+      );
+
+      await generateClaudeResourcesDocs({
+        claudeDir,
+        projectRoot: tmpDir,
+        docsDir,
+      });
+
+      const skillPage = fs.readFileSync(
+        path.join(docsDir, "claude-skills", "colon-skill.mdx"),
+        "utf8",
+      );
+      const parsed = matter(skillPage);
+
+      // Values are correctly preserved
+      expect(parsed.data.title).toBe("colon-skill");
+      expect(parsed.data.description).toBe("Use when: (1) foo (2) bar");
+
+      // The raw frontmatter line for a bare title should NOT be double-quoted
+      expect(skillPage).toContain("title: colon-skill");
+      // The description with ': ' must be quoted (either single or double) to be valid YAML
+      // mdx-formatter uses double quotes for this case
+      expect(skillPage).toContain('description: "Use when: (1) foo (2) bar"');
+
+      // Stability: re-formatting must be a no-op
+      const reformatted = await mdxFormat(skillPage);
+      expect(reformatted).toBe(skillPage);
     });
   });
 });

--- a/docs/src/integrations/claude-resources/generate.ts
+++ b/docs/src/integrations/claude-resources/generate.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import matter from "gray-matter";
+import { format as mdxFormat } from "@takazudo/mdx-formatter";
 import { escapeForMdx } from "./escape-for-mdx";
 
 export interface ClaudeResourcesConfig {
@@ -63,8 +64,10 @@ function parseFrontmatter(content: string) {
   }
 }
 
-function escapeTitle(s: string): string {
-  return s.replace(/"/g, '\\"');
+/** Write an MDX file, normalising its frontmatter quoting via mdx-formatter. */
+async function writeMdx(filePath: string, content: string): Promise<void> {
+  const formatted = await mdxFormat(content);
+  fs.writeFileSync(filePath, formatted);
 }
 
 function listFiles(dir: string): string[] {
@@ -120,7 +123,7 @@ function findClaudeMdFiles(dir: string, excludeDirs: string[]): string[] {
 // CLAUDE.md generation
 // ---------------------------------------------------------------------------
 
-function generateClaudemdDocs(config: ClaudeResourcesConfig): ClaudeMdItem[] {
+async function generateClaudemdDocs(config: ClaudeResourcesConfig): Promise<ClaudeMdItem[]> {
   const projectRoot = config.projectRoot ?? path.dirname(config.claudeDir);
   const outputDir = path.join(config.docsDir, "claude-md");
 
@@ -150,10 +153,10 @@ function generateClaudemdDocs(config: ClaudeResourcesConfig): ClaudeMdItem[] {
 
     const pos = items.length + 1;
     const mdx = `---
-title: "${escapeTitle(displayPath)}"
-description: "CLAUDE.md at ${escapeTitle(displayPath)}"
+title: ${displayPath}
+description: CLAUDE.md at ${displayPath}
 sidebar_position: ${pos}
-sidebar_label: "${escapeTitle(relPath)}"
+sidebar_label: ${relPath}
 generated: true
 ---
 
@@ -161,7 +164,7 @@ generated: true
 
 ${escapeForMdx(content.trim())}
 `;
-    fs.writeFileSync(path.join(outputDir, `${slug}.mdx`), mdx);
+    await writeMdx(path.join(outputDir, `${slug}.mdx`), mdx);
   }
 
   // Sort: root first, then alphabetically
@@ -179,7 +182,7 @@ ${escapeForMdx(content.trim())}
 // Commands generation
 // ---------------------------------------------------------------------------
 
-function generateCommandsDocs(config: ClaudeResourcesConfig): CommandItem[] {
+async function generateCommandsDocs(config: ClaudeResourcesConfig): Promise<CommandItem[]> {
   const commandsDir = path.join(config.claudeDir, "commands");
   const outputDir = path.join(config.docsDir, "claude-commands");
 
@@ -204,15 +207,15 @@ function generateCommandsDocs(config: ClaudeResourcesConfig): CommandItem[] {
     items.push({ name, description });
 
     const mdx = `---
-title: "${escapeTitle(name)}"
-description: "${escapeTitle(description)}"
-sidebar_label: "${escapeTitle(name)}"
+title: ${name}
+description: ${description}
+sidebar_label: ${name}
 generated: true
 ---
 
 ${escapeForMdx(parsed.content.trim())}
 `;
-    fs.writeFileSync(path.join(outputDir, `${name}.mdx`), mdx);
+    await writeMdx(path.join(outputDir, `${name}.mdx`), mdx);
   }
 
   items.sort((a, b) => a.name.localeCompare(b.name));
@@ -287,7 +290,7 @@ function getSkillReferences(skillsDir: string, skillDir: string): SkillReference
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
-function generateSkillsDocs(config: ClaudeResourcesConfig): SkillItem[] {
+async function generateSkillsDocs(config: ClaudeResourcesConfig): Promise<SkillItem[]> {
   const skillsDir = path.join(config.claudeDir, "skills");
   const outputDir = path.join(config.docsDir, "claude-skills");
 
@@ -364,16 +367,16 @@ function generateSkillsDocs(config: ClaudeResourcesConfig): SkillItem[] {
     const body = [fileStructureSection, escapeForMdx(skillBody)].filter(Boolean).join("\n\n");
 
     const mdx = `---
-title: "${escapeTitle(name)}"
-description: "${escapeTitle(shortDesc)}"
-sidebar_label: "${escapeTitle(name)}"
+title: ${name}
+description: ${shortDesc}
+sidebar_label: ${name}
 generated: true
 ---
 
 ${body}`;
 
     // Write skill page as flat file
-    fs.writeFileSync(path.join(outputDir, `${dir}.mdx`), mdx);
+    await writeMdx(path.join(outputDir, `${dir}.mdx`), mdx);
 
     // Generate unlisted sub-pages (flat files with custom slug for nested breadcrumbs)
     // File: <dir>--ref-<name>.mdx, slug: claude-skills/<dir>/ref-<name>
@@ -382,15 +385,15 @@ ${body}`;
     for (const ref of references) {
       const subSlug = `${skillSlugBase}/ref-${ref.name}`;
       const refMdx = `---
-title: "${escapeTitle(ref.title)}"
-slug: "${subSlug}"
+title: ${ref.title}
+slug: ${subSlug}
 unlisted: true
 generated: true
 ---
 
 ${escapeForMdx(ref.content.trim())}
 `;
-      fs.writeFileSync(path.join(outputDir, `${dir}--ref-${ref.name}.mdx`), refMdx);
+      await writeMdx(path.join(outputDir, `${dir}--ref-${ref.name}.mdx`), refMdx);
     }
 
     for (const f of scriptFiles.filter((s) => s.endsWith(".md"))) {
@@ -399,9 +402,9 @@ ${escapeForMdx(ref.content.trim())}
       const raw = fs.readFileSync(path.join(skillsDir, dir, "scripts", f), "utf8");
       const h1Match = raw.match(/^#\s+(.+)$/m);
       const title = h1Match ? h1Match[1] : slug;
-      fs.writeFileSync(
+      await writeMdx(
         path.join(outputDir, `${dir}--script-${slug}.mdx`),
-        `---\ntitle: "${escapeTitle(title)}"\nslug: "${subSlug}"\nunlisted: true\ngenerated: true\n---\n\n${escapeForMdx(raw.trim())}\n`,
+        `---\ntitle: ${title}\nslug: ${subSlug}\nunlisted: true\ngenerated: true\n---\n\n${escapeForMdx(raw.trim())}\n`,
       );
     }
 
@@ -411,9 +414,9 @@ ${escapeForMdx(ref.content.trim())}
       const raw = fs.readFileSync(path.join(skillsDir, dir, "assets", f), "utf8");
       const h1Match = raw.match(/^#\s+(.+)$/m);
       const title = h1Match ? h1Match[1] : slug;
-      fs.writeFileSync(
+      await writeMdx(
         path.join(outputDir, `${dir}--asset-${slug}.mdx`),
-        `---\ntitle: "${escapeTitle(title)}"\nslug: "${subSlug}"\nunlisted: true\ngenerated: true\n---\n\n${escapeForMdx(raw.trim())}\n`,
+        `---\ntitle: ${title}\nslug: ${subSlug}\nunlisted: true\ngenerated: true\n---\n\n${escapeForMdx(raw.trim())}\n`,
       );
     }
   }
@@ -428,7 +431,7 @@ ${escapeForMdx(ref.content.trim())}
 // Agents generation
 // ---------------------------------------------------------------------------
 
-function generateAgentsDocs(config: ClaudeResourcesConfig): AgentItem[] {
+async function generateAgentsDocs(config: ClaudeResourcesConfig): Promise<AgentItem[]> {
   const agentsDir = path.join(config.claudeDir, "agents");
   const outputDir = path.join(config.docsDir, "claude-agents");
 
@@ -457,16 +460,16 @@ function generateAgentsDocs(config: ClaudeResourcesConfig): AgentItem[] {
     const modelBadge = model ? `**Model:** \`${model}\`\n` : "";
 
     const mdx = `---
-title: "${escapeTitle(name)}"
-description: "${escapeTitle(description)}"
-sidebar_label: "${escapeTitle(name)}"
+title: ${name}
+description: ${description}
+sidebar_label: ${name}
 generated: true
 ---
 
 ${modelBadge}
 ${escapeForMdx(parsed.content.trim())}
 `;
-    fs.writeFileSync(path.join(outputDir, `${fileSlug}.mdx`), mdx);
+    await writeMdx(path.join(outputDir, `${fileSlug}.mdx`), mdx);
   }
 
   items.sort((a, b) => a.name.localeCompare(b.name));
@@ -479,14 +482,14 @@ ${escapeForMdx(parsed.content.trim())}
 // Main
 // ---------------------------------------------------------------------------
 
-function generateOverviewIndex(config: ClaudeResourcesConfig) {
+async function generateOverviewIndex(config: ClaudeResourcesConfig) {
   const outputDir = path.join(config.docsDir, "claude");
   cleanDir(outputDir);
   ensureDir(outputDir);
 
   const index = `---
-title: "Claude"
-description: "Claude Code configuration reference."
+title: Claude
+description: Claude Code configuration reference.
 sidebar_position: 899
 generated: true
 ---
@@ -497,16 +500,16 @@ Claude Code configuration reference.
 
 <CategoryTreeNav category="claude" />
 `;
-  fs.writeFileSync(path.join(outputDir, "index.mdx"), index);
+  await writeMdx(path.join(outputDir, "index.mdx"), index);
 }
 
-export function generateClaudeResourcesDocs(config: ClaudeResourcesConfig) {
-  const claudemds = generateClaudemdDocs(config);
-  const commands = generateCommandsDocs(config);
-  const skills = generateSkillsDocs(config);
-  const agents = generateAgentsDocs(config);
+export async function generateClaudeResourcesDocs(config: ClaudeResourcesConfig) {
+  const claudemds = await generateClaudemdDocs(config);
+  const commands = await generateCommandsDocs(config);
+  const skills = await generateSkillsDocs(config);
+  const agents = await generateAgentsDocs(config);
 
-  generateOverviewIndex(config);
+  await generateOverviewIndex(config);
 
   return {
     claudemd: claudemds.length,

--- a/docs/src/integrations/claude-resources/index.ts
+++ b/docs/src/integrations/claude-resources/index.ts
@@ -11,7 +11,7 @@ export function claudeResourcesIntegration(options: ClaudeResourcesOptions): Ast
   return {
     name: "claude-resources",
     hooks: {
-      "astro:config:setup": ({ logger }) => {
+      "astro:config:setup": async ({ logger }) => {
         const rootDir = path.resolve(".");
         const claudeDir = path.resolve(rootDir, options.claudeDir);
         const projectRoot = options.projectRoot
@@ -21,7 +21,7 @@ export function claudeResourcesIntegration(options: ClaudeResourcesOptions): Ast
 
         logger.info(`Generating from ${claudeDir}`);
 
-        const counts = generateClaudeResourcesDocs({
+        const counts = await generateClaudeResourcesDocs({
           claudeDir,
           projectRoot,
           docsDir,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.2.0
         version: 4.2.4(vite@6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))
+      '@takazudo/mdx-formatter':
+        specifier: ^1.0.1
+        version: 1.2.1
       '@types/hast':
         specifier: ^3.0.4
         version: 3.0.4
@@ -115,6 +118,9 @@ importers:
       typescript:
         specifier: ^5.9.0
         version: 5.9.3
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@22.19.17)(happy-dom@15.11.7)(lightningcss@1.32.0)
 
   packages/create-zfb:
     dependencies:
@@ -1598,6 +1604,31 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@takazudo/mdx-formatter-darwin-arm64@1.2.1':
+    resolution: {integrity: sha512-6p2bIGfSQAaDldQwnTsFJKUsiEkMbd7ccZWTITxYym5RPuG46hL/Si2VVuIw3vfwciRbqkxN8k7zkrFSLmgMPA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@takazudo/mdx-formatter-darwin-x64@1.2.1':
+    resolution: {integrity: sha512-1Q6xqzdda8RtAM/LZSRof2L0ggShGjGWGO0zAEb+Kvq3HA3RwNMt7fXr/hEFtn8UarOkvxYAH5puRsJco8JL9g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@takazudo/mdx-formatter-linux-x64-gnu@1.2.1':
+    resolution: {integrity: sha512-qkNufO/xT8o3/BantkemXGkCBcDqzfjfiHLOCcVvQabzhbIVaf7m6ReMRlsXAv/AaZLS3/uPaTBziL75lPysVg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@takazudo/mdx-formatter-win32-x64-msvc@1.2.1':
+    resolution: {integrity: sha512-lmd81nM6+9BmEIUDDrrsR2rvCK01APex8Y5uVZ2xdc4xZagQBRVD2Z2HPCaW3yvoy/jIYmBdRjri84AWZgmadA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@takazudo/mdx-formatter@1.2.1':
+    resolution: {integrity: sha512-voMOJFXGvtOMO+lEzkEbqkz9ZEGNYv2UBtmzvIJ+y328XlUK5xcNgWgHQjEpkTu7G4hdz/X8aBoqy4ZvDiYwHA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   '@types/d3-array@3.2.2':
     resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
 
@@ -1885,6 +1916,10 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   base-64@1.0.0:
     resolution: {integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==}
 
@@ -1902,6 +1937,10 @@ packages:
   boxen@8.0.1:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
     engines: {node: '>=18'}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.2:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
@@ -1995,6 +2034,10 @@ packages:
   commander@11.1.0:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
 
   commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
@@ -2437,6 +2480,10 @@ packages:
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -2989,6 +3036,14 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minisearch@7.2.0:
     resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
 
@@ -3081,6 +3136,10 @@ packages:
 
   path-data-parser@0.1.0:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@6.3.0:
     resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
@@ -5040,6 +5099,30 @@ snapshots:
       tailwindcss: 4.2.4
       vite: 6.4.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3)
 
+  '@takazudo/mdx-formatter-darwin-arm64@1.2.1':
+    optional: true
+
+  '@takazudo/mdx-formatter-darwin-x64@1.2.1':
+    optional: true
+
+  '@takazudo/mdx-formatter-linux-x64-gnu@1.2.1':
+    optional: true
+
+  '@takazudo/mdx-formatter-win32-x64-msvc@1.2.1':
+    optional: true
+
+  '@takazudo/mdx-formatter@1.2.1':
+    dependencies:
+      chalk: 5.6.2
+      commander: 14.0.3
+      glob: 13.0.6
+      js-yaml: 4.1.1
+    optionalDependencies:
+      '@takazudo/mdx-formatter-darwin-arm64': 1.2.1
+      '@takazudo/mdx-formatter-darwin-x64': 1.2.1
+      '@takazudo/mdx-formatter-linux-x64-gnu': 1.2.1
+      '@takazudo/mdx-formatter-win32-x64-msvc': 1.2.1
+
   '@types/d3-array@3.2.2': {}
 
   '@types/d3-axis@3.0.6':
@@ -5475,6 +5558,8 @@ snapshots:
 
   bail@2.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   base-64@1.0.0: {}
 
   baseline-browser-mapping@2.10.22: {}
@@ -5493,6 +5578,10 @@ snapshots:
       type-fest: 4.41.0
       widest-line: 5.0.0
       wrap-ansi: 9.0.2
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   browserslist@4.28.2:
     dependencies:
@@ -5574,6 +5663,8 @@ snapshots:
   comma-separated-tokens@2.0.3: {}
 
   commander@11.1.0: {}
+
+  commander@14.0.3: {}
 
   commander@7.2.0: {}
 
@@ -6105,6 +6196,12 @@ snapshots:
   get-east-asian-width@1.5.0: {}
 
   github-slugger@2.0.0: {}
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   graceful-fs@4.2.11: {}
 
@@ -7000,6 +7097,12 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
+  minipass@7.1.3: {}
+
   minisearch@7.2.0: {}
 
   mlly@1.8.2:
@@ -7105,6 +7208,11 @@ snapshots:
   path-browserify@1.0.1: {}
 
   path-data-parser@0.1.0: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.3.5
+      minipass: 7.1.3
 
   path-to-regexp@6.3.0: {}
 


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/475

---

## Summary

Implements epic #475 — two independent fixes:

### #477 — Emit slug ids + TOC entries for headings nested in MDX JSX bodies
Markdown headings nested inside an MDX JSX element body (e.g. `## …` inside `<Outro>…</Outro>`) previously got `_components` styling (from #439) but no `rehype-slug` `id` and were dropped from the TOC. `crates/zfb-content/src/mdx_jsx_emit.rs` now:
- descends `collect_headings` into `MdxJsxFlow/TextElement` bodies so nested headings reach the `headings` export (→ TOC);
- emits `id` + the same hash-link anchor as top-level headings on nested `<_components.hN>`;
- keeps slug dedup consistent across the hast pass and the JSX-emit pass via a single document-order walk feeding a precomputed slug list (replayed through a `Cell` cursor), guarded by a `debug_assert`.

Upstream tracker: zudolab/zzmod#292 (cross-repo, stays open until re-verified in the consumer after release).

### #476 — Formatter-stable generated frontmatter
`docs/src/integrations/claude-resources/generate.ts` routed generated MDX through a hand-rolled double-quoted-YAML template that `@takazudo/mdx-formatter` then rewrote to bare scalars (churn). It now routes every generated file through the formatter's programmatic `format()` API, so output is formatter-stable (bare where YAML allows, quoted only where required). Generator is now async; all call sites updated.

## Testing
- `cargo test -p zfb-content`: 470 passed (4 new tests cover id + TOC + dedup ordering + anchor shape).
- docs integration vitest: 18 passed (incl. formatter-stability assertions).
- Deep review (gpt-4.1): no actionable findings.
- CI: 17/17 green.

## Topic PRs
Both topics merged into base locally (commits documented in epic #475); topic branches deleted post-merge.