### PR TITLE
fix(renderer): prepend <!doctype html> to emitted HTML (closes #524)

### DIFF
--- a/crates/zfb-build/src/head_inject.rs
+++ b/crates/zfb-build/src/head_inject.rs
@@ -144,6 +144,42 @@ pub fn inject_prod_head_assets<'a>(html: &'a str, assets: &ProdHeadAssets) -> Co
     Cow::Owned(out)
 }
 
+/// The HTML5 doctype prefix prepended to documents that lack one. The
+/// trailing newline is cosmetic (no browser-visible effect); it keeps the
+/// emitted `<html>` on its own line.
+pub const HTML5_DOCTYPE_PREFIX: &str = "<!doctype html>\n";
+
+/// `true` when `html` is an HTML document that should have
+/// [`HTML5_DOCTYPE_PREFIX`] prepended.
+///
+/// `preact-render-to-string` renders the page's `<html>…</html>` shell
+/// verbatim and (correctly) does not emit a doctype — a doctype is not a
+/// valid JSX node. Without `<!doctype html>` browsers fall back to quirks
+/// mode, which silently changes the box model and CSS the template relies
+/// on (issue #524). The renderer prepends the doctype host-side because it
+/// is the same constant byte string for every route.
+///
+/// Conservative, non-parsing rules (mirroring the rest of this module):
+///
+/// - Leading ASCII whitespace is ignored when sniffing the document start.
+///   A leading UTF-8 BOM is *not* whitespace, so a BOM-prefixed document
+///   does not match `<html` and is left untouched — this deliberately
+///   avoids inserting the doctype ahead of a BOM.
+/// - Returns `false` when the document already starts with `<!doctype`
+///   (case-insensitive), so the prefix is never doubled.
+/// - Returns `true` only when the document starts with `<html`
+///   (case-insensitive). Non-HTML output (`feed.xml`'s `<rss/>`, fragments,
+///   binary payloads) is left untouched, matching the `</head>`-passthrough
+///   contract of [`inject_prod_head_assets`].
+pub fn needs_html5_doctype(html: &str) -> bool {
+    let sniff = html.trim_start();
+    let starts_with_ci = |prefix: &str| {
+        sniff.len() >= prefix.len()
+            && sniff.as_bytes()[..prefix.len()].eq_ignore_ascii_case(prefix.as_bytes())
+    };
+    !starts_with_ci("<!doctype") && starts_with_ci("<html")
+}
+
 /// Build the canonical `<link rel="stylesheet" href="…">` tag form
 /// this module injects. Exposed so callers and tests can compare
 /// against an authoritative byte string.
@@ -376,5 +412,47 @@ mod tests {
             island_module_script_tag(STABLE_ISLANDS_URL),
             "<script type=\"module\" src=\"/assets/islands.js\"></script>"
         );
+    }
+
+    #[test]
+    fn needs_doctype_for_bare_html_document() {
+        // The preact-render-to-string shell: starts with `<html …>`, no doctype.
+        assert!(needs_html5_doctype("<html lang=\"en\"><head></head><body></body></html>"));
+        assert!(needs_html5_doctype("<html><body>x</body></html>"));
+    }
+
+    #[test]
+    fn no_doctype_when_already_present() {
+        // Case-insensitive; never doubles an existing doctype.
+        assert!(!needs_html5_doctype("<!doctype html><html></html>"));
+        assert!(!needs_html5_doctype("<!DOCTYPE HTML><html></html>"));
+        assert!(!needs_html5_doctype("<!Doctype html>\n<html lang=\"en\"></html>"));
+    }
+
+    #[test]
+    fn no_doctype_for_non_html_output() {
+        // feed.xml and other non-`<html>` payloads must round-trip untouched.
+        assert!(!needs_html5_doctype("<rss/>"));
+        assert!(!needs_html5_doctype("<?xml version=\"1.0\"?><feed></feed>"));
+        assert!(!needs_html5_doctype("{\"json\":true}"));
+        assert!(!needs_html5_doctype(""));
+    }
+
+    #[test]
+    fn leading_whitespace_is_ignored_when_sniffing() {
+        assert!(needs_html5_doctype("\n\t  <html></html>"));
+        assert!(!needs_html5_doctype("  <!doctype html><html></html>"));
+    }
+
+    #[test]
+    fn leading_bom_is_left_untouched() {
+        // A BOM is not ASCII whitespace, so a BOM-prefixed doc does not match
+        // `<html` — we never insert a doctype ahead of a BOM.
+        assert!(!needs_html5_doctype("\u{feff}<html></html>"));
+    }
+
+    #[test]
+    fn doctype_prefix_is_the_lowercase_html5_form() {
+        assert_eq!(HTML5_DOCTYPE_PREFIX, "<!doctype html>\n");
     }
 }

