### PR TITLE
Recent 3 Issue Fixes (epic #496): dev CSS pipeline, content-snapshot gate, ready-banner LAN URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1377,6 +1383,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getset"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+dependencies = [
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2082,6 +2100,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "local-ip-address"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa08fb2b1ec3ea84575e94b489d06d4ce0cbf052d12acd515838f50e3c3d63e3"
+dependencies = [
+ "libc",
+ "neli",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2199,6 +2228,35 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "neli"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9786d56d972959e1408b6a93be6af13b9c1392036c5c1fafa08a1b0c6ee87"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "derive_builder",
+ "getset",
+ "libc",
+ "log",
+ "neli-proc-macros",
+ "parking_lot",
+]
+
+[[package]]
+name = "neli-proc-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d8d08c6e98f20a62417478ebf7be8e1425ec9acecc6f63e22da633f6b71609"
+dependencies = [
+ "either",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2685,6 +2743,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -5275,6 +5355,7 @@ dependencies = [
  "hex",
  "include_dir",
  "indicatif",
+ "local-ip-address",
  "owo-colors",
  "oxc_resolver",
  "reqwest",

--- a/crates/zfb-server/src/embed.rs
+++ b/crates/zfb-server/src/embed.rs
@@ -281,6 +281,10 @@ impl Server {
             // is gated to `ServerMode::Dev` anyway, but leaving the
             // handle absent makes the no-injection contract obvious.
             islands_bundle_url: None,
+            // Same reasoning as islands — embed callers get no CSS link
+            // injection; the Dev-mode gate in `page_response_bytes` also
+            // enforces this, but `None` keeps the contract explicit.
+            css_bundle_url: None,
         };
         let router = build_router(state);
         let router = apply_request_extension_layer(router, self.request_extensions);

--- a/crates/zfb-server/src/lib.rs
+++ b/crates/zfb-server/src/lib.rs
@@ -78,6 +78,22 @@ use tracing::info;
 /// bin crate's `run_islands` callback holds another.
 pub type IslandsBundleUrl = Arc<RwLock<Option<String>>>;
 
+/// Shared handle to the currently-emitted dev-mode CSS bundle URL
+/// (issue #494 / #498).
+///
+/// Mirrors [`IslandsBundleUrl`] for CSS. `None` (outer) means "no CSS
+/// path configured for this server" — the page handler skips `<link>`
+/// injection entirely. `Some(url)` inside the lock carries the public
+/// URL the dev orchestrator wrote last (`/assets/styles.css` for
+/// projects without a base prefix, or `/foo/assets/styles.css` when
+/// `base: "/foo/"` is configured).
+///
+/// Reads happen on every served HTML response in dev mode; writes happen
+/// once at boot and again on every CSS-rebuild tick. The contention
+/// is one writer thread vs many short-lived readers — [`RwLock`] is
+/// the right shape (not a plain `Mutex`).
+pub type CssBundleUrl = Arc<RwLock<Option<String>>>;
+
 pub use embed::{Server, ServerBuilder, ServerHandle, ServerMode};
 pub use embed_handlers::{
     EmbedHandler, EmbedHandlerFn, EmbedHandlerFuture, EmbedHandlerSet, RouteParams,
@@ -212,6 +228,18 @@ pub struct ServeOpts {
     /// rebuild ticks rewrite the URL), and threads it into `ServeOpts`
     /// before calling [`serve`].
     pub islands_bundle_url: Option<crate::IslandsBundleUrl>,
+
+    /// Shared handle to the current dev-mode CSS bundle URL
+    /// (issue #494 / #498). Mirrors `islands_bundle_url` for CSS.
+    /// `None` for projects with Tailwind disabled, or when the bin crate
+    /// has not yet seeded a bundle. When `Some`, the page handler splices
+    /// a `<link rel="stylesheet" href="<url>">` tag into every served
+    /// HTML response's `<head>` via
+    /// [`zfb_build::head_inject::inject_prod_head_assets`].
+    ///
+    /// Dev-only: gated the same way as `islands_bundle_url` — Preview
+    /// and Embed callers never inject even if they pass a non-`None` handle.
+    pub css_bundle_url: Option<crate::CssBundleUrl>,
 }
 
 impl ServeOpts {
@@ -295,6 +323,7 @@ where
         base_prefix,
         trailing_slash: opts.trailing_slash,
         islands_bundle_url: opts.islands_bundle_url,
+        css_bundle_url: opts.css_bundle_url,
     };
     let router = build_router(state);
 

--- a/crates/zfb-server/src/routes.rs
+++ b/crates/zfb-server/src/routes.rs
@@ -408,6 +408,20 @@ pub struct AppState {
     /// callers never inject even if they accidentally pass a non-`None`
     /// handle, so the production-shaped response contract is preserved.
     pub islands_bundle_url: Option<crate::IslandsBundleUrl>,
+
+    /// Optional shared handle to the current dev-mode CSS bundle URL
+    /// (issue #494 / #498). When `Some` and the inner lock holds `Some(url)`,
+    /// every served HTML response in [`crate::ServerMode::Dev`] mode
+    /// has a `<link rel="stylesheet" href="<url>">` spliced into
+    /// `<head>` via [`zfb_build::head_inject::inject_prod_head_assets`].
+    /// `None` (outer) or `None` inside the lock both fall back to "no
+    /// injection" — projects with Tailwind disabled must not ship a
+    /// link tag pointing at a non-existent file.
+    ///
+    /// Gated to Dev mode at the response-shaping site: Preview / Embed
+    /// callers never inject even if they accidentally pass a non-`None`
+    /// handle.
+    pub css_bundle_url: Option<crate::CssBundleUrl>,
 }
 
 /// Build the axum router for the dev server.
@@ -567,6 +581,23 @@ fn current_islands_bundle_url(handle: &Option<crate::IslandsBundleUrl>) -> Optio
     guard.clone()
 }
 
+/// Read the current dev-mode CSS bundle URL from the shared state
+/// handle, if any. Mirrors [`current_islands_bundle_url`] for CSS.
+/// Returns the locked string by clone so the caller can hold the result
+/// across the response build without keeping the read lock alive. A
+/// poisoned lock is recovered rather than re-panicking.
+fn current_css_bundle_url(handle: &Option<crate::CssBundleUrl>) -> Option<String> {
+    let arc = handle.as_ref()?;
+    let guard = arc.read().unwrap_or_else(|p| {
+        tracing::warn!(
+            site = "AppState.css_bundle_url",
+            "rwlock poisoned, recovered"
+        );
+        p.into_inner()
+    });
+    guard.clone()
+}
+
 fn unprefixed_404_response(prefix: &str, path: &str, mode: crate::ServerMode) -> Response {
     let body = format!(
         "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\"><title>zfb dev — 404 (base mismatch)</title></head><body><h1>404 — outside configured base</h1><p>This dev server is mounted under <code>{}</code> (from <code>base</code> in <code>zfb.config.ts</code>). The path <code>{}</code> is not under that prefix. Try <a href=\"{}/\">{}/</a> instead.</p></body></html>",
@@ -593,6 +624,8 @@ fn unprefixed_404_response(prefix: &str, path: &str, mode: crate::ServerMode) ->
         // anchor, so the islands splicer would no-op anyway. Pass None
         // to keep the surface tight — this handler has no AppState in
         // scope.
+        None,
+        // Same reasoning as islands: no AppState in scope, pass None.
         None,
     )
 }
@@ -777,6 +810,7 @@ async fn serve_page(
                 state.trailing_slash,
                 state.mode,
                 current_islands_bundle_url(&state.islands_bundle_url).as_deref(),
+                current_css_bundle_url(&state.css_bundle_url).as_deref(),
             )
             .await;
         }
@@ -808,6 +842,7 @@ async fn serve_page(
                 state.trailing_slash,
                 state.mode,
                 current_islands_bundle_url(&state.islands_bundle_url).as_deref(),
+                current_css_bundle_url(&state.css_bundle_url).as_deref(),
             );
         }
     }
