### PR TITLE
Extract zfb-test-utils crate, deduplicate test helpers (#559)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5561,6 +5561,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "zfb-test-utils"
+version = "0.0.0"
+
+[[package]]
 name = "zfb-toolchain-pins"
 version = "0.0.0"
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5378,6 +5378,7 @@ dependencies = [
  "zfb-render",
  "zfb-router",
  "zfb-server",
+ "zfb-test-utils",
  "zfb-toolchain-pins",
  "zfb-types",
  "zfb-watcher",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5409,6 +5409,7 @@ dependencies = [
  "zfb-plugin-resolver",
  "zfb-render",
  "zfb-router",
+ "zfb-test-utils",
  "zfb-types",
  "zfb-watcher",
 ]
@@ -5486,6 +5487,7 @@ dependencies = [
  "tracing",
  "walkdir",
  "zfb-plugin-resolver",
+ "zfb-test-utils",
  "zfb-types",
 ]
 

--- a/crates/zfb-build/Cargo.toml
+++ b/crates/zfb-build/Cargo.toml
@@ -117,3 +117,7 @@ zfb-router = { path = "../zfb-router" }
 # the happy path binary-free; the `#[ignore]`-gated test calls the
 # real Tailwind v4 CLI when the binary slot is staged.
 zfb-css = { path = "../zfb-css" }
+# Shared test utilities: locate_esbuild() and zfb_binary!(). Replaces
+# the duplicated locate_esbuild() bodies that previously lived in each
+# integration test file.
+zfb-test-utils = { path = "../zfb-test-utils" }

--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -3110,6 +3110,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use zfb_test_utils::locate_esbuild as locate_real_esbuild;
 
     #[test]
     fn render_css_module_js_emits_sorted_default_export() {
@@ -4387,40 +4388,6 @@ mod tests {
             idx("/docs/[...slug]") < idx("/[lang]/[slug]"),
             "/docs/[...slug] should be before /[lang]/[slug]"
         );
-    }
-
-    /// Locate a real esbuild binary for gated integration tests. Order:
-    ///
-    /// 1. `ZFB_ESBUILD_BIN` env var
-    /// 2. `crates/zfb/binaries/esbuild/esbuild` slot relative to the
-    ///    workspace root (resolved relative to `CARGO_MANIFEST_DIR`).
-    /// 3. `which esbuild` on `$PATH`.
-    pub(super) fn locate_real_esbuild() -> Option<PathBuf> {
-        if let Some(p) = std::env::var_os("ZFB_ESBUILD_BIN") {
-            let p = PathBuf::from(p);
-            if p.exists() {
-                return Some(p);
-            }
-        }
-        // CARGO_MANIFEST_DIR is `crates/zfb-build`.
-        let here = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-        if let Some(workspace) = here.parent().and_then(|p| p.parent()) {
-            let slot = workspace.join("crates/zfb/binaries/esbuild/esbuild");
-            if slot.exists() {
-                return Some(slot);
-            }
-        }
-        // Fallback to PATH.
-        if let Ok(out) = Command::new("which").arg("esbuild").output() {
-            if out.status.success() {
-                let p = String::from_utf8_lossy(&out.stdout).trim().to_string();
-                let p = PathBuf::from(p);
-                if p.exists() {
-                    return Some(p);
-                }
-            }
-        }
-        None
     }
 
     #[test]

--- a/crates/zfb-build/tests/bundler_css_modules.rs
+++ b/crates/zfb-build/tests/bundler_css_modules.rs
@@ -22,43 +22,7 @@ use std::process::Command;
 
 use zfb_build::{bundle, BundleMode, BundlerInput};
 use zfb_render::adapters::Framework;
-
-fn locate_esbuild() -> Option<PathBuf> {
-    if let Some(p) = std::env::var_os("ZFB_ESBUILD_BIN") {
-        let p = PathBuf::from(p);
-        if p.exists() {
-            return Some(p);
-        }
-    }
-    let here = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    if let Some(workspace) = here.parent().and_then(|p| p.parent()) {
-        let slot = workspace.join("crates/zfb/binaries/esbuild/esbuild");
-        if slot.exists() {
-            return Some(slot);
-        }
-        // pnpm-installed esbuild in the workspace node_modules store.
-        let store = workspace.join("node_modules/.pnpm");
-        if let Ok(rd) = fs::read_dir(&store) {
-            for entry in rd.flatten() {
-                let cand = entry
-                    .path()
-                    .join("node_modules/@esbuild/linux-x64/bin/esbuild");
-                if cand.exists() {
-                    return Some(cand);
-                }
-            }
-        }
-    }
-    if let Ok(out) = Command::new("which").arg("esbuild").output() {
-        if out.status.success() {
-            let p = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim());
-            if p.exists() {
-                return Some(p);
-            }
-        }
-    }
-    None
-}
+use zfb_test_utils::locate_esbuild;
 
 /// Construct a `BundlerInput` for the project at `root` with the given
 /// CSS Modules class maps. Keeps the test focused on the one field

--- a/crates/zfb-build/tests/bundler_default_plugins.rs
+++ b/crates/zfb-build/tests/bundler_default_plugins.rs
@@ -61,35 +61,10 @@
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
 
 use zfb_build::{bundle, BundleMode, BundlerInput, ContentCollectionSpec};
 use zfb_render::adapters::Framework;
-
-fn locate_esbuild() -> Option<PathBuf> {
-    if let Some(p) = std::env::var_os("ZFB_ESBUILD_BIN") {
-        let p = PathBuf::from(p);
-        if p.exists() {
-            return Some(p);
-        }
-    }
-    let here = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    if let Some(workspace) = here.parent().and_then(|p| p.parent()) {
-        let slot = workspace.join("crates/zfb/binaries/esbuild/esbuild");
-        if slot.exists() {
-            return Some(slot);
-        }
-    }
-    if let Ok(out) = Command::new("which").arg("esbuild").output() {
-        if out.status.success() {
-            let p = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim());
-            if p.exists() {
-                return Some(p);
-            }
-        }
-    }
-    None
-}
+use zfb_test_utils::locate_esbuild;
 
 /// Build a minimal user-project tree exercising all four marker plugin
 /// paths. Returns the project root.

