### PR TITLE
[Build Exit Hang] Bound all post-dist unbounded-wait vectors so zfb build always terminates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5541,6 +5541,7 @@ dependencies = [
  "hex",
  "include_dir",
  "indicatif",
+ "libc",
  "local-ip-address",
  "owo-colors",
  "oxc_resolver",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4769,6 +4769,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5581,6 +5590,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "wait-timeout",
  "walkdir",
  "zfb-content",
  "zfb-css",

--- a/crates/zfb-build/Cargo.toml
+++ b/crates/zfb-build/Cargo.toml
@@ -95,6 +95,9 @@ fs2 = "0.4"
 # same byte stream.
 sha2 = "0.10"
 hex = "0.4"
+# Bounded wait for child processes so a wedged pnpm or esbuild subprocess
+# cannot hang the build indefinitely. Zero transitive deps; cross-platform.
+wait-timeout = "0.2"
 # Issue #228 / #229: shared HTML link rewriter that the production
 # build pass and the dev server both call so dev-mode and prod-mode
 # render the same `<a href>` / `<form action>` URLs under a `base`

--- a/crates/zfb-build/src/adapter.rs
+++ b/crates/zfb-build/src/adapter.rs
@@ -30,11 +30,14 @@
 //! for that route. We surface this as an immediate error rather than
 //! silently dropping the SSR routes — see [`ensure_no_ssr_without_adapter`].
 
+use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Output, Stdio};
+use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
+use wait_timeout::ChildExt;
 
 /// Adapter selection from `zfb.config.json`.
 ///