@@ -866,6 +901,7 @@ async fn serve_page(
             state.trailing_slash,
             state.mode,
             current_islands_bundle_url(&state.islands_bundle_url).as_deref(),
+            current_css_bundle_url(&state.css_bundle_url).as_deref(),
         );
     }
 
@@ -897,6 +933,7 @@ async fn serve_page(
                 state.trailing_slash,
                 state.mode,
                 current_islands_bundle_url(&state.islands_bundle_url).as_deref(),
+                current_css_bundle_url(&state.css_bundle_url).as_deref(),
             );
         }
     }
@@ -912,6 +949,7 @@ async fn serve_page(
         state.trailing_slash,
         state.mode,
         current_islands_bundle_url(&state.islands_bundle_url).as_deref(),
+        current_css_bundle_url(&state.css_bundle_url).as_deref(),
     )
 }
 
@@ -1150,6 +1188,7 @@ async fn dispatch_ssr(
     add_trailing_slash: bool,
     mode: crate::ServerMode,
     islands_bundle_url: Option<&str>,
+    css_bundle_url: Option<&str>,
 ) -> Response {
     let mut req_headers: std::collections::BTreeMap<String, String> =
         std::collections::BTreeMap::new();
@@ -1191,6 +1230,7 @@ async fn dispatch_ssr(
         add_trailing_slash,
         mode,
         islands_bundle_url,
+        css_bundle_url,
     );
     // Merge any extra headers the SSR handler set (Set-Cookie, Vary,
     // …). Skip headers `page_response_bytes` already wrote
@@ -1445,6 +1485,7 @@ pub(crate) fn page_response_bytes(
     add_trailing_slash: bool,
     mode: crate::ServerMode,
     islands_bundle_url: Option<&str>,
+    css_bundle_url: Option<&str>,
 ) -> Response {
     // Live-reload script injection and the default `Cache-Control: no-
     // store` shaping are Dev-only — Preview and Embed callers want
@@ -1463,6 +1504,15 @@ pub(crate) fn page_response_bytes(
     // when no `"use client"` islands exist).
     let islands_script_url = if is_dev && inject_reload {
         islands_bundle_url
+            .map(str::trim)
+            .filter(|u| !u.is_empty())
+    } else {
+        None
+    };
+    // Issue #494 / #498: dev-mode injection of the CSS `<link>` tag.
+    // Same gate as islands — Dev mode only, HTML responses only.
+    let css_link_url = if is_dev && inject_reload {
+        css_bundle_url
             .map(str::trim)
             .filter(|u| !u.is_empty())
     } else {
@@ -1497,25 +1547,29 @@ pub(crate) fn page_response_bytes(
                         Err(_) => Cow::Borrowed(html),
                     }
                 };
-                // Splice the islands `<script type="module">` tag into
-                // `<head>` first (so livereload's `</body>`-anchored
-                // tag still trails the rest of the body markup). The
-                // shared helper is idempotent and a passthrough for
-                // bodies that have no `</head>`.
-                let with_islands = match islands_script_url {
-                    Some(url) => {
-                        let assets = zfb_build::head_inject::ProdHeadAssets {
-                            css_url: None,
-                            island_module_urls: vec![url.to_string()],
-                        };
+                // Splice the CSS `<link>` and islands `<script type="module">`
+                // tags into `<head>` (so livereload's `</body>`-anchored tag
+                // still trails the rest of the body markup). The shared helper
+                // is idempotent and a passthrough for bodies that have no
+                // `</head>`. CSS is injected before islands so the stylesheet
+                // loads first on initial page render.
+                let with_head_assets = {
+                    let assets = zfb_build::head_inject::ProdHeadAssets {
+                        css_url: css_link_url.map(str::to_owned),
+                        island_module_urls: islands_script_url
+                            .map(|u| vec![u.to_string()])
+                            .unwrap_or_default(),
+                    };
+                    if assets.is_empty() {
+                        rewritten
+                    } else {
                         Cow::Owned(
                             zfb_build::head_inject::inject_prod_head_assets(&rewritten, &assets)
                                 .into_owned(),
                         )
                     }
-                    None => rewritten,
                 };
-                inject_livereload_with_prefix(&with_islands, base_prefix).into_bytes()
+                inject_livereload_with_prefix(&with_head_assets, base_prefix).into_bytes()
             }
             Err(_) => body,
         }
@@ -1566,6 +1620,7 @@ mod tests {
             base_prefix: None,
             trailing_slash: false,
             islands_bundle_url: None,
+            css_bundle_url: None,
         }
     }
 
@@ -1584,6 +1639,7 @@ mod tests {
             base_prefix: Some(prefix.to_string()),
             trailing_slash: false,
             islands_bundle_url: None,
+            css_bundle_url: None,
         }
     }
 
@@ -1953,6 +2009,175 @@ mod tests {
     }
 
     // -------------------------------------------------------------------
+    // Issue #494 / #498 — dev-mode CSS `<link>` injection
+    // -------------------------------------------------------------------
+    //
+    // Mirror of the islands-injection acceptance criterion: the page
+    // handler must splice a `<link rel="stylesheet">` into `<head>` when
+    // `AppState.css_bundle_url` carries a URL.  Two cases:
+    //   1. `css_bundle_url == Some(url)` → link tag present in `<head>`.
+    //   2. `css_bundle_url == None` → no link tag injected.
+    // A combined case also verifies that CSS and islands co-exist when
+    // both handles are seeded.
+
+    fn make_css_bundle_url(url: &str) -> crate::CssBundleUrl {
+        Arc::new(std::sync::RwLock::new(Some(url.to_string())))
+    }
+
+    fn make_islands_bundle_url(url: &str) -> crate::IslandsBundleUrl {
+        Arc::new(std::sync::RwLock::new(Some(url.to_string())))
+    }
+
+    #[tokio::test]
+    async fn css_link_injected_into_head_when_handle_seeded() {
+        let (tx, _rx) = broadcast::channel::<ReloadEvent>(16);
+        let state = AppState {
+            mode: crate::ServerMode::Dev,
+            pages: PageCache::new(),
+            broadcast: tx,
+            plugins: None,
+            injected_routes: None,
+            ssr_routes: None,
+            embed_handlers: None,
+            dist_root: std::env::temp_dir().join("zfb-test-dist"),
+            public_root: std::env::temp_dir().join("zfb-test-public"),
+            base_prefix: None,
+            trailing_slash: false,
+            islands_bundle_url: None,
+            css_bundle_url: Some(make_css_bundle_url("/assets/styles.css")),
+        };
+        // HTML must include <head></head> so inject_prod_head_assets has an anchor.
+        state
+            .pages
+            .insert(
+                "/",
+                "<html><head></head><body><p>hello</p></body></html>",
+            )
+            .await;
+        let router = test_router(state);
+
+        let resp = router
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        assert!(
+            body.contains("<link rel=\"stylesheet\" href=\"/assets/styles.css\">"),
+            "expected css link tag in response body; got:\n{body}",
+        );
+        // Livereload script must also still be present.
+        assert!(body.contains(LIVERELOAD_TAG));
+    }
+
+    #[tokio::test]
+    async fn css_link_absent_when_handle_is_none() {
+        let state = test_state();
+        state
+            .pages
+            .insert(
+                "/",
+                "<html><head></head><body><p>hello</p></body></html>",
+            )
+            .await;
+        let router = test_router(state);
+
+        let resp = router
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        assert!(
+            !body.contains("stylesheet"),
+            "expected no stylesheet link when css_bundle_url is None; got:\n{body}",
+        );
+    }
+
+    #[tokio::test]
+    async fn css_and_islands_both_injected_when_both_handles_seeded() {
+        let (tx, _rx) = broadcast::channel::<ReloadEvent>(16);
+        let state = AppState {
+            mode: crate::ServerMode::Dev,
+            pages: PageCache::new(),
+            broadcast: tx,
+            plugins: None,
+            injected_routes: None,
+            ssr_routes: None,
+            embed_handlers: None,
+            dist_root: std::env::temp_dir().join("zfb-test-dist"),
+            public_root: std::env::temp_dir().join("zfb-test-public"),
+            base_prefix: None,
+            trailing_slash: false,
+            islands_bundle_url: Some(make_islands_bundle_url("/assets/islands.js")),
+            css_bundle_url: Some(make_css_bundle_url("/assets/styles.css")),
+        };
+        state
+            .pages
+            .insert(
+                "/",
+                "<html><head></head><body><p>hello</p></body></html>",
+            )
+            .await;
+        let router = test_router(state);
+
+        let resp = router
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        assert!(
+            body.contains("<link rel=\"stylesheet\" href=\"/assets/styles.css\">"),
+            "expected css link tag; got:\n{body}",
+        );
+        assert!(
+            body.contains("<script type=\"module\" src=\"/assets/islands.js\">"),
+            "expected islands script tag; got:\n{body}",
+        );
+        assert!(body.contains(LIVERELOAD_TAG));
+    }
+
+    #[tokio::test]
+    async fn css_link_not_injected_in_preview_mode() {
+        let (tx, _rx) = broadcast::channel::<ReloadEvent>(16);
+        let state = AppState {
+            mode: crate::ServerMode::Preview,
+            pages: PageCache::new(),
+            broadcast: tx,
+            plugins: None,
+            injected_routes: None,
+            ssr_routes: None,
+            embed_handlers: None,
+            dist_root: std::env::temp_dir().join("zfb-test-dist"),
+            public_root: std::env::temp_dir().join("zfb-test-public"),
+            base_prefix: None,
+            trailing_slash: false,
+            islands_bundle_url: None,
+            css_bundle_url: Some(make_css_bundle_url("/assets/styles.css")),
+        };
+        state
+            .pages
+            .insert(
+                "/",
+                "<html><head></head><body><p>hello</p></body></html>",
+            )
+            .await;
+        let router = test_router(state);
+
+        let resp = router
+            .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = body_string(resp).await;
+        assert!(
+            !body.contains("stylesheet"),
+            "expected no stylesheet link in Preview mode; got:\n{body}",
+        );
+    }
+
+    // -------------------------------------------------------------------
     // Issue #230 — devMiddleware accepts every HTTP method
     // -------------------------------------------------------------------
     //
@@ -2028,6 +2253,7 @@ mod tests {
             base_prefix: None,
             trailing_slash: false,
             islands_bundle_url: None,
+            css_bundle_url: None,
         }
     }
 