--- a/crates/zfb-build/tests/bundler_exact_match_resolution.rs
+++ b/crates/zfb-build/tests/bundler_exact_match_resolution.rs
@@ -23,35 +23,10 @@
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
 
 use zfb_build::{bundle, BundleMode, BundlerInput};
 use zfb_render::adapters::Framework;
-
-fn locate_esbuild() -> Option<PathBuf> {
-    if let Some(p) = std::env::var_os("ZFB_ESBUILD_BIN") {
-        let p = PathBuf::from(p);
-        if p.exists() {
-            return Some(p);
-        }
-    }
-    let here = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    if let Some(workspace) = here.parent().and_then(|p| p.parent()) {
-        let slot = workspace.join("crates/zfb/binaries/esbuild/esbuild");
-        if slot.exists() {
-            return Some(slot);
-        }
-    }
-    if let Ok(out) = Command::new("which").arg("esbuild").output() {
-        if out.status.success() {
-            let p = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim());
-            if p.exists() {
-                return Some(p);
-            }
-        }
-    }
-    None
-}
+use zfb_test_utils::locate_esbuild;
 
 /// Lay down a minimal user-project tree: one TSX page that imports a
 /// single specifier the caller picks. `import_specifier` is what the

--- a/crates/zfb-build/tests/bundler_integration.rs
+++ b/crates/zfb-build/tests/bundler_integration.rs
@@ -38,31 +38,7 @@ use std::process::Command;
 
 use zfb_build::{bundle, BundleMode, BundlerInput};
 use zfb_render::adapters::Framework;
-
-fn locate_esbuild() -> Option<PathBuf> {
-    if let Some(p) = std::env::var_os("ZFB_ESBUILD_BIN") {
-        let p = PathBuf::from(p);
-        if p.exists() {
-            return Some(p);
-        }
-    }
-    let here = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    if let Some(workspace) = here.parent().and_then(|p| p.parent()) {
-        let slot = workspace.join("crates/zfb/binaries/esbuild/esbuild");
-        if slot.exists() {
-            return Some(slot);
-        }
-    }
-    if let Ok(out) = Command::new("which").arg("esbuild").output() {
-        if out.status.success() {
-            let p = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim());
-            if p.exists() {
-                return Some(p);
-            }
-        }
-    }
-    None
-}
+use zfb_test_utils::locate_esbuild;
 
 #[test]
 fn end_to_end_bundles_aliases_mdx_islands_and_define() {

--- a/crates/zfb-build/tests/bundler_md_pages.rs
+++ b/crates/zfb-build/tests/bundler_md_pages.rs
@@ -16,31 +16,7 @@ use std::process::Command;
 
 use zfb_build::{bundle, BundleMode, BundlerInput};
 use zfb_render::adapters::Framework;
-
-fn locate_esbuild() -> Option<PathBuf> {
-    if let Some(p) = std::env::var_os("ZFB_ESBUILD_BIN") {
-        let p = PathBuf::from(p);
-        if p.exists() {
-            return Some(p);
-        }
-    }
-    let here = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    if let Some(workspace) = here.parent().and_then(|p| p.parent()) {
-        let slot = workspace.join("crates/zfb/binaries/esbuild/esbuild");
-        if slot.exists() {
-            return Some(slot);
-        }
-    }
-    if let Ok(out) = Command::new("which").arg("esbuild").output() {
-        if out.status.success() {
-            let p = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim());
-            if p.exists() {
-                return Some(p);
-            }
-        }
-    }
-    None
-}
+use zfb_test_utils::locate_esbuild;
 
 /// Build a minimal `BundlerInput` for an isolated test project.
 fn make_input(root: &std::path::Path, esbuild: PathBuf) -> BundlerInput {

--- a/crates/zfb-build/tests/bundler_resolve_links.rs
+++ b/crates/zfb-build/tests/bundler_resolve_links.rs
@@ -35,38 +35,13 @@
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
 
 use zfb_build::{
     bundle, BundleMode, BundlerInput, ContentCollectionSpec, OnBrokenLinks,
     ResolveMarkdownLinksRoute, ResolveMarkdownLinksSpec,
 };
 use zfb_render::adapters::Framework;
-
-fn locate_esbuild() -> Option<PathBuf> {
-    if let Some(p) = std::env::var_os("ZFB_ESBUILD_BIN") {
-        let p = PathBuf::from(p);
-        if p.exists() {
-            return Some(p);
-        }
-    }
-    let here = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    if let Some(workspace) = here.parent().and_then(|p| p.parent()) {
-        let slot = workspace.join("crates/zfb/binaries/esbuild/esbuild");
-        if slot.exists() {
-            return Some(slot);
-        }
-    }
-    if let Ok(out) = Command::new("which").arg("esbuild").output() {
-        if out.status.success() {
-            let p = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim());
-            if p.exists() {
-                return Some(p);
-            }
-        }
-    }
-    None
-}
+use zfb_test_utils::locate_esbuild;
 
 /// Write the fixture project tree:
 ///

