### PR TITLE
Post next.8 Triage — SSR doctype, scaffold version warning, bundler filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ pnpm add -D @takazudo/zfb
 
 `@takazudo/zfb` ships a prebuilt Rust binary per platform via npm optional-deps — no cargo or Rust toolchain required. Because the package declares `engines.node >=22.0.0`, npm-channel users will see a warning if their Node version is older than 22; the binary itself still runs, but the warning is harmless.
 
+> **pnpm 11 note:** pnpm 11's `minimumReleaseAge` may install a previous release of `create-zfb` within ~48h of any new release. If `create-zfb` warns about a stale install at startup, re-run with `pnpm create zfb@latest --config.minimumReleaseAge=0` or `npm create zfb@latest`.
+
 ## Why Rust?
 
 Rust makes the framework itself fast, memory-safe, and distributable as a single binary — see the [architecture doc](./docs/src/content/docs/architecture/why-rust.mdx) (or the [docs site](https://takazudomodular.com/pj/zudo-front-builder/)) for the full rationale.

--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -524,6 +524,11 @@ pub struct BundlerInput {
     /// are unreachable from the entry — esbuild's tree-shaker drops them
     /// and their transitive deps from the final bundle.
     ///
+    /// **The strings in the set MUST be Hono-form** (e.g. `/blog/:slug`,
+    /// `/manuals/:path{.+}`). `RouteEntry::entry_key` is also stored in
+    /// Hono-form (via `bracket_to_hono`), so the filter matches by exact
+    /// string equality for every route shape, including catch-alls (zfb#532).
+    ///
     /// Intended for "runtime-only" bundle passes consumed by deploy
     /// adapters whose dispatch path serves prerendered routes from a
     /// separate static-asset server (e.g. Cloudflare Pages' `ASSETS first,
@@ -696,10 +701,13 @@ pub struct RouteEntry {
     pub route: String,
     /// Source path of the page module, relative to `project_root`.
     pub source_path: PathBuf,
-    /// Key used in the bundle's `routes` object literal. Equal to
-    /// `route` — kept as a separate field so future schemes (e.g. a
-    /// derived symbol identifier) can change without breaking the
-    /// route-string contract.
+    /// Hono-form filter key used in the bundle's `routes` object literal
+    /// and matched against `BundlerInput::worker_only_routes`. Equal to
+    /// `bracket_to_hono(&route)` — bracket syntax (`/blog/[slug]`) is
+    /// normalised to Hono syntax (`/blog/:slug`) so the
+    /// `filter.contains(&r.entry_key)` check matches `worker_only_routes`
+    /// (which is also Hono-form). Kept as a separate field so the filter
+    /// contract can evolve independently of `route`.
     pub entry_key: String,
     /// When `true`, this route was produced from a `.html` source file.
     /// It is recorded in the manifest for plugin consumers but is NOT
@@ -1171,6 +1179,10 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
     let entry_content_imports_for_write: &[ContentImport];
     let entry_snapshot_for_write: Option<&str>;
     if let Some(filter) = input.worker_only_routes.as_ref() {
+        // `entry_key` is Hono-form (`/blog/:slug{.+}`); `worker_only_routes`
+        // is also Hono-form (populated from `route.template()`). The
+        // string-equality check therefore matches correctly for every route
+        // shape, including catch-alls.
         entry_routes_filtered_storage = routes
             .iter()
             .filter(|r| filter.contains(&r.entry_key))
@@ -1550,7 +1562,8 @@ fn materialise_shadow(
                 routes.push(RouteEntry {
                     route: route.clone(),
                     source_path: project_rel,
-                    entry_key: route,
+                    // Hono-form so `worker_only_routes` filter matches.
+                    entry_key: bracket_to_hono(&route),
                     static_html: true,
                 });
             }
@@ -1665,7 +1678,8 @@ fn materialise_shadow(
                 routes.push(RouteEntry {
                     route: route.clone(),
                     source_path: project_rel,
-                    entry_key: route,
+                    // Hono-form so `worker_only_routes` filter matches.
+                    entry_key: bracket_to_hono(&route),
                     static_html: false,
                 });
             }

--- a/crates/zfb-build/tests/worker_only_routes_filter.rs
+++ b/crates/zfb-build/tests/worker_only_routes_filter.rs
@@ -1,0 +1,195 @@
+//! Regression test for zfb#532 — SSR catch-all survives `worker_only_routes` filter.
+//!
+//! Before the fix, `RouteEntry::entry_key` was stored in bracket-syntax
+//! (`/api/admin/[...adminPath]`) while `worker_only_routes` is populated
+//! in Hono-syntax (`/api/admin/:adminPath{.+}`). The string-equality
+//! check at the filter site (`filter.contains(&r.entry_key)`) never matched
+//! a catch-all, so the SSR catch-all was tree-shaken out of the runtime
+//! bundle. After the fix `entry_key` is stored via `bracket_to_hono`, so
+//! both sides are Hono-form and the filter matches.
+//!
+//! This test calls `bundle()` directly with `worker_only_routes` populated
+//! and asserts:
+//!   1. `RouteEntry::entry_key` on the catch-all entry equals the Hono form.
+//!   2. The emitted bundle JS contains the catch-all Hono template string,
+//!      proving the route survived the filter and reached esbuild's output.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+use zfb_build::{bundle, BundleMode, BundlerInput};
+use zfb_render::adapters::Framework;
+
+fn locate_esbuild() -> Option<PathBuf> {
+    if let Some(p) = std::env::var_os("ZFB_ESBUILD_BIN") {
+        let p = PathBuf::from(p);
+        if p.exists() {
+            return Some(p);
+        }
+    }
+    let here = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    if let Some(workspace) = here.parent().and_then(|p| p.parent()) {
+        let slot = workspace.join("crates/zfb/binaries/esbuild/esbuild");
+        if slot.exists() {
+            return Some(slot);
+        }
+    }
+    if let Ok(out) = Command::new("which").arg("esbuild").output() {
+        if out.status.success() {
+            let p = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim());
+            if p.exists() {
+                return Some(p);
+            }
+        }
+    }
+    None
+}
+
+/// Regression test: SSR catch-all route survives `worker_only_routes` filter.
+///
+/// Constructs a minimal project with:
+///  - A static SSR route (`/api/hello`).
+///  - An SSR catch-all route (`/api/admin/[...adminPath]`).
+///
+/// Sets `worker_only_routes` to the Hono-form templates for both, then
+/// calls `bundle()` and asserts:
+///  - `entry_key` on the catch-all is Hono-form (`/api/admin/:adminPath{.+}`).
+///  - The emitted bundle contains the catch-all Hono template, confirming
+///    the route was NOT tree-shaken.
+#[test]
+fn ssr_catchall_survives_worker_only_routes_filter() {
+    let Some(esbuild) = locate_esbuild() else {
+        eprintln!(
+            "[worker_only_routes_filter] no esbuild binary available; \
+             set ZFB_ESBUILD_BIN, place the binary at \
+             crates/zfb/binaries/esbuild/esbuild, or install esbuild on PATH \
+             to enable this test. Skipping."
+        );
+        return;
+    };
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+
+    // Create pages directory layout:
+    //   pages/api/hello.tsx          → route /api/hello
+    //   pages/api/admin/[...adminPath].tsx  → route /api/admin/[...adminPath]
+    fs::create_dir_all(root.join("pages/api/admin")).unwrap();
+    fs::create_dir_all(root.join("content")).unwrap();
+    fs::create_dir_all(root.join("components")).unwrap();
+    fs::create_dir_all(root.join("layouts")).unwrap();
+
+    // Minimal page module: the bundler just needs a default export.
+    fs::write(
+        root.join("pages/api/hello.tsx"),
+        r#"
+            export default function Hello() {
+              return "hello";
+            }
+        "#,
+    )
+    .unwrap();
+
+    fs::write(
+        root.join("pages/api/admin/[...adminPath].tsx"),
+        r#"
+            export default function AdminCatchAll({ params }) {
+              return "admin path: " + params.adminPath;
+            }
+        "#,
+    )
+    .unwrap();
+
+    // `worker_only_routes` is Hono-form — this is what the build command
+    // populates from `route.template()` / `d.template` (zfb#532).
+    let mut worker_only: BTreeSet<String> = BTreeSet::new();
+    worker_only.insert("/api/hello".into());
+    worker_only.insert("/api/admin/:adminPath{.+}".into());
+
+    let input = BundlerInput {
+        project_root: root.clone(),
+        pages_dir: PathBuf::from("pages"),
+        content_dir: PathBuf::from("content"),
+        components_dir: PathBuf::from("components"),
+        layouts_dir: PathBuf::from("layouts"),
+        framework: Framework::Preact,
+        define_vars: HashMap::new(),
+        tsconfig_paths: BTreeMap::new(),
+        // Mark every bare specifier the synthetic entry.mjs imports as
+        // external so this test doesn't need a node_modules tree.
+        external: vec![
+            "preact".into(),
+            "preact-render-to-string".into(),
+            "@takazudo/zfb-runtime".into(),
+        ],
+        outdir: root.join("dist"),
+        mode: BundleMode::Production,
+        minify: false,
+        esbuild_binary: Some(esbuild),
+        mock_subprocess_output: None,
+        content_snapshot_json: None,
+        node_modules_dir: None,
+        node_modules_preserve_symlinks: false,
+        content_collections: Vec::new(),
+        strip_md_ext: false,
+        code_highlight_theme: None,
+        code_highlight_themes_dir: None,
+        resolve_markdown_links: None,
+        gfm_constructs: zfb_content::ResolvedGfmConstructs::default(),
+        site: None,
+        prefetch_disabled: false,
+        toc: None,
+        external_links: None,
+        cjk_friendly: true,
+        plugin_alias_entries: Vec::new(),
+        plugin_virtual_modules: Vec::new(),
+        worker_only_routes: Some(worker_only),
+        bundle_basename: None,
+        css_module_class_maps: HashMap::new(),
+    };
+
+    let out = bundle(input).expect("bundle should succeed");
+
+    // 1. Assert entry_key on the catch-all is Hono-form.
+    //    (manifest.routes contains ALL routes regardless of filter — this
+    //    assertion checks that the assignment sites now produce Hono-form.)
+    let catchall_entry = out
+        .manifest
+        .routes
+        .iter()
+        .find(|r| r.route == "/api/admin/[...adminPath]")
+        .expect("catch-all route should be in the manifest");
+    assert_eq!(
+        catchall_entry.entry_key,
+        "/api/admin/:adminPath{.+}",
+        "entry_key must be Hono-form so worker_only_routes filter can match catch-alls"
+    );
+
+    // 2. Assert the emitted bundle body contains the catch-all Hono template.
+    //    The `write_entry_module` function emits `__zfb_pages` with
+    //    `bracket_to_hono(&route.route)` — if the catch-all was filtered OUT
+    //    this string would be absent from the bundle body.
+    assert!(out.bundle_path.exists(), "bundle.mjs should exist");
+    let body = fs::read_to_string(&out.bundle_path).expect("read bundle");
+    assert!(
+        !body.is_empty(),
+        "bundle body should be non-empty"
+    );
+    assert!(
+        body.contains(":adminPath{.+}"),
+        "bundle must contain the catch-all Hono route template `:adminPath{{.+}}` — \
+         if absent the catch-all was tree-shaken (filter mismatch bug from zfb#532).\n\
+         --- bundle head ---\n{}",
+        snippet(&body)
+    );
+}
+
+/// Truncate a long string for assert messages.
+fn snippet(s: &str) -> String {
+    if s.len() <= 800 {
+        return s.to_string();
+    }
+    format!("{}…[{} bytes truncated]", &s[..800], s.len() - 800)
+}

--- a/crates/zfb-server/src/routes.rs
+++ b/crates/zfb-server/src/routes.rs
@@ -1577,6 +1577,28 @@ pub(crate) fn page_response_bytes(
         body
     };
 
+    // Issue #530: HTML5 doctype prepend for dev/preview SSR responses.
+    // Mirrors the same guard in `crates/zfb-build/src/renderer.rs::render_one_inner`.
+    // Gated on `text/html` (via the same split on `;` the renderer uses) so
+    // non-HTML routes (XML, JSON, plain-text) are never touched. The helper
+    // `needs_html5_doctype` further skips bodies that already declare a
+    // doctype (case-insensitive, BOM-aware), preventing double-prepend.
+    let is_html_content_type = content_type
+        .split(';')
+        .next()
+        .map(|m| m.trim().eq_ignore_ascii_case("text/html"))
+        .unwrap_or(false);
+    let body_out: Vec<u8> = if is_html_content_type {
+        match std::str::from_utf8(&body_out) {
+            Ok(text) if zfb_build::head_inject::needs_html5_doctype(text) => {
+                format!("{}{text}", zfb_build::head_inject::HTML5_DOCTYPE_PREFIX).into_bytes()
+            }
+            _ => body_out,
+        }
+    } else {
+        body_out
+    };
+
     // The Content-Type may come from a user frontmatter override and
     // therefore can't be statically validated; fall back to a safe
     // default if the value contains characters HTTP rejects.

--- a/crates/zfb-server/tests/islands_head_injection.rs
+++ b/crates/zfb-server/tests/islands_head_injection.rs
@@ -310,3 +310,69 @@ async fn dev_mode_double_request_is_idempotent_on_head_injection() {
         "second request must still yield exactly one islands script tag, body: {body}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Issue #530 — dev SSR doctype prepend
+// ---------------------------------------------------------------------------
+
+/// Regression test for issue #530: `page_response_bytes` must prepend
+/// `<!doctype html>` on dev-mode `text/html` responses that lack a doctype.
+///
+/// All existing test fixtures seed pages with `<!doctype html>` already
+/// present, which masks the bug.  This test uses a doctype-less body
+/// (as a V8 renderer might produce for a `prerender = false` route) and
+/// asserts the response body begins with `<!doctype html>`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dev_mode_prepends_doctype_when_body_lacks_one() {
+    let h = Harness::start(zfb_server::ServerMode::Dev, None).await;
+
+    // Insert a doctype-less HTML page — exactly what a V8 renderer
+    // running a `prerender = false` route might hand back.
+    h.pages
+        .insert(
+            "/",
+            "<html><head><title>no-doctype</title></head><body><p>content</p></body></html>",
+        )
+        .await;
+
+    let resp = reqwest::get(h.url("/")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.starts_with("<!doctype html>"),
+        "dev SSR response must begin with <!doctype html> when the cached body lacks one; got: {body}"
+    );
+    // The original content must survive the prepend unchanged.
+    assert!(
+        body.contains("<title>no-doctype</title>"),
+        "original page content must round-trip, body: {body}"
+    );
+    assert!(
+        body.contains("<p>content</p>"),
+        "body content must round-trip, body: {body}"
+    );
+}
+
+/// Regression guard for issue #530: when the cached page body already
+/// starts with `<!doctype html>` the response must not double-prepend.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dev_mode_does_not_double_prepend_doctype_when_already_present() {
+    let h = Harness::start(zfb_server::ServerMode::Dev, None).await;
+
+    h.pages
+        .insert(
+            "/",
+            "<!doctype html><html><head><title>has-doctype</title></head><body></body></html>",
+        )
+        .await;
+
+    let resp = reqwest::get(h.url("/")).await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    // Exactly one `<!doctype` in the response.
+    let count = body.to_lowercase().matches("<!doctype").count();
+    assert_eq!(
+        count, 1,
+        "must not double-prepend <!doctype html>; found {count} occurrences in: {body}"
+    );
+}

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -1262,10 +1262,15 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
     // bundle pass (zfb#283). The set is computed from the same source as
     // `ssr_route_refs` above; keeping it as an owned `BTreeSet` lets the
     // borrow above end before the runtime bundle (built much later in the
-    // function) consumes the data. The set is keyed by the same
-    // `RouteUniverseEntry::route_key` that `BundlerInput::worker_only_routes`
-    // filters against (`RouteEntry::entry_key`); both are the route
-    // template string, so the filter matches by exact key.
+    // function) consumes the data.
+    //
+    // Contract: `worker_only_routes` is Hono-form (e.g. `/blog/:slug{.+}`),
+    // populated from `route_key` (which equals `d.template` for deferred
+    // routes — both are Hono-form). `BundlerInput::worker_only_routes`
+    // filters against `RouteEntry::entry_key`, which the bundler also stores
+    // in Hono-form (`bracket_to_hono(&route)`). The two sets therefore match
+    // by exact string equality for every route shape, including catch-alls
+    // (zfb#532).
     //
     // We must consult TWO sources, mirroring `ssr_route_refs`:
     //
@@ -4463,6 +4468,11 @@ mod tests {
 
     // ---------------------------------------------------------------------------
     // SSR catch-all with no paths() — issue #520 / #517 regression guard
+    //
+    // Note: this test covers the build-command population path (FakeRunner
+    // stubbing). The bundler-side filter correctness (entry_key Hono-form so
+    // worker_only_routes lookup matches) is exercised by the real-bundler test
+    // in `crates/zfb-build/tests/worker_only_routes_filter.rs` (zfb#532).
     // ---------------------------------------------------------------------------
 
     /// A `prerender = false` catch-all with NO `paths()` export must:

--- a/packages/create-zfb/README.md
+++ b/packages/create-zfb/README.md
@@ -11,3 +11,5 @@ npm create zfb@latest my-site
 ```
 
 This creates a new project directory `my-site/` bootstrapped from the built-in `basic-blog` template. For full documentation, configuration options, and CLI reference, see the [`@takazudo/zfb` docs](https://takazudomodular.com/pj/zudo-front-builder/).
+
+> **pnpm 11 note:** pnpm 11's `minimumReleaseAge` may install a previous release of `create-zfb` within ~48h of any new release. If `create-zfb` warns about a stale install at startup, re-run with `pnpm create zfb@latest --config.minimumReleaseAge=0` or `npm create zfb@latest`.

--- a/packages/create-zfb/bin/create-zfb.mjs
+++ b/packages/create-zfb/bin/create-zfb.mjs
@@ -5,6 +5,61 @@ import { dirname, join } from "node:path";
 
 const require = createRequire(import.meta.url);
 
+// Returns -1 if a < b, 0 if a === b, 1 if a > b.
+// Handles prerelease suffixes: 0.1.0-next.6 < 0.1.0-next.8 < 0.1.0
+function compareSemver(a, b) {
+  const splitRelease = (v) => {
+    const [main, pre] = v.split(/-(.+)/, 2);
+    return { parts: main.split(".").map(Number), pre: pre ?? null };
+  };
+  const ra = splitRelease(a);
+  const rb = splitRelease(b);
+  for (let i = 0; i < Math.max(ra.parts.length, rb.parts.length); i++) {
+    const pa = ra.parts[i] ?? 0;
+    const pb = rb.parts[i] ?? 0;
+    if (pa !== pb) return pa < pb ? -1 : 1;
+  }
+  // same numeric parts — prerelease is less than no prerelease (semver rule)
+  if (ra.pre !== null && rb.pre === null) return -1;
+  if (ra.pre === null && rb.pre !== null) return 1;
+  if (ra.pre !== null && rb.pre !== null) {
+    if (ra.pre < rb.pre) return -1;
+    if (ra.pre > rb.pre) return 1;
+  }
+  return 0;
+}
+
+try {
+  const ownPkg = require("../package.json");
+  const version = ownPkg.version;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 1500);
+  const res = await fetch("https://registry.npmjs.org/create-zfb/latest", {
+    signal: controller.signal,
+    headers: {
+      "User-Agent": `create-zfb/${version}`,
+      Accept: "application/json",
+    },
+  });
+  clearTimeout(timer);
+  if (res.ok) {
+    const data = await res.json();
+    const latest = data?.version;
+    if (typeof latest === "string" && typeof version === "string") {
+      if (compareSemver(version, latest) < 0) {
+        process.stderr.write(
+          `[create-zfb] You are running create-zfb@${version} but @latest is ${latest}.\n` +
+            `[create-zfb] pnpm 11's minimumReleaseAge may have downgraded the install.\n` +
+            `[create-zfb] Re-run with: pnpm create zfb@latest --config.minimumReleaseAge=0\n` +
+            `[create-zfb] Or use: npm create zfb@latest\n`,
+        );
+      }
+    }
+  }
+} catch {
+  // silently skip on any error: network failure, timeout (AbortError), parse error, etc.
+}
+
 const zfbPkgJson = require.resolve("@takazudo/zfb/package.json");
 const zfbBin = join(dirname(zfbPkgJson), "bin", "zfb.mjs");
 