--- a/crates/zfb-build/src/lib.rs
+++ b/crates/zfb-build/src/lib.rs
@@ -71,7 +71,8 @@ pub use bundler::{
     OnBrokenLinks, ResolveMarkdownLinksRoute, ResolveMarkdownLinksSpec, RouteEntry,
 };
 pub use head_inject::{
-    css_link_tag, inject_prod_head_assets, island_module_script_tag, ProdHeadAssets,
+    css_link_tag, inject_prod_head_assets, island_module_script_tag, needs_html5_doctype,
+    ProdHeadAssets, HTML5_DOCTYPE_PREFIX,
 };
 pub use orchestrator::{BuildOrchestrator, OrchestratorConfig};
 pub use plugin_registries::{

--- a/crates/zfb-build/src/renderer.rs
+++ b/crates/zfb-build/src/renderer.rs
@@ -913,17 +913,13 @@ fn render_one_inner(
             source: e,
         })?;
         let body = strip_static_html_frontmatter(&raw);
-        // Prepend the HTML5 doctype when the source page omits it (issue
-        // #524). `needs_html5_doctype` is a no-op for pages that already
-        // declare one and for non-`<html>` bodies.
-        let written: std::borrow::Cow<'_, [u8]> = if crate::head_inject::needs_html5_doctype(body) {
-            std::borrow::Cow::Owned(
-                format!("{}{body}", crate::head_inject::HTML5_DOCTYPE_PREFIX).into_bytes(),
-            )
-        } else {
-            std::borrow::Cow::Borrowed(body.as_bytes())
-        };
-        crate::atomic::atomic_write(&dest, &written).map_err(|e| RendererError::Io {
+        // Static-HTML routes are a documented verbatim bypass: the source
+        // body is written as-is (frontmatter stripped) with no
+        // post-processing. We intentionally do NOT inject a doctype here —
+        // a user-authored `.html` page that omits one did so deliberately.
+        // Issue #524 concerns the framework-rendered pages below, not this
+        // bypass.
+        crate::atomic::atomic_write(&dest, body.as_bytes()).map_err(|e| RendererError::Io {
             path: dest.clone(),
             source: std::io::Error::other(format!("{e:#}")),
         })?;
@@ -932,6 +928,17 @@ fn render_one_inner(
 
     let resp = handle.dispatch(&entry.url_path)?;
     let status = resp.status;
+    // Whether this response is HTML — read the media type before the
+    // `;`-delimited parameters (e.g. `text/html; charset=utf-8`). The
+    // framework runtime defaults page responses to `text/html`
+    // (see zfb-runtime's DEFAULT_CONTENT_TYPE), so HTML pages reliably
+    // carry it. Used to gate the doctype prepend below.
+    let is_html_response = resp
+        .content_type
+        .split(';')
+        .next()
+        .map(|m| m.trim().eq_ignore_ascii_case("text/html"))
+        .unwrap_or(false);
     let body = resp.body;
 
     // The URL used in error messages is the rendered path. For HTTP
@@ -959,9 +966,11 @@ fn render_one_inner(
     //    `</head>`. Dev mode (no `prod_head_assets`) and non-HTML output
     //    (no `</head>`) round-trip unchanged.
     // 2. HTML5 doctype prepend (issue #524): runs in BOTH build and dev so
-    //    every served page leaves quirks mode. `needs_html5_doctype` is a
-    //    no-op for non-`<html>` bodies (`feed.xml`) and pages that already
-    //    declare a doctype, so it never doubles.
+    //    every served page leaves quirks mode. Gated on `text/html`
+    //    responses so non-HTML output (`feed.xml`, `text/plain`, etc.) is
+    //    never touched even if its body happens to start with `<html`;
+    //    `needs_html5_doctype` further skips bodies that already declare a
+    //    doctype, so it never doubles.
     let written_bytes: std::borrow::Cow<'_, [u8]> = match std::str::from_utf8(&body) {
         Ok(text) => {
             let injected: std::borrow::Cow<'_, str> = match prod_head_assets {
@@ -970,7 +979,7 @@ fn render_one_inner(
                 }
                 _ => std::borrow::Cow::Borrowed(text),
             };
-            if crate::head_inject::needs_html5_doctype(&injected) {
+            if is_html_response && crate::head_inject::needs_html5_doctype(&injected) {
                 std::borrow::Cow::Owned(
                     format!("{}{injected}", crate::head_inject::HTML5_DOCTYPE_PREFIX).into_bytes(),
                 )

--- a/crates/zfb-build/src/renderer.rs
+++ b/crates/zfb-build/src/renderer.rs
@@ -913,7 +913,17 @@ fn render_one_inner(
             source: e,
         })?;
         let body = strip_static_html_frontmatter(&raw);
-        crate::atomic::atomic_write(&dest, body.as_bytes()).map_err(|e| RendererError::Io {
+        // Prepend the HTML5 doctype when the source page omits it (issue
+        // #524). `needs_html5_doctype` is a no-op for pages that already
+        // declare one and for non-`<html>` bodies.
+        let written: std::borrow::Cow<'_, [u8]> = if crate::head_inject::needs_html5_doctype(body) {
+            std::borrow::Cow::Owned(
+                format!("{}{body}", crate::head_inject::HTML5_DOCTYPE_PREFIX).into_bytes(),
+            )
+        } else {
+            std::borrow::Cow::Borrowed(body.as_bytes())
+        };
+        crate::atomic::atomic_write(&dest, &written).map_err(|e| RendererError::Io {
             path: dest.clone(),
             source: std::io::Error::other(format!("{e:#}")),
         })?;
@@ -939,24 +949,39 @@ fn render_one_inner(
             user_location,
         });
     }
-    // Prod-only head injection. When `prod_head_assets` is `Some` the
-    // helper splices `<link>` / `<script type="module">` tags before
-    // `</head>`. Non-HTML output (no `</head>`) and dev mode (no
-    // `prod_head_assets`) round-trip unchanged.
+    // Two host-side rewrites run here, both UTF-8-only — binary payloads
+    // (rare — favicons via the route universe, etc.) bypass and are
+    // written verbatim. `from_utf8` on bytes the client returned is cheap
+    // because `reqwest` does not validate.
     //
-    // We only attempt the rewrite when the body parses as UTF-8; binary
-    // payloads (rare — favicons via the route universe, etc.) bypass
-    // the rewriter and are written verbatim. `from_utf8` on bytes the
-    // client returned is cheap because `reqwest` does not validate.
-    let written_bytes: std::borrow::Cow<'_, [u8]> = match prod_head_assets {
-        Some(assets) if !assets.is_empty() => match std::str::from_utf8(&body) {
-            Ok(text) => match crate::head_inject::inject_prod_head_assets(text, assets) {
-                std::borrow::Cow::Borrowed(_) => std::borrow::Cow::Borrowed(body.as_ref()),
-                std::borrow::Cow::Owned(s) => std::borrow::Cow::Owned(s.into_bytes()),
-            },
-            Err(_) => std::borrow::Cow::Borrowed(body.as_ref()),
-        },
-        _ => std::borrow::Cow::Borrowed(body.as_ref()),
+    // 1. Prod-only head injection: when `prod_head_assets` is `Some` the
+    //    helper splices `<link>` / `<script type="module">` tags before
+    //    `</head>`. Dev mode (no `prod_head_assets`) and non-HTML output
+    //    (no `</head>`) round-trip unchanged.
+    // 2. HTML5 doctype prepend (issue #524): runs in BOTH build and dev so
+    //    every served page leaves quirks mode. `needs_html5_doctype` is a
+    //    no-op for non-`<html>` bodies (`feed.xml`) and pages that already
+    //    declare a doctype, so it never doubles.
+    let written_bytes: std::borrow::Cow<'_, [u8]> = match std::str::from_utf8(&body) {
+        Ok(text) => {
+            let injected: std::borrow::Cow<'_, str> = match prod_head_assets {
+                Some(assets) if !assets.is_empty() => {
+                    crate::head_inject::inject_prod_head_assets(text, assets)
+                }
+                _ => std::borrow::Cow::Borrowed(text),
+            };
+            if crate::head_inject::needs_html5_doctype(&injected) {
+                std::borrow::Cow::Owned(
+                    format!("{}{injected}", crate::head_inject::HTML5_DOCTYPE_PREFIX).into_bytes(),
+                )
+            } else {
+                match injected {
+                    std::borrow::Cow::Owned(s) => std::borrow::Cow::Owned(s.into_bytes()),
+                    std::borrow::Cow::Borrowed(_) => std::borrow::Cow::Borrowed(body.as_ref()),
+                }
+            }
+        }
+        Err(_) => std::borrow::Cow::Borrowed(body.as_ref()),
     };
     // Atomic write is consistent with both pipelines (dev and prod) and
     // prevents a half-written .html file from being observed if the
@@ -1355,10 +1380,22 @@ mod tests {
         assert_eq!(out.ssg_files_written.len(), 3);
         let index = fs::read_to_string(dist.path().join("index.html")).unwrap();
         assert!(index.contains("Home"));
+        // Issue #524: doctype is prepended even in dev mode (prod_head_assets
+        // is None here), so the `<html>`-rooted page leaves quirks mode.
+        assert!(
+            index.starts_with("<!doctype html>\n<html"),
+            "index.html must start with the doctype: {index:?}"
+        );
         let about = fs::read_to_string(dist.path().join("about/index.html")).unwrap();
         assert!(about.contains("About"));
+        assert!(about.starts_with("<!doctype html>\n<html"));
         let feed = fs::read_to_string(dist.path().join("feed.xml")).unwrap();
         assert!(feed.contains("<rss/>"));
+        // Non-HTML output (`<rss/>`) must NOT be given a doctype.
+        assert!(
+            !feed.contains("<!doctype"),
+            "feed.xml must not be given a doctype: {feed:?}"
+        );
         // Sentinel: zero pages contain the v0 stub string.
         for p in &out.ssg_files_written {
             let body = fs::read_to_string(p).unwrap();
@@ -1521,6 +1558,55 @@ mod tests {
         assert!(script_at < close_at);
         assert!(written.contains("<title>T</title>"));
         assert!(written.contains("<body>x</body>"));
+    }
+
+    #[test]
+    fn render_all_prod_prepends_doctype_when_body_lacks_one() {
+        // Issue #524: a doctype-less `<html>` body in prod mode must get
+        // BOTH the head-asset injection AND the doctype prefix.
+        let raw_html = b"<html lang=\"en\"><head><title>T</title></head><body>x</body></html>";
+        let raw_html_owned = raw_html.to_vec();
+        let dist = tempfile::tempdir().unwrap();
+        let universe = vec![RouteUniverseEntry {
+            url_path: "/".into(),
+            output_path: PathBuf::from("index.html"),
+            route_key: "/".into(),
+            static_html: false,
+            source_path: None,
+        }];
+        let assets = crate::head_inject::ProdHeadAssets {
+            css_url: Some("/assets/styles.css".into()),
+            island_module_urls: vec![],
+        };
+        render_all(RendererInput {
+            bundle_path: PathBuf::from("/dev/null"),
+            sourcemap_path: PathBuf::from("/dev/null"),
+            manifest: dummy_manifest(),
+            dist_dir: dist.path().to_path_buf(),
+            route_universe: universe,
+            prerender_map: BTreeMap::new(),
+            backend: Backend::Stub {
+                handler: Arc::new(move |_| HttpResponseLike {
+                    status: 200,
+                    content_type: "text/html; charset=utf-8".into(),
+                    body: raw_html_owned.clone(),
+                    ..Default::default()
+                }),
+            },
+            request_timeout: None,
+            prod_head_assets: Some(assets),
+            project_root: PathBuf::new(),
+        })
+        .expect("render_all");
+        let written = fs::read_to_string(dist.path().join("index.html")).unwrap();
+        assert!(
+            written.starts_with("<!doctype html>\n<html"),
+            "prod output must start with the doctype: {written:?}"
+        );
+        // The head-asset injection still ran on the same document.
+        assert!(written.contains("<link rel=\"stylesheet\" href=\"/assets/styles.css\">"));
+        // No double doctype.
+        assert_eq!(written.matches("<!doctype").count(), 1);
     }
 
     #[test]


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/524

---

## Summary
HTML emitted by `zfb build`, `zfb dev`, and `zfb preview` was missing the `<!doctype html>` prefix — every document started with `<html lang="en">`, so browsers fell back to **quirks mode** (broken box model / CSS preflight). `preact-render-to-string` renders the page's `<html>…</html>` shell verbatim and correctly does not emit a doctype (it isn't a valid JSX node), so the fix belongs host-side in the renderer.

## Changes
- **`crates/zfb-build/src/head_inject.rs`**: new `needs_html5_doctype(&str) -> bool` + `HTML5_DOCTYPE_PREFIX` const. Conservative, non-parsing sniff: prepend only when the document (after leading ASCII whitespace) starts with `<html` and not already `<!doctype` (both case-insensitive). A leading BOM is left untouched (never inserted ahead of).
- **`crates/zfb-build/src/renderer.rs`**: in `render_one_inner`, prepend the doctype on the rendered-body path, gated on `text/html` responses **and** the body-sniff. Runs in both build (`prod_head_assets = Some`) and dev (`None`) — dev SSG pages are served from the same `render_one` output, and `preview` serves the built `dist/` files, so all three commands are covered by this one seam.
- The `static_html` raw-page route keeps its documented **verbatim** write (no doctype injection) — user-authored `.html` pages are not post-processed.

## Why this seam
`zfb preview` only serves static `dist/` files (no re-render), and `zfb dev` serves SSG pages from the page cache that `render_one` populates — so `render_one_inner` is the single shared point that covers build + dev + preview for the SSG template.

## Test Plan
- New unit tests for `needs_html5_doctype` (bare `<html>`, already-doctyped, non-HTML `<rss/>`/xml/json, leading whitespace, BOM).
- Renderer tests assert: dev-mode (`prod_head_assets=None`) `index.html`/`about` start with `<!doctype html>`; `feed.xml` (`<rss/>`, `application/xml`) is untouched; prod-mode doctype-less body gets BOTH head-asset injection and the doctype, with exactly one `<!doctype`.
- 246 `zfb-build` lib tests pass. CI green (7/7).

## Reviews
- `/codex-review`: 2 P2s — gate on `text/html` (don't mutate non-HTML bodies that start with `<html`); preserve the static-HTML verbatim contract. Both addressed.
- `/gcoc-review`: no issues.

## Follow-up
- #528 (agent-found): the same doctype gap on the SSR paths (dev request-time SSR + Cloudflare adapter `router.ts`) — out of scope here because the `basic-blog` template is SSG-only.