### PR TITLE
fix(ci): pin node-free released-mode smoke to the released tag

### DIFF
--- a/.github/workflows/node-free-smoke.yml
+++ b/.github/workflows/node-free-smoke.yml
@@ -283,9 +283,17 @@ jobs:
             > tests/smoke/node-free/zfb-bin
 
       - name: Build smoke image (released mode)
+        # head_branch is the tag that triggered the release (e.g. v0.1.0-next.18).
+        # Passed via env (not inline ${{ }}) to avoid shell injection, matching the
+        # repo's security posture. install.sh pins to this tag so the smoke installs
+        # the exact just-released assets — the default /releases/latest path 404s
+        # while the project ships only pre-releases.
+        env:
+          RELEASE_TAG: ${{ github.event.workflow_run.head_branch }}
         run: |
           docker build \
             --build-arg ZFB_SMOKE_MODE=released \
+            --build-arg "ZFB_VERSION=${RELEASE_TAG}" \
             -t zfb-smoke:released \
             tests/smoke/node-free/
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ No Node.js required. zfb ships as a self-contained binary — esbuild and Tailwi
 curl -fsSL https://raw.githubusercontent.com/Takazudo/zudo-front-builder/main/install.sh | sh
 ```
 
+> **Pre-1.0 note:** there are no stable releases yet — only prereleases (`v0.1.0-next.N`). Until `v0.1.0` ships, the default curl command above will fail to resolve a release; install a prerelease explicitly:
+>
+> ```sh
+> curl -fsSL https://raw.githubusercontent.com/Takazudo/zudo-front-builder/main/install.sh | ZFB_VERSION=latest-prerelease sh
+> ```
+
 Installs `zfb` to `$HOME/.local/bin/zfb`. Set `ZFB_INSTALL=/your/path` to change the prefix. Set `ZFB_VERSION=v0.X.Y` to pin a specific release.
 
 **macOS (Homebrew):**

--- a/tests/smoke/node-free-ts/Dockerfile
+++ b/tests/smoke/node-free-ts/Dockerfile
@@ -26,6 +26,11 @@ FROM debian:bookworm-slim
 
 ARG ZFB_SMOKE_MODE=local
 
+# Kept in sync with ../node-free/Dockerfile. See there for the full rationale:
+# ZFB_VERSION pins the release tag install.sh resolves in released mode (default
+# GET /releases/latest 404s while only pre-releases exist). Empty in local mode.
+ARG ZFB_VERSION=
+
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
@@ -43,8 +48,9 @@ COPY zfb-bin /root/.local/bin/zfb
 
 RUN if [ "$ZFB_SMOKE_MODE" = "released" ]; then \
         # released mode: fetch and install from the public GitHub Releases URL.
-        # This validates the exact curl-pipe path that end users run.
-        curl -fsSL https://raw.githubusercontent.com/Takazudo/zudo-front-builder/main/install.sh | sh; \
+        # This validates the exact curl-pipe path that end users run. ZFB_VERSION
+        # pins the tag so install.sh downloads that exact release's assets.
+        curl -fsSL https://raw.githubusercontent.com/Takazudo/zudo-front-builder/main/install.sh | ZFB_VERSION="$ZFB_VERSION" sh; \
     fi
 
 RUN chmod +x /root/.local/bin/zfb

--- a/tests/smoke/node-free/Dockerfile
+++ b/tests/smoke/node-free/Dockerfile
@@ -27,6 +27,13 @@ FROM debian:bookworm-slim
 
 ARG ZFB_SMOKE_MODE=local
 
+# ZFB_VERSION pins the release tag install.sh resolves in released mode. CI passes
+# the just-released tag (workflow_run.head_branch) so the smoke installs that exact
+# release's assets. Required because every release so far is a pre-release, and
+# install.sh's default path (GET /releases/latest) excludes pre-releases → 404.
+# Empty in local mode, where the released branch below is skipped.
+ARG ZFB_VERSION=
+
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
@@ -44,8 +51,9 @@ COPY zfb-bin /root/.local/bin/zfb
 
 RUN if [ "$ZFB_SMOKE_MODE" = "released" ]; then \
         # released mode: fetch and install from the public GitHub Releases URL.
-        # This validates the exact curl-pipe path that end users run.
-        curl -fsSL https://raw.githubusercontent.com/Takazudo/zudo-front-builder/main/install.sh | sh; \
+        # This validates the exact curl-pipe path that end users run. ZFB_VERSION
+        # pins the tag so install.sh downloads that exact release's assets.
+        curl -fsSL https://raw.githubusercontent.com/Takazudo/zudo-front-builder/main/install.sh | ZFB_VERSION="$ZFB_VERSION" sh; \
     fi
 
 RUN chmod +x /root/.local/bin/zfb


### PR DESCRIPTION
## Problem

The `Node-free smoke` workflow's **`smoke-released`** job (triggered by `workflow_run` after a Release on a `v*` tag) curl-pipes the public `install.sh`. By default the installer resolves `GET /releases/latest`, which **excludes pre-releases**. The project currently ships only `v0.1.0-next.N` pre-releases, so that endpoint 404s and the job fails at the `docker build` step:

```
Resolving zfb version...
curl: (22) The requested URL returned error: 404
error: could not resolve the latest release tag from GitHub API
```

This makes `main` red on every release.

## Fix

Pass the just-released tag (`github.event.workflow_run.head_branch`) into the released-mode smoke container as `ZFB_VERSION`, so `install.sh` pins that exact release's assets instead of latest-stable.

- **`node-free-smoke.yml`** — `smoke-released` build step adds `--build-arg "ZFB_VERSION=${RELEASE_TAG}"`, routed through an `env:` var (not inline `${{ }}`) to avoid shell injection.
- **`tests/smoke/node-free/Dockerfile`** + **`node-free-ts/Dockerfile`** — add `ARG ZFB_VERSION=` and pipe `install.sh | ZFB_VERSION="$ZFB_VERSION" sh`. Empty in local mode (that branch is skipped), so PR/push smokes are unaffected.

Verified the pinned asset (`zfb-0.1.0-next.18-x86_64-unknown-linux-gnu.tar.gz`) exists; a local released-mode build+run pinned to that tag passed all smoke assertions.

## Also

- **`README.md`** — added a pre-1.0 note that the default install one-liner needs `ZFB_VERSION=latest-prerelease` until `v0.1.0` ships (the default resolves latest-stable, which 404s today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
