### PR TITLE
ci: add actionlint workflow to lint GitHub Actions files

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,55 @@
+# Lints GitHub Actions workflow files with rhysd/actionlint.
+# Path-filtered: runs ONLY when a workflow file changes, so it stays off the
+# critical path for ordinary PRs. `base/**` covers the long-lived integration
+# branches used by /x-wt-teams epics.
+name: actionlint
+
+on:
+  pull_request:
+    branches:
+      - main
+      - "base/**"
+    paths:
+      - ".github/workflows/**"
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+      - "base/**"
+    paths:
+      - ".github/workflows/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: actionlint-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      # GitHub-hosted ubuntu runners ship shellcheck preinstalled, so actionlint
+      # additionally lints `run:` shell blocks through it (no extra setup).
+      - name: Run actionlint
+        env:
+          # Pinned release + checksum (tamper-evident). Bump both together;
+          # checksum from actionlint_<ver>_checksums.txt on the GitHub release.
+          ACTIONLINT_VERSION: "1.7.12"
+          ACTIONLINT_SHA256: "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+        run: |
+          set -euo pipefail
+          curl --retry 5 --retry-all-errors --retry-delay 5 -fsSL \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" \
+            -o actionlint.tar.gz
+          echo "${ACTIONLINT_SHA256}  actionlint.tar.gz" | sha256sum --check
+          tar -xzf actionlint.tar.gz actionlint
+          ./actionlint -color


### PR DESCRIPTION
## Summary
Adds a dedicated `actionlint` workflow that lints our GitHub Actions workflow files with [rhysd/actionlint](https://github.com/rhysd/actionlint), including shellcheck analysis of `run:` blocks. Modeled on the zudolab/zudo-text actionlint integration (PR #2242), adapted to this repo's conventions.

## Changes
- New `.github/workflows/actionlint.yml`:
  - Path-filtered to `.github/workflows/**` — stays off the critical path for ordinary PRs.
  - Triggers on `pull_request` + `push` to `main` and `base/**` (the long-lived integration branches used by `/x-wt-teams` epics).
  - Downloads actionlint at a pinned version (`1.7.12`) and verifies a pinned **SHA256** before extraction (tamper-evident); the job fails on mismatch.
  - `runs-on: ubuntu-latest` (GitHub-hosted runners ship shellcheck preinstalled).
  - `actions/checkout` pinned to `93cb6efe… # v5.0.1`, matching every other workflow in the repo.
  - Least-privilege `permissions: contents: read`; per-branch `concurrency` with `cancel-in-progress`.

## Notes
- No existing workflow needed fixes: all 7 current workflows pass `actionlint` + shellcheck clean (verified locally with actionlint 1.7.12 + shellcheck 0.10.0).
- No `.github/actionlint.yaml` config added — that file is only needed to declare custom runner labels (e.g. Blacksmith), and this repo uses standard GitHub-hosted runners.

## Test Plan
- [x] `actionlint` + shellcheck pass locally on all workflows (including the new one).
- [ ] The new `actionlint` check runs green on this PR (it self-validates, since the PR touches `.github/workflows/**`).