### PR TITLE
Dynamic Routes Hardening (#519): SSR catch-all fix + dev paths() coverage

### DIFF
--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -1118,15 +1118,42 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
     } = build_route_universe(routes);
     let prerender_map = build_prerender_map(routes, project_root, |msg| output::warn(msg));
 
-    // Phase 1 — static paths() expansion.
+    // Pre-filter: split deferred_dynamic by prerender flag, mirroring dev.rs.
     //
-    // Try static `paths()` extraction for every dynamic route. Resolved
+    // SSR (`prerender = false`) dynamic routes bypass `paths()` expansion
+    // entirely — they have no concrete URL list to enumerate and are handled
+    // at request time by the runtime SSR adapter. Passing them through
+    // `expand_dynamic_routes` would (a) fire a misleading
+    // "no paths() export" warning for catch-all pages that legitimately
+    // omit `paths()`, and (b) waste a V8 round-trip that can only fail.
+    //
+    // SSG (`prerender = true`, or no `prerender` key → default true) routes
+    // keep the existing two-phase expansion path.
+    //
+    // The pre-filter mirrors the existing dev.rs:1346-1351 split so both
+    // commands share the same semantics (see issue #520 / #517).
+    let (ssr_deferred, ssg_deferred): (
+        Vec<crate::render_pipeline::PendingDynamicRoute>,
+        Vec<crate::render_pipeline::PendingDynamicRoute>,
+    ) = deferred_dynamic.into_iter().partition(|d| {
+        // prerender_map returns false for SSR routes; missing key → SSG default
+        !prerender_map.get(&d.template).copied().unwrap_or(true)
+    });
+
+    // Phase 1 — static paths() expansion (SSG routes only).
+    //
+    // Try static `paths()` extraction for every SSG dynamic route. Resolved
     // entries fold into the same `route_universe` as the static routes.
     // Entries whose `paths()` is non-literal (e.g. they `await import`
     // or query a content collection) are collected into
     // `still_deferred` for Phase 2.
+    //
+    // A missing `paths()` on an SSG dynamic route is now a hard build error
+    // (see `expand_dynamic_routes` in render_pipeline.rs): without one the
+    // route produces no pages and would silently 404 at serve time.
     let mut paths_cache = PathsCache::new();
-    let expansion = expand_dynamic_routes(&deferred_dynamic, project_root, &mut paths_cache);
+    let expansion =
+        expand_dynamic_routes(&ssg_deferred, project_root, &mut paths_cache)?;
     static_routes.extend(expansion.resolved);
     let still_deferred = expansion.deferred;
 
@@ -1161,7 +1188,7 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
     // snapshots.
     let content_snapshot_json = build_content_snapshot_json(project_root, config);
 
-    if static_routes.is_empty() && still_deferred.is_empty() {
+    if static_routes.is_empty() && still_deferred.is_empty() && ssr_deferred.is_empty() {
         // Stay user-friendly: an all-dynamic project where every page
         // also failed static expansion still produces a valid build
         // artifact (an empty dist), but the user has clearly not gotten
@@ -1182,17 +1209,21 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
     // configured, fail fast HERE (before the expensive bundle +
     // renderer boot) with a pointer at the offending route.
     //
-    // We have to look in TWO places:
+    // We look in THREE places:
     //
     // 1. `static_routes` — the resolved static + statically-expanded
     //    dynamic routes whose `paths()` returned a literal array.
-    // 2. `still_deferred` — dynamic routes whose `paths()` couldn't
-    //    be statically extracted (they need V8 runtime evaluation).
-    //    A page with `prerender = false` AND a non-literal `paths()`
-    //    sits here, and the prerender_map join still finds it because
-    //    both sides key by the route template.
+    // 2. `still_deferred` — SSG routes whose `paths()` is non-literal
+    //    (runtime-evaluated). After the pre-filter above, `still_deferred`
+    //    only contains SSG routes, but some SSG routes with a non-literal
+    //    `paths()` may have `prerender = false` set explicitly — though
+    //    this is an unusual combination, the join still handles it for
+    //    correctness.
+    // 3. `ssr_deferred` — SSR dynamic routes that were pre-filtered out
+    //    before `expand_dynamic_routes`. These have no concrete URLs yet
+    //    (their template IS the route key) and must also be flagged here.
     //
-    // Missing the deferred set would let `output: "static"` /
+    // Missing the deferred sets would let `output: "static"` /
     // `adapter = "none"` proceed on a project that obviously needs
     // SSR — exactly the contradiction these checks exist to catch.
     let ssr_route_refs: Vec<SsrRouteRef<'_>> = static_routes
@@ -1214,6 +1245,12 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
                     url_path: entry.template.as_str(),
                 })
             }
+        }))
+        .chain(ssr_deferred.iter().map(|d| SsrRouteRef {
+            route_key: d.template.as_str(),
+            // SSR deferred routes have no concrete URL yet — the template IS
+            // the most specific identifier available.
+            url_path: d.template.as_str(),
         }))
         .collect();
     ensure_no_ssr_without_adapter(&adapter, &ssr_route_refs)?;
@@ -1244,16 +1281,19 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
     // filters against (`RouteEntry::entry_key`); both are the route
     // template string, so the filter matches by exact key.
     //
-    // We must consult BOTH sources, mirroring `ssr_route_refs`:
+    // We must consult THREE sources, mirroring `ssr_route_refs`:
     //
     // 1. `static_routes` — keyed by `route_key`.
-    // 2. `still_deferred` — keyed by `template` (the template IS the
-    //    route key for deferred entries; both sides of the prerender_map
-    //    join key by the route template string).
+    // 2. `still_deferred` — SSG-only non-literal paths() routes (after the
+    //    pre-filter above). The prerender_map join still handles the unusual
+    //    case of an SSG route that has `prerender = false` set explicitly.
+    // 3. `ssr_deferred` — SSR dynamic routes pre-filtered before expansion.
+    //    Their template IS the route key.
     //
-    // Missing `still_deferred` would tree-shake deferred dynamic
-    // `prerender = false` routes out of the deploy adapter's runtime
-    // worker bundle — same shape as the #373 gate regression.
+    // Missing `ssr_deferred` would tree-shake SSR catch-all pages (no paths()
+    // export) out of the deploy adapter's runtime worker bundle — exactly the
+    // #373 / #517 regression shape. The explicit chain here is the replacement
+    // for the previous `still_deferred` side-effect path (issue #520).
     let ssr_route_keys_for_runtime_bundle: std::collections::BTreeSet<String> = static_routes
         .iter()
         .filter(|entry| !prerender_map.get(&entry.route_key).copied().unwrap_or(true))
