### PR TITLE
Release CI Hardening: pnpm purge, mac build, Node 24 actions, smoke-clean-room (#588–#591)

### DIFF
--- a/.github/workflows/health.yml
+++ b/.github/workflows/health.yml
@@ -27,11 +27,11 @@ jobs:
     # and typically complete well within this budget.
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
           cache: pnpm
@@ -80,11 +80,11 @@ jobs:
     # budget while the cache primes on the first run.
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -23,15 +23,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm --filter docs build
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: docs-dist
           path: docs/dist/
@@ -42,13 +42,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
           cache: pnpm
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: docs-dist
           path: docs/dist/

--- a/.github/workflows/node-free-smoke.yml
+++ b/.github/workflows/node-free-smoke.yml
@@ -71,12 +71,12 @@ jobs:
     runs-on: ${{ matrix.platform.runner }}
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       # pnpm version is read from package.json's "packageManager" field.
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "22"
           cache: "pnpm"
@@ -136,7 +136,7 @@ jobs:
              tests/smoke/node-free-ts/zfb-bin
 
       - name: Upload binary artifact (JSON smoke)
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.platform.artifact }}
           # Upload the full smoke context dir (Dockerfile + run.sh + binary).
@@ -145,7 +145,7 @@ jobs:
           retention-days: 1
 
       - name: Upload binary artifact (TS smoke)
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.platform.artifact }}-ts
           # Upload the full TS smoke context dir (Dockerfile + run.sh + binary).
@@ -161,7 +161,7 @@ jobs:
     timeout-minutes: 6
     steps:
       - name: Download smoke context (amd64)
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: smoke-binary-amd64
           path: smoke-ctx
@@ -187,7 +187,7 @@ jobs:
     timeout-minutes: 6
     steps:
       - name: Download smoke context (arm64)
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: smoke-binary-arm64
           path: smoke-ctx
@@ -213,7 +213,7 @@ jobs:
     timeout-minutes: 6
     steps:
       - name: Download smoke context (amd64 TS)
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: smoke-binary-amd64-ts
           path: smoke-ctx-ts
@@ -239,7 +239,7 @@ jobs:
     timeout-minutes: 6
     steps:
       - name: Download smoke context (arm64 TS)
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: smoke-binary-arm64-ts
           path: smoke-ctx-ts
@@ -269,7 +269,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           # Check out the tag that triggered the release so tests/smoke/node-free/
           # reflects the same revision that was released.

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -151,9 +151,8 @@ jobs:
           exit 1
 
       - name: Upsert PR preview comment
-        # NOTE: pinned to v7.1.0 — v8.0.0 (Node 24) had token-handling issues
-        # for us. v7 (Node 20) is battle-tested in this exact comment-upsert
-        # pattern. `github-token` passed explicitly because the implicit
+        # NOTE: bumped to v8.0.0 (Node 24) as part of the Node-20 deprecation
+        # migration. `github-token` passed explicitly because the implicit
         # detection failed with 401 Bad credentials on SHA-pinned action runs.
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -30,13 +30,13 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
           cache: pnpm
@@ -48,7 +48,7 @@ jobs:
         run: pnpm --filter docs build
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: docs-dist
           path: docs/dist/
@@ -60,13 +60,13 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
           cache: pnpm
@@ -94,19 +94,19 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
           cache: pnpm
 
       - name: Download build artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: docs-dist
           path: docs/dist/