@@ -248,7 +251,7 @@ impl AdapterRunner for DefaultAdapterRunner {
         cmd.arg("--outdir");
         cmd.arg(&input.outdir);
 
-        let output = cmd.output().with_context(|| {
+        let output = run_capturing(&mut cmd).with_context(|| {
             format!(
                 "spawning `pnpm exec {bin_name} bundle ...` for adapter {package}"
             )
@@ -269,6 +272,75 @@ impl AdapterRunner for DefaultAdapterRunner {
 
         Ok(AdapterBundleOutput { stdout, stderr })
     }
+}
+
+/// Run `cmd`, capturing stdout and stderr without reading inherited-pipe
+/// write-ends to EOF.
+///
+/// `Command::output()` blocks until every write-end of the child's
+/// stdout/stderr pipes is closed — meaning any grandchild that inherits
+/// those fds (e.g. a detached node process spawned by pnpm) holds the
+/// build forever at low CPU. This helper avoids the problem by routing
+/// stdout/stderr through temp files and using `child.wait()` (reaps the
+/// direct child the instant it exits) rather than reading pipes to EOF.
+///
+/// A generous timeout guards against the direct child wedging entirely.
+/// On overrun the child is killed and an error is returned.
+pub(crate) fn run_capturing(cmd: &mut Command) -> Result<Output> {
+    // 5-minute deadline — generous backstop for slow pnpm/esbuild runs;
+    // this is a wedge guard, not a performance bound.
+    const TIMEOUT: Duration = Duration::from_secs(300);
+
+    let mut stdout_file = tempfile::tempfile().context("creating stdout temp file")?;
+    let mut stderr_file = tempfile::tempfile().context("creating stderr temp file")?;
+
+    cmd.stdin(Stdio::null());
+    cmd.stdout(Stdio::from(
+        stdout_file.try_clone().context("cloning stdout temp file")?,
+    ));
+    cmd.stderr(Stdio::from(
+        stderr_file.try_clone().context("cloning stderr temp file")?,
+    ));
+
+    let mut child = cmd.spawn().context("spawning subprocess")?;
+
+    let status = match child
+        .wait_timeout(TIMEOUT)
+        .context("waiting for subprocess")?
+    {
+        Some(s) => s,
+        None => {
+            // Direct child did not exit within the deadline. Kill it and
+            // surface a clear diagnostic rather than hanging indefinitely.
+            let _ = child.kill();
+            let _ = child.wait();
+            bail!(
+                "subprocess did not exit within {}s — killed",
+                TIMEOUT.as_secs()
+            );
+        }
+    };
+
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    stdout_file
+        .seek(SeekFrom::Start(0))
+        .context("seeking stdout temp file")?;
+    stdout_file
+        .read_to_end(&mut stdout)
+        .context("reading stdout temp file")?;
+    stderr_file
+        .seek(SeekFrom::Start(0))
+        .context("seeking stderr temp file")?;
+    stderr_file
+        .read_to_end(&mut stderr)
+        .context("reading stderr temp file")?;
+
+    Ok(Output {
+        status,
+        stdout,
+        stderr,
+    })
 }
 
 /// Drive the dispatch through a custom [`AdapterRunner`]. Production
@@ -606,5 +678,41 @@ mod tests {
         )
         .unwrap_err();
         assert!(format!("{err}").contains("does not exist"));
+    }
+
+    /// Verify that run_capturing returns promptly even when the direct
+    /// child has exited but a backgrounded grandchild still holds the
+    /// inherited pipe write-end open.
+    ///
+    /// The grandchild (`sleep 30 &`) inherits the write-end of the stdout
+    /// temp file's clone passed to the child shell. With the old
+    /// `cmd.output()` approach this would block for 30 s; with
+    /// run_capturing it must return the moment `sh` exits (0 s + noise).
+    ///
+    /// The test wraps the call in its own 5-second watchdog so a
+    /// regression produces a RED test rather than a hung CI job.
+    #[cfg(unix)]
+    #[test]
+    fn run_capturing_returns_promptly_when_grandchild_holds_pipe_open() {
+        use std::sync::mpsc;
+        use std::thread;
+
+        let (tx, rx) = mpsc::channel::<Result<std::process::Output>>();
+
+        thread::spawn(move || {
+            // `sleep 30 &` backgrounds a grandchild that keeps the inherited
+            // file descriptor open after sh exits. run_capturing must NOT
+            // wait for the grandchild — it waits only on the direct child.
+            let mut cmd = Command::new("sh");
+            cmd.arg("-c").arg("sleep 30 & exit 0");
+            let _ = tx.send(run_capturing(&mut cmd));
+        });
+
+        let result = rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("run_capturing did not return within 5 s — pipe-EOF hang regression");
+
+        let output = result.expect("run_capturing returned an error");
+        assert!(output.status.success(), "sh exited non-zero: {}", output.status);
     }
 }

--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -117,6 +117,8 @@ use zfb_content::plugins::util::source_map::{
 };
 use zfb_render::adapters::{make_adapter, Framework};
 
+use crate::adapter::run_capturing;
+
 /// `import.meta.env.{PROD,DEV}` substitution mode.
 ///
 /// `Production` substitutes `PROD=true`, `DEV=false`. `Development` is
@@ -3259,8 +3261,7 @@ fn run_esbuild(input: &BundlerInput, shadow: &Path, bundle_path: &Path) -> Resul
 
     cmd.arg(OsString::from(entry));
 
-    let output = cmd
-        .output()
+    let output = run_capturing(&mut cmd)
         .with_context(|| format!("failed to spawn {}", bin.display()))?;
     // Drop `resolver_inputs` now — the subprocess has finished and
     // esbuild no longer needs the virtual-module `.mjs` temp files.

--- a/crates/zfb-build/src/lib.rs
+++ b/crates/zfb-build/src/lib.rs
@@ -80,9 +80,9 @@ pub use plugin_registries::{
     SetupRegistryError, VirtualLoaderId, VirtualModuleEntry, VirtualModuleRegistry,
 };
 pub use plugin_runner::{
-    annotate_with_plugin_error, extract_plugin_error, BuildHookContext, DevRegisterContext,
-    DevRegistration, DevRequest, DevResponse, PluginError, PluginHost, PluginSpec,
-    PostBuildParamValue, PostBuildRouteEntry, PostBuildRouteManifest, SetupHookContext,
+    annotate_with_plugin_error, extract_plugin_error, resolve_hook_timeout, BuildHookContext,
+    DevRegisterContext, DevRegistration, DevRequest, DevResponse, PluginError, PluginHost,
+    PluginSpec, PostBuildParamValue, PostBuildRouteEntry, PostBuildRouteManifest, SetupHookContext,
 };
 pub use pipeline::{
     apply_prod_asset_pipeline, synthesize_page_id_from_output, AssetEmitter, AssetEmitterPayload,

--- a/crates/zfb-build/src/plugin_runner.rs
+++ b/crates/zfb-build/src/plugin_runner.rs
@@ -295,6 +295,10 @@ struct HostInner {
     child: Mutex<Option<Child>>,
     /// Dropping the [`_tempdir`] removes the staged plugin-host script.
     _tempdir: tempfile::TempDir,
+    /// Maximum time any single plugin hook reply is awaited before the
+    /// host is force-killed and the build fails with a diagnostic error.
+    /// Env: ZFB_PLUGIN_HOOK_TIMEOUT (seconds). Default: 120s.
+    hook_timeout: std::time::Duration,
 }
 
 #[derive(Debug, Deserialize)]
@@ -336,6 +340,29 @@ struct LogPayload {
     message: String,
 }
 
+/// Default hook timeout in seconds — generous because postBuild may do
+/// real work (sitemap generation, asset upload, etc.).
+/// Override via ZFB_PLUGIN_HOOK_TIMEOUT env var or config `pluginHookTimeoutSecs`.
+const DEFAULT_HOOK_TIMEOUT_SECS: u64 = 120;
+
+/// Resolve the hook timeout: config field > env var > 120s default.
+///
+/// Precedence (highest to lowest):
+/// 1. Explicit `config_secs` value (from `Config.pluginHookTimeoutSecs`)
+/// 2. `ZFB_PLUGIN_HOOK_TIMEOUT` env var (seconds)
+/// 3. 120s built-in default
+pub fn resolve_hook_timeout(config_secs: Option<u64>) -> std::time::Duration {
+    if let Some(s) = config_secs {
+        return std::time::Duration::from_secs(s);
+    }
+    if let Ok(val) = std::env::var("ZFB_PLUGIN_HOOK_TIMEOUT") {
+        if let Ok(s) = val.trim().parse::<u64>() {
+            return std::time::Duration::from_secs(s);
+        }
+    }
+    std::time::Duration::from_secs(DEFAULT_HOOK_TIMEOUT_SECS)
+}
+
 impl PluginHost {
     /// Spawn the plugin-host subprocess and load every plugin module
     /// via dynamic `import()`. Returns a handle that can dispatch
@@ -346,10 +373,24 @@ impl PluginHost {
     /// entries with `resolved_module = None` are skipped (they cannot
     /// be loaded; the JSON config path produces `None` and we treat
     /// that as a no-plugin build).
+    ///
+    /// `hook_timeout` is the maximum time any single hook reply is awaited.
+    /// Pass `None` to auto-resolve from `ZFB_PLUGIN_HOOK_TIMEOUT` / 120s default.
     pub async fn spawn(
         plugins: Vec<PluginSpec>,
         node_binary: Option<OsString>,
     ) -> Result<Self> {
+        Self::spawn_with_timeout(plugins, node_binary, None).await
+    }
+
+    /// Like [`spawn`] but with an explicit hook timeout (used by the build
+    /// orchestrator to thread `Config.pluginHookTimeoutSecs`).
+    pub async fn spawn_with_timeout(
+        plugins: Vec<PluginSpec>,
+        node_binary: Option<OsString>,
+        hook_timeout_secs: Option<u64>,
+    ) -> Result<Self> {
+        let hook_timeout = resolve_hook_timeout(hook_timeout_secs);
         let tmp = tempfile::Builder::new()
             .prefix("zfb-plugin-host-")
             .tempdir()
@@ -392,6 +433,7 @@ impl PluginHost {
             next_id: AtomicU64::new(1),
             child: Mutex::new(Some(child)),
             _tempdir: tmp,
+            hook_timeout,
         });
 
         // Reader task — drains stdout, dispatches replies to the
@@ -646,13 +688,25 @@ impl PluginHost {
         Ok(resp)
     }
 
+    /// Force-kill the child process. Used when a hook timeout fires.
+    async fn force_kill_child(&self) {
+        let mut guard = self.inner.child.lock().await;
+        if let Some(mut child) = guard.take() {
+            let _ = child.kill().await;
+        }
+    }
+
     /// Send a `shutdown` command and wait for the child to exit.
     /// Best-effort: if the child has already died, this returns Ok.
     pub async fn shutdown(self) -> Result<()> {
-        // Send the shutdown — ignore any error (the child may have
-        // already exited). The reply is the loaded "bye" object.
+        // Send the shutdown with the 2s shutdown budget, not the hook timeout.
+        let shutdown_budget = std::time::Duration::from_secs(2);
         let _ = self
-            .request_typed::<serde_json::Value>("shutdown", serde_json::json!({}))
+            .request_typed_with_timeout::<serde_json::Value>(
+                "shutdown",
+                serde_json::json!({}),
+                shutdown_budget,
+            )
             .await;
         let mut guard = self.inner.child.lock().await;
         if let Some(mut child) = guard.take() {
@@ -674,6 +728,16 @@ impl PluginHost {
         &self,
         kind: &str,
         body: serde_json::Value,
+    ) -> Result<T> {
+        let timeout = self.inner.hook_timeout;
+        self.request_typed_with_timeout(kind, body, timeout).await
+    }
+
+    async fn request_typed_with_timeout<T: serde::de::DeserializeOwned>(
+        &self,
+        kind: &str,
+        body: serde_json::Value,
+        timeout: std::time::Duration,
     ) -> Result<T> {
         let id = self.inner.next_id.fetch_add(1, Ordering::Relaxed);
         let (tx, rx) = oneshot::channel();
@@ -715,9 +779,31 @@ impl PluginHost {
             return Err(e);
         }
 
-        let reply = rx
-            .await
-            .map_err(|_| anyhow!("plugin host: reply channel dropped"))?;
+        let reply = match tokio::time::timeout(timeout, rx).await {
+            Ok(Ok(reply)) => reply,
+            Ok(Err(_)) => {
+                return Err(anyhow!("plugin host: reply channel dropped"));
+            }
+            Err(_elapsed) => {
+                // Hook did not complete within the deadline. Evict the pending
+                // entry (the channel is gone), force-kill the child so no
+                // future hooks can hang, then return a diagnostic error.
+                {
+                    let mut pend = self.inner.pending.lock().await;
+                    pend.remove(&id);
+                }
+                self.force_kill_child().await;
+                let secs = timeout.as_secs();
+                return Err(anyhow!(
+                    "`{}` hook did not complete within {}s — \
+                     check for an unresolved promise / open handle / setInterval \
+                     in a plugin's `{}` implementation",
+                    kind,
+                    secs,
+                    kind,
+                ));
+            }
+        };
         if !reply.ok {
             let payload = reply.error.unwrap_or(HostErrorPayload {
                 plugin: "(host)".into(),
@@ -1658,5 +1744,138 @@ mod tests {
         let ssr = routes.iter().find(|r| r["url"] == "/api/search").unwrap();
         assert_eq!(ssr["prerender"], serde_json::json!(false),
             "SSR route must have prerender=false, got: {}", ssr);
+    }
+
+    // --- Timeout tests (no node required) -----------------------------------
+
+    /// Build a minimal PluginHost whose child is a `sleep`-style process
+    /// that never writes to stdout, so every hook reply awaits forever.
+    /// We don't need the reader task to be running — the oneshot rx will
+    /// never resolve because no reply ever arrives on stdout.
+    #[cfg(unix)]
+    async fn stub_host_with_timeout(timeout: std::time::Duration) -> Option<PluginHost> {
+        // `sleep 300` never writes anything to stdout, so rx.await blocks forever
+        // unless bounded — exactly the condition under test.
+        let mut child = match tokio::process::Command::new("sleep")
+            .arg("300")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .kill_on_drop(true)
+            .spawn()
+        {
+            Ok(c) => c,
+            Err(_) => return None, // `sleep` not available (extremely rare)
+        };
+        let stdin = child.stdin.take().expect("stdin");
+        // We need a valid tempdir even though the host script is never run.
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let inner = Arc::new(HostInner {
+            pending: Mutex::new(HashMap::new()),
+            stdin: Mutex::new(stdin),
+            next_id: AtomicU64::new(1),
+            child: Mutex::new(Some(child)),
+            _tempdir: tmp,
+            hook_timeout: timeout,
+        });
+        Some(PluginHost { inner })
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn post_build_hook_times_out_and_returns_error() {
+        // Short deadline so the test stays fast; watchdog is 3× to ensure
+        // a regression is RED (hung), not a false-pass from the watchdog.
+        let short = std::time::Duration::from_millis(150);
+        let host = match stub_host_with_timeout(short).await {
+            Some(h) => h,
+            None => {
+                eprintln!("skipping: `sleep` not available");
+                return;
+            }
+        };
+        let ctx = BuildHookContext {
+            project_root: std::path::PathBuf::from("/tmp"),
+            out_dir: std::path::PathBuf::from("/tmp/dist"),
+            config: serde_json::json!({}),
+            routes: None,
+        };
+        // Outer watchdog: if the inner timeout fires correctly the call
+        // returns within ~150ms; allow 5s so CI is never flaky.
+        let watchdog = std::time::Duration::from_secs(5);
+        let result = tokio::time::timeout(watchdog, host.run_post_build(&ctx)).await;
+        match result {
+            Err(_watchdog_fired) => {
+                panic!("run_post_build did NOT time out — the timeout fix is missing");
+            }
+            Ok(inner_result) => {
+                let err = inner_result.expect_err("run_post_build must return Err on timeout");
+                let msg = format!("{err:#}");
+                assert!(
+                    msg.contains("postBuild"),
+                    "error message must name the hook; got: {msg}"
+                );
+                assert!(
+                    msg.contains("did not complete within"),
+                    "error message must state the timeout; got: {msg}"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    #[cfg(unix)]
+    async fn pre_build_hook_times_out_and_returns_error() {
+        let short = std::time::Duration::from_millis(150);
+        let host = match stub_host_with_timeout(short).await {
+            Some(h) => h,
+            None => {
+                eprintln!("skipping: `sleep` not available");
+                return;
+            }
+        };
+        let ctx = BuildHookContext {
+            project_root: std::path::PathBuf::from("/tmp"),
+            out_dir: std::path::PathBuf::from("/tmp/dist"),
+            config: serde_json::json!({}),
+            routes: None,
+        };
+        let watchdog = std::time::Duration::from_secs(5);
+        let result = tokio::time::timeout(watchdog, host.run_pre_build(&ctx)).await;
+        match result {
+            Err(_watchdog_fired) => {
+                panic!("run_pre_build did NOT time out — the timeout fix is missing");
+            }
+            Ok(inner_result) => {
+                let err = inner_result.expect_err("run_pre_build must return Err on timeout");
+                let msg = format!("{err:#}");
+                assert!(
+                    msg.contains("preBuild"),
+                    "error message must name the hook; got: {msg}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn resolve_hook_timeout_uses_default_when_nothing_set() {
+        // Can't safely mutate env in a multi-threaded test process, but
+        // we can test the no-override path with an explicit None.
+        let d = resolve_hook_timeout(None);
+        // Env may or may not be set in the test runner; only verify the
+        // default path when the var is absent.
+        if std::env::var("ZFB_PLUGIN_HOOK_TIMEOUT").is_err() {
+            assert_eq!(
+                d,
+                std::time::Duration::from_secs(DEFAULT_HOOK_TIMEOUT_SECS),
+                "default must be 120s"
+            );
+        }
+    }
+
+    #[test]
+    fn resolve_hook_timeout_config_field_wins_over_default() {
+        let d = resolve_hook_timeout(Some(42));
+        assert_eq!(d, std::time::Duration::from_secs(42));
     }
 }

--- a/crates/zfb-build/src/plugin_runner.rs
+++ b/crates/zfb-build/src/plugin_runner.rs
@@ -352,12 +352,19 @@ const DEFAULT_HOOK_TIMEOUT_SECS: u64 = 120;
 /// 2. `ZFB_PLUGIN_HOOK_TIMEOUT` env var (seconds)
 /// 3. 120s built-in default
 pub fn resolve_hook_timeout(config_secs: Option<u64>) -> std::time::Duration {
+    // A zero (or unparseable env) value is ignored and falls through to the
+    // next source: `0` would make every hook time out instantly, which is
+    // never an intended configuration.
     if let Some(s) = config_secs {
-        return std::time::Duration::from_secs(s);
+        if s > 0 {
+            return std::time::Duration::from_secs(s);
+        }
     }
     if let Ok(val) = std::env::var("ZFB_PLUGIN_HOOK_TIMEOUT") {
         if let Ok(s) = val.trim().parse::<u64>() {
-            return std::time::Duration::from_secs(s);
+            if s > 0 {
+                return std::time::Duration::from_secs(s);
+            }
         }
     }
     std::time::Duration::from_secs(DEFAULT_HOOK_TIMEOUT_SECS)

--- a/crates/zfb/Cargo.toml
+++ b/crates/zfb/Cargo.toml
@@ -124,3 +124,9 @@ tar = "0.4"
 tempfile = { workspace = true }
 tower = { version = "0.5", features = ["util"] }
 zfb-test-utils = { path = "../zfb-test-utils" }
+# Process-group kill for build_terminates e2e (#654).
+# libc is already a transitive dep (via wait-timeout); adding it here
+# avoids the `setsid` wrapper binary and keeps the test self-contained.
+# Unix-only; the test is #[cfg(unix)]-gated.
+[target.'cfg(unix)'.dev-dependencies]
+libc = "0.2"

--- a/crates/zfb/src/bounded_join.rs
+++ b/crates/zfb/src/bounded_join.rs
@@ -59,8 +59,21 @@ mod tests {
             // park() can return spuriously; recv() on a live channel cannot.
             let _ = rx.recv();
         });
-        // A short timeout — should complete quickly (not block for ~5 s).
-        let result = join_with_deadline(handle, Duration::from_millis(100));
-        assert!(result.is_none());
+        // Run the call on a worker thread guarded by an OUTER watchdog: if
+        // join_with_deadline ever regressed to a blocking join, it would hang
+        // here — the watchdog turns that into a RED failure instead of a hung
+        // test run (the whole point of this helper is to never hang).
+        let (done_tx, done_rx) = std_mpsc::channel();
+        thread::spawn(move || {
+            let result = join_with_deadline(handle, Duration::from_millis(100));
+            let _ = done_tx.send(result);
+        });
+        match done_rx.recv_timeout(Duration::from_secs(5)) {
+            Ok(result) => assert!(result.is_none()),
+            Err(_) => panic!(
+                "join_with_deadline did not return within 5s — it is no longer \
+                 bounding the wait (regression)"
+            ),
+        }
     }
 }

--- a/crates/zfb/src/bounded_join.rs
+++ b/crates/zfb/src/bounded_join.rs
@@ -1,0 +1,66 @@
+//! Thread-join with a deadline.
+//!
+//! [`join_with_deadline`] wraps an arbitrary [`std::thread::JoinHandle`] and
+//! returns either the thread's return value (on a clean join within the
+//! deadline) or `None` (on timeout or panic), **without blocking the caller
+//! indefinitely**.  On timeout the watcher thread and the original handle are
+//! both detached; the OS reaps them on process exit.
+//!
+//! The module is unconditionally compiled (no `embed_v8` gate) so its unit
+//! tests run in every CI job, including `--no-default-features`.
+
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+/// Join `handle` with a deadline.
+///
+/// Spawns a watcher thread that calls `handle.join()` and forwards the result
+/// over a channel.  The caller waits on that channel for at most `timeout`.
+///
+/// Returns:
+/// - `Some(value)` — the thread finished and returned `value` within the
+///   deadline.
+/// - `None` — timeout elapsed (or the thread panicked).  The watcher thread
+///   and the original handle are detached; the OS cleans them up on exit.
+pub fn join_with_deadline<T: Send + 'static>(
+    handle: thread::JoinHandle<T>,
+    timeout: Duration,
+) -> Option<T> {
+    let (tx, rx) = mpsc::channel::<thread::Result<T>>();
+    thread::spawn(move || {
+        let _ = tx.send(handle.join());
+    });
+    match rx.recv_timeout(timeout) {
+        Ok(Ok(value)) => Some(value),
+        // Thread panicked or timed out / disconnected — detach.
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::mpsc as std_mpsc;
+    use std::time::Duration;
+
+    #[test]
+    fn happy_path_returns_some() {
+        let handle = thread::spawn(|| 42u32);
+        let result = join_with_deadline(handle, Duration::from_secs(5));
+        assert_eq!(result, Some(42));
+    }
+
+    #[test]
+    fn timeout_returns_none_without_hanging() {
+        // Spawn a thread that blocks forever via a never-sent channel receive.
+        let (_tx, rx) = std_mpsc::channel::<()>();
+        let handle = thread::spawn(move || {
+            // park() can return spuriously; recv() on a live channel cannot.
+            let _ = rx.recv();
+        });
+        // A short timeout — should complete quickly (not block for ~5 s).
+        let result = join_with_deadline(handle, Duration::from_millis(100));
+        assert!(result.is_none());
+    }
+}

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -1579,13 +1579,14 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
     // For any dynamic routes whose `paths()` couldn't be statically
     // extracted (Phase 1), start the embedded V8 host against the freshly-
     // bundled worker and query the `/__paths__/<route>` endpoint for each.
-    // The running host is reused for SSG rendering in step 3 (via
-    // `Backend::Existing`) so we only pay the host startup cost once.
-    // `_worker_handle` deliberately keeps the host alive through the
-    // subsequent `render_all` call: dropping it earlier would shut the host
-    // down before rendering completes. The `_` prefix suppresses
-    // the unused-variable warning without triggering immediate drop
-    // (only `_` alone drops immediately; `_name` lives to end of scope).
+    // `eval_deferred_paths` returns `Backend::EmbeddedV8` (with a factory)
+    // in both the empty-deferred and non-empty branches; `render_all` always
+    // constructs a fresh host from that factory — there is no host reuse.
+    // `_worker_handle` keeps the eval-phase RendererState alive through the
+    // subsequent `render_all` call so its resources (e.g. temp files) are
+    // not dropped prematurely. The `_` prefix suppresses the unused-variable
+    // warning without triggering immediate drop (only `_` alone drops
+    // immediately; `_name` lives to end of scope).
     let (runtime_expansion, backend, _worker_handle) = runner
         .eval_deferred_paths(&still_deferred, &bundler_out, &mut paths_cache)
         .context("runtime paths() evaluation step failed")?;

--- a/crates/zfb/src/commands/plugins.rs
+++ b/crates/zfb/src/commands/plugins.rs
@@ -49,9 +49,10 @@ pub async fn maybe_spawn_host(config: &Config) -> Result<Option<PluginHost>> {
     if specs.is_empty() {
         return Ok(None);
     }
-    let host = PluginHost::spawn(specs, None)
-        .await
-        .context("plugin lifecycle: failed to spawn the plugin host")?;
+    let host =
+        PluginHost::spawn_with_timeout(specs, None, config.plugin_hook_timeout_secs)
+            .await
+            .context("plugin lifecycle: failed to spawn the plugin host")?;
     Ok(Some(host))
 }
 

--- a/crates/zfb/src/config.rs
+++ b/crates/zfb/src/config.rs
@@ -452,6 +452,20 @@ pub struct Config {
     /// the JSON / TS form `output` 1:1.
     #[serde(default)]
     pub output: OutputMode,
+
+    /// Maximum seconds a single plugin lifecycle hook (preBuild,
+    /// postBuild, setup, etc.) may run before the build fails with a
+    /// diagnostic error and the plugin host is force-killed.
+    ///
+    /// Absent / `None` falls through to the `ZFB_PLUGIN_HOOK_TIMEOUT`
+    /// env var, then the 120s built-in default. Set this when your
+    /// plugins do long but bounded work (e.g. large sitemap generation)
+    /// and you want a tighter or more explicit budget. Seconds.
+    ///
+    /// `#[serde(rename_all = "camelCase")]` on this struct deserialises
+    /// the JSON / TS form `pluginHookTimeoutSecs` 1:1.
+    #[serde(default)]
+    pub plugin_hook_timeout_secs: Option<u64>,
 }
 
 impl Default for Config {
@@ -477,6 +491,7 @@ impl Default for Config {
             emit_routes_manifest: None,
             extra_watch_paths: Vec::new(),
             output: OutputMode::default(),
+            plugin_hook_timeout_secs: None,
         }
     }
 }

--- a/crates/zfb/src/lib.rs
+++ b/crates/zfb/src/lib.rs
@@ -3,6 +3,7 @@
 //! This crate exposes the CLI parser, command dispatchers, configuration
 //! loader, and structured output helpers used by the `zfb` binary.
 
+pub mod bounded_join;
 pub mod cli;
 pub mod commands;
 pub mod config;

--- a/crates/zfb/src/v8_host_adapter.rs
+++ b/crates/zfb/src/v8_host_adapter.rs
@@ -73,16 +73,19 @@ unsafe impl Send for ThreadedV8Host {}
 
 impl Drop for ThreadedV8Host {
     /// Close the request channel first (so the V8 thread's receive loop
-    /// exits), then join the thread to guarantee a clean shutdown with no
-    /// leaks.
+    /// exits), then join the thread with a deadline to bound teardown time.
     fn drop(&mut self) {
         // Drop the sender; the V8 thread's `for req in rx` loop will see
         // the channel closed and exit its async block.
         drop(self.tx.take());
         if let Some(handle) = self.thread.take() {
-            // Best-effort join: if the thread panicked, the panic has already
-            // been propagated to the caller via the reply channel; swallow it.
-            let _ = handle.join();
+            // Bounded join: if isolate teardown inside deno_core wedges, we
+            // detach rather than hang the process.  A generous deadline is
+            // fine — the goal is bounding the worst case, not a tight cutoff.
+            let _ = crate::bounded_join::join_with_deadline(
+                handle,
+                std::time::Duration::from_secs(10),
+            );
         }
     }
 }

--- a/crates/zfb/tests/build_terminates.rs
+++ b/crates/zfb/tests/build_terminates.rs
@@ -248,12 +248,23 @@ fn zfb_build_terminates_with_adapter_and_ssr_route() {
     // inherits the child PID.  setpgid(0, 0) moves the child into a new
     // process group (PGID == child PID).  Any grandchild the adapter spawns
     // inherits that PGID, so kill(-pgid, SIGKILL) reaps the whole tree.
+    //
+    // stdout/stderr are redirected to temp files rather than pipes: this
+    // watchdog only drains output *after* the child exits, so a piped child
+    // that wrote more than the ~64KB OS pipe buffer would block on write and
+    // masquerade as a hang — on the very test meant to certify termination.
+    // Files have no backpressure; we read them back for the failure message.
+    let stdout_path = root.join(".zfb-build-stdout.log");
+    let stderr_path = root.join(".zfb-build-stderr.log");
+    let stdout_file = fs::File::create(&stdout_path).expect("create stdout log file");
+    let stderr_file = fs::File::create(&stderr_path).expect("create stderr log file");
+
     let mut cmd = Command::new(zfb_binary!());
     cmd.arg("build")
         .current_dir(&root)
         .env("ZFB_ESBUILD_BIN", &esbuild)
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
+        .stdout(Stdio::from(stdout_file))
+        .stderr(Stdio::from(stderr_file));
 
     // Safety: setpgid(0, 0) is async-signal-safe (POSIX).
     unsafe {
@@ -267,6 +278,9 @@ fn zfb_build_terminates_with_adapter_and_ssr_route() {
 
     let mut child = cmd.spawn().expect("spawn `zfb build`");
     let pgid = child.id() as libc::pid_t; // PGID == child PID after setpgid(0,0)
+
+    // Read a captured output file back (best-effort) for assertion messages.
+    let read_log = |p: &std::path::Path| std::fs::read_to_string(p).unwrap_or_default();
 
     // --- watchdog loop ---
 
@@ -284,35 +298,14 @@ fn zfb_build_terminates_with_adapter_and_ssr_route() {
                     }
                     let _ = child.wait();
 
-                    let stdout = child
-                        .stdout
-                        .take()
-                        .map(|mut r| {
-                            let mut s = String::new();
-                            use std::io::Read;
-                            let _ = r.read_to_string(&mut s);
-                            s
-                        })
-                        .unwrap_or_default();
-                    let stderr = child
-                        .stderr
-                        .take()
-                        .map(|mut r| {
-                            let mut s = String::new();
-                            use std::io::Read;
-                            let _ = r.read_to_string(&mut s);
-                            s
-                        })
-                        .unwrap_or_default();
-
                     panic!(
                         "`zfb build` did not exit within {}s — this indicates a hang. \
                          Process group {} was killed.\n\
                          --- stdout ---\n{}\n--- stderr ---\n{}",
                         BUILD_TIMEOUT.as_secs(),
                         pgid,
-                        stdout,
-                        stderr,
+                        read_log(&stdout_path),
+                        read_log(&stderr_path),
                     );
                 }
                 std::thread::sleep(Duration::from_millis(250));
@@ -330,31 +323,12 @@ fn zfb_build_terminates_with_adapter_and_ssr_route() {
         libc::kill(-pgid, libc::SIGKILL);
     }
 
-    // Collect stdout/stderr for the assertion message.
-    let stdout = child
-        .stdout
-        .take()
-        .map(|mut r| {
-            let mut s = String::new();
-            use std::io::Read;
-            let _ = r.read_to_string(&mut s);
-            s
-        })
-        .unwrap_or_default();
-    let stderr = child
-        .stderr
-        .take()
-        .map(|mut r| {
-            let mut s = String::new();
-            use std::io::Read;
-            let _ = r.read_to_string(&mut s);
-            s
-        })
-        .unwrap_or_default();
-
     assert!(
         exit_status.success(),
         "`zfb build` exited non-zero — adapter+SSR-route fixture should build cleanly.\n\
-         status: {exit_status:?}\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}"
+         status: {:?}\n--- stdout ---\n{}\n--- stderr ---\n{}",
+        exit_status,
+        read_log(&stdout_path),
+        read_log(&stderr_path),
     );
 }

--- a/crates/zfb/tests/build_terminates.rs
+++ b/crates/zfb/tests/build_terminates.rs
@@ -1,0 +1,360 @@
+//! End-to-end watchdog — assert that `zfb build` terminates.
+//!
+//! ## Why this test exists
+//!
+//! No existing test asserts that `zfb build` actually returns to the caller.
+//! This watchdog drives the real `zfb` binary against an adapter + SSR-route
+//! fixture and FAILs if the process does not exit within a wall-clock deadline.
+//!
+//! The discriminating bugs fixed in wave 1 (#651/#652/#653) were:
+//!
+//! - **Candidate A (output() hang):** `run_capturing` in `adapter.rs` called
+//!   `Command::output()`, which blocks until every write-end of stdout/stderr
+//!   pipes is closed.  The stub adapter intentionally detaches a grandchild
+//!   process that keeps those inherited fds open.  Before fix #651 the build
+//!   hung at the `wait_stdout_to_eof` point indefinitely.  After the fix
+//!   (redirect stdout/stderr to temp files + `wait()` on the direct child only)
+//!   the build exits the moment the direct child exits, regardless of the
+//!   grandchild.
+//!
+//! - **Candidate B (V8 Drop hang):** The embedded V8 host was not joined
+//!   before the process exited, leading to a hang in the V8 destructor (#652).
+//!
+//! - **Candidate C (postBuild timeout):** A pathological postBuild plugin
+//!   could block the build indefinitely (#653).
+//!
+//! ## Why process-group kill is required
+//!
+//! The fixture adapter script deliberately detaches a grandchild (`sleep 60`)
+//! that outlives the adapter process.  On timeout, killing only the direct
+//! `zfb` child would leave the grandchild alive, and the test process itself
+//! would stay hung waiting for that grandchild's inherited fds to close.
+//! `kill(-pgid, SIGKILL)` reaps the **entire process group** — the only
+//! reliable exit path when an arbitrary grandchild may be holding fds open.
+//!
+//! The same group-kill is issued after a successful exit to collect the
+//! deliberately-lingering sleep grandchild so it does not leak into CI.
+//!
+//! ## Fixture shape
+//!
+//! Scaffolded inline (no on-disk fixture directory):
+//!
+//! - `zfb.config.json` — `adapter: "zfb-adapter-stub"`, `framework: "preact"`.
+//! - `pages/index.tsx` — `export const prerender = false` (SSR route), renders
+//!   a minimal HTML page.  This is enough to trigger both the V8-on path
+//!   (build.rs decides V8-on when the prerender-false set is non-empty) and the
+//!   adapter dispatch (build.rs:1739).
+//! - `node_modules/` — symlinked to the binary-embedded `@takazudo` packages
+//!   (same technique used by `css_modules_components_build.rs`'s
+//!   `corp_shape_with_real_node_modules_and_no_tsconfig_paths_builds`).
+//!   This allows `detect_project_node_modules` to resolve the framework packages
+//!   while still giving us a writable `node_modules/.bin/` for the stub adapter.
+//! - `node_modules/.bin/zfb-adapter-stub` — a `#!/bin/sh` script that writes
+//!   `dist/_worker.js`, detaches a `sleep 60` grandchild holding the inherited
+//!   stdout/stderr fds, then exits 0.  This is the exact shape Candidate A
+//!   was sensitive to.
+//! - `node_modules/zfb-adapter-stub/package.json` — declares the `bin` entry
+//!   so `pnpm exec zfb-adapter-stub` resolves the script.
+//! - `package.json` at the fixture root — required by `pnpm exec` to
+//!   identify the local workspace root and discover `node_modules/.bin/`.
+//!
+//! Note: because the project has a real `node_modules/` present,
+//! `detect_project_node_modules` returns `Some(...)` and the build uses it for
+//! framework-package resolution (no embedded_node_modules() extraction needed).
+//! The stub adapter entry lives within that same tree.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::os::unix::process::CommandExt;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use zfb_test_utils::{locate_esbuild, zfb_binary};
+
+/// Wall-clock deadline for the build.
+///
+/// 120 seconds is generous: a clean build with V8 + esbuild takes ~10-20 s on
+/// a loaded dev machine. A 120 s overrun is unambiguous evidence of a hang.
+const BUILD_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Scaffold the adapter+SSR-route fixture into `root`.
+///
+/// Returns a `tempfile::TempDir` handle for the extracted embedded node_modules
+/// tree — it must be kept alive for the duration of the test run.
+///
+/// # Fixture structure
+///
+/// - `zfb.config.json` — adapter + preact framework.
+/// - `pages/index.tsx` — `export const prerender = false` (SSR route).
+/// - `node_modules/` — symlinked to the extracted embedded `@takazudo` tree so
+///   `detect_project_node_modules` returns `Some(...)` and esbuild can resolve
+///   `@takazudo/zfb-runtime`, `preact`, etc.
+/// - `node_modules/.bin/zfb-adapter-stub` (mode 0o755) — stub adapter bin that
+///   writes `dist/_worker.js` and detaches a `sleep 60` grandchild.
+/// - `node_modules/zfb-adapter-stub/package.json` — declares the bin entry.
+fn scaffold_fixture(root: &std::path::Path) -> tempfile::TempDir {
+    // Config: adapter + preact framework.
+    fs::write(
+        root.join("zfb.config.json"),
+        r#"{ "framework": "preact", "adapter": "zfb-adapter-stub" }
+"#,
+    )
+    .unwrap();
+
+    // package.json at project root — required by `pnpm exec` to locate the
+    // local node_modules/.bin when run from this directory.
+    fs::write(
+        root.join("package.json"),
+        r#"{ "name": "build-terminates-fixture", "version": "0.0.1", "private": true }
+"#,
+    )
+    .unwrap();
+
+    // SSR route: prerender = false so the build enters V8-on mode and runs
+    // the adapter dispatch step (build.rs:1739).
+    fs::create_dir_all(root.join("pages")).unwrap();
+    fs::write(
+        root.join("pages/index.tsx"),
+        r#"export const prerender = false;
+
+export default function Page() {
+  return (
+    <html lang="en">
+      <head><title>build-terminates fixture</title></head>
+      <body><p>hello</p></body>
+    </html>
+  );
+}
+"#,
+    )
+    .unwrap();
+
+    // Extract the binary-embedded @takazudo packages into a tempdir, then
+    // symlink node_modules/ into the fixture root pointing at that tree.
+    // This mirrors the technique in css_modules_components_build.rs's
+    // `corp_shape_with_real_node_modules_and_no_tsconfig_paths_builds`.
+    let (nm_handle, embedded_nm_path) =
+        zfb::render_pipeline::embedded_node_modules().expect("embedded_node_modules");
+    std::os::unix::fs::symlink(&embedded_nm_path, root.join("node_modules"))
+        .expect("symlink node_modules");
+
+    // Stub adapter bin.
+    //
+    // The script:
+    //   1. Creates the outdir and writes a minimal dist/_worker.js so zfb does
+    //      not reject the adapter output.
+    //   2. Spawns a `sleep 60` grandchild that inherits stdout/stderr, then
+    //      immediately detaches it (& in sh) and exits 0.
+    //
+    // This is the exact shape Candidate A (#651) was sensitive to: a grandchild
+    // holds the inherited pipe write-ends open, so Command::output() would block
+    // until that grandchild exits (~60 s later).  The fixed run_capturing() uses
+    // temp files + wait() on the direct child only, so the grandchild is
+    // irrelevant to the build's exit.
+    //
+    // Note: the symlinked node_modules/ is read-only (embedded tree), so we
+    // create the .bin and stub package entries through the symlink target, which
+    // works because embedded_nm_path itself is a freshly-extracted tempdir we own.
+    let bin_dir = embedded_nm_path.join(".bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    let bin_path = bin_dir.join("zfb-adapter-stub");
+    // argv from DefaultAdapterRunner: bundle <input> --outdir <outdir>
+    //   $1 = "bundle"  $2 = <input>  $3 = "--outdir"  $4 = <outdir>
+    fs::write(
+        &bin_path,
+        r#"#!/bin/sh
+# stub adapter for build_terminates e2e (#654)
+# argv: bundle <input> --outdir <outdir>
+OUTDIR="$4"
+mkdir -p "$OUTDIR"
+printf 'export default { fetch(r){return new Response("ok")} }\n' > "$OUTDIR/_worker.js"
+# Detach a grandchild that holds inherited stdout/stderr fds open.
+# Pre-fix code (Command::output()) would hang here waiting for this fd to close.
+# Fixed code (temp-file redirect + wait-on-direct-child) is unaffected.
+sleep 60 &
+exit 0
+"#,
+    )
+    .unwrap();
+    fs::set_permissions(&bin_path, fs::Permissions::from_mode(0o755)).unwrap();
+
+    // Package metadata so pnpm exec can resolve the bin name.
+    let pkg_dir = embedded_nm_path.join("zfb-adapter-stub");
+    fs::create_dir_all(&pkg_dir).unwrap();
+    fs::write(
+        pkg_dir.join("package.json"),
+        r#"{
+  "name": "zfb-adapter-stub",
+  "version": "0.0.1",
+  "bin": {
+    "zfb-adapter-stub": "../.bin/zfb-adapter-stub"
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    nm_handle
+}
+
+/// Check whether `pnpm` is available on PATH without spawning a shell.
+fn pnpm_available() -> bool {
+    Command::new("pnpm")
+        .arg("--version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Assert that `zfb build` exits within [`BUILD_TIMEOUT`] on an adapter +
+/// SSR-route fixture that deliberately detaches a grandchild holding the
+/// inherited stdout/stderr fds open.
+///
+/// The test fails (not hangs) on a regression because the watchdog kills the
+/// **entire process group** on timeout — the grandchild is in the same group
+/// and is collected together with the zfb build process.
+#[test]
+fn zfb_build_terminates_with_adapter_and_ssr_route() {
+    // --- skip-guards ---
+
+    let Some(esbuild) = locate_esbuild() else {
+        eprintln!(
+            "[build_terminates] no esbuild binary available; skipping. \
+             Set ZFB_ESBUILD_BIN or install esbuild on PATH."
+        );
+        return;
+    };
+
+    if !pnpm_available() {
+        eprintln!("[build_terminates] pnpm not found on PATH; skipping.");
+        return;
+    }
+
+    // --- fixture ---
+
+    let tmp = tempfile::tempdir().expect("create tempdir for build_terminates fixture");
+    let root = tmp.path().to_path_buf();
+    // _nm_handle must stay alive for the duration of the test run so the
+    // embedded node_modules tempdir is not cleaned up before zfb build finishes.
+    let _nm_handle = scaffold_fixture(&root);
+
+    // --- spawn zfb build in its own process group ---
+    //
+    // pre_exec runs after fork() but before execvp() in the child, so it
+    // inherits the child PID.  setpgid(0, 0) moves the child into a new
+    // process group (PGID == child PID).  Any grandchild the adapter spawns
+    // inherits that PGID, so kill(-pgid, SIGKILL) reaps the whole tree.
+    let mut cmd = Command::new(zfb_binary!());
+    cmd.arg("build")
+        .current_dir(&root)
+        .env("ZFB_ESBUILD_BIN", &esbuild)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    // Safety: setpgid(0, 0) is async-signal-safe (POSIX).
+    unsafe {
+        cmd.pre_exec(|| {
+            if libc::setpgid(0, 0) != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+
+    let mut child = cmd.spawn().expect("spawn `zfb build`");
+    let pgid = child.id() as libc::pid_t; // PGID == child PID after setpgid(0,0)
+
+    // --- watchdog loop ---
+
+    let start = Instant::now();
+    let exit_status = loop {
+        match child.try_wait().expect("try_wait on `zfb build`") {
+            Some(status) => break status,
+            None => {
+                if start.elapsed() > BUILD_TIMEOUT {
+                    // Kill the entire process group so neither the direct child
+                    // nor any grandchild (e.g. the detached `sleep 60`) is left
+                    // alive to hold fds open.
+                    unsafe {
+                        libc::kill(-pgid, libc::SIGKILL);
+                    }
+                    let _ = child.wait();
+
+                    let stdout = child
+                        .stdout
+                        .take()
+                        .map(|mut r| {
+                            let mut s = String::new();
+                            use std::io::Read;
+                            let _ = r.read_to_string(&mut s);
+                            s
+                        })
+                        .unwrap_or_default();
+                    let stderr = child
+                        .stderr
+                        .take()
+                        .map(|mut r| {
+                            let mut s = String::new();
+                            use std::io::Read;
+                            let _ = r.read_to_string(&mut s);
+                            s
+                        })
+                        .unwrap_or_default();
+
+                    panic!(
+                        "`zfb build` did not exit within {}s — this indicates a hang. \
+                         Process group {} was killed.\n\
+                         --- stdout ---\n{}\n--- stderr ---\n{}",
+                        BUILD_TIMEOUT.as_secs(),
+                        pgid,
+                        stdout,
+                        stderr,
+                    );
+                }
+                std::thread::sleep(Duration::from_millis(250));
+            }
+        }
+    };
+
+    // --- reap the process group after success ---
+    //
+    // The stub adapter leaves a detached `sleep 60` grandchild alive in the
+    // same process group.  Kill the group now so it does not leak into CI.
+    // This is best-effort: if the grandchild has already exited the signal is
+    // harmless (ESRCH).
+    unsafe {
+        libc::kill(-pgid, libc::SIGKILL);
+    }
+
+    // Collect stdout/stderr for the assertion message.
+    let stdout = child
+        .stdout
+        .take()
+        .map(|mut r| {
+            let mut s = String::new();
+            use std::io::Read;
+            let _ = r.read_to_string(&mut s);
+            s
+        })
+        .unwrap_or_default();
+    let stderr = child
+        .stderr
+        .take()
+        .map(|mut r| {
+            let mut s = String::new();
+            use std::io::Read;
+            let _ = r.read_to_string(&mut s);
+            s
+        })
+        .unwrap_or_default();
+
+    assert!(
+        exit_status.success(),
+        "`zfb build` exited non-zero — adapter+SSR-route fixture should build cleanly.\n\
+         status: {exit_status:?}\n--- stdout ---\n{stdout}\n--- stderr ---\n{stderr}"
+    );
+}


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/650
    - https://github.com/Takazudo/zudo-front-builder/issues/648

---

## Summary

Implements epic #650 (canonical bug #648). `zfb build` could hang at low CPU **after** `dist/` was fully written. A source-grounded audit found four verified post-dist unbounded-wait primitives; because the hang could not be reproduced on next.20 (no pstree/stack disambiguation) and the affected project uses both an adapter and plugins, this bounds **all four** vectors rather than guessing which fired, and puts the regression guarantees in **deterministic unit tests**.

Closes #650
Closes #648

## What changed (the four vectors)

- **Candidate A + A2 (#651)** — `zfb-build/adapter.rs`: `DefaultAdapterRunner::run` no longer calls `cmd.output()` (which blocks until every inherited stdout/stderr write-end closes — a lingering pnpm grandchild kept them open forever). New `run_capturing` helper redirects child stdout/stderr to temp files, `spawn()`s, and `wait()`s on the **direct** child, so it returns the moment pnpm exits regardless of any detached grandchild. Defense-in-depth `wait-timeout` bound kills + diagnoses a wedged direct child. The same pattern is applied to the adapter's post-dist runtime-only esbuild bundle pass (A2) in `bundler.rs` (which now reuses `run_capturing`).
- **Candidate B (#652)** — `zfb/v8_host_adapter.rs`: `ThreadedV8Host::Drop` did an un-timed `handle.join()` reached on every build with ≥1 SSG route (a regression from `06d2567`). New non-feature-gated `bounded_join::join_with_deadline` watcher-thread helper bounds the join (detaches on overrun); stale comment in `commands/build.rs` corrected. The module is declared **outside** the `embed_v8` gate so it compiles under `--no-default-features`.
- **Vector C (#653)** — `zfb-build/plugin_runner.rs`: the plugin `postBuild`/`preBuild` hook await (`rx.await` on a oneshot) was un-timed — a plugin whose hook never resolves hung the build post-dist. Now wrapped in `tokio::time::timeout` with a fail-fast diagnostic that names the hook; default 120s, overridable via `pluginHookTimeoutSecs` config field or `ZFB_PLUGIN_HOOK_TIMEOUT` env (kept distinct from the existing 2s shutdown timeout).

## Test coverage

- Deterministic unit tests for each vector that **fail RED, not hang** (in-test watchdogs): adapter grandchild-holds-pipe, `join_with_deadline` timeout + happy path, plugin hook timeout + resolve-precedence.
- **e2e watchdog** (#654) — `zfb/tests/build_terminates.rs`: drives the real `zfb build` binary against an adapter + deferred-route fixture whose stub adapter detaches a grandchild holding the inherited fds (Candidate A's exact premise), and asserts the process exits within a wall-clock deadline using **process-group kill** (`setpgid` + `kill(-pgid)`). Pre-fix code would hang here; fixed code exits promptly.

## Topics (merged into base)

| # | Wave | Topic |
|---|---|---|
| #651 | 1 | Candidate A + A2 — adapter dispatch |
| #652 | 1 | Candidate B — V8 host Drop join |
| #653 | 1 | Vector C — plugin postBuild await |
| #654 | 2 | e2e watchdog |

## Verification

Local gate matches CI (`health` + `build-no-v8`): `cargo build --workspace --all-targets`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo check --no-default-features -p zfb --tests`, `cargo test --workspace` — all green (96 test binaries, e2e ran and passed). Deep-review (Opus) applied: e2e temp-file redirect, `bounded_join` test watchdog, `pluginHookTimeoutSecs` 0-guard. One out-of-scope same-class finding raised as #656.