### PR TITLE
Followups Cleanup: bundler arg-struct refactor, output-neutrality test, docs-ja translation, port-spec cleanup, flaky-test fix (#624)

### DIFF
--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -1279,14 +1279,16 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
     write_entry_module(
         shadow,
         entry_routes_for_write,
-        adapter.render_to_string_module(),
-        entry_snapshot_for_write,
-        entry_content_imports_for_write,
-        input.site.as_deref(),
-        input.prefetch_disabled,
-        // Emitted independently of `content_imports` / `worker_only_routes`:
-        // a project may define overrides with zero content entries (#616).
-        mdx_components_import_spec.as_deref(),
+        &EntryModuleInputs {
+            render_to_string_module: adapter.render_to_string_module(),
+            content_snapshot_json: entry_snapshot_for_write,
+            content_imports: entry_content_imports_for_write,
+            site: input.site.as_deref(),
+            prefetch_disabled: input.prefetch_disabled,
+            // Emitted independently of `content_imports` / `worker_only_routes`:
+            // a project may define overrides with zero content entries (#616).
+            mdx_components_import_spec: mdx_components_import_spec.as_deref(),
+        },
     )
     .context("bundler: failed writing entry.mjs")?;
 
@@ -2507,6 +2509,21 @@ fn write_synthetic_tsconfig(
     Ok(())
 }
 
+// Emission inputs for write_entry_module. Grouping these into a struct lets
+// future `globalThis.__zfb.*` slots add a field here instead of widening the
+// function signature.
+struct EntryModuleInputs<'a> {
+    render_to_string_module: &'a str,
+    content_snapshot_json: Option<&'a str>,
+    content_imports: &'a [ContentImport],
+    site: Option<&'a str>,
+    prefetch_disabled: bool,
+    /// Shadow-relative specifier of the materialised `mdx-components.tsx`
+    /// (sub-issue #616). When `Some`, emit a default `import` of the file
+    /// plus the `globalThis.__zfb.mdxComponents` installer. `None` => omit.
+    mdx_components_import_spec: Option<&'a str>,
+}
+
 /// Generate the `entry.mjs` module that re-exports `routes`,
 /// `hydrateIsland`, and a Workers-style `default { fetch }` wrapper
 /// driven by `createPageRouter` from `@takazudo/zfb-runtime`. This is