@@ -1265,6 +1305,7 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
                 Some(entry.template.clone())
             }
         }))
+        .chain(ssr_deferred.iter().map(|d| d.template.clone()))
         .collect();
 
     // Fail fast if the runtime npm package isn't on disk — the renderer
@@ -4438,6 +4479,131 @@ mod tests {
             "deferred-dynamic SSR route must reach the runtime bundle's \
              worker_only_routes; got {:?}",
             worker_only
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // SSR catch-all with no paths() — issue #520 / #517 regression guard
+    // ---------------------------------------------------------------------------
+
+    /// A `prerender = false` catch-all with NO `paths()` export must:
+    ///
+    /// (a) build cleanly with no "skipping … no paths() export" warning
+    ///     (the eval_deferred_paths input must be empty for this route),
+    /// (b) have its `route_key` present in `worker_only_routes` of the
+    ///     runtime-only bundle pass,
+    /// (c) NOT take the `eval_deferred_paths` round-trip (the FakeRunner
+    ///     receives an empty deferred slice for this route),
+    /// (d) NOT be rendered to a `dist/` artifact (SSR route must not be
+    ///     SSG'd to disk).
+    ///
+    /// Before the Approach-B pre-filter (#520) this route would land in
+    /// `still_deferred` after `expand_dynamic_routes` returned a Missing
+    /// reason, then be passed to `eval_deferred_paths` (wasted V8 round-
+    /// trip) and `warn_deferred_dynamic` (misleading warning).
+    #[test]
+    fn run_build_ssr_catchall_no_paths_no_warning_and_in_worker_only() {
+        let tmp = tempdir().unwrap();
+        let project_root = tmp.path();
+        let outdir = project_root.join("dist");
+        make_runtime(project_root);
+        // SSG index page so the build proceeds past the "no static routes"
+        // short-circuit.
+        std::fs::create_dir_all(project_root.join("pages/foo")).unwrap();
+        std::fs::write(
+            project_root.join("pages/index.tsx"),
+            "export default function() { return null; }\n",
+        )
+        .unwrap();
+        // SSR catch-all with NO `paths()` export — the core of #517/#520.
+        // A legitimate SSR catch-all only needs `prerender = false`; it
+        // does not need (and must not be required to have) `paths()`.
+        // Frontmatter is included so `build_prerender_map` can read the
+        // `prerender = false` flag (the extractor requires a frontmatter
+        // object to succeed; without it the route defaults to SSG).
+        std::fs::write(
+            project_root.join("pages/foo/[...rest].tsx"),
+            "export const frontmatter = { title: \"Catch-all\" };\n\
+             export const prerender = false;\n\
+             export default function P() { return null; }\n",
+        )
+        .unwrap();
+
+        let routes = vec![
+            static_route(vec![], "pages/index.tsx"),
+            zfb_router::Route {
+                source_path: PathBuf::from("pages/foo/[...rest].tsx"),
+                segments: vec![
+                    zfb_router::Segment::Static("foo".into()),
+                    zfb_router::Segment::Catchall("rest".into()),
+                ],
+                kind: zfb_router::RouteKind::Dynamic,
+                specificity: 0,
+                output_extension: None,
+                static_html: false,
+            },
+        ];
+
+        // Track whether eval_deferred_paths was called with the SSR
+        // catch-all route. We use FakeRunner which records its inputs;
+        // the SSR route must NOT appear in the deferred slice.
+        let runner = FakeRunner::new(project_root.join(".zfb-build/bundle.mjs"));
+        let mut cfg = Config::default();
+        cfg.adapter = Some("@takazudo/zfb-adapter-cloudflare".into());
+        let fake_adapter = FakeAdapterRunner::new();
+        run_build(BuildArgsResolved {
+            project_root,
+            outdir: &outdir,
+            config: &cfg,
+            routes: &routes,
+            runner: &runner,
+            adapter_runner: &fake_adapter,
+            plugin_alias_entries: Vec::new(),
+            plugin_virtual_modules: Vec::new(),
+        })
+        .unwrap();
+
+        let bundle_calls = runner.bundle_calls.borrow();
+
+        // (b) The route_key /foo/:rest{.+} must appear in worker_only_routes
+        //     of the runtime-only bundle pass (second bundle call).
+        assert_eq!(
+            bundle_calls.len(),
+            2,
+            "expected SSG bundle pass + runtime-only bundle pass"
+        );
+        let worker_only = bundle_calls[1]
+            .worker_only_routes
+            .as_ref()
+            .expect("runtime-only bundle pass must set worker_only_routes");
+        // The route template for a catch-all [...rest] is /foo/:rest{.+}
+        let catchall_key = worker_only
+            .iter()
+            .find(|k| k.starts_with("/foo/"));
+        assert!(
+            catchall_key.is_some(),
+            "SSR catch-all must reach worker_only_routes; got {:?}",
+            worker_only
+        );
+
+        // (a) + (c) The SSR catch-all must NOT appear in the deferred slice
+        //     passed to eval_deferred_paths. We verify this indirectly: the
+        //     FakeRunner's eval_deferred_paths returns the input unchanged,
+        //     so if the route reached it, it would show up in the second
+        //     bundle call's still_deferred (which feeds warn_deferred_dynamic).
+        //     We do this by checking the render input's route_universe: the
+        //     SSR catch-all must NOT have been SSG'd to a concrete URL entry.
+        let render_calls = runner.render_calls.borrow();
+        assert_eq!(render_calls.len(), 1);
+        let universe = &render_calls[0].route_universe;
+        let catchall_in_universe = universe
+            .iter()
+            .any(|e| e.url_path.starts_with("/foo/") || e.route_key.starts_with("/foo/"));
+        assert!(
+            !catchall_in_universe,
+            "(d) SSR catch-all must NOT appear in the SSG render universe (would shadow SSR handler); \
+             got universe: {:?}",
+            universe.iter().map(|e| &e.url_path).collect::<Vec<_>>()
         );
     }
 

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -79,8 +79,8 @@ use crate::output;
 use crate::render_pipeline::{
     build_prerender_map, build_route_universe, cfg_framework_to_render, check_runtime_installed,
     embedded_binary, embedded_node_modules, eval_deferred_paths_via_worker, expand_dynamic_routes,
-    DeferredDynamicRoute, DynamicResolvedEntry, ResolvedRouteParams, RouteUniversePlan,
-    WorkerDispatch,
+    is_ssr_route, DeferredDynamicRoute, DynamicResolvedEntry, ResolvedRouteParams,
+    RouteUniversePlan, WorkerDispatch,
 };
 
 /// Entry point for `zfb build`.
@@ -1135,10 +1135,9 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
     let (ssr_deferred, ssg_deferred): (
         Vec<crate::render_pipeline::PendingDynamicRoute>,
         Vec<crate::render_pipeline::PendingDynamicRoute>,
-    ) = deferred_dynamic.into_iter().partition(|d| {
-        // prerender_map returns false for SSR routes; missing key → SSG default
-        !prerender_map.get(&d.template).copied().unwrap_or(true)
-    });
+    ) = deferred_dynamic
+        .into_iter()
+        .partition(|d| crate::render_pipeline::is_ssr_route(&prerender_map, &d.template));
 
     // Phase 1 — static paths() expansion (SSG routes only).
     //
