### PR TITLE
fix(islands): apply react/jsx-runtime→preact alias in islands esbuild (next.18 regression #633)

### DIFF
--- a/crates/zfb-islands/src/esbuild.rs
+++ b/crates/zfb-islands/src/esbuild.rs
@@ -831,6 +831,26 @@ pub(crate) fn build_esbuild_args(
         "--jsx-import-source={}",
         config.jsx_import_source
     )));
+    // Mirror the main SSR bundler (crates/zfb-build/src/bundler.rs:3024-3026).
+    // next.18 dist modules carry an explicit, framework-neutral
+    // `import { jsx } from "react/jsx-runtime"` (e.g.
+    // `@takazudo/zfb-runtime/client-router`, which the shared islands bundle
+    // side-effect-imports when `client_router` is set — see
+    // `render_shared_bundle_entry_source`). In a Preact project `react` is not
+    // installed, so esbuild cannot resolve `react/jsx-runtime` and the islands
+    // build aborts (issue #633). Rewrite it (and the dev-runtime sibling) to the
+    // Preact runtime — the same trick the SSR bundler and the wider Preact
+    // ecosystem use. React projects resolve `react/jsx-runtime` natively, so the
+    // alias is Preact-only (same gating as bundler.rs:3025), leaving the React
+    // argv byte-identical. `--alias`'s prefix-with-slash semantics are safe here
+    // because `react/jsx-runtime` has no deeper subpath to corrupt.
+    if matches!(
+        FrameworkKind::from_jsx_import_source(&config.jsx_import_source),
+        FrameworkKind::Preact
+    ) {
+        args.push(OsString::from("--alias:react/jsx-runtime=preact/jsx-runtime"));
+        args.push(OsString::from("--alias:react/jsx-dev-runtime=preact/jsx-dev-runtime"));
+    }
     if config.minify {
         args.push(OsString::from("--minify"));
     }
@@ -2105,6 +2125,49 @@ mod tests {
         assert!(
             !args.iter().any(|a| a == "--jsx-import-source=preact"),
             "stale --jsx-import-source=preact present: {args:?}"
+        );
+    }
+
+    /// Regression for issue #633.
+    ///
+    /// next.18 dist modules carry an explicit framework-neutral
+    /// `import { jsx } from "react/jsx-runtime"` (e.g.
+    /// `@takazudo/zfb-runtime/client-router`, pulled into the islands shared
+    /// bundle when `clientRouter: true`). In a Preact project `react` is not
+    /// installed, so the islands esbuild must rewrite `react/jsx-runtime` (and
+    /// the dev-runtime sibling) to the Preact runtime — mirroring the main SSR
+    /// bundler (`crates/zfb-build/src/bundler.rs:3024-3026`). For the Preact
+    /// default both aliases MUST be present.
+    #[test]
+    fn build_esbuild_args_aliases_react_jsx_runtime_for_preact() {
+        let cfg = BundleConfig::default();
+        assert_eq!(cfg.jsx_import_source, "preact", "default must be Preact");
+        let args = args_as_strings(&cfg);
+        assert!(
+            args.iter().any(|a| a == "--alias:react/jsx-runtime=preact/jsx-runtime"),
+            "missing --alias:react/jsx-runtime=preact/jsx-runtime in args: {args:?}"
+        );
+        assert!(
+            args.iter().any(|a| a == "--alias:react/jsx-dev-runtime=preact/jsx-dev-runtime"),
+            "missing --alias:react/jsx-dev-runtime=preact/jsx-dev-runtime in args: {args:?}"
+        );
+    }
+
+    /// Companion to the #633 regression: React projects resolve
+    /// `react/jsx-runtime` natively, so the alias is Preact-only and the React
+    /// argv MUST NOT carry either `react/jsx-runtime` alias (same gating as
+    /// `bundler.rs:3025` — keeps the React bundle byte-stable).
+    #[test]
+    fn build_esbuild_args_omits_react_jsx_runtime_alias_for_react() {
+        let cfg = BundleConfig::default().with_jsx_import_source("react");
+        let args = args_as_strings(&cfg);
+        assert!(
+            !args.iter().any(|a| a == "--alias:react/jsx-runtime=preact/jsx-runtime"),
+            "react path must not alias react/jsx-runtime: {args:?}"
+        );
+        assert!(
+            !args.iter().any(|a| a == "--alias:react/jsx-dev-runtime=preact/jsx-dev-runtime"),
+            "react path must not alias react/jsx-dev-runtime: {args:?}"
         );
     }
 