--- a/crates/zfb-server/tests/combined_gap_integration.rs
+++ b/crates/zfb-server/tests/combined_gap_integration.rs
@@ -140,6 +140,7 @@ async fn gap1_ssr_and_gap2_watcher_work_together() {
         trailing_slash: false,
         mode: zfb_server::ServerMode::Dev,
         islands_bundle_url: None,
+        css_bundle_url: None,
     };
     let server = tokio::spawn(async move {
         serve_with_listener(opts, listener, std::future::pending::<()>()).await

--- a/crates/zfb-server/tests/embed_ssr_smoke.rs
+++ b/crates/zfb-server/tests/embed_ssr_smoke.rs
@@ -127,6 +127,7 @@ async fn boot_with_plugins(
         base_prefix: None,
         trailing_slash: false,
         islands_bundle_url: None,
+        css_bundle_url: None,
     };
     let router = build_router(state);
 

--- a/crates/zfb-server/tests/integration.rs
+++ b/crates/zfb-server/tests/integration.rs
@@ -78,6 +78,7 @@ impl Harness {
             trailing_slash: false,
             mode: zfb_server::ServerMode::Dev,
             islands_bundle_url: None,
+            css_bundle_url: None,
         };
 
         let server = tokio::spawn(async move {

--- a/crates/zfb-server/tests/islands_head_injection.rs
+++ b/crates/zfb-server/tests/islands_head_injection.rs
@@ -69,6 +69,7 @@ impl Harness {
             trailing_slash: false,
             mode,
             islands_bundle_url,
+            css_bundle_url: None,
         };
 
         let server = tokio::spawn(async move {

--- a/crates/zfb-server/tests/plugin_middleware_integration.rs
+++ b/crates/zfb-server/tests/plugin_middleware_integration.rs
@@ -118,6 +118,7 @@ async fn boot_with_dispatcher(
         trailing_slash: false,
         mode: zfb_server::ServerMode::Dev,
         islands_bundle_url: None,
+        css_bundle_url: None,
     };
     let server = tokio::spawn(async move {
         serve_with_listener(opts, listener, std::future::pending::<()>()).await

--- a/crates/zfb-server/tests/ssr_integration.rs
+++ b/crates/zfb-server/tests/ssr_integration.rs
@@ -131,6 +131,7 @@ async fn boot_with_base(
         trailing_slash: false,
         mode: zfb_server::ServerMode::Dev,
         islands_bundle_url: None,
+        css_bundle_url: None,
     };
     let server = tokio::spawn(async move {
         serve_with_listener(opts, listener, std::future::pending::<()>()).await

--- a/crates/zfb/Cargo.toml
+++ b/crates/zfb/Cargo.toml
@@ -100,6 +100,10 @@ zfb-watcher = { path = "../zfb-watcher" }
 # packages use.  Pulls ~4 transitive crates (rustc-hash, dashmap, etc.)
 # that are small and not otherwise in the graph.
 oxc_resolver = "11.19.1"
+# IP-enumeration for the dev ready-banner (#487/#499): when the user binds to
+# an unspecified address (0.0.0.0), we list non-loopback IPv4 interfaces so
+# the banner shows actual reachable URLs instead of the literal `0.0.0.0`.
+local-ip-address = "0.6"
 
 [build-dependencies]
 # Binary download and SHA-256 verification in build.rs.

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -1130,32 +1130,36 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
     static_routes.extend(expansion.resolved);
     let still_deferred = expansion.deferred;
 
-    // Phase 2 — embed content snapshot in the bundle so runtime
-    // `paths()` can call `getCollection(...)`.
+    // Phase 2 — embed content snapshot in the bundle.
     //
     // Build the content snapshot from the configured collections and
-    // embed it in the worker bundle. This lets pages whose `paths()`
-    // calls `getCollection(...)` resolve real content entries when
-    // queried via the `/__paths__` endpoint below.
+    // embed it in the worker bundle. This serves TWO consumers:
     //
-    // Errors building the snapshot are non-fatal: if the collection
-    // root is missing or a file is malformed, we warn and fall back to
-    // an empty snapshot. The build will proceed; pages that depend on
-    // the collection data will return empty `paths()` results at render
-    // time, which surfaces as zero dynamic pages — visible in the build
-    // summary.
-    // The snapshot is only needed when at least one route's `paths()`
-    // could not be statically expanded and therefore must be evaluated
-    // at runtime (it may call `getCollection(...)`). Statically-resolved
-    // routes never touch the runtime snapshot, so a project with no
-    // deferred paths() pays nothing. The actual snapshot construction is
-    // shared with `zfb dev` via `build_content_snapshot_json` so the two
-    // commands produce byte-identical snapshots.
-    let content_snapshot_json = if !still_deferred.is_empty() {
-        build_content_snapshot_json(project_root, config)
-    } else {
-        None
-    };
+    // 1. Runtime `paths()` calls — pages whose `paths()` calls
+    //    `getCollection(...)` need the snapshot in the worker bundle so
+    //    the `/__paths__/<route>` endpoint can return real entries.
+    //
+    // 2. `getStaticProps` calls — static pages (no dynamic `[slug].tsx`)
+    //    that call `getCollection(...)` inside `getStaticProps` also need
+    //    the snapshot at render time. The previous `!still_deferred.is_empty()`
+    //    gate skipped snapshot construction for projects with no deferred
+    //    `paths()`, which broke `getCollection(...)` returning `[]` for
+    //    these pages (issue #495).
+    //
+    // The gate is therefore removed. `build_content_snapshot_json` already
+    // short-circuits to `None` when `config.collections.is_empty()`, so
+    // projects without any collections still pay nothing — no file walk,
+    // no JSON serialisation.
+    //
+    // Errors are non-fatal: if the collection root is missing or a file is
+    // malformed, we warn and fall back to an empty snapshot. The build
+    // will proceed; pages that depend on the collection data will see empty
+    // `getCollection(...)` results at render time.
+    //
+    // Snapshot construction is shared with `zfb dev` via
+    // `build_content_snapshot_json` so both commands produce byte-identical
+    // snapshots.
+    let content_snapshot_json = build_content_snapshot_json(project_root, config);
 
     if static_routes.is_empty() && still_deferred.is_empty() {
         // Stay user-friendly: an all-dynamic project where every page
@@ -4434,6 +4438,34 @@ mod tests {
             "deferred-dynamic SSR route must reach the runtime bundle's \
              worker_only_routes; got {:?}",
             worker_only
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // build_content_snapshot_json — no-collections cost guard (issue #495)
+    // ---------------------------------------------------------------------------
+
+    /// `build_content_snapshot_json` must return `None` immediately when
+    /// `config.collections` is empty. This is the "projects without collections
+    /// still pay nothing" guarantee preserved by the helper's own early-return
+    /// guard after the `!still_deferred.is_empty()` gate was removed from the
+    /// orchestrator (issue #495).
+    ///
+    /// A real project root is not needed — the helper exits before touching the
+    /// filesystem when `config.collections` is empty.
+    #[test]
+    fn build_content_snapshot_json_returns_none_for_empty_collections() {
+        let cfg = Config::default();
+        assert!(
+            cfg.collections.is_empty(),
+            "Config::default() must produce no collections for this test to be meaningful"
+        );
+        let tmp = tempdir().unwrap();
+        let result = build_content_snapshot_json(tmp.path(), &cfg);
+        assert!(
+            result.is_none(),
+            "build_content_snapshot_json must return None when collections is empty \
+             (no-collections cost guard must be preserved after gate removal)"
         );
     }
 }

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -665,7 +665,7 @@ impl BuildRunner for DefaultRunner {
 /// (`zfb_css::css_relative_path` and `zfb_types::STABLE_CSS_URL`) so
 /// the renderer's head injector and the prod pipeline's URL rewriter
 /// agree on the same key without a separate string channel.
-fn build_default_css_payload(
+pub(crate) fn build_default_css_payload(
     project_root: &Path,
     outdir: &Path,
     config: &Config,

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -78,7 +78,7 @@ use zfb_build::renderer::{
     render_one, shutdown, start, Backend, RendererStartInput, RendererState, RouteUniverseEntry,
 };
 use zfb_build::{
-    BuildContext, BuildOrchestrator, BuildOutcome, DevAssetPipeline, IslandsBundleInfo,
+    BuildContext, BuildOrchestrator, BuildOutcome, CssRunner, DevAssetPipeline, IslandsBundleInfo,
     IslandsRunner, OrchestratorConfig, PageRenderer, RelDistPath, RenderedPage,
 };
 use zfb_graph::persist::{load_from_disk, save_to_disk, ManifestDigest};
@@ -481,10 +481,114 @@ pub async fn run(args: &DevArgs) -> Result<()> {
         }))
     };
 
+    // Issue #494 / #498: wire the CSS runner end-to-end, mirroring the
+    // islands runner above.
+    //
+    // Step 1: shared URL handle — the dev server reads from this on every
+    // HTML response; the runner writes to it on every CSS rebuild tick.
+    let css_bundle_url_handle: zfb_server::CssBundleUrl =
+        Arc::new(std::sync::RwLock::new(None));
+
+    // Step 2: eager initial CSS bundle at boot so the very first page
+    // request already carries a `<link rel="stylesheet">` tag.
+    // Failures are non-fatal — we warn and let the dev server boot with
+    // unstyled HTML. The hot-rebuild path will retry on the next file
+    // change.
+    let dev_css_url_prefix: String =
+        zfb_types::dev_mount_prefix(cfg.base.as_deref()).unwrap_or_default();
+    match crate::commands::build::build_default_css_payload(&project_root, &dist_root, &cfg) {
+        Ok(Some(payload)) => {
+            // Write the bytes to dist so `GET /assets/styles.css` is
+            // immediately serveable (unlike islands, the CSS pipeline does
+            // not write to disk as a side-effect of building).
+            let out_path = dist_root.join(&payload.relative_path);
+            if let Some(parent) = out_path.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            if std::fs::write(&out_path, &payload.bytes).is_ok() {
+                let url = if dev_css_url_prefix.is_empty() {
+                    payload.stable_url
+                } else {
+                    format!("{dev_css_url_prefix}{}", payload.stable_url)
+                };
+                if let Ok(mut guard) = css_bundle_url_handle.write() {
+                    *guard = Some(url);
+                }
+            } else {
+                output::warn(
+                    "initial CSS bundle: failed to write bytes to dist (no <link> until rebuild)"
+                        .to_string(),
+                );
+            }
+        }
+        Ok(None) => {
+            // Tailwind disabled or no sources. Leave the handle at None.
+        }
+        Err(err) => {
+            output::warn(format!(
+                "initial CSS bundle failed (no <link rel=\"stylesheet\"> \
+                 will be injected until the next successful rebuild): {err:#}"
+            ));
+        }
+    }
+
+    // Step 3: CssRunner closure — re-invokes the payload builder, writes
+    // fresh bytes to disk, and updates the shared URL handle.
+    let run_css: Option<CssRunner> = {
+        let project_root_for_css = project_root.clone();
+        let dist_root_for_css = dist_root.clone();
+        let cfg_for_css = cfg.clone();
+        let url_prefix = dev_css_url_prefix.clone();
+        let url_handle = Arc::clone(&css_bundle_url_handle);
+        Some(Arc::new(move || -> Result<bool> {
+            let payload = crate::commands::build::build_default_css_payload(
+                &project_root_for_css,
+                &dist_root_for_css,
+                &cfg_for_css,
+            )?;
+            let mut guard = url_handle.write().unwrap_or_else(|p| {
+                tracing::warn!(
+                    site = "dev.run_css.url_handle",
+                    "rwlock poisoned, recovered"
+                );
+                p.into_inner()
+            });
+            let Some(payload) = payload else {
+                // CSS disabled / no sources this tick — clear the URL so
+                // subsequent HTML responses don't reference a stale file.
+                *guard = None;
+                return Ok(false);
+            };
+            // Write fresh bytes to dist so the dev server serves them
+            // immediately. This is the "freshness proof" the acceptance
+            // test checks (byte-for-byte match between payload.bytes and
+            // GET /assets/styles.css).
+            let out_path = dist_root_for_css.join(&payload.relative_path);
+            if let Some(parent) = out_path.parent() {
+                let _ = std::fs::create_dir_all(parent);
+            }
+            if let Err(err) = std::fs::write(&out_path, &payload.bytes) {
+                tracing::warn!("css runner: failed to write bytes to dist: {err}");
+                return Ok(false);
+            }
+            let bundle_url = if url_prefix.is_empty() {
+                payload.stable_url
+            } else {
+                format!("{url_prefix}{}", payload.stable_url)
+            };
+            *guard = Some(bundle_url);
+            // Return true unconditionally on a successful emit so the
+            // orchestrator marks outcome.css_changed = true and the
+            // livereload SSE event fires. The URL is stable so the bytes
+            // update in place on disk.
+            Ok(true)
+        }))
+    };
+
     let ctx = BuildContext {
         dist_root: dist_root.clone(),
         render_pages,
-        run_css: None,
+        run_css,
         run_islands,
         // The bundle-rebuild + renderer-reload wiring lands
         // here once the dev-mode bundler is available on a per-tick
@@ -540,6 +644,11 @@ pub async fn run(args: &DevArgs) -> Result<()> {
         // inner Option, page responses read it on every served HTML
         // request. Cloning the Arc is cheap (refcount bump).
         islands_bundle_url: Some(Arc::clone(&islands_bundle_url_handle)),
+        // Issue #494 / #498: same pattern as islands — the dev server
+        // holds the same Arc as the `run_css` callback above; CSS
+        // rebuild ticks rewrite the inner Option, page responses read it
+        // on every served HTML request.
+        css_bundle_url: Some(Arc::clone(&css_bundle_url_handle)),
     };
 
     output::ready(&format!("http://{host}:{port}"));

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -542,7 +542,7 @@ pub async fn run(args: &DevArgs) -> Result<()> {
         islands_bundle_url: Some(Arc::clone(&islands_bundle_url_handle)),
     };
 
-    output::ready(&format!("http://{host}:{port}"));
+    output::ready_with_interfaces("http", &host, port);
 
     // 7. Run the server until Ctrl+C. Pass Ctrl+C as the graceful-shutdown
     //    signal so axum drains in-flight connections before exiting. The

--- a/crates/zfb/src/output.rs
+++ b/crates/zfb/src/output.rs
@@ -18,6 +18,7 @@
 //! `success`, `ready`) and to `stderr` for `warn` / `error`, matching
 //! conventional Unix CLI behaviour.
 
+use std::net::IpAddr;
 use std::time::Duration;
 
 use indicatif::{ProgressBar, ProgressStyle};
@@ -90,8 +91,101 @@ pub fn error(msg: impl AsRef<str>) {
 ///
 /// Output style: `→ ready on <url>` with the arrow in green and the URL in
 /// bold when colours are supported.
+///
+/// This helper is intentionally kept for callers that already know the exact
+/// final URL (e.g. `zfb preview`, which hardcodes `localhost` and has no
+/// `--host` flag — preview is intentionally untouched by the unspecified-host
+/// banner logic because preview cannot bind to unspecified hosts today; the
+/// helper below (`ready_with_interfaces`) is structured so a future preview
+/// `--host` flag can adopt it with no change to this function).
 pub fn ready(url: &str) {
     println!("{}", fmt_ready(url));
+}
+
+/// Format a multi-line "ready" banner for the unspecified-host case.
+///
+/// Pure formatter: accepts a precomputed `network_urls` slice so the rendering
+/// logic can be unit-tested without any OS-level interface enumeration.
+///
+/// Output shape (following Vite's convention):
+/// ```text
+/// → ready
+///   Local:    http://localhost:PORT/
+///   Network:  http://192.168.x.x:PORT/
+///             http://10.x.x.x:PORT/
+/// ```
+fn fmt_ready_multi(scheme: &str, port: u16, network_urls: &[String]) -> String {
+    let arrow = "→".if_supports_color(Stream::Stdout, |t| t.green().to_string());
+    let local_url = format!("{}://localhost:{}/", scheme, port);
+    let local_styled =
+        local_url.if_supports_color(Stream::Stdout, |t| t.bold().to_string());
+    let mut out = format!("{} ready\n", arrow);
+    out.push_str(&format!("  Local:    {}\n", local_styled));
+    if network_urls.is_empty() {
+        out.push_str("  Network:  (none)\n");
+    } else {
+        for (i, url) in network_urls.iter().enumerate() {
+            let url_styled = url.if_supports_color(Stream::Stdout, |t| t.bold().to_string());
+            if i == 0 {
+                out.push_str(&format!("  Network:  {}\n", url_styled));
+            } else {
+                out.push_str(&format!("            {}\n", url_styled));
+            }
+        }
+    }
+    out
+}
+
+/// Return `true` when `host` represents an unspecified (bind-all) address.
+///
+/// Handles `0.0.0.0`, `::`, and the URL-bracketed form `[::]`.
+fn host_is_unspecified(host: &str) -> bool {
+    // Strip URL brackets from IPv6 addresses (e.g. `[::]` → `::`).
+    let stripped = host.strip_prefix('[').and_then(|s| s.strip_suffix(']'));
+    let addr_str = stripped.unwrap_or(host);
+    addr_str
+        .parse::<IpAddr>()
+        .map(|ip| ip.is_unspecified())
+        .unwrap_or(false)
+}
+
+/// Print a "ready" banner for `zfb dev`, choosing single-line or multi-line
+/// output depending on whether the bound host is an unspecified address.
+///
+/// - When `host` is `localhost`, `127.0.0.1`, or any other specific address,
+///   this falls through to the same `→ ready on <url>` single-line shape as
+///   `ready()`, so existing UX is unchanged.
+/// - When `host` is `0.0.0.0` or `::` (bind-all), non-loopback IPv4 interfaces
+///   are enumerated from the OS and printed as `Network:` entries alongside a
+///   `Local: http://localhost:PORT/` entry (following Vite's convention).
+pub fn ready_with_interfaces(scheme: &str, host: &str, port: u16) {
+    if host_is_unspecified(host) {
+        let network_urls = collect_network_urls(scheme, port);
+        print!("{}", fmt_ready_multi(scheme, port, &network_urls));
+    } else {
+        println!("{}", fmt_ready(&format!("{}://{}:{}", scheme, host, port)));
+    }
+}
+
+/// Enumerate non-loopback IPv4 interfaces and build a URL for each.
+fn collect_network_urls(scheme: &str, port: u16) -> Vec<String> {
+    match local_ip_address::list_afinet_netifas() {
+        Ok(interfaces) => interfaces
+            .into_iter()
+            .filter_map(|(_name, ip)| {
+                // IPv4-only for now — IPv6 URL form requires bracketing
+                // (`http://[fe80::1]:PORT/`) which adds surface area; IPv4
+                // covers the common LAN/VPN use-case Vite targets.
+                if let IpAddr::V4(v4) = ip {
+                    if !v4.is_loopback() {
+                        return Some(format!("{}://{}:{}/", scheme, v4, port));
+                    }
+                }
+                None
+            })
+            .collect(),
+        Err(_) => Vec::new(),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -461,6 +555,110 @@ mod tests {
 
         let line = strip_ansi(&fmt_summary(7, Duration::from_millis(1234)));
         assert_eq!(line, "✓ 7 pages built in 1.23s");
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests for the multi-line banner (issue #499 / #487)
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn host_is_unspecified_recognises_all_ipv4() {
+        assert!(host_is_unspecified("0.0.0.0"));
+    }
+
+    #[test]
+    fn host_is_unspecified_recognises_ipv6_bare() {
+        assert!(host_is_unspecified("::"));
+    }
+
+    #[test]
+    fn host_is_unspecified_recognises_ipv6_bracketed() {
+        assert!(host_is_unspecified("[::]"));
+    }
+
+    #[test]
+    fn host_is_unspecified_returns_false_for_specific_hosts() {
+        for h in ["localhost", "127.0.0.1", "192.168.1.1", "::1"] {
+            assert!(
+                !host_is_unspecified(h),
+                "expected false for {:?}, got true",
+                h
+            );
+        }
+    }
+
+    /// fmt_ready_multi with a mock network_urls slice — no real network state.
+    #[test]
+    fn fmt_ready_multi_renders_expected_shape() {
+        owo_colors::set_override(false);
+        let network_urls = vec![
+            "http://192.168.1.10:3000/".to_string(),
+            "http://10.0.0.5:3000/".to_string(),
+        ];
+        let rendered = fmt_ready_multi("http", 3000, &network_urls);
+        let plain = strip_ansi(&rendered);
+
+        assert!(plain.contains("→ ready\n"), "header missing: {plain:?}");
+        assert!(
+            plain.contains("  Local:    http://localhost:3000/\n"),
+            "local URL missing: {plain:?}"
+        );
+        assert!(
+            plain.contains("  Network:  http://192.168.1.10:3000/\n"),
+            "first network URL missing: {plain:?}"
+        );
+        assert!(
+            plain.contains("            http://10.0.0.5:3000/\n"),
+            "second network URL (continuation indent) missing: {plain:?}"
+        );
+
+        owo_colors::unset_override();
+    }
+
+    /// When network_urls is empty, the banner should still render gracefully.
+    #[test]
+    fn fmt_ready_multi_handles_no_network_interfaces() {
+        owo_colors::set_override(false);
+        let rendered = fmt_ready_multi("http", 8080, &[]);
+        let plain = strip_ansi(&rendered);
+
+        assert!(plain.contains("→ ready\n"), "header missing: {plain:?}");
+        assert!(
+            plain.contains("  Local:    http://localhost:8080/\n"),
+            "local URL missing: {plain:?}"
+        );
+        assert!(
+            plain.contains("  Network:  (none)\n"),
+            "none placeholder missing: {plain:?}"
+        );
+
+        owo_colors::unset_override();
+    }
+
+    /// NO_COLOR suppression: owo-colors override=false means no ANSI in output.
+    #[test]
+    fn fmt_ready_multi_no_color_suppresses_ansi() {
+        owo_colors::set_override(false);
+        let network_urls = vec!["http://192.168.1.1:3000/".to_string()];
+        let rendered = fmt_ready_multi("http", 3000, &network_urls);
+        assert!(
+            !rendered.contains('\u{1b}'),
+            "expected no ANSI when colour override is off: {rendered:?}"
+        );
+        owo_colors::unset_override();
+    }
+
+    /// With colour override on, ANSI escapes must be present.
+    #[test]
+    fn fmt_ready_multi_with_color_emits_ansi() {
+        owo_colors::set_override(true);
+        let network_urls = vec!["http://192.168.1.1:3000/".to_string()];
+        let rendered = fmt_ready_multi("http", 3000, &network_urls);
+        assert!(
+            rendered.contains('\u{1b}'),
+            "expected ANSI when colour override is on: {rendered:?}"
+        );
+        owo_colors::unset_override();
     }
 
     #[test]

--- a/crates/zfb/tests/content_snapshot_no_deferred.rs
+++ b/crates/zfb/tests/content_snapshot_no_deferred.rs
@@ -1,0 +1,142 @@
+//! Regression test for issue #495 — content snapshot is built even when there
+//! are no deferred dynamic routes.
+//!
+//! ## What this tests
+//!
+//! A project shaped as "static homepage lists a collection via `getStaticProps`
+//! + `getCollection`, but has NO dynamic `[slug].tsx` page" used to get empty
+//! `getCollection(...)` results in the production build. The bug was that
+//! `build.rs` only called `build_content_snapshot_json` when
+//! `!still_deferred.is_empty()`, so a project with no deferred `paths()` routes
+//! received a `None` snapshot and `getCollection` silently returned `[]`.
+//!
+//! ## Fixture
+//!
+//! `tests/fixtures/collection-static-getStaticProps/` contains:
+//! - `zfb.config.json` with one `posts` collection
+//! - `content/posts/hello.md` — one post with frontmatter `title: "Hello World"`
+//! - `pages/index.tsx` — calls `getCollection("posts")` inside `getStaticProps`,
+//!   renders `post-count:<N>` and the post title; no `[slug].tsx` page
+//!
+//! ## Assertion
+//!
+//! After `zfb build`, `dist/index.html` must contain `post-count:1` and
+//! "Hello World". On the old code (gate present), the snapshot was skipped and
+//! the output contained `post-count:0`.
+//!
+//! ## Skip behaviour
+//!
+//! The test requires the embedded esbuild and V8 runtime. These are present in
+//! the default feature set (`embed_v8` is in `[features] default`). The test
+//! guards against a missing binary via the same skip pattern used elsewhere —
+//! it checks for a non-success exit and a recognisable error message, and skips
+//! gracefully with `eprintln!` rather than panicking.
+
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("collection-static-getStaticProps")
+}
+
+fn zfb_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_zfb"))
+}
+
+/// Run `zfb build` against the fixture in a fresh tempdir copy so parallel
+/// test runs don't stomp on each other's `dist/` outputs.
+#[test]
+fn getstaticprops_collection_appears_in_rendered_html() {
+    // Copy the fixture into a tempdir so multiple test runs stay isolated.
+    let tmp = tempfile::tempdir().expect("create tempdir for fixture copy");
+    let root = tmp.path();
+
+    let fixture = fixture_dir();
+    copy_dir(&fixture, root).expect("copy fixture into tempdir");
+
+    // Run `zfb build` against the copy.
+    let output = Command::new(zfb_binary())
+        .arg("build")
+        .current_dir(root)
+        .output()
+        .expect("spawn zfb binary");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}{stderr}");
+
+    // Skip gracefully when the embedded runtime is unavailable (e.g. build
+    // was done without the embed_v8 feature, or in a stripped CI image).
+    if !output.status.success() {
+        if combined.contains("embed_v8") || combined.contains("no esbuild") {
+            eprintln!(
+                "[content_snapshot_no_deferred] zfb build exited non-zero with \
+                 a known-skip indicator; skipping test.\n\
+                 stdout: {stdout}\nstderr: {stderr}"
+            );
+            return;
+        }
+        panic!(
+            "zfb build failed unexpectedly for collection-static-getStaticProps fixture.\n\
+             status: {:?}\nstdout: {stdout}\nstderr: {stderr}",
+            output.status,
+        );
+    }
+
+    // Read the rendered homepage.
+    let index_html = root.join("dist").join("index.html");
+    assert!(
+        index_html.exists(),
+        "dist/index.html must be written by zfb build; \
+         stdout: {stdout}\nstderr: {stderr}"
+    );
+    let html = fs::read_to_string(&index_html)
+        .expect("read dist/index.html");
+
+    // The load-bearing assertion for issue #495: the content snapshot must
+    // be embedded and getCollection("posts") must see the one fixture post.
+    //
+    // Before the fix (gate present): snapshot was skipped because
+    // `still_deferred.is_empty()` was true, so getCollection returned `[]`
+    // and the rendered HTML contained `post-count:0`.
+    //
+    // After the fix (gate removed): snapshot is always built when collections
+    // are configured, so getCollection returns the real entry and the rendered
+    // HTML contains `post-count:1`.
+    assert!(
+        html.contains("post-count:1"),
+        "rendered dist/index.html must contain 'post-count:1' — \
+         getCollection(\"posts\") must see the fixture's hello.md entry. \
+         This assertion fails on main HEAD (issue #495: gate skips snapshot \
+         when there are no deferred paths()). \
+         Got html:\n{html}"
+    );
+
+    // Belt-and-suspenders: the post title must also appear.
+    assert!(
+        html.contains("Hello World"),
+        "rendered dist/index.html must contain 'Hello World' from the \
+         fixture's hello.md frontmatter title. \
+         Got html:\n{html}"
+    );
+}
+
+/// Recursive directory copy (files only; creates target subdirs as needed).
+fn copy_dir(src: &std::path::Path, dst: &std::path::Path) -> std::io::Result<()> {
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        let dst_path = dst.join(entry.file_name());
+        if ty.is_dir() {
+            copy_dir(&entry.path(), &dst_path)?;
+        } else {
+            fs::copy(entry.path(), dst_path)?;
+        }
+    }
+    Ok(())
+}

--- a/crates/zfb/tests/fixtures/collection-static-getStaticProps/content/posts/hello.md
+++ b/crates/zfb/tests/fixtures/collection-static-getStaticProps/content/posts/hello.md
@@ -1,0 +1,6 @@
+---
+title: Hello World
+date: 2026-01-01
+---
+
+This is the hello world post.

--- a/crates/zfb/tests/fixtures/collection-static-getStaticProps/pages/index.tsx
+++ b/crates/zfb/tests/fixtures/collection-static-getStaticProps/pages/index.tsx
@@ -1,0 +1,35 @@
+type Post = {
+  slug: string;
+  data: { title: string };
+};
+
+export async function getStaticProps() {
+  const { getCollection } = await import("zfb/content");
+  const posts = (await getCollection("posts")) as Post[];
+  return { props: { posts, count: posts.length } };
+}
+
+type Props = {
+  posts: Post[];
+  count: number;
+};
+
+export default function HomePage({ posts, count }: Props) {
+  return (
+    <html lang="en">
+      <head>
+        <title>collection-static-getStaticProps fixture</title>
+      </head>
+      <body>
+        <h1>Posts</h1>
+        {/* Render the count so the test can assert on a concrete number */}
+        <p data-testid="count">post-count:{count}</p>
+        <ul>
+          {posts.map((p) => (
+            <li key={p.slug}>{p.data.title}</li>
+          ))}
+        </ul>
+      </body>
+    </html>
+  );
+}

--- a/crates/zfb/tests/fixtures/collection-static-getStaticProps/zfb.config.json
+++ b/crates/zfb/tests/fixtures/collection-static-getStaticProps/zfb.config.json
@@ -1,0 +1,9 @@
+{
+  "framework": "preact",
+  "collections": [
+    {
+      "name": "posts",
+      "path": "content/posts"
+    }
+  ]
+}


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/496

---

## Summary

Implements the three Wave-1 fixes under epic #496 — three independent open issues, planned via `/big-plan`, executed via `/x-wt-teams` (subagents path, sonnet per topic), and merged sequentially into the base branch:

- **#497 (closes #495)** — `crates/zfb/src/commands/build.rs` always builds the content snapshot when collections are configured. Drops the `!still_deferred.is_empty()` gate so collection + `getStaticProps` sites with no dynamic `paths()` page get real `getCollection(...)` data in production builds. Helper `build_content_snapshot_json` already returns `None` when `config.collections.is_empty()`, so projects without collections still pay nothing.
- **#498 (closes #494)** — `zfb dev` wires a `CssRunner` and injects the styles `<link>` on every served HTML response. Mirrors the existing islands wiring end-to-end: new `CssBundleUrl` type alias + `css_bundle_url` field on `ServeOpts` and `AppState`, `current_css_bundle_url()` helper, dev-only gate, eager initial bundle at boot, runner closure rewired into the orchestrator's `run_css` slot. No `livereload.rs` changes needed — the existing `outcome.css_changed → ReloadEvent::Css` SSE channel flows automatically once `run_css` is wired.
- **#499 (closes #487)** — `zfb dev` ready banner shows Local + Network URLs when the resolved host is unspecified (`0.0.0.0` / `::`). Vite-style multi-line shape with `Local: http://localhost:PORT/` and one or more `Network:` URLs for non-loopback IPv4 interfaces. Adds the `local-ip-address` crate. Specific hosts (`localhost`, `127.0.0.1`, etc.) keep the existing single-line banner unchanged. `zfb preview` is intentionally unchanged (hardcoded to `Ipv4Addr::LOCALHOST` today, no `--host` flag).

## Changes

### #497 — build content snapshot for collection-only projects

- `crates/zfb/src/commands/build.rs` — replaced the `if !still_deferred.is_empty()` block at the previous content-snapshot gate with an unconditional `build_content_snapshot_json(project_root, config)` call. Updated the surrounding comment to capture the gate-removal rationale.
- `crates/zfb/tests/fixtures/collection-static-getStaticProps/` — new regression fixture: `zfb.config.json` with a single `posts` collection, `content/posts/hello.md`, and `pages/index.tsx` calling `getStaticProps → getCollection("posts")`. No dynamic `[slug].tsx` page (this is the trigger condition).
- `crates/zfb/tests/content_snapshot_no_deferred.rs` — new integration test that drives `zfb build` against the fixture, parses `dist/index.html`, and asserts real collection entries appear. Fails on `main` HEAD, passes on this branch. A second focused unit test exercises the empty-collections cost guard (verifies `build_content_snapshot_json` short-circuits to `None` when `config.collections.is_empty()`, so the no-collections cost claim is actively exercised, not just stated).

### #498 — wire dev-mode `CssRunner` + head injection

- `crates/zfb-server/src/lib.rs` — added `pub type CssBundleUrl = Arc<RwLock<Option<String>>>;` and `pub css_bundle_url: Option<crate::CssBundleUrl>` on `ServeOpts`, mirroring the islands plumbing.
- `crates/zfb-server/src/routes.rs` — added `css_bundle_url` field to `AppState`, `current_css_bundle_url()` helper, threaded the resolved value into every `page_response_bytes` call site, and collapsed the islands + CSS injection into a single `inject_prod_head_assets` call (replacing the islands-only match block). Added 4 new unit tests covering CSS link injection present / absent / combined-with-islands / Preview-mode gate.
- `crates/zfb-server/src/embed.rs` plus 5 `crates/zfb-server/tests/*.rs` — added `css_bundle_url: None` to existing test `AppState` constructions (compile-only fix to absorb the new field).
- `crates/zfb/src/commands/build.rs` — raised `build_default_css_payload` visibility from `fn` to `pub(crate) fn` so the dev command can reuse the same payload builder.
- `crates/zfb/src/commands/dev.rs` — added the shared `Arc<RwLock<Option<String>>>` URL handle, an eager initial CSS bundle at dev boot that writes bytes to `dist/assets/styles.css` and seeds the handle, a `CssRunner` closure for hot-rebuild ticks (re-emits bytes + updates the handle, returns `true` on a fresh emit), and wired `run_css: Some(<runner>)` on `BuildContext` plus `css_bundle_url` on `ServeOpts`. One important asymmetry from islands: the CSS pipeline does not write bytes to disk as a side effect (unlike esbuild for islands), so this implementation explicitly calls `std::fs::write` in both the boot path and the runner closure.

### #499 — multi-line dev ready banner with Local + Network URLs

- `crates/zfb/Cargo.toml` — added `local-ip-address 0.6` for non-loopback IPv4 interface enumeration.
- `crates/zfb/src/output.rs` — added a pure `fmt_ready_multi(scheme, port, network_urls: &[String])` formatter, a `host_is_unspecified(host)` decision helper (strips IPv6 URL brackets before parsing), a `ready_with_interfaces(scheme, host, port)` public wrapper that picks single-line vs multi-line, and a `collect_network_urls(scheme, port)` OS-call helper. The existing `ready(url)` helper is preserved unchanged (preview keeps using it). The pure formatter is independent of OS state so unit tests pass a mock `network_urls` slice and assert the rendered string deterministically.
- `crates/zfb/src/commands/dev.rs` — replaced the single `output::ready(&format!("http://{host}:{port}"))` call with `output::ready_with_interfaces("http", &host, port)`.
- `Cargo.lock` — pulls in `local-ip-address` and 6 small transitive crates (`byteorder`, `getset`, `neli`, `neli-proc-macros`, `proc-macro-error-attr2`, `proc-macro-error2`). No existing-crate version bumps.

## Test plan

Verified mechanically before push, and CI green on the merged base (17/17 checks passed):

- `cargo test -p zfb`, `cargo test -p zfb-server`, and `cargo test -p zfb-build` pass when run per-crate against the merged base.
- New `content_snapshot_no_deferred` integration test passes; verified it fails on `main` HEAD (regression-guard property holds).
- New CSS link-injection unit tests in `crates/zfb-server/src/routes.rs` cover injection present (`css_bundle_url: Some(...)`), injection absent (`None`), combined CSS + islands co-presence in HTML, and the Preview-mode gate (no injection regardless of handle state).
- The clean-state `zfb dev` validation (`rm -rf dist .zfb .zfb-build` in `crates/zfb/templates/basic-blog`, then `zfb dev`) returns HTML containing `<link rel="stylesheet" href="/assets/styles.css">`; `GET /assets/styles.css` returns HTTP 200 with `Content-Type: text/css` and a non-empty body byte-for-byte equal to the dev-side `payload.bytes` (proves freshness, not stale `dist/`).
- New banner-formatting unit tests in `crates/zfb/src/output.rs` are driven by a mock `network_urls` slice — no dependency on the host's real network state. Tests cover the multi-line shape, the single-line fallback for specific hosts, and `NO_COLOR` suppression via `owo_colors::set_override`.

## Process notes

- Planned via `/big-plan -impl -co -gcoc` with both Codex and GitHub Copilot (cheap) reviewing the plan in parallel. Codex surfaced 5 concrete tightenings (all applied) before issue creation. Sonnet verification subagent re-confirmed all source-issue requirements were preserved after one round of `gh issue edit` fixes.
- Executed via `/x-wt-teams -a` (subagents path; per-topic sonnet model assignment from the epic's `[Sub]` issue annotations). Three children worked in parallel git worktrees, committed locally only (per the repo's `pre-push` worktree-push policy), and the manager merged sequentially into `base/recent-3-issue-fixes` before pushing.
- Audit-trail asymmetry: topic-494's child posted a full progress comment on #498 and wrote a child log to `$HOME/cclogs/zfb/`; topic-495's and topic-487's children landed their work in commits cleanly but their progress comments and child logs were thinner (topic-487's was rescued via a manager check-in; topic-495 went straight to merge based on the committed work). Work is identical to what the spec demanded; the asymmetry is in the per-topic paper trail only.

Closes #495, #494, #487 (via the epic's sub-issue chain — sub-issues #497, #498, #499 close as this PR merges).