### PR TITLE
Preview & SSR Fixes: preserve query on preview redirect + env-gate SSR error stack

### DIFF
--- a/crates/zfb-render/src/embedded_v8/extensions.rs
+++ b/crates/zfb-render/src/embedded_v8/extensions.rs
@@ -99,6 +99,27 @@ pub const NODE_STUB_SPECIFIERS: &[&str] = &[
     "node:async_hooks",
 ];
 
+#[cfg(test)]
+mod tests {
+    use super::HOST_GLOBALS_SHIM_SRC;
+
+    /// Verify the embedded globals shim sets the `ssrDebug` flag inside the
+    /// `globalThis.__zfb` literal. The flag is the runtime discriminator that
+    /// gates verbose SSR error output to the embedded V8 host — absent on the
+    /// production Cloudflare Workers runtime. A string-match here is the
+    /// lightest-weight way to confirm the shim source (embedded via
+    /// `include_str!`) contains the expected token without spinning up a JS
+    /// runtime.
+    #[test]
+    fn globals_shim_contains_ssr_debug_flag() {
+        assert!(
+            HOST_GLOBALS_SHIM_SRC.contains("ssrDebug"),
+            "globals_shim.js must set the `ssrDebug` flag inside globalThis.__zfb \
+             so the router can gate verbose SSR error output to the embedded V8 host"
+        );
+    }
+}
+
 /// Lookup the synthetic source for a `node:*` specifier. Returns
 /// `None` for any specifier outside [`NODE_STUB_SPECIFIERS`] — the
 /// loader treats that as "not a node stub, fall through".