--- a/crates/zfb-build/tests/bundler_strip_md_ext.rs
+++ b/crates/zfb-build/tests/bundler_strip_md_ext.rs
@@ -24,35 +24,10 @@
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
 
 use zfb_build::{bundle, BundleMode, BundlerInput, ContentCollectionSpec};
 use zfb_render::adapters::Framework;
-
-fn locate_esbuild() -> Option<PathBuf> {
-    if let Some(p) = std::env::var_os("ZFB_ESBUILD_BIN") {
-        let p = PathBuf::from(p);
-        if p.exists() {
-            return Some(p);
-        }
-    }
-    let here = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    if let Some(workspace) = here.parent().and_then(|p| p.parent()) {
-        let slot = workspace.join("crates/zfb/binaries/esbuild/esbuild");
-        if slot.exists() {
-            return Some(slot);
-        }
-    }
-    if let Ok(out) = Command::new("which").arg("esbuild").output() {
-        if out.status.success() {
-            let p = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim());
-            if p.exists() {
-                return Some(p);
-            }
-        }
-    }
-    None
-}
+use zfb_test_utils::locate_esbuild;
 
 /// Build a minimal user-project tree exercising both the page walker
 /// AND the collection walker so we cover both `add_strip_md_ext`

--- a/crates/zfb-build/tests/bundler_workspace_pkg_alias.rs
+++ b/crates/zfb-build/tests/bundler_workspace_pkg_alias.rs
@@ -25,36 +25,10 @@
 
 use std::collections::BTreeMap;
 use std::fs;
-use std::path::PathBuf;
-use std::process::Command;
 
 use zfb_build::{bundle, BundleMode, BundlerInput};
 use zfb_render::adapters::Framework;
-
-fn locate_esbuild() -> Option<PathBuf> {
-    if let Some(p) = std::env::var_os("ZFB_ESBUILD_BIN") {
-        let p = PathBuf::from(p);
-        if p.exists() {
-            return Some(p);
-        }
-    }
-    let here = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    if let Some(workspace) = here.parent().and_then(|p| p.parent()) {
-        let slot = workspace.join("crates/zfb/binaries/esbuild/esbuild");
-        if slot.exists() {
-            return Some(slot);
-        }
-    }
-    if let Ok(out) = Command::new("which").arg("esbuild").output() {
-        if out.status.success() {
-            let p = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim());
-            if p.exists() {
-                return Some(p);
-            }
-        }
-    }
-    None
-}
+use zfb_test_utils::locate_esbuild;
 
 /// Mirror the behaviour of `zfb/src/commands/build.rs::read_tsconfig_paths`:
 /// resolve each `compilerOptions.paths` target to an absolute path against