@@ -155,7 +155,7 @@ jobs:
         # for us. v7 (Node 20) is battle-tested in this exact comment-upsert
         # pattern. `github-token` passed explicitly because the implicit
         # detection failed with 401 Bad credentials on SHA-pinned action runs.
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           DEPLOY_URL: ${{ steps.deploy.outputs.deploy_url }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -124,9 +124,9 @@ jobs:
           exit 1
 
       - name: Upsert commit comment with preview URL
-        # NOTE: pinned to v7.1.0 — see pr-checks.yml for rationale. github-token
-        # passed explicitly because the implicit detection failed with 401 Bad
-        # credentials on SHA-pinned action runs.
+        # NOTE: bumped to v8.0.0 (Node 24) as part of the Node-20 deprecation
+        # migration. `github-token` passed explicitly because the implicit
+        # detection failed with 401 Bad credentials on SHA-pinned action runs.
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           DEPLOY_URL: ${{ steps.deploy.outputs.deploy_url }}

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -28,13 +28,13 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
           cache: pnpm
@@ -46,7 +46,7 @@ jobs:
         run: pnpm --filter docs build
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: docs-dist
           path: docs/dist/
@@ -59,19 +59,19 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
           cache: pnpm
 
       - name: Download build artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: docs-dist
           path: docs/dist/
@@ -127,7 +127,7 @@ jobs:
         # NOTE: pinned to v7.1.0 — see pr-checks.yml for rationale. github-token
         # passed explicitly because the implicit detection failed with 401 Bad
         # credentials on SHA-pinned action runs.
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           DEPLOY_URL: ${{ steps.deploy.outputs.deploy_url }}
           CF_BRANCH: ${{ steps.branch.outputs.name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
     outputs:
       mac_local_present: ${{ steps.detect.outputs.mac_local_present }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - id: detect
         shell: bash
@@ -193,15 +193,15 @@ jobs:
     runs-on: ${{ matrix.settings.host }}
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       # pnpm version is read from package.json's "packageManager" field
       # (pnpm@11.3.0). action-setup@v4 errors out if BOTH "version:" here
       # and "packageManager:" in package.json are set — pick one. We pick
       # package.json so the version is single-source-of-truth.
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "22"
           cache: "pnpm"
@@ -264,7 +264,7 @@ jobs:
       # under QEMU verification step in workflow logs."
       - name: Set up QEMU (linux-arm64 only)
         if: ${{ matrix.settings.use_cross == true }}
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
         with:
           platforms: arm64
 
@@ -397,13 +397,13 @@ jobs:
           Write-Host "--- checksum file contents ---"
           Get-Content "${env:ARCHIVE}.sha256"
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: binary-${{ matrix.settings.target }}
           path: packages/zfb-${{ matrix.settings.platform }}/${{ matrix.settings.binary }}
           if-no-files-found: error
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: archive-${{ matrix.settings.target }}
           path: |
@@ -422,7 +422,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Resolve version and channel
         shell: bash
@@ -439,7 +439,7 @@ jobs:
           echo "Tag: $TAG | semver: $ZFB_SEMVER | prerelease: $IS_PRERELEASE"
 
       - name: Download all archives
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: archive-*
           path: release-assets
@@ -471,7 +471,7 @@ jobs:
 
       - name: Upload archives and checksums to GitHub Release
         if: ${{ inputs.dry_run != true && startsWith(github.ref, 'refs/tags/v') }}
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           prerelease: ${{ env.IS_PRERELEASE == 'true' }}
           files: release-assets/*
@@ -493,22 +493,22 @@ jobs:
     outputs:
       dist_tag: ${{ steps.dist-tag.outputs.dist_tag }}
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       # pnpm version is read from package.json's "packageManager" field
       # (pnpm@11.3.0). action-setup@v4 errors out if BOTH "version:" here
       # and "packageManager:" in package.json are set — pick one. We pick
       # package.json so the version is single-source-of-truth.
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: "pnpm"
 
       - name: Download all platform binaries
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: binary-*
           path: artifacts
@@ -866,13 +866,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
         with:
           # This job has no checkout, so action-setup has no packageManager
           # field to read — pin the version explicitly (match root package.json).
           version: 11.3.0
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "22"
           # No cache: pnpm — there is no lockfile in the runner cwd at setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -903,6 +903,30 @@ jobs:
             delay=$(( delay * 2 ))
           done
 
+          # Wait until the runner-arch platform tarball is actually fetchable.
+          # npm metadata propagates faster than the ~78 MB binary tarballs; when
+          # a tarball hasn't propagated yet, npm SILENTLY SKIPS the optionalDep
+          # install and the `zfb` launcher fails at runtime.  `npm pack --dry-run`
+          # forces npm to resolve and fetch the actual tarball (not just metadata),
+          # confirming it is available before we invoke `npx create-zfb`.
+          # The runner for this job is ubuntu-latest (linux x64).
+          echo "Waiting for @takazudo/zfb-linux-x64-gnu@${DIST_TAG} tarball to be fetchable..."
+          max_attempts=6
+          delay=10
+          for attempt in $(seq 1 $max_attempts); do
+            if npm pack --dry-run "@takazudo/zfb-linux-x64-gnu@${DIST_TAG}" > /dev/null 2>&1; then
+              echo "Registry resolved @takazudo/zfb-linux-x64-gnu@${DIST_TAG} tarball (attempt ${attempt})"
+              break
+            fi
+            if [[ "$attempt" -eq "$max_attempts" ]]; then
+              echo "::error::@takazudo/zfb-linux-x64-gnu@${DIST_TAG} tarball did not become fetchable after ${max_attempts} attempts."
+              exit 1
+            fi
+            echo "  Not yet available (attempt ${attempt}/${max_attempts}); retrying in ${delay}s..."
+            sleep "$delay"
+            delay=$(( delay * 2 ))
+          done
+
       - name: Scaffold project with create-zfb@<dist-tag>
         shell: bash
         env:
@@ -914,9 +938,23 @@ jobs:
           echo "SMOKE_DIR=$SMOKE_DIR" >> "$GITHUB_ENV"
           echo "Scaffolding into $SMOKE_DIR ..."
           cd "$SMOKE_DIR"
+          # Belt-and-suspenders: retry the scaffold up to 3 times with backoff in
+          # case of a momentary registry blip after the tarball-propagation wait.
           # `create-zfb <name>` is the non-interactive form (positional arg, no prompts).
           # --yes suppresses any interactive npm/npx prompts.
-          npx --yes "create-zfb@${DIST_TAG}" smoke-site
+          scaffold_delay=15
+          for scaffold_attempt in 1 2 3; do
+            if npx --yes "create-zfb@${DIST_TAG}" smoke-site; then
+              break
+            fi
+            if [[ "$scaffold_attempt" -eq 3 ]]; then
+              echo "::error::npx create-zfb@${DIST_TAG} failed after 3 attempts."
+              exit 1
+            fi
+            echo "  Scaffold attempt ${scaffold_attempt}/3 failed; retrying in ${scaffold_delay}s..."
+            sleep "$scaffold_delay"
+            scaffold_delay=$(( scaffold_delay * 2 ))
+          done
           echo "Scaffold complete. Contents of $SMOKE_DIR/smoke-site:"
           ls -la "$SMOKE_DIR/smoke-site"
 

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -28,13 +28,13 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 22
           cache: pnpm

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,13 @@ packages:
 autoInstallPeers: true
 engineStrict: true
 
+# After a workspace version bump pnpm wants to purge + relink node_modules.
+# Under a non-interactive shell (agent/CI-like local run) pnpm aborts with
+# ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY. The relink is not
+# security-sensitive, so auto-confirming is safe. CI is unaffected because it
+# already passes CI=true, which skips the prompt independently.
+confirmModulesPurge: false
+
 # pnpm 11 defaults minimumReleaseAge to 1440 (24h), which would block CI
 # `pnpm install --frozen-lockfile` on any dep published in the last day. CI must be
 # deterministic, so disable the delay here.

--- a/scripts/build-macos-x64-local.sh
+++ b/scripts/build-macos-x64-local.sh
@@ -92,10 +92,50 @@ semver="$(node -p "require('./packages/zfb/package.json').version")"
 archive="zfb-${semver}-${target}.tar.gz"
 echo "==> Building zfb ${semver} for ${target}"
 
+# ── Fix (a): Homebrew rust shadows rustup → ensure rustup toolchain wins ──────
+# When ~/.cargo/bin is not ahead of /opt/homebrew/bin on PATH, `cargo` may
+# resolve to Homebrew's host-only rust which cannot cross-compile x86_64-apple-
+# darwin (error[E0463]: can't find crate for `core`). Detect and fix it here,
+# before any cargo/rustup invocation, so the whole script uses the right cargo.
+if ! command -v rustup >/dev/null 2>&1; then
+  echo "ERROR: rustup not found. Install rustup (https://rustup.rs/) and ensure" >&2
+  echo "       ~/.cargo/bin precedes /opt/homebrew/bin on PATH." >&2
+  exit 1
+fi
+if cargo --version 2>/dev/null | grep -q '(Homebrew)'; then
+  echo "==> Homebrew rust detected on PATH — prepending rustup toolchain bin"
+  _rustup_toolchain="$(rustup show active-toolchain | awk '{print $1}')"
+  _rustup_toolchain_bin="$HOME/.rustup/toolchains/${_rustup_toolchain}/bin"
+  if [[ ! -d "$_rustup_toolchain_bin" ]]; then
+    echo "ERROR: resolved rustup toolchain bin not found: ${_rustup_toolchain_bin}" >&2
+    echo "       Run 'rustup toolchain install ${_rustup_toolchain}' and retry." >&2
+    exit 1
+  fi
+  export PATH="${_rustup_toolchain_bin}:$PATH"
+  echo "    cargo now: $(cargo --version)"
+fi
+
 # ── Toolchain target (idempotent — Apple Silicon hosts need this once) ────────
 
 echo "==> Ensuring rust target ${target} is installed"
 rustup target add "$target"
+
+# Fix (c): wait for the target to be fully registered before building.
+# On first-ever install the rust-std download can lag behind cargo build and
+# produce the same E0463 error. Poll until the target is listed (bounded).
+_target_wait=0
+_target_timeout=60
+until rustup target list --installed | grep -qx "$target"; do
+  if [[ $_target_wait -ge $_target_timeout ]]; then
+    echo "ERROR: ${target} still not listed by 'rustup target list --installed'" >&2
+    echo "       after ${_target_timeout}s. Check your rustup installation." >&2
+    exit 1
+  fi
+  echo "    Waiting for ${target} to finish installing... (${_target_wait}s)"
+  sleep 2
+  _target_wait=$(( _target_wait + 2 ))
+done
+echo "    Target ${target} is ready."
 
 # ── Install node deps before cargo build ──────────────────────────────────────
 # build.rs embeds framework packages from node_modules at compile time.
@@ -125,14 +165,33 @@ fi
 
 # ── Assert --version equals release semver (mirrors release.yml:284-296) ──────
 # Catches a missed ZFB_RELEASE_VERSION injection before the binary is archived.
-actual_version="$("$built_binary" --version)"
+# Fix (b): on Apple Silicon without Rosetta 2 the x86_64 binary cannot execute
+# (Bad CPU type in executable), so guard the runtime assertion behind a Rosetta
+# check and fall back to a static rodata grep when Rosetta is absent.
+# The version string is embedded via option_env!("ZFB_RELEASE_VERSION") in
+# crates/zfb/src/cli.rs and appears literally in the binary's read-only data.
 expected_version="zfb $semver"
-echo "Expected: $expected_version"
-echo "Actual:   $actual_version"
-if [[ "$actual_version" != "$expected_version" ]]; then
-  echo "ERROR: built binary --version mismatch: got '$actual_version', want '$expected_version'" >&2
-  echo "       (ZFB_RELEASE_VERSION injection likely missing)" >&2
-  exit 1
+if arch -x86_64 /usr/bin/true 2>/dev/null; then
+  # Rosetta present — execute the binary directly (original assertion).
+  actual_version="$("$built_binary" --version)"
+  echo "Expected: $expected_version"
+  echo "Actual:   $actual_version"
+  if [[ "$actual_version" != "$expected_version" ]]; then
+    echo "ERROR: built binary --version mismatch: got '$actual_version', want '$expected_version'" >&2
+    echo "       (ZFB_RELEASE_VERSION injection likely missing)" >&2
+    exit 1
+  fi
+else
+  # No Rosetta — verify the version stamp statically by grepping rodata.
+  echo "==> Rosetta absent — verifying version stamp via static rodata grep"
+  echo "Expected: $expected_version"
+  if grep -aF "$semver" "$built_binary" >/dev/null 2>&1; then
+    echo "Actual:   $semver found in binary rodata — OK"
+  else
+    echo "ERROR: '$semver' not found in binary rodata." >&2
+    echo "       ZFB_RELEASE_VERSION injection likely failed." >&2
+    exit 1
+  fi
 fi
 
 # ── Place binary in the platform package (mirrors release.yml) ────────────────


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/592

---

## Summary

Epic #592 — four release/CI infrastructure fixes that surfaced during v0.1.0-next.12. No product/runtime behavior change; config, workflows, and the local build script only.

- **#593 (supersedes #591)** — add `confirmModulesPurge: false` to `pnpm-workspace.yaml` (pnpm 11's settings home, not `.npmrc`) so a non-interactive `pnpm install` after a version bump no longer aborts with `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`.
- **#594 (supersedes #589)** — harden `scripts/build-macos-x64-local.sh` for Apple Silicon: (a) detect Homebrew-rust shadowing and prepend the rustup toolchain bin; (b) guard the `--version` assertion behind a Rosetta check with a static rodata-grep fallback; (c) wait for `rustup target add` to finish before building.
- **#595 (supersedes #590)** — migrate all `.github/workflows/*.yml` actions off the deprecated Node 20 runtime to Node-24 releases, re-pinned by SHA (checkout v5, setup-node v5, pnpm/action-setup v6, upload-artifact v7, download-artifact v8, github-script v8, action-gh-release v3, setup-qemu-action v4). actionlint passes.
- **#596 (supersedes #588)** — `release.yml` smoke-clean-room now waits for the runner-arch platform tarball (`npm pack --dry-run`), not just `create-zfb` metadata, plus a bounded scaffold retry — fixes intermittent post-publish false failures.

## Topic PRs

Topics were merged into the base branch locally (worktree workflow); no separate topic PRs.

## Review

/gcoc-review against main: no actionable issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)