--- a/crates/zfb-render/src/embedded_v8/js/globals_shim.js
+++ b/crates/zfb-render/src/embedded_v8/js/globals_shim.js
@@ -23,6 +23,9 @@ const __zfb_state = {
 };
 
 globalThis.__zfb = {
+  // ssrDebug: present only in the embedded build/dev V8 host, never in the
+  // production Cloudflare Workers runtime — gates verbose SSR error output.
+  ssrDebug: true,
   setBundle(defaultExport) {
     __zfb_state.bundle = defaultExport;
   },

--- a/crates/zfb-server/src/routes.rs
+++ b/crates/zfb-server/src/routes.rs
@@ -501,11 +501,19 @@ pub fn build_router(state: AppState) -> Router {
         // Bare `/` lands the developer on the home page — but only `/`
         // exactly, never `<prefix>/...`, because the prefixed routes
         // above already catch those and a redirect there would loop.
+        // The Uri is extracted so any query string on `/?x=1` is carried
+        // through to `<prefix>/?x=1` rather than silently dropped.
         .route(
             "/",
-            get(move || {
+            get(move |uri: Uri| {
                 let target = redirect_target.clone();
-                async move { Redirect::to(&target).into_response() }
+                async move {
+                    let target = match uri.query() {
+                        Some(q) if !q.is_empty() => format!("{target}?{q}"),
+                        _ => target,
+                    };
+                    Redirect::to(&target).into_response()
+                }
             }),
         )
         // Any other unprefixed path (e.g. an HTML link that forgot the
@@ -2719,6 +2727,37 @@ mod tests {
             .unwrap_or_default()
             .to_string();
         assert_eq!(location, "/foo/", "expected redirect to /foo/, got {location}");
+    }
+
+    #[tokio::test]
+    async fn base_prefix_redirects_bare_root_with_query_to_prefix() {
+        // GET /?x=1 must redirect to /foo/?x=1 — the query string must
+        // be preserved so shareable URLs (e.g. /?c=1a) survive the
+        // base-prefix redirect without silently losing their params.
+        let state = test_state_with_base("/foo");
+        let router = test_router_with_base(state);
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/?x=1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::SEE_OTHER);
+        let location = resp
+            .headers()
+            .get(header::LOCATION)
+            .and_then(|h| h.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        assert_eq!(
+            location, "/foo/?x=1",
+            "query string must be carried through the bare-root redirect (got {location:?})"
+        );
     }
 
     #[tokio::test]

--- a/crates/zfb/src/commands/preview.rs
+++ b/crates/zfb/src/commands/preview.rs
@@ -179,15 +179,26 @@ pub(crate) fn build_static_router(dist_root: PathBuf) -> Router {
 /// One handler covering every path. Easier than wiring `/`, `/*path`
 /// separately because we want identical behaviour for both.
 async fn static_fallback(State(state): State<StaticState>, uri: Uri) -> Response {
-    serve_static(&state.dist_root, uri.path()).await
+    serve_static(&state.dist_root, uri.path(), uri.query()).await
 }
 
 /// Apply the Cloudflare-Pages-style routing rule to a request, then
 /// either serve a file, redirect, or 404.
-async fn serve_static(dist_root: &Path, url_path: &str) -> Response {
+///
+/// `query` is the raw (already percent-encoded) query string from the
+/// request URI, if any. It is appended verbatim to redirect targets so
+/// that `/m?c=1a` → `301 /m/?c=1a` rather than silently dropping
+/// the query.
+async fn serve_static(dist_root: &Path, url_path: &str, query: Option<&str>) -> Response {
     match resolve_static(dist_root, url_path) {
         Resolution::File(path) => serve_file(&path, dist_root).await,
-        Resolution::Redirect(target) => redirect_response(&target),
+        Resolution::Redirect(target) => {
+            let target = match query {
+                Some(q) if !q.is_empty() => format!("{target}?{q}"),
+                _ => target,
+            };
+            redirect_response(&target)
+        }
         Resolution::NotFound => not_found_response(dist_root).await,
     }
 }
@@ -806,6 +817,64 @@ mod tests {
             .unwrap_or_default()
             .to_string();
         assert_eq!(location, "/about/");
+    }
+
+    #[tokio::test]
+    async fn handler_redirects_directory_with_query_string() {
+        // GET /about?c=1a (no trailing slash, dist/about/index.html exists)
+        // must redirect to /about/?c=1a — query string must be preserved
+        // exactly (verbatim, no re-encoding).
+        let dist = fixture_dist();
+        let router = build_static_router(dist.path().to_path_buf());
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/about?c=1a")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::MOVED_PERMANENTLY);
+        let location = resp
+            .headers()
+            .get(header::LOCATION)
+            .and_then(|h| h.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        assert_eq!(
+            location, "/about/?c=1a",
+            "redirect must carry the query string verbatim (got {location:?})"
+        );
+    }
+
+    #[tokio::test]
+    async fn handler_redirects_directory_no_bare_question_mark_when_no_query() {
+        // GET /about (no query) must redirect to /about/ — NOT /about/? (bare ?).
+        let dist = fixture_dist();
+        let router = build_static_router(dist.path().to_path_buf());
+
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/about")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::MOVED_PERMANENTLY);
+        let location = resp
+            .headers()
+            .get(header::LOCATION)
+            .and_then(|h| h.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        assert_eq!(
+            location, "/about/",
+            "no query string means no bare ? in Location (got {location:?})"
+        );
     }
 
     #[tokio::test]

--- a/packages/zfb-runtime/src/__tests__/router.test.ts
+++ b/packages/zfb-runtime/src/__tests__/router.test.ts
@@ -437,6 +437,56 @@ describe("createPageRouter", () => {
     expect(body).toContain('"/ruby-page"');
   });
 
+  // -------------------------------------------------------------------------
+  // Issue #607 — env-gate: stack absent in production, present with flag
+  // -------------------------------------------------------------------------
+
+  it("omits the stack trace by default (production Workers path — no globalThis.__zfb.ssrDebug)", async () => {
+    // Default behaviour (no includeErrorStack option, no host flag):
+    // the 500 body must contain message + route but NO stack trace.
+    // Use includeErrorStack: false to keep the test hermetic against
+    // any globalThis.__zfb mutation by other suites.
+    const throwingPage: PageModule = {
+      default: () => {
+        throw new Error("boom");
+      },
+    };
+    const router = createPageRouter({
+      pages: [{ route: "/throws", module: () => Promise.resolve(throwingPage) }],
+      contentSnapshot: { collections: {} },
+      framework: stubFramework(),
+      includeErrorStack: false,
+    });
+    const res = await router(new Request("http://test.local/throws"));
+    expect(res.status).toBe(500);
+    const body = await res.text();
+    // Exact body — message + route only, no trailing stack.
+    expect(body).toBe('[zfb-runtime] render threw for "/throws": boom');
+  });
+
+  it("includes the full stack trace when includeErrorStack is true (embedded V8 / test path)", async () => {
+    // Explicit includeErrorStack: true simulates the embedded V8 host
+    // (where globalThis.__zfb.ssrDebug would be true).
+    const throwingPage: PageModule = {
+      default: () => {
+        throw new Error("boom");
+      },
+    };
+    const router = createPageRouter({
+      pages: [{ route: "/throws", module: () => Promise.resolve(throwingPage) }],
+      contentSnapshot: { collections: {} },
+      framework: stubFramework(),
+      includeErrorStack: true,
+    });
+    const res = await router(new Request("http://test.local/throws"));
+    expect(res.status).toBe(500);
+    const body = await res.text();
+    // Must start with the message + route header.
+    expect(body.startsWith('[zfb-runtime] render threw for "/throws": boom')).toBe(true);
+    // Must also contain a stack frame (V8 stacks have lines starting with "    at ").
+    expect(body).toContain("\n    at ");
+  });
+
   it("successful renders are unaffected after adding the render try/catch", async () => {
     // Happy-path guard: the try/catch must not interfere with 200 renders.
     const { pages, contentSnapshot } = buildFixture();

--- a/packages/zfb-runtime/src/router.ts
+++ b/packages/zfb-runtime/src/router.ts
@@ -116,6 +116,17 @@ export interface CreatePageRouterOptions {
   readonly contentSnapshot: ContentSnapshot;
   /** Framework adapter pinning the SSR call. */
   readonly framework: FrameworkAdapter;
+  /**
+   * When `true`, the 500 body for render errors includes the full JS stack
+   * trace. When `false`, only the message + route are included. When
+   * omitted, the runtime checks `globalThis.__zfb.ssrDebug` at request time:
+   * that flag is set by the embedded V8 build/dev host (`globals_shim.js`)
+   * and is absent on the production Cloudflare Workers runtime.
+   *
+   * Default is effectively OFF for production (no flag ⇒ message + route only).
+   * Useful for explicit injection in unit tests without global mutation.
+   */
+  readonly includeErrorStack?: boolean;
 }
 
 /**
@@ -435,7 +446,12 @@ export function createPageRouter(opts: CreatePageRouterOptions): PageRouter {
         return c.body(ensureHtml5Doctype(html, contentType), 200, { "Content-Type": contentType });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
-        const stack = err instanceof Error && err.stack ? `\n${err.stack}` : "";
+        // __zfb.ssrDebug is set only by the embedded V8 build/dev host
+        // (globals_shim.js), never by the production Workers runtime.
+        const includeStack =
+          opts.includeErrorStack ??
+          (globalThis as { __zfb?: { ssrDebug?: boolean } }).__zfb?.ssrDebug === true;
+        const stack = includeStack && err instanceof Error && err.stack ? `\n${err.stack}` : "";
         return c.body(`[zfb-runtime] render threw for "${page.route}": ${msg}${stack}`, 500, {
           "Content-Type": "text/plain; charset=utf-8",
         });


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/609

---

## Summary

Two independent bugfixes (epic #609), found while migrating a real app onto zfb (React 19, next.16). Disjoint files, merged into base/preview-ssr-fixes.

### #610 — Preserve query string on preview/dev trailing-slash redirects (fixes #608)
- `crates/zfb/src/commands/preview.rs`: `static_fallback` now threads `uri.query()` into `serve_static`; the `Resolution::Redirect` arm appends the (already percent-encoded) query verbatim, **only when non-empty** so no bare `?` is emitted. `resolve_static` stays a pure path→Resolution function (existing tests unchanged). New handler tests assert the exact `Location` (e.g. `/about/?c=1a`) and the no-bare-`?` case.
- `crates/zfb-server/src/routes.rs`: the dev-server bare-root redirect (`/` → `/<base>/`) was found to drop the query too — fixed the same way, with a new test.
- Confirmed zfb emits no `_redirects`/`_headers` host redirect-rules file, so production hosts (Netlify/CF Pages) handle their own normalization. Nothing to fix there.

### #611 — Env-gate the SSR 500 error stack to dev/build only (fixes #607)
- The `createPageRouter` render catch in `packages/zfb-runtime/src/router.ts` leaked the full `err.stack` in the 500 body on every consumer. Because the bundle is shared by the embedded V8 host (build/dev) and the Cloudflare Workers runtime, the gate is read at **request time**: `opts.includeErrorStack ?? globalThis.__zfb?.ssrDebug === true`. Default **OFF** (message + route only), matching the sibling `getStaticProps` catch.
- `crates/zfb-render/src/embedded_v8/js/globals_shim.js` sets `ssrDebug: true` (host-only marker); the production Worker never loads the shim, so the stack is suppressed there while build/dev still surfaces it (#604's debugging intent preserved).
- Hermetic unit tests cover both branches via the option; a Rust string-match test asserts the embedded shim carries the flag.

## Verification
- `cargo test` (zfb-server, zfb-render, zfb preview module) green on the merged base; `@takazudo/zfb-runtime` 102/102 pass; clippy clean.
- `/gcoc-review`: no actionable findings.
- Full CI on this PR: all checks green.

## Topic PRs
Implemented in worktrees and merged locally into the base (topic branches deleted):
- #610 — preview query redirect
- #611 — SSR stack gating