--- a/crates/zfb-build/tests/embedded_v8_snapshot_e2e.rs
+++ b/crates/zfb-build/tests/embedded_v8_snapshot_e2e.rs
@@ -28,7 +28,6 @@
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::sync::Arc;
 
 use zfb_build::{
@@ -37,6 +36,7 @@ use zfb_build::{
 };
 use zfb_content::{build_snapshot, CollectionConfig};
 use zfb_render::adapters::Framework;
+use zfb_test_utils::locate_esbuild;
 
 // ---------------------------------------------------------------------------
 // Shared fixture helpers
@@ -377,45 +377,6 @@ fn snapshot_json_is_stable_under_reversed_config_order() {
 // ---------------------------------------------------------------------------
 // Group 3 — EmbeddedV8 render path
 // ---------------------------------------------------------------------------
-
-/// Resolve the esbuild binary. Same precedence as the other integration
-/// tests (`bundler_integration.rs`, `integration_e2e_routing_rendering.rs`):
-///
-/// 1. `ZFB_ESBUILD_BIN` env var (an absolute path).
-/// 2. `crates/zfb/binaries/esbuild/esbuild` (the workspace-staged binary).
-/// 3. `which esbuild` (pnpm-store bin, system PATH).
-fn locate_esbuild() -> Option<PathBuf> {
-    if let Some(p) = std::env::var_os("ZFB_ESBUILD_BIN") {
-        let p = PathBuf::from(p);
-        if p.exists() {
-            return Some(p);
-        }
-    }
-    let here = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    if let Some(workspace) = here.parent().and_then(|p| p.parent()) {
-        let slot = workspace.join("crates/zfb/binaries/esbuild/esbuild");
-        if slot.exists() {
-            return Some(slot);
-        }
-    }
-    // Fallback: any pnpm-staged esbuild reachable from the worktree (the
-    // sibling main-repo's `node_modules/.pnpm/node_modules/esbuild/bin`).
-    if let Some(store) = locate_pnpm_node_modules() {
-        let pnpm_slot = store.join("esbuild/bin/esbuild");
-        if pnpm_slot.exists() {
-            return Some(pnpm_slot);
-        }
-    }
-    if let Ok(out) = Command::new("which").arg("esbuild").output() {
-        if out.status.success() {
-            let p = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim());
-            if p.exists() {
-                return Some(p);
-            }
-        }
-    }
-    None
-}
 
 /// Workspace root (two levels up from `CARGO_MANIFEST_DIR`).
 fn workspace_root() -> PathBuf {

--- a/crates/zfb-build/tests/integration_e2e_routing_rendering.rs
+++ b/crates/zfb-build/tests/integration_e2e_routing_rendering.rs
@@ -43,43 +43,17 @@
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use zfb_build::{
     bundle, render_all, Backend, BundleMode, BundlerInput, BundlerOutput, RendererInput,
     RouteUniverseEntry,
 };
 use zfb_render::adapters::Framework;
+use zfb_test_utils::locate_esbuild;
 
 // ---------------------------------------------------------------------------
 // Infrastructure helpers
 // ---------------------------------------------------------------------------
-
-/// Resolve the esbuild binary. Same order as `bundler_integration.rs`.
-fn locate_esbuild() -> Option<PathBuf> {
-    if let Some(p) = std::env::var_os("ZFB_ESBUILD_BIN") {
-        let p = PathBuf::from(p);
-        if p.exists() {
-            return Some(p);
-        }
-    }
-    let here = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    if let Some(workspace) = here.parent().and_then(|p| p.parent()) {
-        let slot = workspace.join("crates/zfb/binaries/esbuild/esbuild");
-        if slot.exists() {
-            return Some(slot);
-        }
-    }
-    if let Ok(out) = Command::new("which").arg("esbuild").output() {
-        if out.status.success() {
-            let p = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim());
-            if p.exists() {
-                return Some(p);
-            }
-        }
-    }
-    None
-}
 
 /// Locate the workspace root (two levels up from CARGO_MANIFEST_DIR:
 /// `crates/zfb-build` → `crates` → workspace root).

--- a/crates/zfb-build/tests/migration_fixes_integration_confirm.rs
+++ b/crates/zfb-build/tests/migration_fixes_integration_confirm.rs
@@ -43,39 +43,10 @@
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
 
 use zfb_build::{bundle, BundleMode, BundlerInput, ContentCollectionSpec, OnBrokenLinks, ResolveMarkdownLinksRoute, ResolveMarkdownLinksSpec};
 use zfb_render::adapters::Framework;
-
-// ---------------------------------------------------------------------------
-// Binary discovery (mirrors every other bundler integration test)
-// ---------------------------------------------------------------------------
-
-fn locate_esbuild() -> Option<PathBuf> {
-    if let Some(p) = std::env::var_os("ZFB_ESBUILD_BIN") {
-        let p = PathBuf::from(p);
-        if p.exists() {
-            return Some(p);
-        }
-    }
-    let here = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    if let Some(workspace) = here.parent().and_then(|p| p.parent()) {
-        let slot = workspace.join("crates/zfb/binaries/esbuild/esbuild");
-        if slot.exists() {
-            return Some(slot);
-        }
-    }
-    if let Ok(out) = Command::new("which").arg("esbuild").output() {
-        if out.status.success() {
-            let p = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim());
-            if p.exists() {
-                return Some(p);
-            }
-        }
-    }
-    None
-}
+use zfb_test_utils::locate_esbuild;
 
 // ===========================================================================
 // Content-pipeline assertions (always run — no esbuild)

--- a/crates/zfb-build/tests/worker_only_routes_filter.rs
+++ b/crates/zfb-build/tests/worker_only_routes_filter.rs
@@ -17,35 +17,10 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
 
 use zfb_build::{bundle, BundleMode, BundlerInput};
 use zfb_render::adapters::Framework;
-
-fn locate_esbuild() -> Option<PathBuf> {
-    if let Some(p) = std::env::var_os("ZFB_ESBUILD_BIN") {
-        let p = PathBuf::from(p);
-        if p.exists() {
-            return Some(p);
-        }
-    }
-    let here = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    if let Some(workspace) = here.parent().and_then(|p| p.parent()) {
-        let slot = workspace.join("crates/zfb/binaries/esbuild/esbuild");
-        if slot.exists() {
-            return Some(slot);
-        }
-    }
-    if let Ok(out) = Command::new("which").arg("esbuild").output() {
-        if out.status.success() {
-            let p = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim());
-            if p.exists() {
-                return Some(p);
-            }
-        }
-    }
-    None
-}
+use zfb_test_utils::locate_esbuild;
 
 /// Regression test: SSR catch-all route survives `worker_only_routes` filter.
 ///

--- a/crates/zfb-islands/Cargo.toml
+++ b/crates/zfb-islands/Cargo.toml
@@ -68,3 +68,6 @@ lol_html = "2.8.1"
 [dev-dependencies]
 tempfile = { workspace = true }
 serde_json = { workspace = true }
+# Shared test utilities: locate_esbuild(). Replaces the duplicated
+# locate_esbuild() body that previously lived in each integration test file.
+zfb-test-utils = { path = "../zfb-test-utils" }

--- a/crates/zfb-islands/tests/exact_match_resolution.rs
+++ b/crates/zfb-islands/tests/exact_match_resolution.rs
@@ -18,36 +18,11 @@
 
 use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
 
 use zfb_islands::{
     BundleConfig, ClientBundler, EsbuildSubprocessBundler, EsbuildSubprocessConfig, Island,
 };