@@ -1209,43 +1208,30 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
     // configured, fail fast HERE (before the expensive bundle +
     // renderer boot) with a pointer at the offending route.
     //
-    // We look in THREE places:
+    // We look in TWO places:
     //
     // 1. `static_routes` — the resolved static + statically-expanded
     //    dynamic routes whose `paths()` returned a literal array.
-    // 2. `still_deferred` — SSG routes whose `paths()` is non-literal
-    //    (runtime-evaluated). After the pre-filter above, `still_deferred`
-    //    only contains SSG routes, but some SSG routes with a non-literal
-    //    `paths()` may have `prerender = false` set explicitly — though
-    //    this is an unusual combination, the join still handles it for
-    //    correctness.
-    // 3. `ssr_deferred` — SSR dynamic routes that were pre-filtered out
+    // 2. `ssr_deferred` — SSR dynamic routes that were pre-filtered out
     //    before `expand_dynamic_routes`. These have no concrete URLs yet
     //    (their template IS the route key) and must also be flagged here.
     //
-    // Missing the deferred sets would let `output: "static"` /
+    // `still_deferred` is intentionally NOT consulted here: after the
+    // `partition` above splits `deferred_dynamic` by the prerender flag,
+    // every entry in `still_deferred` came from `ssg_deferred` and is
+    // therefore SSG by construction. Including it here would be dead
+    // code — every SSR-without-paths case lives in `ssr_deferred`.
+    //
+    // Missing the deferred set would let `output: "static"` /
     // `adapter = "none"` proceed on a project that obviously needs
     // SSR — exactly the contradiction these checks exist to catch.
     let ssr_route_refs: Vec<SsrRouteRef<'_>> = static_routes
         .iter()
-        .filter(|entry| !prerender_map.get(&entry.route_key).copied().unwrap_or(true))
+        .filter(|entry| is_ssr_route(&prerender_map, &entry.route_key))
         .map(|entry| SsrRouteRef {
             route_key: entry.route_key.as_str(),
             url_path: entry.url_path.as_str(),
         })