--- a/crates/zfb-islands/src/esbuild.rs
+++ b/crates/zfb-islands/src/esbuild.rs
@@ -831,9 +831,10 @@ pub(crate) fn build_esbuild_args(
         "--jsx-import-source={}",
         config.jsx_import_source
     )));
-    // Mirror the main SSR bundler (crates/zfb-build/src/bundler.rs:3024-3026).
-    // next.18 dist modules carry an explicit, framework-neutral
-    // `import { jsx } from "react/jsx-runtime"` (e.g.
+    // Mirror the main SSR bundler's Preact `--alias` block in
+    // `crates/zfb-build/src/bundler.rs` (the `Framework::Preact` arm of the
+    // SSR esbuild command builder). next.18 dist modules carry an explicit,
+    // framework-neutral `import { jsx } from "react/jsx-runtime"` (e.g.
     // `@takazudo/zfb-runtime/client-router`, which the shared islands bundle
     // side-effect-imports when `client_router` is set — see
     // `render_shared_bundle_entry_source`). In a Preact project `react` is not
@@ -841,7 +842,7 @@ pub(crate) fn build_esbuild_args(
     // build aborts (issue #633). Rewrite it (and the dev-runtime sibling) to the
     // Preact runtime — the same trick the SSR bundler and the wider Preact
     // ecosystem use. React projects resolve `react/jsx-runtime` natively, so the
-    // alias is Preact-only (same gating as bundler.rs:3025), leaving the React
+    // alias is Preact-only (same gate as the SSR bundler), leaving the React
     // argv byte-identical. `--alias`'s prefix-with-slash semantics are safe here
     // because `react/jsx-runtime` has no deeper subpath to corrupt.
     if matches!(
@@ -2136,8 +2137,8 @@ mod tests {
     /// bundle when `clientRouter: true`). In a Preact project `react` is not
     /// installed, so the islands esbuild must rewrite `react/jsx-runtime` (and
     /// the dev-runtime sibling) to the Preact runtime — mirroring the main SSR
-    /// bundler (`crates/zfb-build/src/bundler.rs:3024-3026`). For the Preact
-    /// default both aliases MUST be present.
+    /// bundler (`crates/zfb-build/src/bundler.rs`, `Framework::Preact` arm). For
+    /// the Preact default both aliases MUST be present.
     #[test]
     fn build_esbuild_args_aliases_react_jsx_runtime_for_preact() {
         let cfg = BundleConfig::default();
@@ -2155,8 +2156,8 @@ mod tests {
 
     /// Companion to the #633 regression: React projects resolve
     /// `react/jsx-runtime` natively, so the alias is Preact-only and the React
-    /// argv MUST NOT carry either `react/jsx-runtime` alias (same gating as
-    /// `bundler.rs:3025` — keeps the React bundle byte-stable).
+    /// argv MUST NOT carry either `react/jsx-runtime` alias (same Preact-only
+    /// gate as the SSR bundler — keeps the React bundle byte-stable).
     #[test]
     fn build_esbuild_args_omits_react_jsx_runtime_alias_for_react() {
         let cfg = BundleConfig::default().with_jsx_import_source("react");

--- a/crates/zfb-islands/tests/preact_jsx_runtime_alias.rs
+++ b/crates/zfb-islands/tests/preact_jsx_runtime_alias.rs
@@ -1,0 +1,151 @@
+//! Real-esbuild end-to-end regression test for issue #633.
+//!
+//! Since v0.1.0-next.18 the islands esbuild bundler omitted the
+//! `react/jsx-runtime` → `preact/jsx-runtime` alias that the main SSR bundler
+//! applies (`crates/zfb-build/src/bundler.rs:3024-3026`). next.18 dist modules
+//! mint VNodes via a framework-neutral `import { jsx } from "react/jsx-runtime"`;
+//! when `clientRouter: true` the islands shared bundle side-effect-imports
+//! `@takazudo/zfb-runtime/client-router` (`esbuild.rs::render_shared_bundle_entry_source`),
+//! whose `react/jsx-runtime` import is unresolvable in a Preact project (no
+//! `react` installed) — so `zfb build` aborts.
+//!
+//! This test reproduces the **real failing path** — the `client_router=true`
+//! shared bundle pulling in `@takazudo/zfb-runtime/client-router` — using a
+//! **local on-disk stub** of that dist module (so there is no dependency on the
+//! published `@takazudo/zfb-runtime` dist). With the fix the alias rewrites
+//! `react/jsx-runtime` to the externalized `preact/jsx-runtime` and the bundle
+//! succeeds.
+//!
+//! ## RED-before-green (verified during implementation)
+//!
+//! Removing the alias block in `build_esbuild_args` makes this test fail with
+//! `esbuild ... Could not resolve "react/jsx-runtime"` (the exact #633 error);
+//! restoring it makes the test pass. The two arg-assertion unit tests in
+//! `esbuild.rs` (`build_esbuild_args_aliases_react_jsx_runtime_for_preact` /
+//! `..._omits_..._for_react`) are the always-run guard regardless of esbuild
+//! availability; this test is the behavioral guard that actually exercises
+//! esbuild's alias→external resolution.
+//!
+//! Esbuild gating mirrors the other islands integration tests: it locates a
+//! binary via `zfb_test_utils::locate_esbuild()` (env `ZFB_ESBUILD_BIN` →
+//! workspace `crates/zfb/binaries/esbuild/` slot → `which esbuild`) and skips
+//! with a printed note when none is present.
+
+use std::ffi::OsString;
+use std::fs;
+use std::path::Path;
+
+use zfb_islands::{
+    BundleConfig, ClientBundler, EsbuildSubprocessBundler, EsbuildSubprocessConfig, Island,
+};
+use zfb_test_utils::locate_esbuild;
+
+/// Lay down a fixture project under `root`:
+///
+/// - `components/counter.tsx` — one trivial island module (the namespace the
+///   shared bundle imports + registers).
+/// - `node_modules/@takazudo/zfb-runtime/` — a **local stub** of the dist
+///   package whose `client-router` subpath body carries the framework-neutral
+///   `import { jsx } from "react/jsx-runtime"` that triggers #633. esbuild must
+///   bundle *into* this stub (it is NOT externalized), so it actually
+///   encounters — and must resolve — the `react/jsx-runtime` import.
+///
+/// Returns the absolute path to the island `.tsx` file.
+fn write_client_router_fixture(root: &Path) -> std::path::PathBuf {
+    fs::create_dir_all(root.join("components")).unwrap();
+    let island_path = root.join("components/counter.tsx");
+    fs::write(&island_path, "export const Counter = () => null;\n").unwrap();
+
+    let pkg_dir = root.join("node_modules/@takazudo/zfb-runtime");
+    fs::create_dir_all(&pkg_dir).unwrap();
+    fs::write(
+        pkg_dir.join("package.json"),
+        r#"{
+  "name": "@takazudo/zfb-runtime",
+  "version": "0.0.0-test-stub",
+  "type": "module",
+  "exports": { "./client-router": "./client-router.js" }
+}
+"#,
+    )
+    .unwrap();
+    // Mirrors the real next.18 dist: a framework-neutral `react/jsx-runtime`
+    // import used to mint a VNode. The top-level `init()` call is an
+    // unconditional side effect so esbuild keeps the module (and therefore must
+    // resolve its `react/jsx-runtime` import) rather than tree-shaking it away.
+    fs::write(
+        pkg_dir.join("client-router.js"),
+        "import { jsx } from \"react/jsx-runtime\";\n\
+         export function init() { return jsx(\"div\", { children: \"client-router\" }); }\n\
+         init();\n",
+    )
+    .unwrap();
+
+    island_path
+}
+
+/// Externals for the shared-bundle imports the synthetic entry emits, EXCEPT
+/// `@takazudo/zfb-runtime` — that one is deliberately bundled (not external) so
+/// esbuild walks into the stub and hits its `react/jsx-runtime` import.
+///
+/// Note the externals are scoped to `@takazudo/zfb` (and its subpaths), NOT
+/// `@takazudo/*` — the latter would externalize the `@takazudo/zfb-runtime`
+/// stub and the test would never exercise the failing import.
+fn shared_externals() -> Vec<OsString> {
+    [
+        "--external:preact",
+        "--external:preact/*",
+        "--external:@takazudo/zfb",
+        "--external:@takazudo/zfb/*",
+    ]
+    .into_iter()
+    .map(OsString::from)
+    .collect()
+}
+
+/// **#633 regression — Preact + `clientRouter: true` + an island bundles cleanly.**
+///
+/// The shared islands bundle (`client_router = true`) side-effect-imports the
+/// local `@takazudo/zfb-runtime/client-router` stub, whose body imports
+/// `react/jsx-runtime`. With the fix the Preact alias rewrites it to the
+/// externalized `preact/jsx-runtime`, so esbuild resolves it and the bundle
+/// succeeds. Before the fix this errored with `Could not resolve "react/jsx-runtime"`.
+#[test]
+fn preact_client_router_islands_bundle_resolves_react_jsx_runtime() {
+    let Some(esbuild) = locate_esbuild() else {
+        eprintln!("[preact_jsx_runtime_alias] no esbuild binary available; skipping.");
+        return;
+    };
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+    let island_path = write_client_router_fixture(&root);
+
+    let cfg = EsbuildSubprocessConfig {
+        extra_args: shared_externals(),
+        ..EsbuildSubprocessConfig::default()
+    }
+    .with_binary_path(esbuild)
+    .with_working_dir(&root);
+
+    // Default config is Preact (`jsx_import_source = "preact"`), so the fix's
+    // Preact-only alias applies. `with_client_router(true)` makes the shared
+    // bundle prepend `import "@takazudo/zfb-runtime/client-router";`.
+    let bundle_cfg = BundleConfig::default()
+        .with_outdir(root.join("dist"))
+        .with_client_router(true);
+
+    let bundler = EsbuildSubprocessBundler::new(cfg);
+    let out = bundler
+        .bundle(&[Island::new("Counter", &island_path)], &bundle_cfg)
+        .expect(
+            "issue #633: Preact clientRouter+islands bundle must resolve \
+             react/jsx-runtime via the preact alias and succeed",
+        );
+
+    let body = fs::read_to_string(&out.asset_path).expect("read bundle");
+    assert!(
+        !body.is_empty(),
+        "bundle output should be non-empty (client-router side-effect import + island)"
+    );
+}

--- a/crates/zfb-islands/tests/preact_jsx_runtime_alias.rs
+++ b/crates/zfb-islands/tests/preact_jsx_runtime_alias.rs
@@ -2,7 +2,7 @@
 //!
 //! Since v0.1.0-next.18 the islands esbuild bundler omitted the
 //! `react/jsx-runtime` → `preact/jsx-runtime` alias that the main SSR bundler
-//! applies (`crates/zfb-build/src/bundler.rs:3024-3026`). next.18 dist modules
+//! applies (`crates/zfb-build/src/bundler.rs`, `Framework::Preact` arm). next.18 dist modules
 //! mint VNodes via a framework-neutral `import { jsx } from "react/jsx-runtime"`;
 //! when `clientRouter: true` the islands shared bundle side-effect-imports
 //! `@takazudo/zfb-runtime/client-router` (`esbuild.rs::render_shared_bundle_entry_source`),
@@ -147,5 +147,14 @@ fn preact_client_router_islands_bundle_resolves_react_jsx_runtime() {
     assert!(
         !body.is_empty(),
         "bundle output should be non-empty (client-router side-effect import + island)"
+    );
+    // Prove the alias actually rewrote the target (not just that the build
+    // succeeded): the stub's `react/jsx-runtime` import surfaces in the output
+    // as the externalized `preact/jsx-runtime`. NB: a naive
+    // `!body.contains("react/jsx-runtime")` would be a false guard —
+    // `preact/jsx-runtime` contains it as a substring.
+    assert!(
+        body.contains("preact/jsx-runtime"),
+        "alias must rewrite react/jsx-runtime → preact/jsx-runtime in the bundle output"
     );
 }


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/635
    - https://github.com/Takazudo/zudo-front-builder/issues/634 (epic)
    - https://github.com/Takazudo/zudo-front-builder/issues/633 (source)

---

## Summary

Fixes the **v0.1.0-next.18** regression (#633): a Preact project (`framework: "preact"`) with `clientRouter: true` **and** client islands failed `zfb build` in the islands production emitter with `Could not resolve "react/jsx-runtime"`.

next.18 switched several dist files to mint VNodes via a framework-neutral `import { jsx } from "react/jsx-runtime"`. The **main SSR bundler** aliases that to `preact/jsx-runtime` for Preact (`crates/zfb-build/src/bundler.rs`, `Framework::Preact` arm); the **islands esbuild bundler** did not. When `clientRouter: true`, the islands shared bundle side-effect-imports `@takazudo/zfb-runtime/client-router` (a dist module importing `react/jsx-runtime`), unresolvable in a Preact project (no `react` installed).

## Changes

- `crates/zfb-islands/src/esbuild.rs` — `build_esbuild_args` now emits `--alias:react/jsx-runtime=preact/jsx-runtime` and `--alias:react/jsx-dev-runtime=preact/jsx-dev-runtime` when the resolved framework is Preact. `build_esbuild_args` is the single arg-assembly point feeding both the per-island and shared-bundle esbuild passes, so the one change covers every islands esbuild pass. Gated Preact-only via `FrameworkKind::from_jsx_import_source` (React resolves `react/jsx-runtime` natively) — the React argv is byte-identical, mirroring the main SSR bundler's gate.
- `crates/zfb-islands/tests/preact_jsx_runtime_alias.rs` (new) — real-esbuild regression test reproducing the **actual** failing path: a Preact `clientRouter: true` + islands bundle with a local on-disk stub of `@takazudo/zfb-runtime/client-router` (whose body imports `react/jsx-runtime`). Asserts the bundle resolves cleanly and that the output contains the rewritten `preact/jsx-runtime`.
- Two arg-assertion unit tests in `esbuild.rs`: Preact emits both aliases; React emits neither.

## Test Plan

- `cargo test -p zfb-islands` — green (179 lib unit tests incl. the 2 new arg-assertion tests; the new real-esbuild e2e test passes against the workspace esbuild binary).
- `cargo clippy -p zfb-islands --all-targets` — clean.
- **RED-before-green verified**: with the alias block disabled, the e2e test fails with the exact #633 error `Could not resolve "react/jsx-runtime"`; restoring the alias makes it pass.

> Note: a deep-review pass found that CI does not currently execute the Rust test suite (only `cargo build`), so these guards are local-only — tracked separately in #638.

Closes #633.