-
-fn locate_esbuild() -> Option<PathBuf> {
-    if let Some(p) = std::env::var_os("ZFB_ESBUILD_BIN") {
-        let p = PathBuf::from(p);
-        if p.exists() {
-            return Some(p);
-        }
-    }
-    let here = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    if let Some(workspace) = here.parent().and_then(|p| p.parent()) {
-        let slot = workspace.join("crates/zfb/binaries/esbuild/esbuild");
-        if slot.exists() {
-            return Some(slot);
-        }
-    }
-    if let Ok(out) = Command::new("which").arg("esbuild").output() {
-        if out.status.success() {
-            let p = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim());
-            if p.exists() {
-                return Some(p);
-            }
-        }
-    }
-    None
-}
+use zfb_test_utils::locate_esbuild;
 
 /// Build a working_dir with a `components/` subtree holding one island
 /// TSX file. `island_source` is the file body; `aliased_target_filename`

--- a/crates/zfb-test-utils/Cargo.toml
+++ b/crates/zfb-test-utils/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "zfb-test-utils"
+version = "0.0.0"
+edition = "2021"
+license = "MIT"
+description = "Shared test helpers for zfb integration tests (std-only, no runtime dependencies)"
+
+[lib]

--- a/crates/zfb-test-utils/src/lib.rs
+++ b/crates/zfb-test-utils/src/lib.rs
@@ -1,0 +1,147 @@
+use std::path::PathBuf;
+
+/// Locate an esbuild binary suitable for integration tests.
+///
+/// Resolution order (union of all existing 17+ per-test copies):
+///
+/// 1. `ZFB_ESBUILD_BIN` env var — if set and points to an existing file,
+///    return it immediately.
+/// 2. Workspace-local slot:
+///    `<workspace_root>/crates/zfb/binaries/esbuild/<binary>`.
+///    Binary name is `esbuild` on Unix, `esbuild.exe` on Windows.
+///    Workspace root is two parents up from `CARGO_MANIFEST_DIR`
+///    (i.e. `crates/zfb-test-utils` → `crates` → repo root).
+/// 3. Workspace-root pnpm nested store:
+///    `node_modules/.pnpm/*/node_modules/@esbuild/<suffix>/bin/<binary>`
+///    where `*` is each directory entry under `.pnpm` (pnpm's content-
+///    addressed layout). Mirrors the shape in
+///    `crates/zfb/tests/css_modules_components_build.rs:166-176`.
+///    Note: the pnpm Windows package puts the binary at the package root
+///    rather than under `bin/`; this path uses `bin/` uniformly following
+///    the spec — a future Windows fix can adjust the suffix path if needed.
+/// 4. Workspace-root flat pnpm store:
+///    `node_modules/.pnpm/node_modules/esbuild/bin/<binary>` — kept for
+///    parity with `crates/zfb-build/tests/embedded_v8_snapshot_e2e.rs`.
+/// 5. Portable PATH walk — iterates `$PATH` entries via
+///    `std::env::split_paths` (platform-aware `:` vs `;` split) and
+///    checks `<entry>/<binary>`. Does NOT shell out to `which`, which is
+///    absent on Windows.
+///
+/// Returns `None` if no candidate exists. Callers should gate with
+/// `let Some(esbuild) = locate_esbuild() else { return; }` to skip
+/// gracefully, matching the convention in all existing integration tests.
+pub fn locate_esbuild() -> Option<PathBuf> {
+    // Step 1: ZFB_ESBUILD_BIN env var.
+    if let Some(p) = std::env::var_os("ZFB_ESBUILD_BIN") {
+        let p = PathBuf::from(p);
+        if p.is_file() {
+            return Some(p);
+        }
+    }
+
+    let binary = esbuild_binary_name();
+    // Workspace root: two parents up from this crate's manifest directory.
+    // CARGO_MANIFEST_DIR = <repo>/crates/zfb-test-utils → parent = <repo>/crates → parent = <repo>
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace = manifest_dir
+        .parent()
+        .and_then(|p| p.parent())
+        .map(|p| p.to_path_buf());
+
+    if let Some(ref workspace) = workspace {
+        // Step 2: workspace-local binary slot.
+        let slot = workspace
+            .join("crates/zfb/binaries/esbuild")
+            .join(binary);
+        if slot.is_file() {
+            return Some(slot);
+        }
+
+        // Step 3: pnpm nested store — node_modules/.pnpm/*/node_modules/@esbuild/<suffix>/bin/<binary>.
+        if let Some(suffix) = esbuild_npm_suffix() {
+            let pnpm_dir = workspace.join("node_modules/.pnpm");
+            if let Ok(rd) = std::fs::read_dir(&pnpm_dir) {
+                for entry in rd.flatten() {
+                    let cand = entry
+                        .path()
+                        .join("node_modules/@esbuild")
+                        .join(suffix)
+                        .join("bin")
+                        .join(binary);
+                    if cand.is_file() {
+                        return Some(cand);
+                    }
+                }
+            }
+        }
+
+        // Step 4: flat pnpm store — node_modules/.pnpm/node_modules/esbuild/bin/<binary>.
+        let flat_slot = workspace
+            .join("node_modules/.pnpm/node_modules/esbuild/bin")
+            .join(binary);
+        if flat_slot.is_file() {
+            return Some(flat_slot);
+        }
+    }
+
+    // Step 5: portable PATH walk — no `which` shell-out (missing on Windows).
+    if let Some(path_var) = std::env::var_os("PATH") {
+        for dir in std::env::split_paths(&path_var) {
+            let cand = dir.join(binary);
+            if cand.is_file() {
+                return Some(cand);
+            }
+        }
+    }
+
+    None
+}
+
+/// Returns the esbuild binary file name for the current platform.
+///
+/// `esbuild.exe` on Windows, `esbuild` everywhere else.
+fn esbuild_binary_name() -> &'static str {
+    if cfg!(windows) {
+        "esbuild.exe"
+    } else {
+        "esbuild"
+    }
+}
+
+/// Returns the esbuild npm package suffix for the current platform/arch,
+/// or `None` for unsupported combinations (causing step 3 to be skipped).
+///
+/// These suffixes match the `esbuild_platform_meta` table in
+/// `crates/zfb/build.rs:238` — keep both in sync if either changes.
+fn esbuild_npm_suffix() -> Option<&'static str> {
+    if cfg!(target_os = "linux") && cfg!(target_arch = "x86_64") {
+        Some("linux-x64")
+    } else if cfg!(target_os = "linux") && cfg!(target_arch = "aarch64") {
+        Some("linux-arm64")
+    } else if cfg!(target_os = "macos") && cfg!(target_arch = "x86_64") {
+        Some("darwin-x64")
+    } else if cfg!(target_os = "macos") && cfg!(target_arch = "aarch64") {
+        Some("darwin-arm64")
+    } else if cfg!(target_os = "windows") && cfg!(target_arch = "x86_64") {
+        Some("win32-x64")
+    } else {
+        None
+    }
+}
+
+/// Expands to `PathBuf::from(env!("CARGO_BIN_EXE_zfb"))` at the call site.
+///
+/// `CARGO_BIN_EXE_zfb` is set by Cargo only when compiling integration
+/// tests for the crate that owns the `zfb` binary (`crates/zfb/`). The
+/// macro form is required so that `env!()` expands at the *caller's*
+/// compile unit — a plain function call cannot access a test-binary env
+/// var from another crate.
+///
+/// Usage: place `use zfb_test_utils::zfb_binary;` in your test file, then
+/// call `zfb_binary!()` to obtain the path to the compiled `zfb` binary.
+#[macro_export]
+macro_rules! zfb_binary {
+    () => {{
+        ::std::path::PathBuf::from(env!("CARGO_BIN_EXE_zfb"))
+    }};
+}

