### PR TITLE
docs: drop stale 'flip private:true' section from RELEASE_DAY_CHECKLIST

### DIFF
--- a/RELEASE_DAY_CHECKLIST.md
+++ b/RELEASE_DAY_CHECKLIST.md
@@ -1,17 +1,4 @@
-## Release-day checklist (out of scope for this PR — flip manually)
-
-Each package below has `private: true` and (for two of them) a
-`*-migration.0` version string. Before publishing each one to npm:
-
-- `packages/zfb` — bump `version` (currently `0.0.0`), remove `"private": true`, then `pnpm publish --access public`.
-- `packages/zfb-runtime` — bump `version` (currently `0.2.0-migration.0`), remove `"private": true`, then `pnpm publish --access public`.
-- `packages/zfb-adapter-cloudflare` — bump `version` (currently `0.1.0-migration.0`), remove `"private": true`, then `pnpm publish --access public`.
-
-Sub 7b (this PR) prepared the surrounding metadata — descriptions,
-keywords, repository / homepage / bugs / author / license / files
-allowlists, `publishConfig.access: "public"`, READMEs as finished
-npmjs.com landing pages, and CHANGELOGs — but did **not** touch
-`version` or `private` per the issue body's explicit non-scope.
+# Release process
 
 ## Release channels and GitHub Release assets (added by issue #381, updated by issue #455)
 


### PR DESCRIPTION
## Summary

The first section of `RELEASE_DAY_CHECKLIST.md` ("Release-day checklist — flip manually") is stale. It claimed all three packages were `private: true` at `0.0.0` / `*-migration.0` and needed a manual flip before publishing. That flip already happened — every package is now `0.1.0-next.6`, `private: false`, `publishConfig.access: public`, and published. The section described a completed one-time migration step that no longer applies.

## Changes
- Remove the obsolete "flip private:true" section (it referenced "this PR" / "Sub 7b" from an old migration PR).
- Add an H1 `# Release process` title, since the file no longer opens with that section's heading.
- Keep the rest intact — release channels, fast-Mac path, Homebrew tap — which is current and referenced from `release.yml`, `build-macos-x64-local.sh`, and `l-make-release`.

## Test Plan
- Verified against actual state: all three `package.json` files report `version: 0.1.0-next.6`, `private: false`, `access: public`.
- Doc-only change; no code paths affected.

## Note (out-of-band cleanup)
Alongside this PR, 8 stale local build artifacts (`zfb-0.1.0-next.{2,3,5,6}-x86_64-apple-darwin.tar.gz` + `.sha256`, ~240MB) and a duplicate stale `__inbox/release-day-checklist.md` snippet were deleted from the working tree. Those are gitignored, so they do **not** appear in this diff — noting here for the record.