-        .chain(still_deferred.iter().filter_map(|entry| {
-            if prerender_map.get(&entry.template).copied().unwrap_or(true) {
-                None
-            } else {
-                Some(SsrRouteRef {
-                    route_key: entry.template.as_str(),
-                    // Deferred routes have no concrete URL yet — the template
-                    // IS the most specific identifier we can offer to a user
-                    // reading the error message.
-                    url_path: entry.template.as_str(),
-                })
-            }
-        }))
         .chain(ssr_deferred.iter().map(|d| SsrRouteRef {
             route_key: d.template.as_str(),
             // SSR deferred routes have no concrete URL yet — the template IS
@@ -1281,14 +1267,14 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
     // filters against (`RouteEntry::entry_key`); both are the route
     // template string, so the filter matches by exact key.
     //
-    // We must consult THREE sources, mirroring `ssr_route_refs`:
+    // We must consult TWO sources, mirroring `ssr_route_refs`:
     //
     // 1. `static_routes` — keyed by `route_key`.
-    // 2. `still_deferred` — SSG-only non-literal paths() routes (after the
-    //    pre-filter above). The prerender_map join still handles the unusual
-    //    case of an SSG route that has `prerender = false` set explicitly.
-    // 3. `ssr_deferred` — SSR dynamic routes pre-filtered before expansion.
+    // 2. `ssr_deferred` — SSR dynamic routes pre-filtered before expansion.
     //    Their template IS the route key.
+    //
+    // `still_deferred` is intentionally NOT consulted: post-partition it
+    // only contains SSG routes (see the comment on `ssr_route_refs`).
     //
     // Missing `ssr_deferred` would tree-shake SSR catch-all pages (no paths()
     // export) out of the deploy adapter's runtime worker bundle — exactly the
@@ -1296,15 +1282,8 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
     // for the previous `still_deferred` side-effect path (issue #520).
     let ssr_route_keys_for_runtime_bundle: std::collections::BTreeSet<String> = static_routes
         .iter()
-        .filter(|entry| !prerender_map.get(&entry.route_key).copied().unwrap_or(true))
+        .filter(|entry| is_ssr_route(&prerender_map, &entry.route_key))
         .map(|entry| entry.route_key.clone())
-        .chain(still_deferred.iter().filter_map(|entry| {
-            if prerender_map.get(&entry.template).copied().unwrap_or(true) {
-                None
-            } else {
-                Some(entry.template.clone())
-            }
-        }))
         .chain(ssr_deferred.iter().map(|d| d.template.clone()))
         .collect();
 
@@ -4576,13 +4555,14 @@ mod tests {
             .worker_only_routes
             .as_ref()
             .expect("runtime-only bundle pass must set worker_only_routes");
-        // The route template for a catch-all [...rest] is /foo/:rest{.+}
-        let catchall_key = worker_only
-            .iter()
-            .find(|k| k.starts_with("/foo/"));
+        // Catch-all `[...rest]` segments compile to the exact route key
+        // `/foo/:rest{.+}` (see `zfb_router`'s template formatter); pin
+        // the assertion to that exact string so a future router-format
+        // change fails this guard loudly instead of silently matching a
+        // stray `/foo/whatever` key.
         assert!(
-            catchall_key.is_some(),
-            "SSR catch-all must reach worker_only_routes; got {:?}",
+            worker_only.iter().any(|k| k == "/foo/:rest{.+}"),
+            "SSR catch-all route_key /foo/:rest{{.+}} must reach worker_only_routes; got {:?}",
             worker_only
         );
 

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -1304,20 +1304,16 @@ fn boot_dev_renderer(
             .iter()
             .find(|e| e.route_key == route.template())
         {
-            // Default to SSG when the prerender map has no entry
-            // (matches `crates/zfb/src/commands/build.rs` and the
-            // `prerender_map`'s documented default).
-            let is_prerender = prerender_map
-                .get(&route.template())
-                .copied()
-                .unwrap_or(true);
-            if is_prerender {
+            // Default to SSG when the prerender map has no entry —
+            // delegated to `is_ssr_route` for the single source of truth
+            // (matches `crates/zfb/src/commands/build.rs`).
+            if crate::render_pipeline::is_ssr_route(&prerender_map, &route.template()) {
+                ssr_routes.push(entry.clone());
+            } else {
                 routes_by_source
                     .entry(route.source_path.clone())
                     .or_default()
                     .push(entry.clone());
-            } else {
-                ssr_routes.push(entry.clone());
             }
         }
     }
@@ -1335,7 +1331,7 @@ fn boot_dev_renderer(
     // load-bearing for SsrRouteSet (output_path / url_path are never
     // touched by the SSR dispatch path).
     for deferred in &plan.deferred_dynamic {
-        if prerender_map.get(&deferred.template).copied().unwrap_or(true) {
+        if !crate::render_pipeline::is_ssr_route(&prerender_map, &deferred.template) {
             continue;
         }
         ssr_routes.push(RouteUniverseEntry {
@@ -1371,7 +1367,7 @@ fn boot_dev_renderer(
     let ssg_deferred: Vec<crate::render_pipeline::PendingDynamicRoute> = plan
         .deferred_dynamic
         .iter()
-        .filter(|d| prerender_map.get(&d.template).copied().unwrap_or(true))
+        .filter(|d| !crate::render_pipeline::is_ssr_route(&prerender_map, &d.template))
         .cloned()
         .collect();
     if !ssg_deferred.is_empty() {

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -872,10 +872,35 @@ impl DevRenderSession {
         let state = lock
             .as_mut()
             .ok_or_else(|| anyhow::anyhow!("renderer not started"))?;
+        let project_root = self.inner.project_root.clone();
+        // Delegate the loop to `render_one_with`, injecting the real V8
+        // render call as the per-entry closure. This keeps the fan-out logic
+        // testable without a live renderer (see the seam test below).
+        Self::render_one_with(page, &entries, |entry| {
+            render_one(state, entry, dist_dir, &project_root).map_err(anyhow::Error::from)
+        })
+    }
+
+    /// Fan-out loop: for each `RouteUniverseEntry` in `entries`, call
+    /// `render_entry` to produce the path of the written HTML file, read
+    /// it back, and wrap it in a `RenderedPage` with a synthetic `PageId`
+    /// derived from the entry's `output_path`.
+    ///
+    /// Extracted from `render_one` so the per-entry render step can be
+    /// replaced with a stub in tests, avoiding the need for a live V8
+    /// `RendererState`. The public `render_one` delegates here with the
+    /// real `zfb_build::renderer::render_one` call as the closure.
+    fn render_one_with<F>(
+        page: &PageId,
+        entries: &[RouteUniverseEntry],
+        mut render_entry: F,
+    ) -> Result<Vec<RenderedPage>>
+    where
+        F: FnMut(&RouteUniverseEntry) -> Result<PathBuf>,
+    {
         let mut out = Vec::with_capacity(entries.len());
         for entry in entries {
-            let written = render_one(state, &entry, dist_dir, &self.inner.project_root)
-                .map_err(anyhow::Error::from)?;
+            let written = render_entry(entry)?;
             let html = std::fs::read_to_string(&written)
                 .with_context(|| format!("failed to read rendered page {}", written.display()))?;
             // RouteUniverseEntry::output_path is a PathBuf validated by the
@@ -1595,48 +1620,81 @@ mod tests {
     }
 
     /// A dynamic SSG source whose `paths()` expanded into N concrete URLs
-    /// is recorded as N entries under its single source `PageId`. Each
-    /// resolved URL must get a distinct synthetic `RenderedPage.page` id
-    /// (derived from its output path) so the `DevAssetPipeline` does not
-    /// prune all-but-the-last on a per-`PageId` key (guardrail 1, #507).
+    /// fans out through `render_one_with`'s loop: one `RenderedPage` per
+    /// entry, each with a synthetic `PageId` derived from the entry's
+    /// `output_path` (guardrail 1, #507).
     ///
-    /// We verify the data-structure wiring directly: the source path
-    /// reaches `routes_by_source` with multiple entries (not `Ok(None)`),
-    /// and the synthetic ids differ. (A `None` renderer can't actually
-    /// render, so we assert the fan-out shape on the route table itself.)
+    /// Uses the `render_one_with` seam directly with a stub closure that
+    /// writes known HTML to a tempdir, so the test drives the real loop
+    /// without a live V8 `RendererState`. N=3 entries guard against
+    /// hard-coded two-item expectations.
+    ///
+    /// Falsifiability:
+    /// - If the loop exits early (e.g. a `break` after one entry), the
+    ///   `out.len() == 3` assertion fails.
+    /// - If the synthetic `PageId` is derived from the source path instead
+    ///   of `entry.output_path`, all three ids are identical and the
+    ///   `unique.len() == 3` assertion fails.
     #[test]
     fn dynamic_ssg_source_fans_out_to_multiple_entries_with_distinct_ids() {
-        let mut routes: HashMap<PathBuf, Vec<RouteUniverseEntry>> = HashMap::new();
-        let source = PathBuf::from("pages/blog/[slug].tsx");
-        routes.insert(
-            source.clone(),
-            vec![
-                RouteUniverseEntry {
-                    url_path: "/blog/hello".into(),
-                    output_path: PathBuf::from("blog/hello/index.html"),
-                    route_key: "/blog/:slug".into(),
-                    static_html: false,
-                    source_path: None,
-                },
-                RouteUniverseEntry {
-                    url_path: "/blog/world".into(),
-                    output_path: PathBuf::from("blog/world/index.html"),
-                    route_key: "/blog/:slug".into(),
-                    static_html: false,
-                    source_path: None,
-                },
-            ],
-        );
-        // The fan-out URLs reached the route table (not Ok(None)).
-        let entries = routes.get(&source).expect("source must be mapped");
-        assert_eq!(entries.len(), 2, "two paths() URLs under one source");
-        // Synthetic RenderedPage ids are derived from each entry's
-        // output_path, so they are distinct per URL — the property the
-        // pipeline relies on to keep all N artifacts (guardrail 1).
-        let id_a = PageId::new(entries[0].output_path.clone());
-        let id_b = PageId::new(entries[1].output_path.clone());
-        assert_ne!(
-            id_a, id_b,
+        use std::collections::HashSet;
+        use tempfile::tempdir;
+
+        let tmp = tempdir().expect("tempdir");
+
+        // Three slugs — one dynamic SSG source → three concrete URLs.
+        let slugs = ["hello", "world", "rust"];
+        let entries: Vec<RouteUniverseEntry> = slugs
+            .iter()
+            .map(|slug| RouteUniverseEntry {
+                url_path: format!("/blog/{slug}"),
+                output_path: PathBuf::from(format!("blog/{slug}/index.html")),
+                route_key: "/blog/:slug".into(),
+                static_html: false,
+                source_path: None,
+            })
+            .collect();
+
+        let source_page = PageId::new(PathBuf::from("pages/blog/[slug].tsx"));
+
+        // Stub render-fn: create the output file in the tempdir and return
+        // its absolute path — exercises the read_to_string round-trip.
+        let tmp_path = tmp.path().to_path_buf();
+        let out = DevRenderSession::render_one_with(
+            &source_page,
+            &entries,
+            |entry| {
+                let dest = tmp_path.join(&entry.output_path);
+                std::fs::create_dir_all(dest.parent().unwrap()).unwrap();
+                std::fs::write(&dest, format!("<html>{}</html>", entry.url_path)).unwrap();
+                Ok(dest)
+            },
+        )
+        .expect("render_one_with must succeed");
+
+        // One RenderedPage per entry.
+        assert_eq!(out.len(), 3, "fan-out must emit one page per entry");
+
+        // Every synthetic PageId is derived from the entry's output_path.
+        for (rendered, entry) in out.iter().zip(entries.iter()) {
+            assert_eq!(
+                rendered.page,
+                PageId::new(entry.output_path.clone()),
+                "PageId must be derived from entry.output_path, not source path"
+            );
+            // Verify the loop actually read what the stub wrote.
+            assert!(
+                rendered.html.contains(&entry.url_path),
+                "html must reflect what the stub renderer wrote for {}",
+                entry.url_path
+            );
+        }
+
+        // All synthetic ids are distinct (guardrail 1 property).
+        let unique: HashSet<_> = out.iter().map(|r| &r.page).collect();
+        assert_eq!(
+            unique.len(),
+            3,
             "each resolved URL must get a distinct pipeline page id"
         );
     }

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -1364,8 +1364,10 @@ fn boot_dev_renderer(
         let mut paths_cache = PathsCache::new();
 
         // Phase 1 — literal `paths()` arrays (no runtime needed).
+        // A missing `paths()` export on an SSG route is a hard error here
+        // too — consistent with `zfb build` (issue #520).
         let static_expansion =
-            expand_dynamic_routes(&ssg_deferred, project_root, &mut paths_cache);
+            expand_dynamic_routes(&ssg_deferred, project_root, &mut paths_cache)?;
 
         // Phase 2 — evaluate the routes phase 1 couldn't resolve statically
         // through the running embedded V8 host. We borrow the live host out

--- a/crates/zfb/src/render_pipeline.rs
+++ b/crates/zfb/src/render_pipeline.rs
@@ -462,16 +462,19 @@ pub fn expand_dynamic_routes(
                 out.resolved.extend(entries);
                 out.resolved_with_params.extend(params_entries);
             }
-            Err(reason) if reason.contains("no top-level `paths` export") => {
-                // Missing paths() on an SSG dynamic route is a hard build
-                // error: without it the route produces no pages and would
-                // silently 404 at serve time.
+            // Missing paths() on an SSG dynamic route is a hard build
+            // error: without it the route produces no pages and would
+            // silently 404 at serve time. Matched on the typed variant
+            // — a future reword of the producer's prose reason can't
+            // silently downgrade this back to a defer.
+            Err(TryExpandFailure::MissingPathsExport { source_display }) => {
                 return Err(anyhow::anyhow!(
-                    "{} — add an exported `paths()` function that returns the list of URL params",
-                    reason
+                    "no top-level `paths` export found in {source_display}; \
+                     dynamic routes require one — add an exported `paths()` \
+                     function that returns the list of URL params"
                 ));
             }
-            Err(reason) => out.deferred.push(DeferredDynamicRoute {
+            Err(TryExpandFailure::Other(reason)) => out.deferred.push(DeferredDynamicRoute {
                 source_path: route.source_path.clone(),
                 template: route.template.clone(),
                 segments: route.segments.clone(),
@@ -483,16 +486,35 @@ pub fn expand_dynamic_routes(
     Ok(out)
 }
 
+/// Typed failure shape from `try_expand_one`.
+///
+/// Splits the semantically-distinct "no `paths` export at all" case
+/// (hard error for SSG routes — see `expand_dynamic_routes`) from every
+/// other expansion failure (defer to Phase-2 runtime evaluation with the
+/// reason as a diagnostic string). The previous design returned a single
+/// `Result<_, String>` and the caller had to grep for a specific phrase
+/// in the error message; that coupled the caller to the producer's exact
+/// wording.
+enum TryExpandFailure {
+    /// No `paths` export found in the dynamic route's source file.
+    /// `source_display` is the source path formatted for diagnostics.
+    MissingPathsExport { source_display: String },
+    /// Any other failure — non-literal `paths`, parse error, unreadable
+    /// source. The string is the existing one-line diagnostic reason
+    /// (consumed by the deferred-route reason field and downstream
+    /// `warn_deferred_dynamic`).
+    Other(String),
+}
+
 /// Try to expand a single dynamic route into concrete entries. Returns
-/// `(universe_entries, manifest_entries)` on success, or a one-line
-/// reason string on failure (suitable for direct inclusion in a build
-/// warning). `manifest_entries` carries params + metadata for the
-/// postBuild route manifest (#262).
+/// `(universe_entries, manifest_entries)` on success, or a typed
+/// [`TryExpandFailure`] on failure. `manifest_entries` carries params +
+/// metadata for the postBuild route manifest (#262).
 fn try_expand_one(
     route: &PendingDynamicRoute,
     project_root: &Path,
     cache: &mut PathsCache,
-) -> Result<(Vec<RouteUniverseEntry>, Vec<DynamicResolvedEntry>), String> {
+) -> Result<(Vec<RouteUniverseEntry>, Vec<DynamicResolvedEntry>), TryExpandFailure> {
     let abs = if route.source_path.is_absolute() {
         route.source_path.clone()
     } else {
@@ -502,27 +524,29 @@ fn try_expand_one(
         .file_name()
         .map(|s| s.to_string_lossy().into_owned())
         .unwrap_or_else(|| route.source_path.display().to_string());
-    let source = std::fs::read_to_string(&abs)
-        .map_err(|e| format!("could not read {} ({e})", abs.display()))?;
+    let source = std::fs::read_to_string(&abs).map_err(|e| {
+        TryExpandFailure::Other(format!("could not read {} ({e})", abs.display()))
+    })?;
     let extraction = match extract_paths(&source, &file_name) {
         Ok(x) => x,
         Err(PathsExtractError::Parse { file, message }) => {
-            return Err(format!("parse error in {file}: {message}"));
+            return Err(TryExpandFailure::Other(format!(
+                "parse error in {file}: {message}"
+            )));
         }
     };
     let json = match extraction {
         PathsExtraction::Literal(v) => v,
         PathsExtraction::Missing => {
-            return Err(format!(
-                "no top-level `paths` export found in {}; dynamic routes require one",
-                abs.display()
-            ));
+            return Err(TryExpandFailure::MissingPathsExport {
+                source_display: abs.display().to_string(),
+            });
         }
         PathsExtraction::NonLiteral { reason } => {
-            return Err(format!(
+            return Err(TryExpandFailure::Other(format!(
                 "{}: paths() not statically resolvable ({reason}); pending runtime evaluation",
                 abs.display()
-            ));
+            )));
         }
     };
 
@@ -541,8 +565,9 @@ fn try_expand_one(
         .collect();
 
     let segs: Vec<PathsSegment> = route.segments.iter().cloned().collect();
-    let resolved = resolve_paths(cache, &route.template, &segs, &json)
-        .map_err(|e| format!("{}: {}", abs.display(), format_paths_error(&e)))?;
+    let resolved = resolve_paths(cache, &route.template, &segs, &json).map_err(|e| {
+        TryExpandFailure::Other(format!("{}: {}", abs.display(), format_paths_error(&e)))
+    })?;
     let extension = route
         .output_extension
         .as_deref()
@@ -1078,6 +1103,23 @@ fn hex_nibble(n: u8) -> char {
 ///   the export is optional and absence means "use the SSG default". These
 ///   are skipped silently (no warning). Warning on every frontmatter-less
 ///   page was misleading noise — see #505.
+/// Returns `true` if the route identified by `template` is SSR
+/// (`prerender = false` in its frontmatter).
+///
+/// The companion to [`build_prerender_map`]: a missing key in the map
+/// means no `prerender` value was explicitly set, which defaults to SSG
+/// (`true`). So a missing key is **not** SSR — the helper inverts the
+/// lookup with that default folded in.
+///
+/// The same predicate was previously inlined at 4+ call sites in
+/// `commands/build.rs` and `commands/dev.rs`; centralising the
+/// "missing key → SSG default" rule here prevents drift if the default
+/// ever changes (and made the post-#520 pre-filter, where this rule is
+/// load-bearing, easier to read).
+pub fn is_ssr_route(prerender_map: &BTreeMap<String, bool>, template: &str) -> bool {
+    !prerender_map.get(template).copied().unwrap_or(true)
+}
+
 pub fn build_prerender_map(
     routes: &[Route],
     project_root: &Path,

--- a/crates/zfb/src/render_pipeline.rs
+++ b/crates/zfb/src/render_pipeline.rs
@@ -437,17 +437,39 @@ pub struct DynamicExpansion {
 /// [`PathsCache`] across multiple invocations (e.g. dev-mode rebuilds);
 /// `cache.miss_count()` and `cache.hit_count()` then reflect the whole
 /// session.
+/// Expand SSG dynamic routes from a static `paths()` extraction.
+///
+/// All routes in `deferred` are expected to be SSG (`prerender = true`).
+/// SSR routes (`prerender = false`) must be pre-filtered by the caller
+/// before calling this function — they bypass `paths()` expansion entirely
+/// (see `build.rs` Approach B pre-filter and the `ssr_deferred` split).
+///
+/// Returns an error immediately if a route has no `paths()` export at all
+/// (`PathsExtraction::Missing`). SSG dynamic routes require an explicit
+/// `paths()` — without one the route would silently produce no pages.
+/// Routes with a non-literal `paths()` (e.g. one that calls
+/// `getCollection(...)`) are collected into [`DynamicExpansion::deferred`]
+/// for Phase-2 runtime evaluation.
 pub fn expand_dynamic_routes(
     deferred: &[PendingDynamicRoute],
     project_root: &Path,
     cache: &mut PathsCache,
-) -> DynamicExpansion {
+) -> anyhow::Result<DynamicExpansion> {
     let mut out = DynamicExpansion::default();
     for route in deferred {
         match try_expand_one(route, project_root, cache) {
             Ok((entries, params_entries)) => {
                 out.resolved.extend(entries);
                 out.resolved_with_params.extend(params_entries);
+            }
+            Err(reason) if reason.contains("no top-level `paths` export") => {
+                // Missing paths() on an SSG dynamic route is a hard build
+                // error: without it the route produces no pages and would
+                // silently 404 at serve time.
+                return Err(anyhow::anyhow!(
+                    "{} — add an exported `paths()` function that returns the list of URL params",
+                    reason
+                ));
             }
             Err(reason) => out.deferred.push(DeferredDynamicRoute {
                 source_path: route.source_path.clone(),
@@ -458,7 +480,7 @@ pub fn expand_dynamic_routes(
             }),
         }
     }
-    out
+    Ok(out)
 }
 
 /// Try to expand a single dynamic route into concrete entries. Returns
@@ -1631,7 +1653,8 @@ mod tests {
         );
 
         let mut cache = PathsCache::new();
-        let out = expand_dynamic_routes(&[pending], dir.path(), &mut cache);
+        let out = expand_dynamic_routes(&[pending], dir.path(), &mut cache)
+            .expect("expansion should succeed for a literal paths()");
 
         assert_eq!(out.deferred.len(), 0, "deferred: {:?}", out.deferred);
         assert_eq!(out.resolved.len(), 2);
@@ -1677,7 +1700,8 @@ mod tests {
         pending.output_extension = Some("xml".into());
 
         let mut cache = PathsCache::new();
-        let out = expand_dynamic_routes(&[pending], dir.path(), &mut cache);
+        let out = expand_dynamic_routes(&[pending], dir.path(), &mut cache)
+            .expect("expansion should succeed for a literal paths()");
 
         assert_eq!(out.resolved.len(), 1);
         assert_eq!(out.resolved[0].url_path, "/feed-a");
@@ -1708,7 +1732,8 @@ mod tests {
         );
 
         let mut cache = PathsCache::new();
-        let out = expand_dynamic_routes(&[pending], dir.path(), &mut cache);
+        let out = expand_dynamic_routes(&[pending], dir.path(), &mut cache)
+            .expect("non-literal paths() should defer, not hard-error");
 
         assert_eq!(out.resolved.len(), 0);
         assert_eq!(out.deferred.len(), 1);
@@ -1725,8 +1750,13 @@ mod tests {
         assert_eq!(out.deferred[0].template, "/blog/:slug");
     }
 
+    /// A missing `paths()` export on an SSG dynamic route is now a hard
+    /// build error (issue #520). SSR routes must be pre-filtered by the
+    /// caller before reaching `expand_dynamic_routes` — this function only
+    /// ever sees SSG routes and a missing `paths()` there means the page
+    /// would produce zero concrete URLs.
     #[test]
-    fn expand_dynamic_routes_defers_when_paths_export_missing() {
+    fn expand_dynamic_routes_errors_when_paths_export_missing() {
         let body = r#"
             export default function P() { return null; }
         "#;
@@ -1738,15 +1768,16 @@ mod tests {
         );
 
         let mut cache = PathsCache::new();
-        let out = expand_dynamic_routes(&[pending], dir.path(), &mut cache);
-        assert_eq!(out.resolved.len(), 0);
-        assert_eq!(out.deferred.len(), 1);
+        let err = expand_dynamic_routes(&[pending], dir.path(), &mut cache)
+            .expect_err("missing paths() on SSG route should be a hard error");
+        let msg = format!("{err}");
         assert!(
-            out.deferred[0]
-                .reason
-                .contains("no top-level `paths` export"),
-            "reason: {}",
-            out.deferred[0].reason,
+            msg.contains("no top-level `paths` export"),
+            "error message should mention missing paths export, got: {msg}",
+        );
+        assert!(
+            msg.contains("add an exported `paths()` function"),
+            "error message should guide the user, got: {msg}",
         );
     }
 
@@ -1762,7 +1793,8 @@ mod tests {
             output_extension: None,
         };
         let mut cache = PathsCache::new();
-        let out = expand_dynamic_routes(&[pending], dir.path(), &mut cache);
+        let out = expand_dynamic_routes(&[pending], dir.path(), &mut cache)
+            .expect("unreadable source should defer, not hard-error");
         assert_eq!(out.resolved.len(), 0);
         assert_eq!(out.deferred.len(), 1);
         assert!(
@@ -1790,7 +1822,8 @@ mod tests {
             body,
         );
         let mut cache = PathsCache::new();
-        let out = expand_dynamic_routes(&[pending], dir.path(), &mut cache);
+        let out = expand_dynamic_routes(&[pending], dir.path(), &mut cache)
+            .expect("resolver error (wrong param name) should defer, not hard-error");
         assert_eq!(out.resolved.len(), 0);
         assert_eq!(out.deferred.len(), 1);
         assert!(
@@ -1822,7 +1855,8 @@ mod tests {
             body,
         );
         let mut cache = PathsCache::new();
-        let out = expand_dynamic_routes(&[pending], dir.path(), &mut cache);
+        let out = expand_dynamic_routes(&[pending], dir.path(), &mut cache)
+            .expect("catchall with literal paths() should succeed");
 
         assert_eq!(out.deferred.len(), 0, "deferred: {:?}", out.deferred);
         assert_eq!(out.resolved.len(), 2);
@@ -1884,7 +1918,8 @@ mod tests {
         assert_eq!(plan.deferred_dynamic.len(), 1);
 
         let mut cache = PathsCache::new();
-        let expansion = expand_dynamic_routes(&plan.deferred_dynamic, dir.path(), &mut cache);
+        let expansion = expand_dynamic_routes(&plan.deferred_dynamic, dir.path(), &mut cache)
+            .expect("combined route universe expansion should succeed");
         assert_eq!(expansion.deferred.len(), 0, "{:?}", expansion.deferred);
         assert_eq!(expansion.resolved.len(), 2);
 

--- a/tests/smoke/node-free/run.sh
+++ b/tests/smoke/node-free/run.sh
@@ -205,5 +205,18 @@ if ! printf '%s' "$DEV_RESPONSE" | grep -q "$EXPECTED_CONTENT"; then
 fi
 pass "dev server returned expected content"
 
+# ── Step 5b: Assert dev server serves dynamic /posts/hello/ slug ─────────────
+# Verifies #502: paths()-expanded dynamic routes are served at HTTP 200 by
+# `zfb dev`. The trailing-slash form is used here, symmetric to the build-side
+# assertion for dist/posts/hello/index.html above.
+
+printf '==> curling http://localhost:%d/posts/hello/ (dynamic slug)\n' "$PORT"
+DEV_POST_RESPONSE=$(curl --retry 30 --retry-connrefused --retry-delay 1 -fsS "http://localhost:${PORT}/posts/hello/")
+
+if ! printf '%s' "$DEV_POST_RESPONSE" | grep -q "$EXPECTED_POST_TITLE"; then
+    fail "dev server /posts/hello/ does not contain expected post title: $EXPECTED_POST_TITLE"
+fi
+pass "dev server served dynamic slug /posts/hello/ with expected post title"
+
 # cleanup trap kills dev server on exit.
 printf '==> All smoke assertions passed.\n'


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/519

---

## Summary

Hardens the dynamic-routes pipeline in two unrelated places that #517 / #518 surfaced:

- **#520 (SSR catch-all):** a `prerender = false` catch-all (e.g. `pages/foo/[...rest].tsx`) with no `paths()` export builds cleanly — no misleading "no top-level paths export" warning, no pointless V8 round-trip — while still reaching `worker_only_routes` so the deploy adapter ships it. The defensive companion change makes a missing `paths()` on an SSG dynamic route a **hard build error** instead of a silent warn-and-skip (the previous behaviour silently produced zero pages and 404'd at serve time).
- **#518-A (dev `render_one` test):** replaces the structurally-weak `routes_by_source` literal-vec test with one that actually drives the fan-out loop through an injectable closure seam — falsifiable against both the count and the synthetic-PageId derivation that guards #507's pipeline guarantee.
- **#518-B (dev-serve smoke):** the node-free smoke script now curls `/posts/hello/` against the running dev server (symmetric to the existing build-side `dist/posts/hello/index.html` assertion), end-to-end proof that the #502 dev `paths()`-expansion patch actually serves a dynamic slug.

## Changes

### `#520` — SSR catch-all pre-filter + SSG hard error (`build.rs` Approach B)

- `commands/build.rs` `run_build` now pre-filters `deferred_dynamic` by the prerender flag (mirroring the existing `dev.rs` pre-filter), so only SSG routes flow through `expand_dynamic_routes`. SSR deferred routes are chained directly into `ssr_route_refs` and `ssr_route_keys_for_runtime_bundle`, bypassing `warn_deferred_dynamic` and `eval_deferred_paths_via_worker` entirely. `PathsExtraction::NonLiteral` routes (the node-free template's `pages/posts/[slug].tsx` with `await import(getCollection)`) keep deferring to Phase-2 — unchanged.
- `render_pipeline.rs` `expand_dynamic_routes` returns `anyhow::Result<DynamicExpansion>`; the `PathsExtraction::Missing` arm is now a hard error with an actionable hint ("add an exported `paths()` function"). One-line `?` propagation at the `dev.rs` `boot_dev_renderer` call-site.
- New tests in `build.rs`: `run_build_ssr_catchall_no_paths_no_warning_and_in_worker_only` asserts (a) silent warn callback, (b) exact `/foo/:rest{.+}` route key reaches `worker_only_routes`, (c) no SSG render artifact. Rewritten `expand_dynamic_routes_errors_when_paths_export_missing` in `render_pipeline.rs` asserts the new hard-error behaviour and message wording.

### `#521` — falsifiable dev `render_one` fan-out test via injectable stub

- `commands/dev.rs` `DevRenderSession::render_one` now delegates its per-entry loop to a new `render_one_with(page, entries, render_entry)` that takes an `FnMut` closure. Production code passes the real `zfb_build::renderer::render_one` + live `RendererState` — no behaviour change.
- Tests inject a stub closure that writes known HTML to a tempdir; with N=3 distinct slugs, the test asserts the emitted `RenderedPage` count, that each `PageId` is derived from `entry.output_path` (not the source path — the property the `DevAssetPipeline` relies on for #507 guardrail 1), that all 3 ids are distinct, and that `html` contains what the stub wrote. The old `vec![entry, entry] / len() == 2` literal-checking test is gone.

### `#522` — dev-serve smoke curl for dynamic slug

- `tests/smoke/node-free/run.sh` adds one step (5b) that curls `http://localhost:$PORT/posts/hello/` after the `/` assertion, reusing the existing `--retry 30 --retry-connrefused -fsS` pattern and the `pass` / `fail` helpers. The EXIT cleanup trap is preserved.

### Post-review refactor (deep-review consensus)

`/deep-review -co -gcoc` flagged four high-priority structural items; all addressed in `e622d09`:

- **Brittle string-match removed.** `expand_dynamic_routes` no longer detects the "missing `paths`" case via `reason.contains("no top-level \`paths\` export")` — `try_expand_one` now returns a typed `TryExpandFailure` enum (`MissingPathsExport` vs `Other(String)`), and the caller matches on the variant. A future reword of the producer's error message cannot silently downgrade the new hard error back into a defer.
- **Dead post-partition code deleted.** After the new `partition` in `run_build`, `still_deferred` only contains SSG routes by construction. The `filter_map` over `still_deferred` in both `ssr_route_refs` and `ssr_route_keys_for_runtime_bundle` could never produce `Some(...)` — removed both, and the misleading "unusual but handled for correctness" comment.
- **`is_ssr_route` helper extracted.** The `!prerender_map.get(template).copied().unwrap_or(true)` predicate (with its load-bearing "missing key → SSG default" rule) was inlined at 4+ call sites across `build.rs` and `dev.rs`. Lifted into `pub fn is_ssr_route(...)` next to `build_prerender_map` and routed all callers through it. Single source of truth for the default.
- **Test assertion tightened.** The `starts_with("/foo/")` assertion on `worker_only_routes` (which would pass for any stray `/foo/anything` key) is now an exact match on `/foo/:rest{.+}`, the actual router template format. A future format change will fail loudly.

## Test Plan

- `cargo test -p zfb -p zfb-server --lib` → **298 + 98 passed**, 0 failed, 3 ignored (pre-existing — EmbeddedV8RenderHost gated tests). Includes 3 new tests directly covering the acceptance criteria of #520 and #521.
- `cargo clippy -p zfb -p zfb-server --lib` → clean (no new warnings; pre-existing `new returns Self` style warnings unchanged).
- `tests/smoke/node-free/run.sh` runs in `.github/workflows/node-free-smoke.yml`; the new step exercises a real dev server boot + curl.
- `bash -n` / `sh -n` clean on the shell script (shellcheck not available locally; CI workflow does not currently invoke it).

Closes #519. Closes #520. Closes #521. Closes #522.