--- a/crates/zfb-test-utils/tests/locate_esbuild_self.rs
+++ b/crates/zfb-test-utils/tests/locate_esbuild_self.rs
@@ -1,0 +1,34 @@
+//! Compile-time + runtime sanity check for `locate_esbuild()`.
+//!
+//! Verifies that:
+//! 1. The function compiles and links correctly.
+//! 2. It does not panic under any circumstances (returning `None` is fine).
+//!
+//! This test does NOT check for the macro — `CARGO_BIN_EXE_zfb` is only
+//! set when compiling integration tests for the `zfb` binary crate; using
+//! `zfb_binary!()` here would cause a compile error.
+
+use zfb_test_utils::locate_esbuild;
+
+#[test]
+fn locate_esbuild_does_not_panic() {
+    // Returning None is perfectly valid — the test environment may not have
+    // esbuild installed. We only assert the call completes without panicking.
+    let _result = locate_esbuild();
+    // If we reach here, the function ran successfully.
+}
+
+#[test]
+fn locate_esbuild_returns_existing_file_when_env_set() {
+    // If ZFB_ESBUILD_BIN is set in the test environment and points to a real
+    // file, locate_esbuild() must return that path.
+    if let Some(bin_path) = std::env::var_os("ZFB_ESBUILD_BIN") {
+        let p = std::path::PathBuf::from(&bin_path);
+        if p.is_file() {
+            let result = locate_esbuild();
+            assert_eq!(result.as_deref(), Some(p.as_path()));
+        }
+    }
+    // If ZFB_ESBUILD_BIN is not set or doesn't point to a file, the test
+    // passes trivially — this branch is just a bonus correctness check.
+}

--- a/crates/zfb/Cargo.toml
+++ b/crates/zfb/Cargo.toml
@@ -119,3 +119,4 @@ tar = "0.4"
 [dev-dependencies]
 tempfile = { workspace = true }
 tower = { version = "0.5", features = ["util"] }
+zfb-test-utils = { path = "../zfb-test-utils" }

--- a/crates/zfb/tests/check_command.rs
+++ b/crates/zfb/tests/check_command.rs
@@ -12,6 +12,8 @@
 use std::path::PathBuf;
 use std::process::Command;
 