@@ -2548,20 +2565,17 @@ fn write_synthetic_tsconfig(
 /// runtime `bridge?.get(...)` calls fall through to the
 /// `<pre data-zfb-content-fallback>` shape, matching the behaviour of
 /// builds with no content collections.
-#[allow(clippy::too_many_arguments)]
 fn write_entry_module(
     shadow: &Path,
     routes: &[RouteEntry],
-    render_to_string_module: &str,
-    content_snapshot_json: Option<&str>,
-    content_imports: &[ContentImport],
-    site: Option<&str>,
-    prefetch_disabled: bool,
-    // Shadow-relative specifier of the materialised `mdx-components.tsx`
-    // (sub-issue #616). When `Some`, emit a default `import` of the file
-    // plus the `globalThis.__zfb.mdxComponents` installer. `None` => omit.
-    mdx_components_import_spec: Option<&str>,
+    inputs: &EntryModuleInputs<'_>,
 ) -> Result<()> {
+    let render_to_string_module = inputs.render_to_string_module;
+    let content_snapshot_json = inputs.content_snapshot_json;
+    let content_imports = inputs.content_imports;
+    let site = inputs.site;
+    let prefetch_disabled = inputs.prefetch_disabled;
+    let mdx_components_import_spec = inputs.mdx_components_import_spec;
     use std::fmt::Write as _;
 
     // Static-HTML routes are emitted verbatim by the renderer and must
@@ -3510,12 +3524,14 @@ mod tests {
         write_entry_module(
             shadow,
             &routes,
-            "preact-render-to-string",
-            None,
-            &[],
-            None,
-            false,
-            None,
+            &EntryModuleInputs {
+                render_to_string_module: "preact-render-to-string",
+                content_snapshot_json: None,
+                content_imports: &[],
+                site: None,
+                prefetch_disabled: false,
+                mdx_components_import_spec: None,
+            },
         )
         .unwrap();
 
@@ -3593,12 +3609,14 @@ mod tests {
         write_entry_module(
             shadow,
             &[],
-            "preact-render-to-string",
-            None,
-            &imports,
-            None,
-            false,
-            None,
+            &EntryModuleInputs {
+                render_to_string_module: "preact-render-to-string",
+                content_snapshot_json: None,
+                content_imports: &imports,
+                site: None,
+                prefetch_disabled: false,
+                mdx_components_import_spec: None,
+            },
         )
         .unwrap();
 
@@ -3667,12 +3685,14 @@ mod tests {
         write_entry_module(
             shadow,
             &[],
-            "preact-render-to-string",
-            None,
-            &[],
-            None,
-            false,
-            None,
+            &EntryModuleInputs {
+                render_to_string_module: "preact-render-to-string",
+                content_snapshot_json: None,
+                content_imports: &[],
+                site: None,
+                prefetch_disabled: false,
+                mdx_components_import_spec: None,
+            },
         )
         .unwrap();
 
@@ -3700,12 +3720,14 @@ mod tests {
         write_entry_module(
             shadow,
             &[],
-            "preact-render-to-string",
-            None,
-            &[],
-            Some("https://example.com"),
-            false,
-            None,
+            &EntryModuleInputs {
+                render_to_string_module: "preact-render-to-string",
+                content_snapshot_json: None,
+                content_imports: &[],
+                site: Some("https://example.com"),
+                prefetch_disabled: false,
+                mdx_components_import_spec: None,
+            },
         )
         .unwrap();
 
@@ -3745,12 +3767,14 @@ mod tests {
         write_entry_module(
             shadow,
             &[],
-            "preact-render-to-string",
-            None,
-            &[],
-            None,
-            false,
-            None,
+            &EntryModuleInputs {
+                render_to_string_module: "preact-render-to-string",
+                content_snapshot_json: None,
+                content_imports: &[],
+                site: None,
+                prefetch_disabled: false,
+                mdx_components_import_spec: None,
+            },
         )
         .unwrap();
 
@@ -3773,12 +3797,14 @@ mod tests {
         write_entry_module(
             shadow,
             &[],
-            "preact-render-to-string",
-            None,
-            &[],
-            None,
-            true,
-            None,
+            &EntryModuleInputs {
+                render_to_string_module: "preact-render-to-string",
+                content_snapshot_json: None,
+                content_imports: &[],
+                site: None,
+                prefetch_disabled: true,
+                mdx_components_import_spec: None,
+            },
         )
         .unwrap();
 
@@ -3818,12 +3844,14 @@ mod tests {
         write_entry_module(
             shadow,
             &[],
-            "preact-render-to-string",
-            None,
-            &[],
-            None,
-            false,
-            None,
+            &EntryModuleInputs {
+                render_to_string_module: "preact-render-to-string",
+                content_snapshot_json: None,
+                content_imports: &[],
+                site: None,
+                prefetch_disabled: false,
+                mdx_components_import_spec: None,
+            },
         )
         .unwrap();
 
@@ -3871,12 +3899,14 @@ mod tests {
         write_entry_module(
             shadow,
             &[],
-            "preact-render-to-string",
-            None,
-            &[],
-            None,
-            false,
-            Some("./mdx-components.tsx"),
+            &EntryModuleInputs {
+                render_to_string_module: "preact-render-to-string",
+                content_snapshot_json: None,
+                content_imports: &[],
+                site: None,
+                prefetch_disabled: false,
+                mdx_components_import_spec: Some("./mdx-components.tsx"),
+            },
         )
         .unwrap();
 
@@ -3923,12 +3953,14 @@ mod tests {
         write_entry_module(
             shadow,
             &[],
-            "preact-render-to-string",
-            None,
-            &[], // zero content imports
-            None,
-            false,
-            Some("./mdx-components.tsx"),
+            &EntryModuleInputs {
+                render_to_string_module: "preact-render-to-string",
+                content_snapshot_json: None,
+                content_imports: &[], // zero content imports
+                site: None,
+                prefetch_disabled: false,
+                mdx_components_import_spec: Some("./mdx-components.tsx"),
+            },
         )
         .unwrap();
 
@@ -3955,12 +3987,14 @@ mod tests {
         write_entry_module(
             shadow,
             &[],
-            "preact-render-to-string",
-            None,
-            &[],
-            None,
-            false,
-            None,
+            &EntryModuleInputs {
+                render_to_string_module: "preact-render-to-string",
+                content_snapshot_json: None,
+                content_imports: &[],
+                site: None,
+                prefetch_disabled: false,
+                mdx_components_import_spec: None,
+            },
         )
         .unwrap();
 
@@ -3994,12 +4028,14 @@ mod tests {
         write_entry_module(
             shadow,
             &[],
-            "preact-render-to-string",
-            None,
-            &[],
-            None,
-            false,
-            Some("./mdx-components.tsx"),
+            &EntryModuleInputs {
+                render_to_string_module: "preact-render-to-string",
+                content_snapshot_json: None,
+                content_imports: &[],
+                site: None,
+                prefetch_disabled: false,
+                mdx_components_import_spec: Some("./mdx-components.tsx"),
+            },
         )
         .unwrap();
 
@@ -4222,12 +4258,14 @@ mod tests {
         write_entry_module(
             &shadow_root,
             &[],
-            "preact-render-to-string",
-            None,
-            &imports,
-            None,
-            false,
-            None,
+            &EntryModuleInputs {
+                render_to_string_module: "preact-render-to-string",
+                content_snapshot_json: None,
+                content_imports: &imports,
+                site: None,
+                prefetch_disabled: false,
+                mdx_components_import_spec: None,
+            },
         )
         .unwrap();
         let entry = fs::read_to_string(shadow_root.join(SHADOW_ENTRY_FILENAME)).unwrap();
@@ -4359,7 +4397,19 @@ mod tests {
         // is the documented zero-routes behaviour.
         let tmp = tempfile::tempdir().unwrap();
         let shadow = tmp.path();
-        write_entry_module(shadow, &[], "react-dom/server", None, &[], None, false, None).unwrap();
+        write_entry_module(
+            shadow,
+            &[],
+            &EntryModuleInputs {
+                render_to_string_module: "react-dom/server",
+                content_snapshot_json: None,
+                content_imports: &[],
+                site: None,
+                prefetch_disabled: false,
+                mdx_components_import_spec: None,
+            },
+        )
+        .unwrap();
 
         let body = fs::read_to_string(shadow.join(SHADOW_ENTRY_FILENAME)).unwrap();
         assert!(body.contains("\"react-dom/server\""));
@@ -4374,7 +4424,19 @@ mod tests {
     fn entry_module_snapshot_literal(snapshot: Option<&str>) -> String {
         let tmp = tempfile::tempdir().unwrap();
         let shadow = tmp.path();
-        write_entry_module(shadow, &[], "react-dom/server", snapshot, &[], None, false, None).unwrap();
+        write_entry_module(
+            shadow,
+            &[],
+            &EntryModuleInputs {
+                render_to_string_module: "react-dom/server",
+                content_snapshot_json: snapshot,
+                content_imports: &[],
+                site: None,
+                prefetch_disabled: false,
+                mdx_components_import_spec: None,
+            },
+        )
+        .unwrap();
         let body = fs::read_to_string(shadow.join(SHADOW_ENTRY_FILENAME)).unwrap();
         // Pull just the assignment line so the assertion is precise.
         let prefix = "const __zfb_content_snapshot = ";

--- a/crates/zfb/src/config.rs
+++ b/crates/zfb/src/config.rs
@@ -3410,50 +3410,158 @@ mod tests {
 
     // --- Sub #417 V8 evaluator wiring tests ----------------------------------
 
-    /// V8 path end-to-end: spawn_blocking wrapping test.
+    /// `spawn_blocking` in the V8 eval path keeps the tokio event loop free.
     ///
-    /// Runs `load_from_dir` through the real esbuild + V8 evaluator path
-    /// (no test-override short-circuit). A sibling `tokio::time::sleep` of
-    /// equal wall-clock duration must complete within tolerance — proving that
-    /// the `spawn_blocking` wrapper is in place and the tokio event loop stays
-    /// unblocked during V8 boot. If a future refactor drops `spawn_blocking`
-    /// the sibling sleep would be starved, failing the time-comparison assertion.
+    /// ## What is tested
+    ///
+    /// `config.rs` wraps `ThreadedConfigEvaluator::eval_bundle` inside
+    /// `tokio::task::spawn_blocking` so the synchronous `rx.recv()` call
+    /// (blocking the calling thread until the JS eval finishes) does not pin
+    /// the single-threaded tokio event loop. This test goes through the full
+    /// production `load_from_dir` path and detects a dropped `spawn_blocking`
+    /// by measuring the maximum event-loop starvation gap.
+    ///
+    /// ## Detection mechanism
+    ///
+    /// A heartbeat probe runs concurrently with `load_from_dir` via
+    /// `tokio::join!`. The probe loops, sleeping 2 ms on each iteration and
+    /// recording the wall-clock gap since the previous wakeup. The worst gap
+    /// observed over the entire load captures whether the event loop was ever
+    /// frozen for a long time.
+    ///
+    /// - **With `spawn_blocking`:** eval_bundle's `rx.recv()` runs on the
+    ///   blocking thread pool; the event loop stays free; the probe wakes on
+    ///   schedule; `max_gap` ≈ probe interval + jitter (small, a few ms).
+    /// - **Without `spawn_blocking`:** `rx.recv()` freezes the current-thread
+    ///   event loop for the full JS eval duration; the probe cannot be polled
+    ///   during that window; `max_gap` ≈ JS eval duration (large, ~150 ms).
+    ///
+    /// ## Why `current_thread`
+    ///
+    /// A `multi_thread` runtime has spare workers that can advance the probe
+    /// even when one worker is blocked. `current_thread` forces a single event
+    /// loop, making the starvation effect visible.
+    ///
+    /// ## Why the config has a CPU-heavy warm-up expression
+    ///
+    /// deno_core ships a **V8 snapshot** — V8 boot is pre-baked into the
+    /// binary. Natural eval on warm V8 takes only ~20 ms, too short and too
+    /// timing-sensitive to discriminate WITH vs WITHOUT spawn_blocking. A
+    /// deliberate CPU-busy loop embedded in the config's default export forces
+    /// the eval to take ~150–200 ms deterministically on every attempt (V8
+    /// cannot DCE it because the result is part of the exported object). This
+    /// wide, stable signal makes the threshold reliable and removes the flake
+    /// root cause that affected the original test.
+    ///
+    /// ## Retry rationale
+    ///
+    /// Under heavy OS scheduler load the probe gap can be elevated even with
+    /// `spawn_blocking` in place (transient false failure). A bounded retry
+    /// loop (up to `MAX_ATTEMPTS`) passes as soon as ANY attempt's `max_gap`
+    /// is below the threshold, and only panics if ALL attempts exceed it. This
+    /// tolerates transient spikes while still detecting a removed
+    /// `spawn_blocking`: every attempt would have a large gap (the full JS
+    /// eval duration ~150–200 ms), so no retry would ever pass the threshold.
+    ///
+    /// ## Threshold
+    ///
+    /// The threshold (75 ms) sits cleanly between the WITH case (typically
+    /// < 15 ms) and the WITHOUT case (~150 ms). The original 10× sleep
+    /// tolerance was too wide — this test needs a gap-based measurement to
+    /// discriminate the two cases.
     #[cfg(feature = "embed_v8")]
-    #[tokio::test(flavor = "multi_thread")]
+    #[tokio::test(flavor = "current_thread")]
     async fn v8_eval_spawn_blocking_does_not_starve_event_loop() {
-        let tmp = TempDir::new().unwrap();
-        tokio::fs::write(
-            tmp.path().join("zfb.config.ts"),
-            "export default { port: 7777 };\n",
-        )
-        .await
-        .unwrap();
+        use std::cell::Cell;
+        use std::rc::Rc;
 
-        // Record wall-clock time of a plain tokio sleep so we have a
-        // baseline for what "the event loop is free" looks like.
-        let sleep_start = std::time::Instant::now();
-        let sleep_dur = std::time::Duration::from_millis(50);
+        const MAX_ATTEMPTS: u32 = 5;
+        // Threshold between WITH (~few ms) and WITHOUT (~150+ ms).
+        // 75 ms provides a wide, stable margin between the two cases.
+        let gap_threshold = std::time::Duration::from_millis(75);
 
-        // Run the V8 eval and the sleep concurrently.
-        let (load_result, ()) = tokio::join!(
-            load_from_dir(tmp.path()),
-            tokio::time::sleep(sleep_dur),
-        );
-        let sleep_elapsed = sleep_start.elapsed();
+        // CPU-heavy config: the IIFE runs a busy loop whose result is part of
+        // the exported object, preventing V8 dead-code elimination.
+        // This forces the eval to take ~150-200 ms regardless of V8 warm/cold
+        // state — necessary because deno_core's snapshot makes natural eval
+        // only ~20 ms, which is too short to discriminate spawn_blocking
+        // presence from absence. The `_warmup` field is ignored by assertions.
+        // iteration count: 2e8 ≈ 150-200 ms on modern hardware (calibrated).
+        const HEAVY_CONFIG: &str = "\
+            export default { port: 7777, \
+                _warmup: (() => { let s = 0; for (let i = 0; i < 2e8; i++) s += i; return s; })() \
+            };";
 
-        // The load must succeed.
-        let cfg = load_result.expect("V8 eval should load a simple config");
-        assert_eq!(cfg.port, Some(7777));
+        let mut last_max_gap = std::time::Duration::ZERO;
 
-        // The sleep must have completed within 10× its requested duration.
-        // If spawn_blocking is missing, the V8-boot thread would pin the
-        // single tokio worker and the sleep would be delayed by the full
-        // V8 startup time (typically 200–600 ms), which is > 500 ms.
-        let tolerance = sleep_dur * 10;
-        assert!(
-            sleep_elapsed < sleep_dur + tolerance,
-            "tokio::time::sleep({sleep_dur:?}) took {sleep_elapsed:?} — \
-             event loop may have been starved (spawn_blocking missing?)"
+        for attempt in 1..=MAX_ATTEMPTS {
+            let tmp = TempDir::new().unwrap();
+            tokio::fs::write(tmp.path().join("zfb.config.ts"), HEAVY_CONFIG)
+                .await
+                .unwrap();
+
+            let done = Rc::new(Cell::new(false));
+            let probe_done = done.clone();
+
+            // Heartbeat probe: runs while load_from_dir is active.
+            // Records the maximum gap between successive wakeups, which is a
+            // proxy for how long the event loop was unavailable.
+            //
+            // The loop checks `probe_done` AFTER measuring, not before, so
+            // it always records the gap that ends the final blocking window.
+            let probe = async move {
+                let probe_interval = std::time::Duration::from_millis(2);
+                let mut max_gap = std::time::Duration::ZERO;
+                let mut last = std::time::Instant::now();
+                loop {
+                    tokio::time::sleep(probe_interval).await;
+                    let now = std::time::Instant::now();
+                    let gap = now.duration_since(last);
+                    if gap > max_gap {
+                        max_gap = gap;
+                    }
+                    last = now;
+                    if probe_done.get() {
+                        break;
+                    }
+                }
+                max_gap
+            };
+
+            let load = async {
+                let result = load_from_dir(tmp.path()).await;
+                done.set(true);
+                result
+            };
+
+            let (load_result, max_gap) = tokio::join!(load, probe);
+
+            // The load must succeed on every attempt.
+            let cfg = load_result.expect("V8 eval should load a simple config");
+            assert_eq!(cfg.port, Some(7777));
+
+            last_max_gap = max_gap;
+
+            if max_gap < gap_threshold {
+                // Event loop stayed free — spawn_blocking is in place.
+                return;
+            }
+
+            eprintln!(
+                "attempt {attempt}/{MAX_ATTEMPTS}: max_gap={max_gap:?} \
+                 (threshold {gap_threshold:?}) — retrying"
+            );
+        }
+
+        // Every attempt had a large event-loop gap. With spawn_blocking
+        // present the gap is tiny (probe jitter only). This large gap means
+        // the event loop was frozen — almost certainly because spawn_blocking
+        // was removed and eval_bundle's rx.recv() ran inline.
+        panic!(
+            "max event-loop gap was {last_max_gap:?} on all {MAX_ATTEMPTS} attempts \
+             (threshold {gap_threshold:?}) — the tokio current-thread event loop \
+             was frozen; spawn_blocking may have been removed from the V8 eval \
+             path in config.rs"
         );
     }
 

--- a/docs/src/content/docs-ja/concepts/mdx-components.mdx
+++ b/docs/src/content/docs-ja/concepts/mdx-components.mdx
@@ -1,23 +1,23 @@
 ---
 title: MDX Components
-description: How MDX entries reach your pages as renderable React/Preact components, and how to override individual elements via the components prop.
+description: MDX エントリがレンダリング可能な React/Preact コンポーネントとしてページに届く仕組みと、components prop で個々の要素をオーバーライドする方法。
 sidebar_position: 2.5
 category: Concepts
 ---
 
-<Info title="What this page covers">
+<Info title="このページの内容">
 
-How `.mdx` content collection entries become renderable JSX components, what arrives by default through `getCollection()`, how to override individual HTML elements with your own components, and where the convention comes from.
+`.mdx` コンテンツコレクションのエントリがどのようにレンダリング可能な JSX コンポーネントになるのか、`getCollection()` を通じてデフォルトで何が届くのか、個々の HTML 要素を自前のコンポーネントでオーバーライドする方法、グローバルな `mdx-components.tsx` 規約の仕組み、そして各オーバーライドが受け取る完全な props の契約を解説します。
 
 </Info>
 
-## The mental model
+## メンタルモデル
 
-Every `.mdx` file in a content collection is compiled to a JSX module at build time. The compiled module exports an `MDXContent({ components })` function — a regular component whose only job is to render the post body, with optional per-element overrides supplied through the `components` prop.
+コンテンツコレクション内のすべての `.mdx` ファイルは、ビルド時に JSX モジュールへコンパイルされます。コンパイル後のモジュールは `MDXContent({ components })` 関数をエクスポートします。これは投稿本文をレンダリングするだけが役割の通常のコンポーネントで、`components` prop を通じて要素ごとのオーバーライドを任意に差し込めます。
 
-This is the same contract Astro's `@astrojs/mdx` exposes via `<Content components={...} />`. zfb adopts it directly so the mental model transfers across the Astro ecosystem.
+これは Astro の `@astrojs/mdx` が `<Content components={...} />` で公開しているものと同じ契約です。zfb はこれをそのまま採用しているため、Astro エコシステム全体でメンタルモデルがそのまま通用します。
 
-The shape is:
+その形は次のとおりです。
 
 ```tsx
 // Conceptually, your `hello-zfb.mdx` becomes:
@@ -26,29 +26,29 @@ export default function MDXContent({ components }: { components?: Record<string,
 }
 ```
 
-When MDX encounters `<p>some text</p>` (which is what a markdown paragraph compiles to), it looks up `p` in the `components` map. If you supply one, your component renders. If you don't, the raw HTML element renders. The same lookup applies to your custom JSX — `<Note>...</Note>` in the post body is resolved against `components.Note` at evaluation time.
+MDX が `<p>some text</p>`（Markdown の段落がコンパイルされた結果）に出会うと、`components` マップから `p` を探します。自前のコンポーネントを渡していればそれがレンダリングされ、渡していなければ素の HTML 要素がレンダリングされます。同じルックアップはカスタム JSX にも適用されます。投稿本文中の `<Note>...</Note>` は、評価時に `components.Note` に対して解決されます。
 
-## What `getCollection()` already gives you
+## `getCollection()` がすでに与えてくれるもの
 
-You don't construct `MDXContent` yourself. The collection layer wraps every entry's compiled module in a `Content` component and attaches it to the entry. That means:
+`MDXContent` を自分で組み立てることはありません。コレクション層が各エントリのコンパイル済みモジュールを `Content` コンポーネントでラップし、エントリに付与します。つまり次のようになります。
 
 ```tsx
 import { getCollection } from "zfb/content";
 
-const posts = await getCollection("blog");
+const posts = getCollection("blog");
 const post = posts[0];
 
 // `post.Content` is a renderable component:
 <post.Content />;
 ```
 
-You get `post.data` (the parsed frontmatter), `post.slug`, and `post.Content` (the renderable body). Same shape for `.md` and `.mdx` — CommonMark is a strict MDX subset, so the same pipeline handles both. Plain markdown entries simply have no JSX nodes to override, but the `components` prop still applies to the HTML elements they emit.
+`post.data`（パース済みのフロントマター）、`post.slug`、そして `post.Content`（レンダリング可能な本文）が得られます。`.md` と `.mdx` で形は同じです。CommonMark は MDX の厳密なサブセットなので、同じパイプラインが両方を扱います。プレーンな Markdown エントリにはオーバーライドすべき JSX ノードがそもそもありませんが、それでも `components` prop はそれらが出力する HTML 要素に適用されます。
 
-The bridge that connects `post.Content` to the actual compiled JSX module lives at `globalThis.__zfb.content.get(specifier)`, installed by the Rust-side renderer before the page module evaluates. When the bridge isn't present (unit tests, dev sandboxes), `Content` falls back to a clearly marked `<pre data-zfb-content-fallback>` block so the absence is obvious.
+`post.Content` を実際のコンパイル済み JSX モジュールに繋ぐブリッジは `globalThis.__zfb.content.get(specifier)` にあり、ページモジュールが評価される前に Rust 側のレンダラーがインストールします。ブリッジが存在しない場合（ユニットテストや開発用サンドボックスなど）、`Content` は明示的にマークされた `<pre data-zfb-content-fallback>` ブロックにフォールバックし、欠落がひと目で分かるようになっています。
 
-## Spreading `defaultComponents`
+## `defaultComponents` をスプレッドする
 
-zfb ships a `defaultComponents` map from its root export — a set of element-level overrides (the **htmlOverrides** convention) that wrap the bare HTML tags MDX emits with sensible component implementations. The recipe is to spread it first, then layer your own overrides on top:
+zfb はルートエクスポートから `defaultComponents` マップを提供しています。これは MDX が出力する素の HTML タグを、適切なコンポーネント実装でラップする要素レベルのオーバーライド群（**htmlOverrides** 規約）です。使い方の定石は、まずこれをスプレッドし、その上に自前のオーバーライドを重ねることです。
 
 ```tsx
 import { defaultComponents } from "zfb";
@@ -57,9 +57,9 @@ import Note from "../../components/note";
 <post.Content components={{ ...defaultComponents, ...mine, Note }} />;
 ```
 
-Spread order matters: keys to the right win. Putting `defaultComponents` first means your individual overrides take precedence on collisions, while everything you don't override still picks up the default behavior.
+スプレッドの順序が重要です。右側のキーが勝ちます。`defaultComponents` を最初に置くことで、衝突時には個々のオーバーライドが優先され、オーバーライドしていないものはすべてデフォルトの挙動を引き継ぎます。
 
-The current `defaultComponents` set covers:
+現在の `defaultComponents` セットがカバーするのは次のとおりです。
 
 | Key          | Component           | Wraps                                       |
 | ------------ | ------------------- | ------------------------------------------- |
@@ -75,11 +75,138 @@ The current `defaultComponents` set covers:
 | `table`      | `ContentTable`      | `<table>`                                   |
 | `code`       | `ContentCode`       | `<code>` (inline; block code is unaffected) |
 
-Each is also exported individually (`import { ContentLink } from "zfb"`) for cases where you want a single override without dragging in the whole map.
+それぞれ個別にもエクスポートされており（`import { ContentLink } from "zfb"`）、マップ全体を引き込まずに単一のオーバーライドだけを使いたい場合に利用できます。
 
-## Authoring `.mdx` with custom components
+`h1` は意図的に含まれていません。ページタイトルは zudo-doc の規約に従ってフロントマターから `<h1>` をレンダリングします。`h1` をオーバーライドに加えると、タイトルが気付かないうちに二重レンダリングされてしまいます。
 
-The basic-blog example demonstrates the end-to-end shape. The MDX post uses a custom `<Note>` admonition:
+## グローバルな `mdx-components.tsx` 規約
+
+すべての `<entry.Content />` 呼び出しに対して、呼び出しごとのスプレッドなしで適用したいプロジェクト全体の要素オーバーライドには、プロジェクトルート（`zfb.config.ts` の隣）に `mdx-components.tsx` ファイルを置き、フラットな `{ tag: Component }` マップを**デフォルトエクスポート**します。
+
+```tsx
+// mdx-components.tsx (project root)
+import MyH2 from "./components/my-h2";
+
+export default {
+  h2: MyH2,
+};
+```
+
+ビルドパイプラインはこのファイルを検出してシャドウバンドルにコピーし、ページルーターが走る前にそのデフォルトエクスポートを `globalThis.__zfb.mdxComponents` にインストールします。その時点以降、すべての `<entry.Content />` 呼び出しが自動的にこれを拾います。呼び出し側でのスプレッドは不要です。
+
+### 優先順位
+
+コンポーネントがマージされるとき、後のエントリが勝ちます。マージの順序は次のとおりです。
+
+1. `defaultComponents`（最も優先度が低い。組み込みの 11 個のパススルー）
+2. `mdx-components.tsx` のデフォルトエクスポート（プロジェクト全体のオーバーライド）
+3. `<entry.Content />` の `components` prop（最も優先度が高い。呼び出しごとのオーバーライド）
+
+したがって、呼び出しごとの `components={{ h2: MyCallSiteH2 }}` はプロジェクトルートのファイルに勝ち、そのファイルは組み込みのデフォルトに勝ちます。内部的には `mergeMdxComponents`（`"zfb"` からエクスポート）がこの三方向のスプレッドを実行します。
+
+```ts
+{ ...defaultComponents, ...globalSlot, ...perCall }
+```
+
+### 実行可能な例 — `<h2>` を `<span>` でラップする
+
+よくあるパターンは、見出しをスタイル付きのコンテナでラップすることです。
+
+```tsx
+// mdx-components.tsx (project root)
+type Props = { id?: string; children?: unknown };
+
+function MyH2({ id, children }: Props) {
+  return (
+    <h2 id={id}>
+      <span>{children}</span>
+    </h2>
+  );
+}
+
+export default { h2: MyH2 };
+```
+
+これで、すべてのコンテンツエントリのすべての `##` 見出しが、ページごとの配線なしにプロジェクト全体で `<h2 id="…"><span>…</span></h2>` としてレンダリングされます。
+
+## 標準的にマップ可能な要素の集合
+
+次の HTML タグは MDX エミッターによって `_components.<tag>` 経由でルーティングされ、`components` マップでオーバーライド可能になります。このリストにないタグは、そもそも Markdown から出力されないか、生の HTML リテラルとして出力されます（後者は `components` マップではオーバーライドできません）。
+
+**コア CommonMark:**
+
+`a` `blockquote` `br` `code` `em` `h1` `h2` `h3` `h4` `h5` `h6` `hr` `img` `li` `ol` `p` `pre` `strong` `ul`
+
+**GFM 拡張**（`zfb.config.ts` で GFM 構文が有効なときに利用可能）:
+
+`del` `input` `section` `sup` `table` `tbody` `td` `th` `thead` `tr`
+
+`defaultComponents` マップはこのうち 11 個（h2–h4、p、a、strong、blockquote、ul、ol、table、code）をあらかじめ配線します。残りは素の HTML 文字列のままですが、キーを `components` マップに含めればどれでもオーバーライドできます。
+
+## Props の契約
+
+各オーバーライドコンポーネントが受け取るのは、その要素に対して Markdown パイプラインが実際に生成する属性だけです。任意の HTML 属性を `{...props}` で網羅的にスプレッドして渡すような仕組みはありません。渡されるのは下表に挙げたフィールドだけです。
+
+| Element(s)    | Props received                                        |
+| ------------- | ----------------------------------------------------- |
+| `a`           | `href`、`title`（任意）、`children`                  |
+| `img`         | `src`、`alt`、`title`（任意） — void、children なし  |
+| `h2`–`h6`    | `id`（見出しリンクプラグインが有効で、その見出しに slug が付与されている場合に存在）、`children` |
+| `h1`          | `children` のみ — `h1` には slug は付与されない      |
+| `pre`         | `children`（`<code>` の子をラップする）              |
+| `code`        | `className="language-*"`（フェンス付きブロックのみ。インラインコードは `children` のみ受け取る） |
+| `ol`          | `start`（1 以外のときのみ）、`children`              |
+| その他すべて  | `children` のみ                                       |
+
+オーバーライドに `{...rest}` を加えて HTML 要素にスプレッドしても、未知の属性は届きません。エミッターは Markdown ソースから任意の属性を転送しないからです。
+
+## 小文字と PascalCase の非対称性
+
+`components` マップにおける小文字の HTML タグと PascalCase のコンポーネント名のあいだには、意図的な挙動の違いがあります。
+
+- **小文字のタグ**（`h2`、`p`、`a` など）は、出力される `_components` マップの中で素の HTML 文字列をデフォルトとします。小文字のキーを省略した場合、生の要素がレンダリングされます。エラーにはなりません。
+- **PascalCase の名前**（`Note`、`Callout` など）は、呼び出し側の `components` prop からルックアップされ、見つからなければ即座に throw します。
+
+  ```js
+  // Inside compiled MDX output:
+  const Note = _components.Note ?? components.Note;
+  if (!Note) throw new Error("MDX requires `Note` to be passed via the `components` prop");
+  ```
+
+  `.mdx` ファイルで参照されている PascalCase コンポーネントが、レンダリング時に `components` マップに存在しない場合、ビルド時ではなく実行時に throw します。これは意図的なものです。コンパイル済みモジュールはポータブルなまま保たれ、必要なコンポーネントをすべて渡す責任は呼び出し側にあります。
+
+## Islands による制約
+
+`components` マップは、SSR 時に解決されるプレーンな JavaScript オブジェクトです。値が関数参照であるため、JSON としてハイドレーション境界を越えられません。これは次のことを意味します。
+
+- マップ内のコンポーネントは**サーバーサイド専用**です。サーバー上でレンダリングされ、その HTML が静的なマークアップとしてブラウザに届けられます。
+- マップ内のコンポーネントがクライアントサイドのインタラクティブ性（状態、イベントハンドラ、ブラウザ API）を必要とする場合は、そのインタラクティブな部分を `<Island>` コンポーネントでラップし、インタラクティブなコンポーネントを直接マップに入れないでください。
+
+```tsx
+// Correct: interactive content goes through Island
+import { Island } from "zfb";
+import MyCounter from "./my-counter";
+
+function WrappedCounter() {
+  return (
+    <Island>
+      <MyCounter />
+    </Island>
+  );
+}
+
+export default { div: WrappedCounter };
+```
+
+`components` マップは SSR を通ります。`<Island>` はブラウザへ抜けるための脱出口です。
+
+## 保留中の未解決項目 — `wrapper`
+
+MDX は `components` マップ内の特別な `wrapper` キーをサポートしています。これはレンダリング結果全体をラップするコンポーネントです。zfb のエミッターは `wrapper` を認識しません。本文は直接 `<_Fragment>` でラップされ、`wrapper` キーに対するルックアップは行われません。`wrapper` のサポートは追跡中の未解決項目であり、現在のリリースでは実装されていません。
+
+## カスタムコンポーネントで `.mdx` を書く
+
+同梱の `basic-blog` テンプレートが、エンドツーエンドの形を実演しています（全ソースは [zfb-example-blog スタンドアロンリポジトリ](https://github.com/Takazudo/zfb-example-blog) を参照）。この MDX 投稿はカスタムの `<Note>` admonition を使っています。
 
 ```mdx
 ---
@@ -100,7 +227,7 @@ Welcome to the **basic-blog** example.
 </Note>
 ```
 
-The per-post route resolves `<Note>` against the `components` map by passing it in alongside `defaultComponents`:
+投稿ごとのルートは、`<Note>` を `defaultComponents` と一緒に渡すことで `components` マップに対して解決します。
 
 ```tsx
 // pages/blog/[slug].tsx
@@ -117,7 +244,7 @@ export default function BlogPostPage({ post }: Props) {
 }
 ```
 
-The `Note` component itself is an ordinary Preact (or React) component that receives `title` and `children`:
+`Note` コンポーネント自体は、`title` と `children` を受け取るごく普通の Preact（または React）コンポーネントです。
 
 ```tsx
 // components/note.tsx
@@ -138,14 +265,16 @@ export default function Note({ title, children }: Props) {
 }
 ```
 
-The full source lives in the [zfb-example-blog standalone repo](https://github.com/Takazudo/zfb-example-blog) — see `content/blog/hello-zfb.mdx`, `pages/blog/[slug].tsx`, and `components/note.tsx`. A live build is available at [zfb-example-blog.pages.dev](https://zfb-example-blog.pages.dev/).
+全ソースは [zfb-example-blog スタンドアロンリポジトリ](https://github.com/Takazudo/zfb-example-blog) にあります。`content/blog/hello-zfb.mdx`、`pages/blog/[slug].tsx`、`components/note.tsx` を参照してください。ライブビルドは [zfb-example-blog.pages.dev](https://zfb-example-blog.pages.dev/) で確認できます。
 
-## Reference
+## リファレンス
 
-- The `defaultComponents` set is zfb's port of the htmlOverrides convention pioneered by [zudo-doc](https://github.com/zudolab/zudo-doc), where the same map shape solves the same problem for that documentation framework.
-- The upstream pattern from Astro is documented at [Astro: Assigning custom components to HTML elements](https://docs.astro.build/en/guides/integrations-guide/mdx/#assigning-custom-components-to-html-elements). The contract is intentionally identical: a flat record of element-name → component, passed through the `components` prop.
+- `defaultComponents` セットは、[zudo-doc](https://github.com/zudolab/zudo-doc) が確立した htmlOverrides 規約を zfb に移植したものです。zudo-doc では、同じマップの形が同じ問題をそのドキュメントフレームワーク向けに解決しています。
+- Astro の上流パターンは [Astro: Assigning custom components to HTML elements](https://docs.astro.build/en/guides/integrations-guide/mdx/#assigning-custom-components-to-html-elements) に記載されています。契約は意図的に同一です。要素名 → コンポーネントのフラットなレコードを `components` prop で渡すというものです。
 
-## See also
+## あわせて読む
 
-- [Content Collections](/concepts/content-collections) — how entries are discovered and exposed via `getCollection()`.
-- [Build Pipeline](/concepts/build-pipeline) — where MDX-to-JSX compilation sits in the end-to-end flow.
+- [Content Collections](/concepts/content-collections) — エントリがどのように発見され、`getCollection()` を通じて公開されるか。
+- [Build Pipeline](/concepts/build-pipeline) — MDX から JSX へのコンパイルがエンドツーエンドのフローのどこに位置するか。
+- [Custom Directives](/concepts/custom-directives) — 自前の JSX コンポーネントにマッピングされる新しい MDX ディレクティブ構文（例: `:::callout`）を追加する。
+- [Islands](/concepts/islands) — コンテンツエントリ内でインタラクティブなコンポーネントを動かす方法。

--- a/packages/zfb-runtime/docs/client-router/port-spec.md
+++ b/packages/zfb-runtime/docs/client-router/port-spec.md
@@ -352,7 +352,6 @@ For islands specifically (Astro's branch around line 124–132 detects `astro-is
 | toc | no | n/a | (b) discarded; remount fresh |
 | doc-history | no | n/a | (b) |
 | find-bar | yes (search state survives navs) | no | (a) |
-| image-enlarge | no | n/a | (b) |
 | design-token-tweak panel | yes | no | (a) |
 
 W3D applies this table by writing or updating `data-zfb-transition-persist="<id>"` attributes on the relevant island markers in zudo-doc's layout components. Stable ID convention: kebab-case island-component name (`sidebar-tree`, `theme-toggle`, etc.).

--- a/packages/zfb/src/__tests__/content.test.ts
+++ b/packages/zfb/src/__tests__/content.test.ts
@@ -660,6 +660,30 @@ describe("defaultComponents (htmlOverrides convention)", () => {
     const node = ContentParagraph({ children });
     expect(node.props.children).toBe(children);
   });
+
+  it("set-level output-neutrality: every entry is a pure passthrough (no injected props)", () => {
+    // Regression guard — if any defaultComponents entry starts injecting a
+    // class, data-*, or wrapper element this loop goes red immediately.
+    const sentinel = { type: "span", props: {}, key: null };
+    for (const [key, Component] of Object.entries(defaultComponents)) {
+      const node = (
+        Component as (props: Record<string, unknown>) => {
+          type: string;
+          props: Record<string, unknown>;
+          key: unknown;
+        }
+      )({ children: sentinel, id: "x" });
+      // 1. The intrinsic tag is unchanged.
+      expect(node.type, `${key}: type`).toBe(key);
+      // 2. Exactly the props we passed — nothing injected.
+      expect(Object.keys(node.props).sort(), `${key}: prop keys`).toEqual(
+        ["children", "id"].sort(),
+      );
+      // 3. Both values pass through verbatim.
+      expect(node.props["children"], `${key}: children`).toBe(sentinel);
+      expect(node.props["id"], `${key}: id`).toBe("x");
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/624

---

## Summary

Epic #624 — five independent Wave-1 follow-ups (sub-issues #625–#629), each touching a disjoint file. Supersedes the three source issues #621/#622/#623.

| Sub | Issue | Change | File |
|---|---|---|---|
| 1 | #625 | Group `write_entry_module`'s 8 positional params into an `EntryModuleInputs` struct (8→3 args); drop its `#[allow(too_many_arguments)]`; update all 15 call sites | `crates/zfb-build/src/bundler.rs` |
| 2 | #626 | Add a set-level output-neutrality guard: every `defaultComponents` entry is asserted to be a pure passthrough (intrinsic tag `type`, only the passed props, no injected class/attr/wrapper) | `packages/zfb/src/__tests__/content.test.ts` |
| 3 | #627 | Remove the stale `image-enlarge` row (built-in removed in B1 #615) from the island transition-persistence table | `packages/zfb-runtime/docs/client-router/port-spec.md` |
| 4 | #628 | Translate the new mdx-components override-system sections into the Japanese mirror (native-feel JA; the JA file was a stale English copy, so it was fully translated) | `docs/src/content/docs-ja/concepts/mdx-components.mdx` |
| 5 | #629 | Stabilize the flaky `v8_eval_spawn_blocking_does_not_starve_event_loop` test via a heartbeat probe + bounded retry; still goes red if `spawn_blocking` is dropped (empirically verified) | `crates/zfb/src/config.rs` |

## Verification (manager gate — CI runs only `cargo build`, so tests were run locally)

- `cargo test --workspace`: zfb-build 252 lib tests pass, zfb 313 lib tests pass (incl. the rewritten v8_eval test); `cargo clippy` clean on `bundler.rs`.
- `pnpm --filter zfb test` (vitest): 151 pass, incl. the new passthrough guard.
- `pnpm --filter docs build`: 193 pages, both EN and JA mdx-components render.
- Sub5 empirical detector: removing `spawn_blocking` → test RED (event-loop gap ~263–293ms); restored → GREEN (<15ms). Production `spawn_blocking` path untouched.
- Deep review (gpt-4.1): clean, no findings.

## Note

A pre-existing flaky test `bundler_threads_default_plugins_through_mdx_compile` surfaced during the full-suite run; it fails on `main` too (temp-dir-path nondeterminism under parallel load) and is **not** caused by this PR. Tracked separately as #631.