--- a/packages/create-zfb/package.json
+++ b/packages/create-zfb/package.json
@@ -31,6 +31,9 @@
     "CHANGELOG.md",
     "LICENSE"
   ],
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
     "@takazudo/zfb": "workspace:0.1.0-next.8"
   }

--- a/packages/zfb-runtime/src/__tests__/router.test.ts
+++ b/packages/zfb-runtime/src/__tests__/router.test.ts
@@ -385,6 +385,111 @@ describe("createPageRouter", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Issue #530 — SSR HTML5 doctype prepend
+// ---------------------------------------------------------------------------
+
+describe("createPageRouter — SSR doctype prepend (issue #530)", () => {
+  afterEach(() => {
+    setContentSnapshot(undefined);
+  });
+
+  /**
+   * Helper: build a router whose single page returns a canned string body
+   * via renderToString.
+   */
+  function routerWithBody(
+    renderedHtml: string,
+    contentType?: string,
+  ): ReturnType<typeof createPageRouter> {
+    const page: PageModule = {
+      default: () => null,
+      ...(contentType ? { contentType } : {}),
+    };
+    return createPageRouter({
+      pages: [{ route: "/", module: () => Promise.resolve(page) }],
+      contentSnapshot: { collections: {} },
+      framework: { renderToString: () => renderedHtml },
+    });
+  }
+
+  // (a) Plain <html> body without doctype — must prepend
+  it("(a) prepends <!doctype html> when renderToString returns doctype-less <html> body", async () => {
+    const router = routerWithBody("<html><head></head><body>hello</body></html>");
+    const res = await router(new Request("http://test.local/"));
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body.startsWith("<!doctype html>")).toBe(true);
+    expect(body).toContain("<html>");
+  });
+
+  // (b) Already has doctype — no double-prepend (case variation)
+  it("(b) does not double-prepend when renderToString already returns <!DOCTYPE html>", async () => {
+    const router = routerWithBody("<!DOCTYPE html><html><head></head><body>x</body></html>");
+    const res = await router(new Request("http://test.local/"));
+    const body = await res.text();
+    expect(body.startsWith("<!DOCTYPE html>")).toBe(true);
+    expect(body.toLowerCase().indexOf("<!doctype")).toBe(
+      body.toLowerCase().lastIndexOf("<!doctype"),
+    );
+  });
+
+  // (c-1) BOM-prefixed, no doctype — must prepend
+  it("(c) prepends correctly when body starts with UTF-8 BOM + <html> (no doctype)", async () => {
+    const bom = "﻿";
+    const router = routerWithBody(`${bom}<html><head></head><body>bom</body></html>`);
+    const res = await router(new Request("http://test.local/"));
+    const body = await res.text();
+    expect(body.startsWith("<!doctype html>")).toBe(true);
+    expect(body).toContain("<html>");
+  });
+
+  // (c-2) BOM-prefixed + doctype already present — no double-prepend.
+  // Note: Hono's c.body() strips the UTF-8 BOM when it encodes the
+  // string to bytes, so the response body starts with `<!doctype html>`
+  // (no BOM). The guard must not add a second doctype — there should be
+  // exactly one `<!doctype` in the response.
+  it("(c) does not double-prepend when BOM-prefixed body already has <!doctype html>", async () => {
+    const bom = "﻿";
+    const router = routerWithBody(`${bom}<!doctype html><html><head></head><body>x</body></html>`);
+    const res = await router(new Request("http://test.local/"));
+    const body = await res.text();
+    // Exactly one <!doctype in the response (no double-prepend).
+    const count = body.toLowerCase().split("<!doctype").length - 1;
+    expect(count).toBe(1);
+  });
+
+  // (d-1) Leading whitespace, no doctype — must prepend
+  it("(d) prepends correctly when body has leading whitespace before <html> (no doctype)", async () => {
+    const router = routerWithBody("  \n<html><head></head><body>ws</body></html>");
+    const res = await router(new Request("http://test.local/"));
+    const body = await res.text();
+    expect(body.startsWith("<!doctype html>")).toBe(true);
+    expect(body).toContain("<html>");
+  });
+
+  // (d-2) Leading whitespace + doctype already present — no double-prepend
+  it("(d) does not double-prepend when leading-whitespace body already has <!doctype html>", async () => {
+    const router = routerWithBody("  \n<!doctype html><html><head></head><body>x</body></html>");
+    const res = await router(new Request("http://test.local/"));
+    const body = await res.text();
+    expect(body.startsWith("<!doctype html>")).toBe(false);
+    expect(body.startsWith("  \n<!doctype html>")).toBe(true);
+  });
+
+  // Non-HTML content type — must not touch the body
+  it("does not prepend doctype for non-text/html content types", async () => {
+    const router = routerWithBody(
+      "<rss><channel><title>feed</title></channel></rss>",
+      "application/xml; charset=utf-8",
+    );
+    const res = await router(new Request("http://test.local/"));
+    const body = await res.text();
+    expect(body.startsWith("<!doctype html>")).toBe(false);
+    expect(body.startsWith("<rss>")).toBe(true);
+  });
+});
+
 describe("createPageRouter — determinism", () => {
   beforeEach(() => {
     setContentSnapshot(undefined);

--- a/packages/zfb-runtime/src/router.ts
+++ b/packages/zfb-runtime/src/router.ts
@@ -139,6 +139,35 @@ export type PageRouter = (request: Request) => Promise<Response>;
 const DEFAULT_CONTENT_TYPE = "text/html; charset=utf-8";
 
 /**
+ * Issue #530: prepend `<!doctype html>\n` to SSR-rendered HTML bodies that
+ * lack a doctype declaration, mirroring the guard in
+ * `crates/zfb-build/src/renderer.rs::render_one_inner` (issue #524).
+ *
+ * Gate conditions (all must hold to prepend):
+ *   1. `contentType` media-type (before `;`) is `text/html` (case-insensitive).
+ *   2. The body, after stripping an optional UTF-8 BOM (U+FEFF) and leading
+ *      ASCII whitespace, starts with `<html` (case-insensitive) — i.e. it is
+ *      an `<html>`-rooted document, not XML / JSON / a fragment.
+ *   3. The body (same stripped prefix) does NOT already begin with `<!doctype`
+ *      (case-insensitive).
+ *
+ * Deliberately NOT shared with the Rust side — duplication of a 5-line guard
+ * is the right call rather than introducing a new cross-language boundary.
+ */
+function ensureHtml5Doctype(body: string, contentType: string): string {
+  const mediaType = contentType.split(";")[0]?.trim().toLowerCase();
+  if (mediaType !== "text/html") return body;
+  // Strip optional BOM and leading whitespace to inspect the root element.
+  const stripped = body.replace(/^﻿/, "").trimStart();
+  if (!stripped.toLowerCase().startsWith("<!doctype")) {
+    if (stripped.toLowerCase().startsWith("<html")) {
+      return `<!doctype html>\n${body}`;
+    }
+  }
+  return body;
+}
+
+/**
  * Build a page router for the SSG-first architecture (ADR-005).
  *
  * Side effects:
@@ -395,7 +424,7 @@ export function createPageRouter(opts: CreatePageRouterOptions): PageRouter {
       // VNodes.
       const html = typeof result === "string" ? result : opts.framework.renderToString(result);
       const contentType = mod.contentType ?? DEFAULT_CONTENT_TYPE;
-      return c.body(html, 200, { "Content-Type": contentType });
+      return c.body(ensureHtml5Doctype(html, contentType), 200, { "Content-Type": contentType });
     });
   }
 


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/529

---

## Summary
Three independent post-next.8 bugfixes bundled under epic #529 — all goal-clear, all parallelizable, single root PR into main.

- **Renderer SSR doctype prefix (#530 → closes #528):** Mirror the existing SSG-side guard (PR #525) on both remaining SSR emit paths — Rust dev request-time SSR in zfb-server and TS Cloudflare adapter SSR in zfb-runtime. Gate on text/html, never double-prepend, handle BOM/leading-whitespace.
- **`create-zfb` self-check (#531 → closes #527):** Add a startup version check that warns when pnpm 11's `minimumReleaseAge` silently downgrades `pnpm create zfb@latest`. 1.5-second `AbortController` timeout, silent skip on any failure, no new deps. Both README surfaces get the workaround callout. `engines.node` floor pinned to >=18 so global `fetch` is contractual.
- **Bundler `worker_only_routes` filter (#532 → closes #526):** Normalize `entry_key` to Hono syntax at the two assignment sites in `bundler.rs` so the filter (also Hono-keyed) finally matches SSR catch-alls. Adds a real-bundler integration test in `crates/zfb-build/tests/` to lock in the fix.

## Changes

### `zfb-server` (Rust dev SSR)
- `crates/zfb-server/src/routes.rs` — `page_response_bytes(…)` now prepends `<!doctype html>` on text/html responses lacking one, using the existing `zfb_build::head_inject` helpers. Placed after `inject_reload` so it covers Dev + Preview/Embed uniformly.
- `crates/zfb-server/tests/islands_head_injection.rs` — new regression test exercising a doctype-less V8 render.

### `zfb-runtime` (TS Cloudflare SSR)
- `packages/zfb-runtime/src/router.ts` — `createPageRouter` now applies `ensureHtml5Doctype()` (small inline helper) before `c.body(html, 200, …)`. Intentionally duplicated from the Rust side rather than sharing a crate — guard is 5–10 lines and tight Worker-runtime coupling to a Rust crate is undesirable.
- `packages/zfb-runtime/src/__tests__/router.test.ts` — new tests cover missing-doctype, already-has-doctype no-double-prepend, BOM and leading-whitespace cases.

### `create-zfb` (scaffold)
- `packages/create-zfb/bin/create-zfb.mjs` — fetch-based startup self-check; 1.5s timeout; warning printed only when `installed < latest` strictly; silent skip on every other path.
- `packages/create-zfb/package.json` — `engines.node: ">=18"` added; zero new runtime deps.
- `packages/create-zfb/README.md` + repo `README.md` — pnpm 11 `minimumReleaseAge` callout under the install instructions.

### `zfb-build` + `zfb` (bundler filter)
- `crates/zfb-build/src/bundler.rs` — `entry_key` is now Hono-form at both assignment sites (uses existing `bracket_to_hono` helper). Field doc + `BundlerInput::worker_only_routes` doc updated to document the Hono-form contract.
- `crates/zfb-build/tests/worker_only_routes_filter.rs` (new) — real-bundler integration test calling `bundle()` directly with an SSR catch-all and asserting it survives the filter (both manifest and emitted JS).
- `crates/zfb/src/commands/build.rs` — rewrote the L1265–1274 comment that literally encoded the bug ("both are the route template string"); added a cross-reference near the FakeRunner catch-all test pointing to the new real-bundler test.

## Test plan

- [x] `cargo test -p zfb-server --test islands_head_injection` — new doctype-prefix Rust regression test passes.
- [x] `pnpm --filter @takazudo/zfb-runtime test` — new TS doctype-prefix tests pass (including BOM/leading-whitespace cases).
- [x] `cargo test -p zfb-build --test worker_only_routes_filter` — new real-bundler integration test passes.
- [x] Existing `run_build_ssr_catchall_no_paths_no_warning_and_in_worker_only` still passes.
- [x] /gcoc-review on the merged diff — clean, no blocking issues.
- [ ] CI green on PR #533 (in progress at session end).
- [ ] Post-merge: `fgrep ':path{' .zfb-build/bundle-runtime.mjs` on a consumer project with an SSR catch-all (e.g., zudolab/zzmod) returns the catch-all line.

Closes #528, #527, #526, #529.