+use zfb_test_utils::zfb_binary;
+
 fn fixture(name: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests")
@@ -19,17 +21,10 @@ fn fixture(name: &str) -> PathBuf {
         .join(name)
 }
 
-fn zfb_binary() -> PathBuf {
-    // `CARGO_BIN_EXE_<bin>` is set by Cargo when building integration
-    // tests for the same package — the value is the absolute path to
-    // the built binary, no `cargo run` overhead.
-    PathBuf::from(env!("CARGO_BIN_EXE_zfb"))
-}
-
 #[test]
 fn check_passes_on_valid_fixture() {
     let dir = fixture("check-good");
-    let output = Command::new(zfb_binary())
+    let output = Command::new(zfb_binary!())
         .args(["check", "--skip-tsc"])
         .current_dir(&dir)
         .output()
@@ -53,7 +48,7 @@ fn check_passes_on_valid_fixture() {
 #[test]
 fn check_fails_with_schema_violation() {
     let dir = fixture("check-bad-schema");
-    let output = Command::new(zfb_binary())
+    let output = Command::new(zfb_binary!())
         .args(["check", "--skip-tsc"])
         .current_dir(&dir)
         .output()

--- a/crates/zfb/tests/content_snapshot_no_deferred.rs
+++ b/crates/zfb/tests/content_snapshot_no_deferred.rs
@@ -36,15 +36,13 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 
+use zfb_test_utils::zfb_binary;
+
 fn fixture_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests")
         .join("fixtures")
         .join("collection-static-getStaticProps")
-}
-
-fn zfb_binary() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_zfb"))
 }
 
 /// Run `zfb build` against the fixture in a fresh tempdir copy so parallel
@@ -59,7 +57,7 @@ fn getstaticprops_collection_appears_in_rendered_html() {
     copy_dir(&fixture, root).expect("copy fixture into tempdir");
 
     // Run `zfb build` against the copy.
-    let output = Command::new(zfb_binary())
+    let output = Command::new(zfb_binary!())
         .arg("build")
         .current_dir(root)
         .output()

--- a/crates/zfb/tests/css_modules_components_build.rs
+++ b/crates/zfb/tests/css_modules_components_build.rs
@@ -145,50 +145,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-/// Locate the test esbuild binary the same way the other zfb / zfb-build
-/// integration tests do: prefer `ZFB_ESBUILD_BIN`, then the workspace
-/// `crates/zfb/binaries/esbuild/esbuild` slot, then a pnpm-installed
-/// esbuild under `node_modules/.pnpm`, then `which esbuild`. Returns
-/// `None` if nothing is available so the test can skip gracefully.
-fn locate_esbuild() -> Option<PathBuf> {
-    if let Some(p) = std::env::var_os("ZFB_ESBUILD_BIN") {
-        let p = PathBuf::from(p);
-        if p.exists() {
-            return Some(p);
-        }
-    }
-    let here = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    if let Some(workspace) = here.parent().and_then(|p| p.parent()) {
-        let slot = workspace.join("crates/zfb/binaries/esbuild/esbuild");
-        if slot.exists() {
-            return Some(slot);
-        }
-        let store = workspace.join("node_modules/.pnpm");
-        if let Ok(rd) = fs::read_dir(&store) {
-            for entry in rd.flatten() {
-                let cand = entry
-                    .path()
-                    .join("node_modules/@esbuild/linux-x64/bin/esbuild");
-                if cand.exists() {
-                    return Some(cand);
-                }
-            }
-        }
-    }
-    if let Ok(out) = Command::new("which").arg("esbuild").output() {
-        if out.status.success() {
-            let p = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim());
-            if p.exists() {
-                return Some(p);
-            }
-        }
-    }
-    None
-}
-
-fn zfb_binary() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_zfb"))
-}
+use zfb_test_utils::{locate_esbuild, zfb_binary};
 
 /// Write a small component that imports its own `.module.css` and
 /// references three class names from it. The component renders a
@@ -321,7 +278,7 @@ fn build_and_assert_corp_shape(
     module_css_paths: &[PathBuf],
     original_module_css: &[String],
 ) {
-    let output = Command::new(zfb_binary())
+    let output = Command::new(zfb_binary!())
         .arg("build")
         .current_dir(root)
         .env("ZFB_ESBUILD_BIN", esbuild)

--- a/crates/zfb/tests/framework_packages_no_pnpm.rs
+++ b/crates/zfb/tests/framework_packages_no_pnpm.rs
@@ -37,36 +37,11 @@
 use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::PathBuf;
-use std::process::Command;
 
 use zfb::render_pipeline::embedded_node_modules;
 use zfb_build::{bundle, BundleMode, BundlerInput};
 use zfb_render::adapters::Framework;
-
-fn locate_esbuild() -> Option<PathBuf> {
-    if let Some(p) = std::env::var_os("ZFB_ESBUILD_BIN") {
-        let p = PathBuf::from(p);
-        if p.exists() {
-            return Some(p);
-        }
-    }
-    let here = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    if let Some(workspace) = here.parent().and_then(|p| p.parent()) {
-        let slot = workspace.join("crates/zfb/binaries/esbuild/esbuild");
-        if slot.exists() {
-            return Some(slot);
-        }
-    }
-    if let Ok(out) = Command::new("which").arg("esbuild").output() {
-        if out.status.success() {
-            let p = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim());
-            if p.exists() {
-                return Some(p);
-            }
-        }
-    }
-    None
-}
+use zfb_test_utils::locate_esbuild;
 
 #[test]
 fn embedded_extraction_resolves_framework_imports_with_no_consumer_node_modules() {


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/559

---

## Summary

- Extract a shared workspace crate `zfb-test-utils` exposing the previously-duplicated test helpers as a single source of truth.
- Migrate 17 copies of `locate_esbuild()` plus 1 in-src test helper (`locate_real_esbuild()` in `crates/zfb-build/src/bundler.rs`) to `zfb_test_utils::locate_esbuild`.
- Migrate 3 copies of `zfb_binary()` to a `zfb_binary!()` macro (env!() must expand at the caller site).
- Net diff: −486 / +228 lines across 25 files (one shared 147-line crate replaces ~28 lines × 18 sites of byte-near-identical duplication).

## Changes

### New crate: `crates/zfb-test-utils/`

- `Cargo.toml` — std-only, no runtime deps, auto-included via the workspace `members = ["crates/*"]` glob.
- `src/lib.rs` — exports `locate_esbuild() -> Option<PathBuf>` and a `zfb_binary!()` macro.
- `tests/locate_esbuild_self.rs` — sanity compile-test that the helper builds and runs.

The new `locate_esbuild()` is a superset of the union of all 17+1 prior copies, with platform awareness baked in via `cfg!`:

1. `ZFB_ESBUILD_BIN` env var override.
2. Workspace-local slot at `crates/zfb/binaries/esbuild/<binary>`.
3. pnpm-nested store: `node_modules/.pnpm/*/node_modules/@esbuild/<suffix>/bin/<binary>` (was previously only in `crates/zfb/tests/css_modules_components_build.rs`).
4. Flat pnpm store: `node_modules/.pnpm/node_modules/esbuild/bin/<binary>` (was previously only in `crates/zfb-build/tests/embedded_v8_snapshot_e2e.rs`).
5. Portable `/Applications/KiCad/KiCad.app/Contents/MacOS:/home/takazudo/.antigravity/antigravity/bin:/home/takazudo/scripts:/home/takazudo/.local/share/uv/tools/shims:/home/takazudo/.local/bin:/home/takazudo/.anyenv/envs/nodenv/shims:/home/takazudo/.anyenv/envs/nodenv/bin:/home/takazudo/.anyenv/bin:/home/takazudo/.yarn/bin:/usr/local/bin:/Applications/KiCad/KiCad.app/Contents/MacOS:/home/takazudo/.antigravity/antigravity/bin:/home/takazudo/Library/pnpm:/home/takazudo/scripts:/home/takazudo/.local/share/uv/tools/shims:/home/takazudo/.local/bin:/home/takazudo/.anyenv/envs/nodenv/shims:/home/takazudo/.anyenv/envs/nodenv/bin:/home/takazudo/.anyenv/envs/nodenv/bin:/home/takazudo/.anyenv/bin:/home/takazudo/.yarn/bin:/usr/local/bin:/home/takazudo/.deno/bin:/home/takazudo/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/home/takazudo/.oh-my-zsh/custom/plugins/zeno/bin:/home/takazudo/.oh-my-zsh/custom/plugins/zeno/bin:/home/takazudo/.claude/plugins/cache/claude-plugins-official/frontend-design/1f9b04bdde6c/bin:/home/takazudo/.claude/plugins/cache/claude-plugins-official/rust-analyzer-lsp/1.0.0/bin:/home/takazudo/.claude/plugins/cache/openai-codex/codex/1.0.2/bin` walk via `std::env::split_paths` — replaces the previous `Command::new("which")` shell-out, which is missing on Windows.

Platform suffix table mirrors `crates/zfb/build.rs:238` (`esbuild_platform_meta`): linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64. Binary name switches between `esbuild` (Unix) and `esbuild.exe` (Windows) via `cfg!(windows)`.

### `zfb_binary!()` macro

`#[macro_export] macro_rules! zfb_binary { () => { ::std::path::PathBuf::from(env!("CARGO_BIN_EXE_zfb")) } }` — a macro rather than a function because Cargo only sets `CARGO_BIN_EXE_zfb` when compiling the integration tests of the crate that owns the `zfb` bin. `env!()` must expand at the caller site.

### Migration scope

- **Wave 1 — #560** — created the new crate.
- **Wave 2a — #561** — migrated 13 callers (12 in `crates/zfb-build/tests/`, 1 in `crates/zfb-islands/tests/`) plus the 18th in-src helper `locate_real_esbuild()` in `crates/zfb-build/src/bundler.rs`'s `mod tests` block.
- **Wave 2b — #562** — migrated 4 callers in `crates/zfb/tests/`, including `zfb_binary()` → `zfb_binary!()` call-site conversion in 3 files.

Each migrated caller crate gains one `[dev-dependencies]` entry pinning `zfb-test-utils = { path = "../zfb-test-utils" }`. The function signature `() -> Option<PathBuf>` is preserved exactly, so caller code is unchanged at call sites for `locate_esbuild`.

## Test plan

- `cargo check --workspace --tests` — clean (verified locally; pre-existing dead-code warnings unrelated).
- `cargo test -p zfb-test-utils` — passes (compile-test).
- `cargo test -p zfb-build` — passes; esbuild-dependent tests skip gracefully when no esbuild is present (existing behavior preserved).
- `cargo test -p zfb-islands` — passes (same gating).
- `cargo test -p zfb` — passes (11 tests; same gating).
- CI: 13/13 checks green on this PR.
- Static cleanup checks: zero remaining `fn locate_esbuild` / `fn zfb_binary` / `fn locate_real_esbuild` definitions in `crates/*/tests/` and `crates/zfb-build/src/bundler.rs`; zero remaining `zfb_binary()` function-call call sites (all converted to `zfb_binary!()`).

🤖 Generated by `/big-plan -a -impl -co -gcoc` + `/x-wt-teams -a -seq` via Claude Code.