### PR TITLE
ci: run the Rust test suite in CI (with esbuild provisioned) — fixes #638

### DIFF
--- a/.github/workflows/health.yml
+++ b/.github/workflows/health.yml
@@ -70,8 +70,10 @@ jobs:
       # `return` (recorded by cargo as a PASS) when no esbuild binary is found, so
       # a green `cargo test` alone cannot prove they actually executed. Fail loudly
       # here if build.rs did not stage the binary, making "green but silently
-      # skipped" impossible. `--version` confirms it is the pinned 0.25.12 rather
-      # than some transitive esbuild that happens to be on PATH.
+      # skipped" impossible. (The binary's version + SHA-256 are already verified
+      # upstream by crates/zfb/build.rs before staging; the `--version` run here is
+      # just a smoke test that the staged binary actually executes on this runner's
+      # architecture — a corrupt or wrong-arch binary fails the step.)
       - name: Assert esbuild was provisioned for the test suite
         run: |
           SLOT="crates/zfb/binaries/esbuild/esbuild"

--- a/.github/workflows/health.yml
+++ b/.github/workflows/health.yml
@@ -24,8 +24,10 @@ jobs:
   health:
     runs-on: ubuntu-latest
     # V8 first compile costs 15-30 min; subsequent runs hit the Swatinem cache
-    # and typically complete well within this budget.
-    timeout-minutes: 45
+    # and typically complete well within this budget. Headroom bumped 45 -> 60
+    # when this job started *running* the test suite (issue #638), not just
+    # compiling it — test execution had never been timed in CI before.
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
@@ -57,7 +59,33 @@ jobs:
 
       - run: pnpm format:check
 
+      # Compiles every target (incl. benches/examples) AND triggers crates/zfb's
+      # build.rs to download + SHA-verify + stage the pinned esbuild 0.25.12 into
+      # crates/zfb/binaries/esbuild/esbuild — the slot that
+      # zfb_test_utils::locate_esbuild() resolves for the esbuild-gated
+      # integration tests run below.
       - run: cargo build --workspace --all-targets
+
+      # Guard (issue #638): the esbuild-gated integration tests skip via an early
+      # `return` (recorded by cargo as a PASS) when no esbuild binary is found, so
+      # a green `cargo test` alone cannot prove they actually executed. Fail loudly
+      # here if build.rs did not stage the binary, making "green but silently
+      # skipped" impossible. `--version` confirms it is the pinned 0.25.12 rather
+      # than some transitive esbuild that happens to be on PATH.
+      - name: Assert esbuild was provisioned for the test suite
+        run: |
+          SLOT="crates/zfb/binaries/esbuild/esbuild"
+          if [ ! -x "$SLOT" ]; then
+            echo "::error::esbuild not staged at $SLOT — the esbuild-gated tests would silently skip (issue #638). Failing the job instead."
+            exit 1
+          fi
+          "$SLOT" --version
+
+      # Run the workspace test suite. CI previously only *compiled* the test code
+      # (the cargo build --all-targets step above) but never executed it, so unit
+      # and integration regression guards — including the #633 react/jsx-runtime ->
+      # preact/jsx-runtime islands alias guards — were local-only (issue #638).
+      - run: cargo test --workspace
 
       - name: actionlint
         uses: docker://rhysd/actionlint:1.7.12


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/638

---

## Summary

CI **compiled** the Rust test code (`cargo build --workspace --all-targets` in the `health` job) but never **ran** it, so every unit/integration regression guard — including the #633 `react/jsx-runtime`→`preact/jsx-runtime` islands-alias guards added in #637 — was local-only. A logic regression that still compiles (e.g. deleting the Preact alias block) would pass CI green while only a developer's local `cargo test` would catch it. This is the exact gap #638 reports.

This PR makes the `health` job **execute** the workspace test suite, with the pinned esbuild binary provisioned so the `locate_esbuild()`-gated integration tests actually run instead of skipping.

## Changes

`.github/workflows/health.yml` (`health` job only):

- **Run the tests:** add `cargo test --workspace` after the existing `cargo build --workspace --all-targets`.
- **esbuild provisioning is automatic:** `crates/zfb/build.rs` already downloads + SHA-256-verifies + stages the pinned esbuild `0.25.12` into `crates/zfb/binaries/esbuild/esbuild` during compilation, which `zfb_test_utils::locate_esbuild()` resolves (slot is resolution step 2). No new download step needed — the build that already runs in CI does it.
- **Anti-silent-skip guard:** the esbuild-gated tests skip via an early `return` that cargo records as a **PASS**, so a green `cargo test` alone cannot prove they executed. A new guard step fails the job loudly if the esbuild binary was not staged, making "green but silently skipped" impossible. (`--version` is a smoke test that the staged binary runs on the runner arch; version/SHA integrity is guaranteed upstream by build.rs.)
- **Timeout:** bump `timeout-minutes` 45 → 60 for headroom now that the job runs tests, not just compiles them.

### Why fold into `health` rather than a new `tests.yml`?

The `health` job already pays the expensive one-time V8 compile and shares a Swatinem rust-cache. A separate job runs on its own runner, cannot share `target/`, and would double-pay the 15–30 min cold V8 compile. Reusing the existing job is the CI-cost-correct choice (and matches this repo's cost-conscious CI posture).

## Test plan / verification (local)

- **Positive — gated test runs, does not skip:** `cargo test --workspace` ran the esbuild-gated integration test `preact_client_router_islands_bundle_resolves_react_jsx_runtime` with result `ok` and **no** skip note, alongside the always-run arg-assertion unit tests. ~1500 tests pass.
- **RED demo — the guard is meaningful:** temporarily removing the alias block (`crates/zfb-islands/src/esbuild.rs:852-853`) and running the integration test **in isolation with esbuild present** makes it FAIL with the exact #633 error `Could not resolve "react/jsx-runtime"` — proving the gated body actually executes and catches the regression (not just the unit tests). Restored after.
- CI (linux) is the cross-platform confirmation: this PR's own `health` run executes the full suite on `ubuntu-latest`.

## Follow-ups raised (out of scope for #638)

- #640 — add `cargo clippy --workspace --all-targets -- -D warnings` as a CI lint gate (needs a warning cleanup first; kept out to keep this PR focused).
- #641 — `zfb-watcher` smoke test is macOS-fragile (asserts a non-canonicalized tempdir path); passes on Linux CI.