### PR TITLE
Build & Dev Robustness: config-loader hang hardening + dev watch-add discovery (#657)

### DIFF
--- a/crates/zfb-build/src/lib.rs
+++ b/crates/zfb-build/src/lib.rs
@@ -74,7 +74,7 @@ pub use head_inject::{
     css_link_tag, inject_prod_head_assets, island_module_script_tag, needs_html5_doctype,
     ProdHeadAssets, HTML5_DOCTYPE_PREFIX,
 };
-pub use orchestrator::{BuildOrchestrator, OrchestratorConfig};
+pub use orchestrator::{BuildOrchestrator, DiscoveryHook, OrchestratorConfig};
 pub use plugin_registries::{
     AliasEntry, AliasMap, InjectedRoute, InjectedRouteList, SetupCommand, SetupRegistries,
     SetupRegistryError, VirtualLoaderId, VirtualModuleEntry, VirtualModuleRegistry,

--- a/crates/zfb-build/src/orchestrator.rs
+++ b/crates/zfb-build/src/orchestrator.rs
@@ -45,12 +45,39 @@ use std::time::Duration;
 
 use anyhow::Result;
 use tracing::{debug, info, warn};
-use zfb_graph::DependencyGraph;
-use zfb_watcher::{Change, Watcher};
+use zfb_graph::{DependencyGraph, PageId};
+use zfb_watcher::{Change, ChangeKind, Watcher};
 
 use crate::pipeline::{AssetPipeline, BuildContext, BuildOutcome};
 use crate::plan::{PageSelection, RebuildPlan};
 use crate::policy::{classify_change, GranularityPolicy, PathClass};
+
+/// Live watch-ADD discovery hook (issue #659).
+///
+/// Invoked from [`BuildOrchestrator::tick_with_kinds`] /
+/// [`BuildOrchestrator::run`] with the subset of a tick's changed paths
+/// whose [`ChangeKind`] is [`ChangeKind::Created`]. The implementation
+/// (in the `zfb dev` command layer) is responsible for the side-effecting
+/// "the running renderer cannot see a file created after boot" fix:
+/// recompute the content snapshot, re-bundle the SSR worker, reload the
+/// embedded V8 host **in place**, re-enumerate `paths()`, and rebuild the
+/// dev session's source→route table. It returns the source [`PageId`]s
+/// that newly became renderable so the orchestrator can fold them into
+/// the tick's [`RebuildPlan`] and render them through the same
+/// page-render path an edit tick uses.
+///
+/// Why a separate hook rather than [`BuildContext::reload_renderer`]:
+/// `reload_renderer` fires on **every** page tick (including edits) and
+/// only reloads the host — it neither rebundles a new content snapshot
+/// nor rediscovers routes, so it cannot make a brand-new file appear.
+/// The Created path is distinct and additive: it leaves the edit path
+/// (which never calls this hook) behaviourally identical.
+///
+/// Returning an empty `Vec` (no created path mapped to a discoverable
+/// page) folds into the tick as a no-op for discovery — the rest of the
+/// tick's changes are still planned normally.
+pub type DiscoveryHook =
+    std::sync::Arc<dyn Fn(&[PathBuf]) -> Result<Vec<PageId>> + Send + Sync + 'static>;
 
 /// Construction-time configuration for [`BuildOrchestrator`].
 #[derive(Debug, Clone)]
@@ -309,6 +336,72 @@ impl<P: AssetPipeline> BuildOrchestrator<P> {
         Ok(Some(outcome))
     }
 
+    /// Kind-aware tick (issue #659 — live watch-ADD discovery).
+    ///
+    /// Additive sibling of [`tick`]: same plan-fold + resolve + apply
+    /// pipeline, but it also threads the per-change [`ChangeKind`] so a
+    /// file **created** after dev-server boot can be discovered and
+    /// rendered without a restart. The path classification / dirty-page
+    /// fold is unchanged — it reuses [`plan_for_changes`] verbatim, so
+    /// the EDIT path ([`ChangeKind::Modified`]) behaves exactly as
+    /// [`tick`] does (the discovery hook is never consulted for it).
+    ///
+    /// When `discover` is `Some`, the [`ChangeKind::Created`] subset of
+    /// `changes` is handed to the hook; any source [`PageId`]s it returns
+    /// are merged into the plan's page set so the new page renders through
+    /// the same render→write boundary an edit traverses. The hook is
+    /// responsible for the side effects (rebundle / reload-in-place /
+    /// graph upsert / route-table rebuild) — see [`DiscoveryHook`].
+    ///
+    /// `tick`'s public signature is intentionally left untouched (it has
+    /// many existing call sites); this is the new, explicit entry point
+    /// the dev `run` loop uses.
+    pub fn tick_with_kinds(
+        &self,
+        changes: Vec<(PathBuf, ChangeKind)>,
+        ctx: &BuildContext,
+        discover: Option<&DiscoveryHook>,
+    ) -> Result<Option<BuildOutcome>> {
+        // Discovery runs first so a newly-created page is upserted into
+        // the graph (by the hook) before `plan_for_changes` folds the
+        // change set — and so the discovered page ids survive even when
+        // the path-only fold would have produced an empty/no-op plan
+        // (a brand-new content file has no reverse edge yet, exactly the
+        // #659 symptom).
+        let discovered: Vec<PageId> = match discover {
+            Some(hook) => {
+                let created: Vec<PathBuf> = changes
+                    .iter()
+                    .filter(|(_, kind)| *kind == ChangeKind::Created)
+                    .map(|(p, _)| p.clone())
+                    .collect();
+                if created.is_empty() {
+                    Vec::new()
+                } else {
+                    hook(&created)?
+                }
+            }
+            None => Vec::new(),
+        };
+
+        let mut plan = self.plan_for_changes(changes.into_iter().map(|(p, _)| p));
+
+        if !discovered.is_empty() {
+            let set: std::collections::BTreeSet<PageId> = discovered.into_iter().collect();
+            plan.mark_pages(PageSelection::Specific(set));
+        }
+
+        if plan.is_noop() {
+            return Ok(None);
+        }
+        self.resolve_all(&mut plan);
+        if plan.pages.is_empty() && !plan.rerun_css && !plan.rerun_islands {
+            return Ok(None);
+        }
+        let outcome = self.pipeline.apply(&plan, ctx)?;
+        Ok(Some(outcome))
+    }
+
     /// Eager initial render of **every** page in the graph, run once at
     /// dev-server boot before the watcher loop and before the server
     /// starts accepting requests.
@@ -346,7 +439,19 @@ impl<P: AssetPipeline> BuildOrchestrator<P> {
     ///
     /// `on_outcome` is called after every non-noop tick — typically the
     /// dev preview server uses this to push a websocket reload signal.
-    pub async fn run<F>(self, ctx: BuildContext, mut on_outcome: F) -> Result<()>
+    ///
+    /// `discover` is the live watch-ADD discovery hook (issue #659).
+    /// `None` keeps the legacy behaviour (a file created after boot 404s
+    /// until restart); the `zfb dev` command passes `Some(..)` so a
+    /// brand-new content file is rebundled + rediscovered in place. The
+    /// hook only ever sees [`ChangeKind::Created`] paths, so the edit
+    /// path is unaffected.
+    pub async fn run<F>(
+        self,
+        ctx: BuildContext,
+        discover: Option<DiscoveryHook>,
+        mut on_outcome: F,
+    ) -> Result<()>
     where
         F: FnMut(&BuildOutcome) + Send + 'static,
     {
@@ -375,8 +480,9 @@ impl<P: AssetPipeline> BuildOrchestrator<P> {
                 batch.push(c);
             }
 
-            let paths: Vec<PathBuf> = batch.iter().map(|c| c.path.clone()).collect();
-            match self.tick(paths, &ctx) {
+            let changes: Vec<(PathBuf, ChangeKind)> =
+                batch.iter().map(|c| (c.path.clone(), c.kind)).collect();
+            match self.tick_with_kinds(changes, &ctx, discover.as_ref()) {
                 Ok(Some(outcome)) => on_outcome(&outcome),
                 Ok(None) => {
                     debug!("rebuild tick was a no-op");

--- a/crates/zfb-build/tests/integration_dev_loop.rs
+++ b/crates/zfb-build/tests/integration_dev_loop.rs
@@ -17,11 +17,11 @@ use std::time::Duration;
 
 use tempfile::tempdir;
 use zfb_build::{
-    AssetPipeline, BuildContext, BuildOrchestrator, DevAssetPipeline, OrchestratorConfig,
-    PageSelection, RebuildPlan, RelDistPath, RenderedPage,
+    AssetPipeline, BuildContext, BuildOrchestrator, DevAssetPipeline, DiscoveryHook,
+    OrchestratorConfig, PageSelection, RebuildPlan, RelDistPath, RenderedPage,
 };
 use zfb_graph::{DepKind, DependencyGraph, PageDeps, PageId};
-use zfb_watcher::Watcher;
+use zfb_watcher::{ChangeKind, Watcher};
 
 fn pid(p: PathBuf) -> PageId {
     PageId::new(p)
@@ -409,6 +409,339 @@ impl AssetPipeline for TestPipeline {
         *self.applied.lock().unwrap() += 1;
         self.inner.apply(plan, ctx)
     }
+}
+
+// ---------------------------------------------------------------------------
+// Issue #659 — live watch-ADD discovery of a newly-created content file.
+//
+// Mechanism under test (resolved against the CURRENT tree): a content
+// file like `content/blog/foo.mdx` is NOT a `pages/`-scanned route. It is
+// reached through a dynamic `pages/blog/[slug].tsx` page whose `paths()`
+// export enumerates the `blog` content collection (see
+// `crates/zfb/templates/basic-blog/pages/blog/[slug].tsx`). So "adding a
+// content file" must make the dynamic `[slug]` SOURCE page re-render with
+// one more concrete URL — it never adds a new `pages/` source.
+//
+// The defect (#659): while `zfb dev` runs, the orchestrator's `run()`
+// folds only the changed *path* into a plan and discards the
+// `ChangeKind`. A brand-new content file has no reverse edge in the dep
+// graph yet, so the path-only fold dirties no page and the new route
+// 404s until restart. Editing an EXISTING content file works because its
+// `[slug]` consumer edge already lives in the graph.
+//
+// The fix (#659): `tick_with_kinds` carries `ChangeKind` and, on a
+// `Created` change, runs a discovery hook that (in `zfb dev`) rebundles
+// the content snapshot, reloads the embedded V8 host in place, re-expands
+// `paths()`, rebuilds the source→route table, and returns the dynamic
+// source `PageId`s that became renderable. The orchestrator folds those
+// ids into the plan so the new page renders through the same render→write
+// path an edit traverses.
+//
+// This is an orchestrator-level proxy: the real snapshot/rebundle/reload
+// lives in `zfb`'s dev command and needs a live V8 host, so it is not
+// unit-testable here. The fake hook stands in for that side effect (and
+// mirrors the graph upsert the real hook performs). Sub-issue #649-B's
+// real-watcher e2e is the stronger net for the actual GET path.
+
+/// Build a dev fixture whose only page is the dynamic `[slug]` consumer
+/// of a `blog` content collection. Mirrors the basic-blog template shape.
+fn make_dynamic_blog_fixture(project: &std::path::Path) {
+    std::fs::create_dir_all(project.join("pages/blog")).unwrap();
+    std::fs::create_dir_all(project.join("content/blog")).unwrap();
+    std::fs::write(
+        project.join("pages/blog/[slug].tsx"),
+        "export async function paths(){return []}\nexport default function P(){}\n",
+    )
+    .unwrap();
+    // One pre-existing post so the project boots with a non-empty graph.
+    std::fs::write(
+        project.join("content/blog/hello.mdx"),
+        "---\ntitle: Hello\n---\nhi\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(project.join("dist")).unwrap();
+}
+
+/// Graph seeded the way `boot_dev_renderer` seeds it: the `[slug]` source
+/// page node plus its edge to the one pre-existing post. A post added
+/// AFTER boot has no edge here — the #659 cold spot.
+fn seed_blog_graph(project: &std::path::Path) -> Arc<Mutex<DependencyGraph>> {
+    let slug_page = project.join("pages/blog/[slug].tsx");
+    let hello_md = project.join("content/blog/hello.mdx");
+    let mut g = DependencyGraph::new();
+    g.upsert(PageDeps::new(
+        pid(slug_page),
+        vec![(hello_md, DepKind::Content)],
+    ));
+    Arc::new(Mutex::new(g))
+}
+
+/// The dev session's frozen-at-boot route table, modelled faithfully:
+/// source page → the concrete output paths its `paths()` expanded to.
+/// `render_one` fans out over exactly this Vec, so the discriminator for
+/// #659 is whether the table gains `/blog/foo` BEFORE the fan-out runs —
+/// not whether the `[slug]` page is "rendered" (the All-fallback renders
+/// it either way). Keyed by source `PathBuf`, value is dist-relative
+/// output paths.
+type RouteTable = Arc<Mutex<std::collections::HashMap<PathBuf, Vec<String>>>>;
+
+/// Route table seeded the way `boot_dev_renderer` freezes
+/// `routes_by_source` at boot: the dynamic `[slug]` source maps to the
+/// ONE concrete URL its `paths()` resolved from the single pre-existing
+/// post. A post added after boot is absent here — the #659 cold spot.
+fn seed_route_table(project: &std::path::Path) -> RouteTable {
+    let mut t = std::collections::HashMap::new();
+    t.insert(
+        project.join("pages/blog/[slug].tsx"),
+        vec!["blog/hello.html".to_string()],
+    );
+    Arc::new(Mutex::new(t))
+}
+
+/// A `BuildContext` whose renderer FANS OUT over the shared route table —
+/// one `RenderedPage` (and one dist file) per output path the requested
+/// source page maps to. This mirrors `DevRenderSession::render_one`'s real
+/// fan-out, so a frozen table writes only the URLs known at boot and a
+/// rebuilt table writes the new URL too. Records which source pages it was
+/// asked to render.
+fn fanout_ctx(
+    project: &std::path::Path,
+    routes: RouteTable,
+    render_calls: Arc<Mutex<Vec<Vec<PageId>>>>,
+) -> BuildContext {
+    BuildContext {
+        dist_root: project.join("dist"),
+        render_pages: Arc::new(move |pages: &[PageId]| {
+            render_calls.lock().unwrap().push(pages.to_vec());
+            let table = routes.lock().unwrap();
+            let mut out = Vec::new();
+            for p in pages {
+                // Fan out over the source page's frozen/rebuilt route Vec.
+                // Unknown source (no table entry) yields nothing — exactly
+                // `render_one`'s "empty Vec for an unknown source" contract.
+                for output in table.get(p.path()).into_iter().flatten() {
+                    out.push(RenderedPage {
+                        // Each concrete URL gets a distinct synthetic PageId
+                        // keyed on its output path, mirroring `render_one_with`.
+                        page: PageId::new(PathBuf::from(output)),
+                        output_path: RelDistPath::new(output.clone())
+                            .expect("test output is a relative html path"),
+                        html: format!("<h1>{output}</h1>"),
+                        content_type: None,
+                    });
+                }
+            }
+            Ok(out)
+        }),
+        run_css: None,
+        run_islands: None,
+        reload_renderer: None,
+    }
+}
+
+/// A discovery hook faithful to `zfb dev`'s real `discover_created`: for a
+/// created file under `content/blog/`, REBUILD THE ROUTE TABLE so the
+/// dynamic `[slug]` source now also maps to the new `/blog/foo` URL (this
+/// is the load-bearing side effect — the real hook rebundles the content
+/// snapshot, reloads the V8 host, and re-expands `paths()` to produce this
+/// same table mutation), upsert the graph, and return the `[slug]` source
+/// `PageId`. Records the created-path batches so a test can assert it is
+/// NOT called on an edit tick.
+fn fake_blog_discovery_hook(
+    project: &std::path::Path,
+    routes: RouteTable,
+    graph: Arc<Mutex<DependencyGraph>>,
+    invocations: Arc<Mutex<Vec<Vec<PathBuf>>>>,
+) -> DiscoveryHook {
+    let slug_page = project.join("pages/blog/[slug].tsx");
+    let content_blog = project.join("content/blog");
+    Arc::new(move |created: &[PathBuf]| {
+        invocations.lock().unwrap().push(created.to_vec());
+        let mut out = Vec::new();
+        for c in created {
+            if c.starts_with(&content_blog) {
+                let page = pid(slug_page.clone());
+                let slug = c.file_stem().and_then(|s| s.to_str()).unwrap_or("post");
+                // Rebuild the route table: the dynamic source now also
+                // resolves the new concrete URL (mirrors the real
+                // `routes_by_source` rebuild after a rebundle + paths()
+                // re-expansion).
+                if let Ok(mut t) = routes.lock() {
+                    t.entry(slug_page.clone())
+                        .or_default()
+                        .push(format!("blog/{slug}.html"));
+                }
+                // Mirror the real hook's graph upsert.
+                if let Ok(mut g) = graph.lock() {
+                    g.upsert(PageDeps::new(
+                        page.clone(),
+                        vec![(c.clone(), DepKind::Content)],
+                    ));
+                }
+                out.push(page);
+            }
+        }
+        Ok(out)
+    })
+}
+
+/// BUG CHARACTERISATION: a content file CREATED after boot, fed through
+/// the legacy path-only `tick` (no discovery), re-renders the `[slug]`
+/// page (via the All-fallback) BUT the frozen route table never gained
+/// `/blog/foo`, so `blog/foo.html` is never written — the new route 404s
+/// until restart. This pins the precise discovery defect: the missing
+/// output file, not a missing render.
+#[test]
+fn created_content_file_without_discovery_does_not_emit_new_url() {
+    let dir = tempdir().unwrap();
+    let project = dir.path();
+    make_dynamic_blog_fixture(project);
+
+    let routes = seed_route_table(project);
+    let graph = seed_blog_graph(project);
+    let render_calls: Arc<Mutex<Vec<Vec<PageId>>>> = Arc::new(Mutex::new(Vec::new()));
+    let ctx = fanout_ctx(project, routes, render_calls);
+
+    let orch = BuildOrchestrator::new(
+        OrchestratorConfig::new(project, vec![PathBuf::from("content")]),
+        graph,
+        DevAssetPipeline::new(),
+    );
+
+    // A brand-new post appears on disk after boot.
+    let new_post = project.join("content/blog/foo.mdx");
+    std::fs::write(&new_post, "---\ntitle: Foo\n---\nfoo\n").unwrap();
+
+    // Legacy path-only tick (the pre-#659 `run()` behaviour).
+    let _ = orch.tick(vec![new_post], &ctx).expect("tick ok");
+
+    assert!(
+        !project.join("dist/blog/foo.html").exists(),
+        "pre-fix: the new /blog/foo URL must NOT be emitted (frozen route table) — \
+         this is the 404-until-restart bug",
+    );
+    // The pre-existing URL is still emitted (the [slug] page did re-render).
+    assert!(
+        project.join("dist/blog/hello.html").exists(),
+        "the pre-existing /blog/hello URL is still served",
+    );
+}
+
+/// THE FIX (red→green): the same created post, fed through
+/// `tick_with_kinds` as a `ChangeKind::Created` change with the discovery
+/// hook wired, rebuilds the route table and emits `dist/blog/foo.html` —
+/// closing the watch-ADD 404. Falsifiability: with the discovery branch
+/// removed from `tick_with_kinds` (or the hook not invoked), the table
+/// stays frozen and `blog/foo.html` is never written, failing the central
+/// assertion.
+#[test]
+fn created_content_file_with_discovery_emits_new_url() {
+    let dir = tempdir().unwrap();
+    let project = dir.path();
+    make_dynamic_blog_fixture(project);
+
+    let routes = seed_route_table(project);
+    let graph = seed_blog_graph(project);
+    let render_calls: Arc<Mutex<Vec<Vec<PageId>>>> = Arc::new(Mutex::new(Vec::new()));
+    let ctx = fanout_ctx(project, routes.clone(), render_calls);
+
+    let hook_invocations: Arc<Mutex<Vec<Vec<PathBuf>>>> = Arc::new(Mutex::new(Vec::new()));
+    let discover =
+        fake_blog_discovery_hook(project, routes, graph.clone(), hook_invocations.clone());
+
+    let orch = BuildOrchestrator::new(
+        OrchestratorConfig::new(project, vec![PathBuf::from("content")]),
+        graph,
+        DevAssetPipeline::new(),
+    );
+
+    let new_post = project.join("content/blog/foo.mdx");
+    std::fs::write(&new_post, "---\ntitle: Foo\n---\nfoo\n").unwrap();
+
+    orch.tick_with_kinds(
+        vec![(new_post.clone(), ChangeKind::Created)],
+        &ctx,
+        Some(&discover),
+    )
+    .expect("tick_with_kinds ok")
+    .expect("a Created content file must produce a non-noop tick");
+
+    // The central acceptance check: the new URL is now emitted to dist.
+    assert!(
+        project.join("dist/blog/foo.html").exists(),
+        "the discovery hook must rebuild the route table so /blog/foo is written",
+    );
+    // The pre-existing URL survives the rebuild.
+    assert!(
+        project.join("dist/blog/hello.html").exists(),
+        "the pre-existing /blog/hello URL must still be emitted",
+    );
+
+    // The discovery hook saw exactly the created path, once.
+    let invs = hook_invocations.lock().unwrap();
+    assert_eq!(invs.len(), 1, "discovery hook called once for the Created tick");
+    assert_eq!(invs[0], vec![new_post]);
+}
+
+/// EDIT PATH NOT REGRESSED: editing an EXISTING content file is a
+/// `ChangeKind::Modified` change. Its consumer page still hot-reloads
+/// (the pre-existing URL re-renders), the discovery hook is NEVER invoked
+/// (add-only stays add-only), and no new URL is invented.
+#[test]
+fn modified_content_file_does_not_invoke_discovery_and_still_hot_reloads() {
+    let dir = tempdir().unwrap();
+    let project = dir.path();
+    make_dynamic_blog_fixture(project);
+
+    let routes = seed_route_table(project);
+    let graph = seed_blog_graph(project);
+    let render_calls: Arc<Mutex<Vec<Vec<PageId>>>> = Arc::new(Mutex::new(Vec::new()));
+    let ctx = fanout_ctx(project, routes.clone(), render_calls.clone());
+
+    let hook_invocations: Arc<Mutex<Vec<Vec<PathBuf>>>> = Arc::new(Mutex::new(Vec::new()));
+    let discover =
+        fake_blog_discovery_hook(project, routes, graph.clone(), hook_invocations.clone());
+
+    let orch = BuildOrchestrator::new(
+        OrchestratorConfig::new(project, vec![PathBuf::from("content")]),
+        graph,
+        DevAssetPipeline::new(),
+    );
+
+    // Edit the EXISTING post (it already has a graph edge to [slug].tsx).
+    let existing = project.join("content/blog/hello.mdx");
+    std::fs::write(&existing, "---\ntitle: Hello\n---\nedited\n").unwrap();
+
+    orch.tick_with_kinds(
+        vec![(existing.clone(), ChangeKind::Modified)],
+        &ctx,
+        Some(&discover),
+    )
+    .expect("tick_with_kinds ok")
+    .expect("editing an existing post must still produce a non-noop tick");
+
+    // Hot-reload still works: the consumer [slug] page re-rendered its URL.
+    let calls = render_calls.lock().unwrap();
+    assert!(
+        calls[0].contains(&pid(project.join("pages/blog/[slug].tsx"))),
+        "the edit must re-render the dynamic [slug] consumer; got {:?}",
+        calls[0],
+    );
+    assert!(
+        project.join("dist/blog/hello.html").exists(),
+        "editing an existing post must still emit its URL (hot reload)",
+    );
+
+    // The discovery hook was NOT consulted — the edit path is untouched.
+    assert!(
+        hook_invocations.lock().unwrap().is_empty(),
+        "a Modified change must never invoke the watch-ADD discovery hook",
+    );
+    // No phantom URL was invented for the edit.
+    assert!(
+        !project.join("dist/blog/edited.html").exists(),
+        "editing a post must not invent a new URL",
+    );
 }
 
 #[allow(dead_code)]

--- a/crates/zfb-server/tests/watch_add_confirm.rs
+++ b/crates/zfb-server/tests/watch_add_confirm.rs
@@ -36,8 +36,24 @@
 //! ## Timing strategy
 //!
 //! The test uses a generous 200ms debounce and polls the HTTP endpoint with a
-//! 5s overall deadline. Poll-with-timeout (not a fixed sleep) is how the
+//! 30s overall deadline (generous for loaded CI), and a shared lock serializes
+//! the two tests so they never contend. Poll-with-timeout (not a fixed sleep) is how the
 //! zfb-watcher smoke suite handles the same flake class.
+//!
+//! ### Watcher-live handshake (ADD test)
+//!
+//! macOS FSEvents has a *per-stream startup latency*: a file CREATED in the
+//! first window after the watch stream is registered can be dropped entirely
+//! — the raw `notify` channel receives no event at all (confirmed by
+//! instrumentation: a 200ms warmup yielded zero raw events for the new file;
+//! a longer wait yielded the expected Create+Modify burst). A fixed warmup
+//! sleep is fragile under `cargo test --workspace` load. So before writing
+//! the real `foo.mdx`, the ADD test repeatedly creates fresh-named throwaway
+//! files under `content/blog/` and polls the discovery hook until one is
+//! observed — proving the stream is live (past its dead window). The dead
+//! window is per-stream, not per-path, so once any create is delivered the
+//! subsequent `foo.mdx` create is reliably delivered too. See the inline
+//! handshake comment for why fresh names (not a re-write) are required.
 //!
 //! ## Path canonicalization
 //!
@@ -58,7 +74,7 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 use std::time::Duration;
 
 use tokio::net::TcpListener;
@@ -70,6 +86,14 @@ use zfb_build::{
 use zfb_graph::{DepKind, DependencyGraph, PageDeps, PageId};
 use zfb_server::livereload::ReloadEvent;
 use zfb_server::{serve_with_listener, PageCache, ServeOpts};
+
+/// Serialize the two real-watcher tests. Each stands up a live notify watcher
+/// plus an in-process dev server; cargo runs tests in a file concurrently by
+/// default, and under full-suite load (`cargo test --workspace`) that
+/// contention pushed the HTTP poll past its deadline (both passed when run
+/// alone or with --test-threads=1). A shared async lock forces them to run
+/// one at a time regardless of cargo's thread count.
+static SERIAL: LazyLock<tokio::sync::Mutex<()>> = LazyLock::new(|| tokio::sync::Mutex::new(()));
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -232,6 +256,8 @@ async fn bind_ephemeral() -> (TcpListener, SocketAddr) {
 /// without the V8 rebundle step (not reachable from crate tests).
 #[tokio::test(flavor = "multi_thread")]
 async fn real_watcher_add_content_file_serves_new_route_as_200() {
+    let _serial = SERIAL.lock().await;
+
     let tmp = tempfile::tempdir().expect("tempdir");
     // Canonicalize so notify's FSEvents paths and our prefix checks agree.
     // On macOS /tmp is a symlink to /private/tmp; without canonicalization
@@ -299,9 +325,65 @@ async fn real_watcher_add_content_file_serves_new_route_as_200() {
         orch.run(ctx, Some(discover), |_outcome| {}).await
     });
 
-    // Give the watcher a beat to register the OS-level watch. Consistent
-    // with the existing real-watcher test's timing approach.
-    tokio::time::sleep(Duration::from_millis(200)).await;
+    // ----------------------------------------------------------------
+    // 2b. Watcher-live handshake (deterministic warmup).
+    //
+    // macOS FSEvents has a per-stream startup latency: a brand-new file
+    // CREATED in the first window after the watch stream is registered can
+    // be DROPPED entirely — no Create, no Modify event reaches the watcher
+    // (confirmed by instrumentation: with a 200ms sleep, the raw notify
+    // channel received zero events for the new file; with a longer wait it
+    // received Create+Modify as expected). A fixed sleep is fragile under
+    // load (`cargo test --workspace`), so instead we prove the stream is
+    // live before writing the real file.
+    //
+    // We repeatedly create FRESH-NAMED warmup files under `content/blog/`
+    // (same operation class as the real ADD — a brand-new file create) and
+    // poll the discovery hook's invocation log until one is observed. A
+    // single warmup write would have the identical startup-window
+    // vulnerability (its own create could be dropped), and re-writing the
+    // same path only fires Modify (never re-triggers discovery), so the
+    // loop uses a new name each iteration. Once ANY warmup create is
+    // observed, the FSEvents stream is past its dead window and stays live
+    // (startup latency is per-stream, not per-path), so the subsequent
+    // `foo.mdx` create lands in the live window.
+    //
+    // Separate deadline + panic message so a genuinely dead watcher fails
+    // fast and is diagnosable as a watcher problem, not a discovery
+    // regression. Warmup files create `/blog/__warmup_*` routes, never
+    // `/blog/foo`, so the baseline 404 assertion below still holds.
+    {
+        let warmup_deadline = std::time::Instant::now() + Duration::from_secs(10);
+        let mut warmup_idx = 0u32;
+        let mut watcher_live = false;
+        while std::time::Instant::now() < warmup_deadline {
+            let warmup = project.join(format!("content/blog/__warmup_{warmup_idx}.mdx"));
+            std::fs::write(&warmup, "---\ntitle: warmup\n---\nwarmup\n")
+                .expect("write warmup content file");
+            warmup_idx += 1;
+
+            // Give this warmup's event a beat to propagate through
+            // FSEvents → debounce (200ms) → hook.
+            tokio::time::sleep(Duration::from_millis(400)).await;
+
+            let saw_warmup = hook_invocations.lock().unwrap().iter().flatten().any(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .map(|n| n.starts_with("__warmup_"))
+                    .unwrap_or(false)
+            });
+            if saw_warmup {
+                watcher_live = true;
+                break;
+            }
+        }
+        assert!(
+            watcher_live,
+            "watcher never became live: no warmup create reached the discovery hook within 10s \
+             (the FSEvents stream never started delivering events — a watcher-layer problem, \
+             not a discovery regression)",
+        );
+    }
 
     // ----------------------------------------------------------------
     // 3. Confirm /blog/foo 404s BEFORE the file is created (baseline).
@@ -330,10 +412,10 @@ async fn real_watcher_add_content_file_serves_new_route_as_200() {
 
     // ----------------------------------------------------------------
     // 5. Poll the new route until it returns 200.
-    //    Overall deadline: 5s — far longer than the 200ms debounce + tick
+    //    Overall deadline: 30s — far longer than the 200ms debounce + tick
     //    lag, short enough to fail fast on a genuine regression.
     // ----------------------------------------------------------------
-    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
     let mut got_200 = false;
     while std::time::Instant::now() < deadline {
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -360,7 +442,7 @@ async fn real_watcher_add_content_file_serves_new_route_as_200() {
 
     assert!(
         got_200,
-        "GET /blog/foo must return 200 within 5s after writing the new content file \
+        "GET /blog/foo must return 200 within 30s after writing the new content file \
          (real watcher → Created kind → discovery hook → render → 200)",
     );
 
@@ -413,6 +495,8 @@ async fn real_watcher_add_content_file_serves_new_route_as_200() {
 /// the endpoint must return 200 after the edit.
 #[tokio::test(flavor = "multi_thread")]
 async fn real_watcher_edit_existing_file_still_hot_reloads() {
+    let _serial = SERIAL.lock().await;
+
     let tmp = tempfile::tempdir().expect("tempdir");
     let project = tmp.path().canonicalize().expect("canonicalize project");
 
@@ -508,9 +592,9 @@ async fn real_watcher_edit_existing_file_still_hot_reloads() {
     // 4. Poll until the route returns 200. The exact body doesn't change
     //    (our stub renderer uses the output path as body, not the source
     //    content), but the endpoint must not regress to 404 or 500.
-    //    Overall deadline: 5s.
+    //    Overall deadline: 30s.
     // ----------------------------------------------------------------
-    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
     let mut got_200_after_edit = false;
     while std::time::Instant::now() < deadline {
         tokio::time::sleep(Duration::from_millis(100)).await;
@@ -532,7 +616,7 @@ async fn real_watcher_edit_existing_file_still_hot_reloads() {
 
     assert!(
         got_200_after_edit,
-        "GET /blog/hello must return 200 within 5s after editing hello.mdx (hot-reload regression guard)",
+        "GET /blog/hello must return 200 within 30s after editing hello.mdx (hot-reload regression guard)",
     );
 
     // ----------------------------------------------------------------

--- a/crates/zfb-server/tests/watch_add_confirm.rs
+++ b/crates/zfb-server/tests/watch_add_confirm.rs
@@ -1,0 +1,543 @@
+//! Real-watcher end-to-end confirmation for the watch-ADD discovery fix
+//! (issue #659 / confirm sub #660).
+//!
+//! ## Why this test exists
+//!
+//! #659's integration test (`crates/zfb-build/tests/integration_dev_loop.rs`)
+//! injects synthetic `ChangeKind::Created` ticks directly into the
+//! orchestrator, bypassing the real watcher and the debounce/coalescing path.
+//! That encodes the same assumption as the fix: "a synthetic Created tick
+//! faithfully represents a brand-new file on disk." Under autonomous merge to
+//! `main` with no human gate, that is not enough.
+//!
+//! This test exercises the **complete path**: real file write → real `notify`
+//! watcher → debouncer coalescing → `ChangeKind::Created` emitted on the
+//! channel → `BuildOrchestrator::run()` drain loop → `tick_with_kinds` with
+//! discovery hook → render → disk write → HTTP `GET` returns 200.
+//!
+//! ## What is real vs stubbed
+//!
+//! Real (this test exercises live code all the way through):
+//!   - `fs::write` to a brand-new path on the real filesystem
+//!   - `notify` OS-level watcher (FSEvents on macOS, inotify on Linux)
+//!   - Debouncer coalescing (the "sticky Created" fix in `zfb-watcher`)
+//!   - `BuildOrchestrator::run()` drain/debounce loop
+//!   - `tick_with_kinds` Created-path → discovery-hook invocation
+//!   - `DevAssetPipeline` render → atomic disk write
+//!   - `zfb-server` HTTP layer serving from `html_root` on disk
+//!   - In-process `reqwest` GET → real 200 response
+//!
+//! Stubbed (requires a live V8 host, not reachable from crate-level tests):
+//!   - The real discovery hook's V8 rebundle/reload-in-place step. The fake
+//!     hook below mirrors the real hook's contract (route-table rebuild,
+//!     graph upsert, return discovered PageIds) without reaching into the
+//!     embedded V8 host.
+//!
+//! ## Timing strategy
+//!
+//! The test uses a generous 200ms debounce and polls the HTTP endpoint with a
+//! 5s overall deadline. Poll-with-timeout (not a fixed sleep) is how the
+//! zfb-watcher smoke suite handles the same flake class.
+//!
+//! ## Path canonicalization
+//!
+//! On macOS, `/tmp` is a symlink to `/private/tmp`. `notify` (via FSEvents)
+//! reports events on the canonical path. The orchestrator's `classify_change`
+//! uses `path.strip_prefix(project_root)` which fails if `project_root` is
+//! the non-canonical symlink path. We canonicalize `project` once at setup
+//! to ensure the orchestrator, the discovery hook, and the watcher all agree
+//! on the same form.
+//!
+//! ## Route/file layout
+//!
+//! Pages are rendered to `<html_root>/blog/<slug>/index.html` so the server's
+//! `read_from_dist` fallback (`<html_root>/<path>/index.html`) can serve them
+//! at `GET /blog/<slug>`. This mirrors the directory-style layout that `zfb
+//! dev`'s actual renderer writes for clean URLs.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use tokio::net::TcpListener;
+use tokio::sync::broadcast;
+use zfb_build::{
+    BuildContext, BuildOrchestrator, DevAssetPipeline, DiscoveryHook, OrchestratorConfig,
+    RelDistPath, RenderedPage,
+};
+use zfb_graph::{DepKind, DependencyGraph, PageDeps, PageId};
+use zfb_server::livereload::ReloadEvent;
+use zfb_server::{serve_with_listener, PageCache, ServeOpts};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn pid(p: impl Into<PathBuf>) -> PageId {
+    PageId::new(p.into())
+}
+
+/// Set up the blog fixture directory layout under `project` (must be
+/// canonical — no symlinks):
+///
+/// ```text
+/// pages/blog/[slug].tsx   — the dynamic consumer source
+/// content/blog/hello.mdx  — one pre-existing post
+/// dist/assets/            — required by the server
+/// public/                 — required by the server
+/// ```
+fn setup_fixture(project: &Path) {
+    std::fs::create_dir_all(project.join("pages/blog")).unwrap();
+    std::fs::create_dir_all(project.join("content/blog")).unwrap();
+    std::fs::create_dir_all(project.join("dist/assets")).unwrap();
+    std::fs::create_dir_all(project.join("public")).unwrap();
+    std::fs::write(
+        project.join("pages/blog/[slug].tsx"),
+        "export async function paths(){return []}\nexport default function P(){}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        project.join("content/blog/hello.mdx"),
+        "---\ntitle: Hello\n---\nhi\n",
+    )
+    .unwrap();
+}
+
+/// The route table the orchestrator uses to fan out a dynamic `[slug]` source
+/// page to concrete output paths. Mirrors `routes_by_source` in `dev.rs`.
+type RouteTable = Arc<Mutex<HashMap<PathBuf, Vec<String>>>>;
+
+/// Seed the route table: the `[slug]` source maps to ONE output path for the
+/// pre-existing post. Directory-style (`blog/hello/index.html`) so the
+/// server serves it at `GET /blog/hello`.
+fn seed_route_table(project: &Path) -> RouteTable {
+    let mut t = HashMap::new();
+    t.insert(
+        project.join("pages/blog/[slug].tsx"),
+        vec!["blog/hello/index.html".to_string()],
+    );
+    Arc::new(Mutex::new(t))
+}
+
+/// Seed the dep graph: the `[slug]` source plus its edge to the pre-existing post.
+fn seed_graph(project: &Path) -> Arc<Mutex<DependencyGraph>> {
+    let mut g = DependencyGraph::new();
+    g.upsert(PageDeps::new(
+        pid(project.join("pages/blog/[slug].tsx")),
+        vec![(project.join("content/blog/hello.mdx"), DepKind::Content)],
+    ));
+    Arc::new(Mutex::new(g))
+}
+
+/// Build the `BuildContext` whose `render_pages` fans out over the shared
+/// route table. `DevAssetPipeline` then writes each rendered page to
+/// `ctx.dist_root/<output_path>` atomically.
+fn make_ctx(html_root: PathBuf, routes: RouteTable) -> BuildContext {
+    BuildContext {
+        dist_root: html_root,
+        render_pages: Arc::new(move |pages: &[PageId]| {
+            let table = routes.lock().unwrap();
+            let mut out = Vec::new();
+            for p in pages {
+                for output in table.get(p.path()).into_iter().flatten() {
+                    let html = format!("<html><body><p>{output}</p></body></html>");
+                    let output_path = RelDistPath::new(output.clone())
+                        .expect("test output is a relative path");
+                    out.push(RenderedPage {
+                        page: PageId::new(PathBuf::from(output)),
+                        output_path,
+                        html,
+                        content_type: None,
+                    });
+                }
+            }
+            Ok(out)
+        }),
+        run_css: None,
+        run_islands: None,
+        reload_renderer: None,
+    }
+}
+
+/// Build the discovery hook that mirrors `zfb dev`'s `make_discovery_hook`:
+/// for a newly-created content file under `content/blog/`, rebuild the route
+/// table and graph, return the `[slug]` source PageId.
+///
+/// `project` MUST be canonical (no symlinks) so `starts_with` comparisons
+/// against notify's reported canonical paths succeed.
+fn make_discovery_hook(
+    project: PathBuf,
+    routes: RouteTable,
+    graph: Arc<Mutex<DependencyGraph>>,
+    invocations: Arc<Mutex<Vec<Vec<PathBuf>>>>,
+) -> DiscoveryHook {
+    let slug_src = project.join("pages/blog/[slug].tsx");
+    let content_blog = project.join("content/blog");
+    Arc::new(move |created: &[PathBuf]| {
+        invocations.lock().unwrap().push(created.to_vec());
+        let mut out = Vec::new();
+        for c in created {
+            // Normalize both paths for comparison: canonicalize if possible,
+            // fall back to the raw path. This handles cases where the
+            // incoming path is canonical but the prefix isn't (or vice versa).
+            let c_norm = std::fs::canonicalize(c).unwrap_or_else(|_| c.clone());
+            let blog_norm = std::fs::canonicalize(&content_blog)
+                .unwrap_or_else(|_| content_blog.clone());
+
+            if c_norm.starts_with(&blog_norm) {
+                let slug = c.file_stem().and_then(|s| s.to_str()).unwrap_or("post");
+                {
+                    let mut t = routes.lock().unwrap();
+                    t.entry(slug_src.clone())
+                        .or_default()
+                        .push(format!("blog/{slug}/index.html"));
+                }
+                {
+                    let mut g = graph.lock().unwrap();
+                    g.upsert(PageDeps::new(
+                        pid(slug_src.clone()),
+                        vec![(c.clone(), DepKind::Content)],
+                    ));
+                }
+                out.push(pid(slug_src.clone()));
+            }
+        }
+        Ok(out)
+    })
+}
+
+/// Bind an ephemeral port and return `(listener, addr)`.
+async fn bind_ephemeral() -> (TcpListener, SocketAddr) {
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .expect("bind ephemeral port");
+    let addr = listener.local_addr().expect("local_addr");
+    (listener, addr)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Real-watcher end-to-end: ADD a new content file → GET /blog/foo returns 200.
+///
+/// Exercises the full path (disk → notify → debounce → tick_with_kinds →
+/// discovery hook → render → disk → HTTP GET 200) without any synthetic tick
+/// injection.
+///
+/// The discovery hook is a faithful stub: it performs the same route-table
+/// rebuild, graph upsert, and PageId return as `zfb dev`'s real hook, but
+/// without the V8 rebundle step (not reachable from crate tests).
+#[tokio::test(flavor = "multi_thread")]
+async fn real_watcher_add_content_file_serves_new_route_as_200() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    // Canonicalize so notify's FSEvents paths and our prefix checks agree.
+    // On macOS /tmp is a symlink to /private/tmp; without canonicalization
+    // classify_change's strip_prefix fails and the path is mis-classified
+    // as External, bypassing the discovery hook.
+    let project = tmp.path().canonicalize().expect("canonicalize project");
+
+    setup_fixture(&project);
+
+    let routes = seed_route_table(&project);
+    let graph = seed_graph(&project);
+    let hook_invocations: Arc<Mutex<Vec<Vec<PathBuf>>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let discover = make_discovery_hook(
+        project.clone(),
+        routes.clone(),
+        graph.clone(),
+        hook_invocations.clone(),
+    );
+
+    let html_root = project.join("dist");
+    let ctx = make_ctx(html_root.clone(), routes.clone());
+
+    // Debounce: 200ms — generous for macOS FSEvents coalescing.
+    let debounce = Duration::from_millis(200);
+
+    let orch = BuildOrchestrator::new(
+        OrchestratorConfig::new(project.clone(), vec![PathBuf::from("content")])
+            .with_debounce(debounce),
+        graph.clone(),
+        DevAssetPipeline::new(),
+    );
+
+    // ----------------------------------------------------------------
+    // 1. Boot the HTTP server
+    // ----------------------------------------------------------------
+    let (listener, addr) = bind_ephemeral().await;
+    let (tx, _rx) = broadcast::channel::<ReloadEvent>(8);
+    let opts = ServeOpts {
+        project_root: project.clone(),
+        dist_root: html_root.clone(),
+        html_root: html_root.clone(),
+        public_root: project.join("public"),
+        addr,
+        pages: PageCache::new(),
+        broadcast: tx,
+        plugins: None,
+        injected_routes: None,
+        ssr_routes: None,
+        base: None,
+        trailing_slash: false,
+        mode: zfb_server::ServerMode::Dev,
+        islands_bundle_url: None,
+        css_bundle_url: None,
+    };
+    let server = tokio::spawn(async move {
+        serve_with_listener(opts, listener, std::future::pending::<()>()).await
+    });
+    tokio::task::yield_now().await;
+
+    // ----------------------------------------------------------------
+    // 2. Spin up the orchestrator run() loop with discovery hook wired.
+    // ----------------------------------------------------------------
+    let orch_task = tokio::spawn(async move {
+        orch.run(ctx, Some(discover), |_outcome| {}).await
+    });
+
+    // Give the watcher a beat to register the OS-level watch. Consistent
+    // with the existing real-watcher test's timing approach.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // ----------------------------------------------------------------
+    // 3. Confirm /blog/foo 404s BEFORE the file is created (baseline).
+    // ----------------------------------------------------------------
+    let client = reqwest::Client::new();
+    let before = client
+        .get(format!("http://{addr}/blog/foo"))
+        .send()
+        .await
+        .expect("GET /blog/foo before write");
+    assert_eq!(
+        before.status().as_u16(),
+        404,
+        "/blog/foo must 404 before the content file is created",
+    );
+
+    // ----------------------------------------------------------------
+    // 4. Write a brand-new content file to disk. The real `notify`
+    //    watcher picks this up; the debouncer preserves ChangeKind::Created
+    //    (the "sticky Created" fix — without it macOS FSEvents collapses
+    //    the Create+Modify burst to Modified, preventing hook invocation).
+    // ----------------------------------------------------------------
+    let new_post = project.join("content/blog/foo.mdx");
+    std::fs::write(&new_post, "---\ntitle: Foo\n---\nfoo content\n")
+        .expect("write new content file");
+
+    // ----------------------------------------------------------------
+    // 5. Poll the new route until it returns 200.
+    //    Overall deadline: 5s — far longer than the 200ms debounce + tick
+    //    lag, short enough to fail fast on a genuine regression.
+    // ----------------------------------------------------------------
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let mut got_200 = false;
+    while std::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        match client
+            .get(format!("http://{addr}/blog/foo"))
+            .send()
+            .await
+        {
+            Ok(resp) if resp.status().as_u16() == 200 => {
+                got_200 = true;
+                let body = resp.text().await.unwrap_or_default();
+                // The render_pages callback embeds the output path in the
+                // body. Check it matches the expected URL.
+                assert!(
+                    body.contains("blog/foo/index.html"),
+                    "body should contain the rendered output path; got: {body}",
+                );
+                break;
+            }
+            Ok(_) => {} // still 404, keep polling
+            Err(e) => eprintln!("poll error (will retry): {e}"),
+        }
+    }
+
+    assert!(
+        got_200,
+        "GET /blog/foo must return 200 within 5s after writing the new content file \
+         (real watcher → Created kind → discovery hook → render → 200)",
+    );
+
+    // ----------------------------------------------------------------
+    // 6. The pre-existing route (/blog/hello) must still be served.
+    //    (Discovery must not break existing routes.)
+    // ----------------------------------------------------------------
+    let hello = client
+        .get(format!("http://{addr}/blog/hello"))
+        .send()
+        .await
+        .expect("GET /blog/hello after add");
+    assert_eq!(
+        hello.status().as_u16(),
+        200,
+        "/blog/hello must still serve 200 after the new-file discovery",
+    );
+
+    // ----------------------------------------------------------------
+    // 7. The discovery hook must have fired at least once for foo.mdx.
+    // ----------------------------------------------------------------
+    let invs = hook_invocations.lock().unwrap();
+    let hook_saw_foo = invs.iter().flatten().any(|p| {
+        p.file_name().and_then(|n| n.to_str()) == Some("foo.mdx")
+    });
+    assert!(
+        hook_saw_foo,
+        "the discovery hook must have been invoked with the new content file; \
+         invocations: {invs:?}",
+    );
+
+    // ----------------------------------------------------------------
+    // 8. Teardown
+    // ----------------------------------------------------------------
+    orch_task.abort();
+    server.abort();
+}
+
+/// Edit-path regression: editing an EXISTING content file still hot-reloads
+/// through the real watcher.
+///
+/// The route `GET /blog/hello` must return 200 before AND after an edit to
+/// `content/blog/hello.mdx`. This guards against the re-scan/re-bundle
+/// changes in #659 breaking the previously-working edit path.
+///
+/// Note on macOS FSEvents: editing an existing file can also surface as
+/// `ChangeKind::Created` (FSEvents sets ITEM_CREATED for metadata updates).
+/// So we do NOT assert "hook not called for edit" — on macOS the hook may
+/// be called, and that is fine (it is idempotent). We assert behavior only:
+/// the endpoint must return 200 after the edit.
+#[tokio::test(flavor = "multi_thread")]
+async fn real_watcher_edit_existing_file_still_hot_reloads() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project = tmp.path().canonicalize().expect("canonicalize project");
+
+    setup_fixture(&project);
+
+    let routes = seed_route_table(&project);
+    let graph = seed_graph(&project);
+    let hook_invocations: Arc<Mutex<Vec<Vec<PathBuf>>>> = Arc::new(Mutex::new(Vec::new()));
+
+    let discover = make_discovery_hook(
+        project.clone(),
+        routes.clone(),
+        graph.clone(),
+        hook_invocations.clone(),
+    );
+
+    let html_root = project.join("dist");
+    let ctx = make_ctx(html_root.clone(), routes.clone());
+    let debounce = Duration::from_millis(200);
+
+    let orch = BuildOrchestrator::new(
+        OrchestratorConfig::new(project.clone(), vec![PathBuf::from("content")])
+            .with_debounce(debounce),
+        graph.clone(),
+        DevAssetPipeline::new(),
+    );
+
+    // Pre-render the hello route so the server can serve it at boot.
+    {
+        let hello_dir = html_root.join("blog/hello");
+        std::fs::create_dir_all(&hello_dir).unwrap();
+        std::fs::write(
+            hello_dir.join("index.html"),
+            "<html><body><p>blog/hello/index.html</p></body></html>",
+        )
+        .unwrap();
+    }
+
+    // ----------------------------------------------------------------
+    // 1. Boot the HTTP server
+    // ----------------------------------------------------------------
+    let (listener, addr) = bind_ephemeral().await;
+    let (tx, _rx) = broadcast::channel::<ReloadEvent>(8);
+    let opts = ServeOpts {
+        project_root: project.clone(),
+        dist_root: html_root.clone(),
+        html_root: html_root.clone(),
+        public_root: project.join("public"),
+        addr,
+        pages: PageCache::new(),
+        broadcast: tx,
+        plugins: None,
+        injected_routes: None,
+        ssr_routes: None,
+        base: None,
+        trailing_slash: false,
+        mode: zfb_server::ServerMode::Dev,
+        islands_bundle_url: None,
+        css_bundle_url: None,
+    };
+    let server = tokio::spawn(async move {
+        serve_with_listener(opts, listener, std::future::pending::<()>()).await
+    });
+    tokio::task::yield_now().await;
+
+    // Verify initial 200 before the orchestrator does anything.
+    let client = reqwest::Client::new();
+    let r0 = client
+        .get(format!("http://{addr}/blog/hello"))
+        .send()
+        .await
+        .expect("GET /blog/hello initial");
+    assert_eq!(r0.status().as_u16(), 200, "hello must serve 200 before edit");
+
+    // ----------------------------------------------------------------
+    // 2. Spin up orchestrator run() with discovery hook wired.
+    // ----------------------------------------------------------------
+    let orch_task = tokio::spawn(async move {
+        orch.run(ctx, Some(discover), |_outcome| {}).await
+    });
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // ----------------------------------------------------------------
+    // 3. Edit the EXISTING hello.mdx. The orchestrator should re-render
+    //    the [slug] page and write a fresh blog/hello/index.html.
+    // ----------------------------------------------------------------
+    let hello_content = project.join("content/blog/hello.mdx");
+    std::fs::write(&hello_content, "---\ntitle: Hello\n---\nv2 content\n")
+        .expect("write updated hello.mdx");
+
+    // ----------------------------------------------------------------
+    // 4. Poll until the route returns 200. The exact body doesn't change
+    //    (our stub renderer uses the output path as body, not the source
+    //    content), but the endpoint must not regress to 404 or 500.
+    //    Overall deadline: 5s.
+    // ----------------------------------------------------------------
+    let deadline = std::time::Instant::now() + Duration::from_secs(5);
+    let mut got_200_after_edit = false;
+    while std::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        match client
+            .get(format!("http://{addr}/blog/hello"))
+            .send()
+            .await
+        {
+            Ok(resp) if resp.status().as_u16() == 200 => {
+                // We got 200 — the route still exists and the file was
+                // (re-)written. That's the hot-reload invariant.
+                got_200_after_edit = true;
+                break;
+            }
+            Ok(_) => {}
+            Err(e) => eprintln!("poll error: {e}"),
+        }
+    }
+
+    assert!(
+        got_200_after_edit,
+        "GET /blog/hello must return 200 within 5s after editing hello.mdx (hot-reload regression guard)",
+    );
+
+    // ----------------------------------------------------------------
+    // 5. Teardown
+    // ----------------------------------------------------------------
+    orch_task.abort();
+    server.abort();
+}

--- a/crates/zfb-watcher/src/lib.rs
+++ b/crates/zfb-watcher/src/lib.rs
@@ -343,12 +343,42 @@ async fn debouncer_task(
                         let kind = classify(&evt.kind);
                         let now = Instant::now();
                         for path in evt.paths {
-                            // For a given burst we keep the *latest* kind.
-                            // A Created followed by Modified collapses to
-                            // Modified, which is fine: the consumer will
-                            // re-read the file either way. A trailing
-                            // Removed wins, which is correct (file is gone).
-                            pending.insert(path, Pending { kind, last_seen: now });
+                            // Merge the incoming kind with any already-pending
+                            // kind for this path, preserving the highest-priority
+                            // kind across the burst window.
+                            //
+                            // Priority (highest → lowest): Removed > Created > Modified.
+                            //
+                            // Rationale:
+                            //   - `Removed` always wins: the file is gone — any
+                            //     preceding Create/Modify is moot.
+                            //   - `Created` wins over `Modified`: on macOS FSEvents
+                            //     (and some Linux inotify setups), `fs::write` to a
+                            //     brand-new path fires both a Create event and then
+                            //     one or more Modify events within the debounce
+                            //     window. The old "keep latest" rule collapsed the
+                            //     burst to `Modified`, silently dropping the `Created`
+                            //     signal that the watch-ADD discovery hook relies on
+                            //     (`tick_with_kinds` only calls the hook for
+                            //     `ChangeKind::Created`). Preserving `Created` when
+                            //     it was ever seen during the burst closes that hole.
+                            //   - `Modified` is a no-op upgrade when `Created` is
+                            //     already pending: the consumer re-reads the file
+                            //     either way, so demoting `Created` to `Modified`
+                            //     would only hurt (breaks discovery), never help.
+                            let merged_kind = match pending.get(&path).map(|p| p.kind) {
+                                Some(ChangeKind::Removed) => ChangeKind::Removed, // Removed is sticky
+                                Some(ChangeKind::Created) => {
+                                    // Created already seen; only Removed can upgrade it.
+                                    if kind == ChangeKind::Removed {
+                                        ChangeKind::Removed
+                                    } else {
+                                        ChangeKind::Created
+                                    }
+                                }
+                                _ => kind, // Modified or nothing: take the incoming kind
+                            };
+                            pending.insert(path, Pending { kind: merged_kind, last_seen: now });
                         }
                     }
                     Err(e) => {
@@ -412,5 +442,86 @@ mod tests {
         use notify::event::EventKind;
         assert_eq!(classify(&EventKind::Any), ChangeKind::Modified);
         assert_eq!(classify(&EventKind::Other), ChangeKind::Modified);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Burst-coalescing merge tests (the "sticky Created" fix — issue #660).
+    //
+    // On macOS FSEvents (and some Linux inotify setups), `fs::write` to a
+    // brand-new path fires both a `Create` event and then one or more
+    // `Modify` events within the debounce window. The "keep latest kind" rule
+    // that existed before this fix collapsed such a burst to `Modified`,
+    // silently dropping the `Created` signal that the watch-ADD discovery hook
+    // relies on. The merged-kind logic below guarantees `Created` is preserved
+    // when it was ever seen for a path during the burst window.
+    // ---------------------------------------------------------------------------
+
+    /// Simulate the merge logic inline so we can property-test it without
+    /// reaching into the private debouncer internals.
+    fn merge(existing: Option<ChangeKind>, incoming: ChangeKind) -> ChangeKind {
+        match existing {
+            Some(ChangeKind::Removed) => ChangeKind::Removed,
+            Some(ChangeKind::Created) => {
+                if incoming == ChangeKind::Removed {
+                    ChangeKind::Removed
+                } else {
+                    ChangeKind::Created
+                }
+            }
+            _ => incoming,
+        }
+    }
+
+    #[test]
+    fn created_then_modified_stays_created() {
+        // The primary fix: a new file write on macOS fires Create→Modify.
+        // Downstream discovery hook requires Created.
+        assert_eq!(
+            merge(Some(ChangeKind::Created), ChangeKind::Modified),
+            ChangeKind::Created,
+            "Created must survive a subsequent Modified in the same burst",
+        );
+    }
+
+    #[test]
+    fn created_then_removed_becomes_removed() {
+        // Created then immediately Removed: file is gone; Removed wins.
+        assert_eq!(
+            merge(Some(ChangeKind::Created), ChangeKind::Removed),
+            ChangeKind::Removed,
+        );
+    }
+
+    #[test]
+    fn modified_then_removed_becomes_removed() {
+        assert_eq!(
+            merge(Some(ChangeKind::Modified), ChangeKind::Removed),
+            ChangeKind::Removed,
+        );
+    }
+
+    #[test]
+    fn removed_is_sticky_against_anything() {
+        // Once Removed is the pending kind, nothing demotes it.
+        assert_eq!(merge(Some(ChangeKind::Removed), ChangeKind::Created), ChangeKind::Removed);
+        assert_eq!(merge(Some(ChangeKind::Removed), ChangeKind::Modified), ChangeKind::Removed);
+        assert_eq!(merge(Some(ChangeKind::Removed), ChangeKind::Removed), ChangeKind::Removed);
+    }
+
+    #[test]
+    fn no_prior_takes_incoming_kind() {
+        assert_eq!(merge(None, ChangeKind::Created), ChangeKind::Created);
+        assert_eq!(merge(None, ChangeKind::Modified), ChangeKind::Modified);
+        assert_eq!(merge(None, ChangeKind::Removed), ChangeKind::Removed);
+    }
+
+    #[test]
+    fn modified_then_created_upgrades_to_created() {
+        // Unusual but possible: Modify event arrives before Create (OS ordering).
+        // The incoming Created must win over the prior Modified.
+        assert_eq!(
+            merge(Some(ChangeKind::Modified), ChangeKind::Created),
+            ChangeKind::Created,
+        );
     }
 }

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -74,7 +74,8 @@ use anyhow::{Context, Result};
 use tokio::sync::broadcast;
 use zfb_build::bundler::{bundle, BundleMode, BundlerInput, BundlerOutput};
 use zfb_build::renderer::{
-    render_one, shutdown, start, Backend, RendererStartInput, RendererState, RouteUniverseEntry,
+    reload, render_one, shutdown, start, Backend, RendererStartInput, RendererState,
+    RouteUniverseEntry,
 };
 use zfb_build::{
     BuildContext, BuildOrchestrator, BuildOutcome, CssRunner, DevAssetPipeline, IslandsBundleInfo,
@@ -721,8 +722,19 @@ pub async fn run(args: &DevArgs) -> Result<()> {
     };
 
     // 5. Spawn the orchestrator's watcher loop.
+    //
+    // Issue #659 — `discover_hook` makes a content file CREATED after
+    // boot discoverable without a `zfb dev` restart: it rebundles the
+    // content snapshot, reloads the embedded V8 host in place, re-expands
+    // `paths()`, and rebuilds the dev session's source→route table. Built
+    // from `dev_session` (the V8-backed renderer); `None` when the
+    // renderer is disabled, which keeps the legacy add-needs-restart
+    // behaviour.
+    let discover_hook: Option<zfb_build::DiscoveryHook> = dev_session
+        .as_ref()
+        .map(|session| make_discovery_hook(session.clone(), Arc::clone(&graph_for_save)));
     let orch_handle = tokio::spawn(async move {
-        if let Err(err) = orchestrator.run(ctx, on_outcome).await {
+        if let Err(err) = orchestrator.run(ctx, discover_hook, on_outcome).await {
             output::error(format!("build orchestrator stopped: {err:#}"));
         }
     });
@@ -931,13 +943,21 @@ struct DevRenderSession {
     inner: Arc<DevRenderInner>,
 }
 
-struct DevRenderInner {
+/// The dev session's source→route + SSR route tables.
+///
+/// Issue #659 — wrapped in a single [`RwLock`] inside [`DevRenderInner`]
+/// so a content file CREATED after boot can rebuild them in place (the
+/// running render callback / SSR adapter read the SAME tables via the
+/// shared `Arc<DevRenderInner>`). The EDIT path never mutates these — it
+/// re-renders against the frozen boot tables exactly as before.
+struct DevRouteTables {
     /// Mapped from the page module's project-relative source path
     /// (which is what the dependency graph keys on) to the renderer
-    /// entries. Built once at boot from the router scan.
+    /// entries. Seeded at boot from the router scan; rebuilt on a
+    /// watch-ADD (#659).
     ///
     /// Issue #367: only pages with `prerender != false` are kept
-    /// here. Pages that opted out of SSG go into [`ssr_routes`]
+    /// here. Pages that opted out of SSG go into `ssr_routes`
     /// instead and reach the V8 host at request time.
     ///
     /// Issue #502/#507: the value is a `Vec` because one dynamic SSG
@@ -953,6 +973,25 @@ struct DevRenderInner {
     /// server reads this list (via [`DevRenderSession::ssr_patterns`])
     /// and builds an [`zfb_server::SsrRouteSet`] from it.
     ssr_routes: Vec<RouteUniverseEntry>,
+}
+
+/// Boot-time inputs stashed so a watch-ADD (#659) can re-bundle the SSR
+/// worker with a fresh content snapshot and reload the V8 host in place.
+///
+/// Only compiled in on the V8 path — the discovery hook that consumes
+/// these is `embed_v8`-gated like `boot_dev_renderer`.
+#[cfg(feature = "embed_v8")]
+struct DevRebuildInputs {
+    cfg: config::Config,
+    v8_plugin_hooks: zfb_render::PluginRegistryHooks,
+    plugin_alias_entries: Vec<(String, String)>,
+    plugin_virtual_modules: Vec<(String, String)>,
+}
+
+struct DevRenderInner {
+    /// Source→route + SSR route tables (issue #659 — interior-mutable so
+    /// a watch-ADD rebuilds them in place; see [`DevRouteTables`]).
+    routes: std::sync::RwLock<DevRouteTables>,
     /// Mutex-wrapped renderer state. The orchestrator's callback runs
     /// on the watcher's thread; render_one is sync and short, so a
     /// global lock is fine here.
@@ -967,6 +1006,11 @@ struct DevRenderInner {
     /// Project root. Passed to `render_one` so it can locate the source
     /// file for static-HTML routes (#409).
     project_root: PathBuf,
+    /// Boot-time bundle inputs for the watch-ADD re-bundle + host reload
+    /// (issue #659). `None` would mean "no discovery" but boot always
+    /// populates it on the V8 path.
+    #[cfg(feature = "embed_v8")]
+    rebuild_inputs: DevRebuildInputs,
 }
 
 impl DevRenderSession {
@@ -982,7 +1026,18 @@ impl DevRenderSession {
     /// when the source path is unknown to the renderer (dynamic route
     /// deferred to SSR, or a page never seen by the router scan).
     fn render_one(&self, page: &PageId, dist_dir: &Path) -> Result<Vec<RenderedPage>> {
-        let entries = match self.inner.routes_by_source.get(page.path()) {
+        // Read the (possibly watch-ADD-rebuilt, #659) route table. Clone
+        // the entries out so the lock is released before the V8 render —
+        // the reload path takes the write lock, and `render_one` may run
+        // on the same tick that just rebuilt the table.
+        let entries = match self
+            .inner
+            .routes
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .routes_by_source
+            .get(page.path())
+        {
             Some(es) => es.clone(),
             None => return Ok(Vec::new()),
         };
@@ -1088,6 +1143,9 @@ impl DevRenderSession {
     /// follow-up.
     fn ssr_patterns(&self) -> Vec<String> {
         self.inner
+            .routes
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
             .ssr_routes
             .iter()
             .map(|e| colon_template_to_bracket(&e.route_key))
@@ -1099,6 +1157,9 @@ impl DevRenderSession {
     /// non-empty page set to resolve against.
     fn page_ids(&self) -> Vec<PageId> {
         self.inner
+            .routes
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
             .routes_by_source
             .keys()
             .map(|p| PageId::new(p.clone()))
@@ -1110,7 +1171,12 @@ impl DevRenderSession {
     /// routes" silent-failure case (zfb#642 / #644): if this is non-zero
     /// but the initial render produced nothing, every route would 404.
     fn route_count(&self) -> usize {
-        self.inner.routes_by_source.len()
+        self.inner
+            .routes
+            .read()
+            .unwrap_or_else(|p| p.into_inner())
+            .routes_by_source
+            .len()
     }
 
     /// Tear down the underlying [`RendererState`] cleanly. Safe to call
@@ -1123,6 +1189,123 @@ impl DevRenderSession {
         if let Some(state) = lock.take() {
             let _ = shutdown(state);
         }
+    }
+
+    /// Discover content files CREATED after dev-server boot (issue #659).
+    ///
+    /// This is the load-bearing fix. A content file like
+    /// `content/blog/foo.mdx` is reached through a dynamic
+    /// `pages/blog/[slug].tsx` page whose `paths()` walks the `blog`
+    /// collection. The collection snapshot is baked into the SSR bundle at
+    /// boot, and `routes_by_source` is frozen at boot — so a file created
+    /// afterwards is invisible to the running V8 host and never appears in
+    /// the route table, 404ing until restart.
+    ///
+    /// On a `Created` tick we therefore:
+    /// 1. re-bundle the SSR worker (recomputes the content snapshot from
+    ///    disk, so `getCollection` will see the new file),
+    /// 2. reload the embedded V8 host **in place** — `take()` the
+    ///    `Option<RendererState>` out of the SAME `Arc<Mutex<…>>` the
+    ///    render callback and SSR adapter hold, `reload()` it against the
+    ///    new bundle, and put it back, so the running server sees the new
+    ///    host (NOT a fresh `DevRenderSession` it never reads),
+    /// 3. re-scan the router + re-expand `paths()` through the reloaded
+    ///    host to rebuild `routes_by_source` (now the new `/blog/foo` URL
+    ///    is present),
+    /// 4. swap the rebuilt tables in under the route `RwLock`.
+    ///
+    /// Returns the source [`PageId`]s whose route set changed (the dynamic
+    /// `[slug]` page), so the orchestrator renders them and writes the new
+    /// URL to `dist/`. EDIT ticks never call this (the discovery hook only
+    /// sees `Created` paths), so the edit path is untouched.
+    ///
+    /// `embed_v8`-gated like `boot_dev_renderer` — the reload + `paths()`
+    /// runtime eval need the embedded V8 host.
+    #[cfg(feature = "embed_v8")]
+    fn discover_created(&self, created: &[PathBuf]) -> Result<Vec<PageId>> {
+        if created.is_empty() {
+            return Ok(Vec::new());
+        }
+        let project_root = &self.inner.project_root;
+        let inputs = &self.inner.rebuild_inputs;
+
+        // Re-scan the router. `Router::scan` is unchanged by adding a
+        // CONTENT file (the dynamic `[slug].tsx` source is the same), but
+        // re-running it is cheap and keeps boot and rebuild symmetrical —
+        // and it correctly picks up a brand-new `.tsx`/`.md` page placed
+        // directly under `pages/` too.
+        let pages_dir = project_root.join("pages");
+        let router = zfb_router::Router::scan(&pages_dir).map_err(anyhow::Error::from)?;
+        let plan = build_route_universe(router.routes());
+
+        // 1. Re-bundle with a fresh content snapshot (reads content/ from
+        //    disk, so the created file is now in the snapshot).
+        let bundler_out = assemble_and_bundle_dev(
+            project_root,
+            &inputs.cfg,
+            inputs.plugin_alias_entries.clone(),
+            inputs.plugin_virtual_modules.clone(),
+        )
+        .context("watch-add re-bundle failed")?;
+
+        // 2. Reload the embedded V8 host IN PLACE so the running server's
+        //    render callback + SSR adapter (which share this exact Arc)
+        //    see the rebuilt bundle. Take/reload/put on the existing mutex
+        //    — do NOT construct a fresh session.
+        {
+            let mut lock = self.inner.renderer.lock().unwrap_or_else(|p| {
+                tracing::warn!(site = "discover_created", "renderer mutex poisoned, recovered");
+                p.into_inner()
+            });
+            let previous = lock
+                .take()
+                .ok_or_else(|| anyhow::anyhow!("renderer not started for watch-add reload"))?;
+            let reloaded = reload(
+                previous,
+                RendererStartInput {
+                    bundle_path: bundler_out.bundle_path.clone(),
+                    sourcemap_path: bundler_out.sourcemap_path.clone(),
+                    backend: Backend::EmbeddedV8 {
+                        host_factory: crate::v8_host_adapter::make_v8_host_factory_with_hooks(
+                            inputs.v8_plugin_hooks.clone(),
+                        ),
+                    },
+                    request_timeout: None,
+                },
+            )
+            .map_err(anyhow::Error::from)
+            .context("watch-add renderer reload failed")?;
+            *lock = Some(reloaded);
+        }
+
+        // 3. Rebuild the route tables through the reloaded host (re-expands
+        //    `paths()`, so the dynamic source now resolves the new URL).
+        let (new_routes_by_source, new_ssr_routes) =
+            build_dev_route_tables(&router, &plan, project_root, &self.inner.renderer)
+                .context("watch-add route-table rebuild failed")?;
+
+        // 4. Diff against the frozen table to find which source pages
+        //    gained/changed entries, then swap the new tables in.
+        let changed: Vec<PageId> = {
+            let old = self.inner.routes.read().unwrap_or_else(|p| p.into_inner());
+            new_routes_by_source
+                .iter()
+                .filter(|(src, entries)| {
+                    old.routes_by_source
+                        .get(*src)
+                        .map(|prev| prev.len() != entries.len())
+                        .unwrap_or(true)
+                })
+                .map(|(src, _)| PageId::new(src.clone()))
+                .collect()
+        };
+        {
+            let mut tables = self.inner.routes.write().unwrap_or_else(|p| p.into_inner());
+            tables.routes_by_source = new_routes_by_source;
+            tables.ssr_routes = new_ssr_routes;
+        }
+
+        Ok(changed)
     }
 }
 
@@ -1140,53 +1323,25 @@ impl Drop for DevRenderInner {
     }
 }
 
-/// Bring up the renderer and the route map for the dev session.
+/// Assemble the dev-mode bundler input and run the bundler, returning the
+/// fresh [`BundlerOutput`] (issue #659 — extracted from `boot_dev_renderer`
+/// so the watch-ADD re-bundle reuses the EXACT same configuration the boot
+/// bundle used; any drift here would make a newly-added page render
+/// differently in dev than it did at boot). The embedded node_modules /
+/// esbuild tempdir handles live only for the synchronous `bundle()` call
+/// (which writes `bundle_path` to disk), so scoping them to this function
+/// is correct.
 ///
-/// On any error, returns it unchanged so the caller decides whether to
-/// fall back to a noop renderer or hard-fail. Today the dev command
-/// chooses to fall back so the user still gets a reachable HTTP server
-/// while they fix the underlying issue.
-// `boot_dev_renderer` constructs the long-lived dev RendererState
-// backed by the in-process V8 host. Compiled in only when the
-// `embed_v8` feature is on (issue #371, sub-task 4.1a).
+/// `recompute snapshot` is implicit: `build_content_snapshot_json` re-reads
+/// the content collections from disk on every call, so a re-bundle here
+/// picks up a content file created after boot.
 #[cfg(feature = "embed_v8")]
-fn boot_dev_renderer(
+fn assemble_and_bundle_dev(
     project_root: &Path,
     cfg: &config::Config,
-    v8_plugin_hooks: zfb_render::PluginRegistryHooks,
-    // Plugin-registered import aliases from `setup_registries.aliases`.
-    // Threaded into `BundlerInput::plugin_alias_entries` so the dev-mode
-    // esbuild invocation can resolve plugin aliases from pages / layouts /
-    // shared modules (#268).
     plugin_alias_entries: Vec<(String, String)>,
-    // Plugin-registered virtual-module `(specifier, source)` pairs.
-    // Threaded into `BundlerInput::plugin_virtual_modules` (#268).
     plugin_virtual_modules: Vec<(String, String)>,
-) -> Result<DevRenderSession> {
-    check_runtime_installed(project_root)?;
-
-    let pages_dir = project_root.join("pages");
-    if !pages_dir.is_dir() {
-        return Err(anyhow::anyhow!(
-            "no pages/ directory under {}",
-            project_root.display()
-        ));
-    }
-    let router = zfb_router::Router::scan(&pages_dir).map_err(anyhow::Error::from)?;
-
-    let plan = build_route_universe(router.routes());
-    // Guardrail 2 (#507): an all-dynamic SSG project (only `paths()`-based
-    // routes, no static `/`) has an empty `static_routes` but a non-empty
-    // `deferred_dynamic`. Bailing on `static_routes.is_empty()` alone would
-    // skip renderer boot before the dynamic-route expansion below ever runs,
-    // so such a project would never serve any page. Only skip the boot when
-    // the project has neither static nor dynamic routes at all.
-    if plan.static_routes.is_empty() && plan.deferred_dynamic.is_empty() {
-        return Err(anyhow::anyhow!(
-            "no routes to render — dev mode skips renderer boot"
-        ));
-    }
-
+) -> Result<BundlerOutput> {
     // Embed the content snapshot so a page's `getStaticProps()` (and any
     // runtime `paths()`) sees the same collection data the production
     // build does. The published `zfb/content` `getCollection(...)` reads
@@ -1398,35 +1553,27 @@ fn boot_dev_renderer(
         _embedded_esbuild_handle = None;
     }
     let bundler_out: BundlerOutput = bundle(bundler_input).context("bundler step failed")?;
+    Ok(bundler_out)
+}
 
-    let state = start(RendererStartInput {
-        bundle_path: bundler_out.bundle_path.clone(),
-        sourcemap_path: bundler_out.sourcemap_path.clone(),
-        backend: Backend::EmbeddedV8 {
-            host_factory: crate::v8_host_adapter::make_v8_host_factory_with_hooks(
-                v8_plugin_hooks,
-            ),
-        },
-        request_timeout: None,
-    })
-    .map_err(anyhow::Error::from)
-    .context("renderer start failed")?;
+/// `(routes_by_source, ssr_routes)` — the pair [`build_dev_route_tables`]
+/// produces and [`DevRouteTables`] stores.
+#[cfg(feature = "embed_v8")]
+type BuiltRouteTables = (HashMap<PathBuf, Vec<RouteUniverseEntry>>, Vec<RouteUniverseEntry>);
 
-    // Wrap the renderer state in the shared `Arc<Mutex<Option<...>>>` up
-    // front so the SSG `paths()` runtime-evaluation phase below can borrow
-    // the live embedded V8 host out of the same handle the SSG render
-    // callback and the SSR adapter use later (#502/#507). One host, shared
-    // across boot-time paths() eval, build-time SSG render, and request-time
-    // SSR.
-    let renderer: Arc<Mutex<Option<RendererState>>> = Arc::new(Mutex::new(Some(state)));
-
-    // Issue #367 — extract `export const prerender = …` per page so
-    // we can keep SSG-eligible pages in `routes_by_source` (the SSG
-    // render callback's lookup table) while routing `prerender =
-    // false` pages into the request-time SSR set instead. Without this
-    // split the SSG callback would stamp a stale snapshot to disk on
-    // every watcher tick and the dist fallback would shadow the SSR
-    // handler.
+/// Build the dev session's source→route + SSR route tables from the router
+/// scan + the live V8 host (issue #659 — extracted from `boot_dev_renderer`
+/// so boot and the watch-ADD rebuild produce byte-identical tables). The
+/// `renderer` mutex must already hold a started/reloaded [`RendererState`]
+/// because the dynamic-route `paths()` runtime phase borrows the live
+/// embedded V8 host out of it.
+#[cfg(feature = "embed_v8")]
+fn build_dev_route_tables(
+    router: &zfb_router::Router,
+    plan: &crate::render_pipeline::RouteUniversePlan,
+    project_root: &Path,
+    renderer: &Arc<Mutex<Option<RendererState>>>,
+) -> Result<BuiltRouteTables> {
     let prerender_map = build_prerender_map(router.routes(), project_root, |msg| {
         crate::output::warn(msg)
     });
@@ -1595,12 +1742,121 @@ fn boot_dev_renderer(
         }
     }
 
+    Ok((routes_by_source, ssr_routes))
+}
+
+/// Bring up the renderer and the route map for the dev session.
+///
+/// On any error, returns it unchanged so the caller decides whether to
+/// fall back to a noop renderer or hard-fail. Today the dev command
+/// chooses to fall back so the user still gets a reachable HTTP server
+/// while they fix the underlying issue.
+// `boot_dev_renderer` constructs the long-lived dev RendererState
+// backed by the in-process V8 host. Compiled in only when the
+// `embed_v8` feature is on (issue #371, sub-task 4.1a).
+#[cfg(feature = "embed_v8")]
+fn boot_dev_renderer(
+    project_root: &Path,
+    cfg: &config::Config,
+    v8_plugin_hooks: zfb_render::PluginRegistryHooks,
+    // Plugin-registered import aliases from `setup_registries.aliases`.
+    // Threaded into `BundlerInput::plugin_alias_entries` so the dev-mode
+    // esbuild invocation can resolve plugin aliases from pages / layouts /
+    // shared modules (#268).
+    plugin_alias_entries: Vec<(String, String)>,
+    // Plugin-registered virtual-module `(specifier, source)` pairs.
+    // Threaded into `BundlerInput::plugin_virtual_modules` (#268).
+    plugin_virtual_modules: Vec<(String, String)>,
+) -> Result<DevRenderSession> {
+    check_runtime_installed(project_root)?;
+
+    let pages_dir = project_root.join("pages");
+    if !pages_dir.is_dir() {
+        return Err(anyhow::anyhow!(
+            "no pages/ directory under {}",
+            project_root.display()
+        ));
+    }
+    let router = zfb_router::Router::scan(&pages_dir).map_err(anyhow::Error::from)?;
+
+    let plan = build_route_universe(router.routes());
+    // Guardrail 2 (#507): an all-dynamic SSG project (only `paths()`-based
+    // routes, no static `/`) has an empty `static_routes` but a non-empty
+    // `deferred_dynamic`. Bailing on `static_routes.is_empty()` alone would
+    // skip renderer boot before the dynamic-route expansion below ever runs,
+    // so such a project would never serve any page. Only skip the boot when
+    // the project has neither static nor dynamic routes at all.
+    if plan.static_routes.is_empty() && plan.deferred_dynamic.is_empty() {
+        return Err(anyhow::anyhow!(
+            "no routes to render — dev mode skips renderer boot"
+        ));
+    }
+
+    // Assemble + run the dev bundle (#659: extracted into
+    // `assemble_and_bundle_dev` so the watch-ADD rebuild reuses the exact
+    // same bundler configuration). Recomputes the content snapshot from
+    // disk, so a re-bundle on a created file sees the new content.
+    // Stash the bundle inputs BEFORE they are moved into the bundle /
+    // host-start calls below, so a watch-ADD (#659) can re-bundle with the
+    // identical configuration and reload the host in place. The clones are
+    // cheap relative to a bundle (a few small Vecs + the config).
+    let rebuild_inputs = DevRebuildInputs {
+        cfg: cfg.clone(),
+        v8_plugin_hooks: v8_plugin_hooks.clone(),
+        plugin_alias_entries: plugin_alias_entries.clone(),
+        plugin_virtual_modules: plugin_virtual_modules.clone(),
+    };
+
+    let bundler_out: BundlerOutput = assemble_and_bundle_dev(
+        project_root,
+        cfg,
+        plugin_alias_entries,
+        plugin_virtual_modules,
+    )?;
+
+    let state = start(RendererStartInput {
+        bundle_path: bundler_out.bundle_path.clone(),
+        sourcemap_path: bundler_out.sourcemap_path.clone(),
+        backend: Backend::EmbeddedV8 {
+            host_factory: crate::v8_host_adapter::make_v8_host_factory_with_hooks(
+                v8_plugin_hooks,
+            ),
+        },
+        request_timeout: None,
+    })
+    .map_err(anyhow::Error::from)
+    .context("renderer start failed")?;
+
+    // Wrap the renderer state in the shared `Arc<Mutex<Option<...>>>` up
+    // front so the SSG `paths()` runtime-evaluation phase below can borrow
+    // the live embedded V8 host out of the same handle the SSG render
+    // callback and the SSR adapter use later (#502/#507). One host, shared
+    // across boot-time paths() eval, build-time SSG render, and request-time
+    // SSR.
+    let renderer: Arc<Mutex<Option<RendererState>>> = Arc::new(Mutex::new(Some(state)));
+
+    // Issue #367 — extract `export const prerender = …` per page so
+    // we can keep SSG-eligible pages in `routes_by_source` (the SSG
+    // render callback's lookup table) while routing `prerender =
+    // false` pages into the request-time SSR set instead. Without this
+    // split the SSG callback would stamp a stale snapshot to disk on
+    // every watcher tick and the dist fallback would shadow the SSR
+    // handler.
+    // Build the route tables from the router scan + the live host (#659:
+    // extracted into `build_dev_route_tables` so the watch-ADD rebuild
+    // reproduces the boot tables exactly).
+    let (routes_by_source, ssr_routes) =
+        build_dev_route_tables(&router, &plan, project_root, &renderer)?;
+
     Ok(DevRenderSession {
         inner: Arc::new(DevRenderInner {
-            routes_by_source,
-            ssr_routes,
+            routes: std::sync::RwLock::new(DevRouteTables {
+                routes_by_source,
+                ssr_routes,
+            }),
             renderer,
             project_root: project_root.to_path_buf(),
+            rebuild_inputs,
         }),
     })
 }
@@ -1652,6 +1908,66 @@ fn make_render_callback(session: DevRenderSession, dist_dir: PathBuf) -> PageRen
             }
         }
         Ok(out)
+    })
+}
+
+/// Build the live watch-ADD discovery hook handed to
+/// [`zfb_build::BuildOrchestrator::run`] (issue #659).
+///
+/// The orchestrator invokes it with the `Created` subset of a tick's
+/// changed paths. We restrict the expensive re-bundle to files created
+/// under `content/` or `pages/` (the roots that feed the SSR bundle and
+/// the route table); a file created elsewhere — `styles/`, `public/` —
+/// can never add a content-collection route, so we skip discovery for it
+/// and let the normal tick handle it.
+///
+/// On a relevant create we delegate to
+/// [`DevRenderSession::discover_created`] (re-bundle → reload host in
+/// place → rebuild route tables) and then upsert the new file into the
+/// dependency graph as a content dep of each rediscovered source page, so
+/// a LATER edit of that same file hot-reloads its consumer exactly like a
+/// pre-existing post does.
+///
+/// `embed_v8`-gated: discovery needs the embedded V8 host.
+#[cfg(feature = "embed_v8")]
+fn make_discovery_hook(
+    session: DevRenderSession,
+    graph: Arc<Mutex<DependencyGraph>>,
+) -> zfb_build::DiscoveryHook {
+    let content_root = session.inner.project_root.join("content");
+    let pages_root = session.inner.project_root.join("pages");
+    Arc::new(move |created: &[PathBuf]| {
+        // Only created files under content/ or pages/ can introduce a new
+        // content-collection route; skip the re-bundle otherwise.
+        let relevant: Vec<PathBuf> = created
+            .iter()
+            .filter(|p| p.starts_with(&content_root) || p.starts_with(&pages_root))
+            .cloned()
+            .collect();
+        if relevant.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let changed = session.discover_created(&relevant)?;
+
+        // Upsert each newly-created content file as a content dep of the
+        // rediscovered source pages, so subsequent EDITs of the new file
+        // map to their consumer page in the graph (matching how a
+        // pre-existing post behaves). `upsert` merges deps, so this does
+        // not clobber the page's other edges.
+        if !changed.is_empty() {
+            if let Ok(mut g) = graph.lock() {
+                for page in &changed {
+                    let deps: Vec<(PathBuf, zfb_graph::DepKind)> = relevant
+                        .iter()
+                        .map(|c| (c.clone(), zfb_graph::DepKind::Content))
+                        .collect();
+                    g.upsert(PageDeps::new(page.clone(), deps));
+                }
+            }
+        }
+
+        Ok(changed)
     })
 }
 
@@ -1740,6 +2056,47 @@ mod tests {
     // `resolve_host` / `resolve_addr` live in `crate::commands::resolve` (shared
     // with `preview`); their precedence and binding tests live there too.
 
+    /// Build a stub [`DevRenderInner`] for the route-plumbing seam tests
+    /// (no live V8 host). The discovery (#659) `rebuild_inputs` are filled
+    /// with defaults — these tests never call `discover_created`.
+    #[cfg(feature = "embed_v8")]
+    fn stub_dev_inner(
+        routes_by_source: HashMap<PathBuf, Vec<RouteUniverseEntry>>,
+        ssr_routes: Vec<RouteUniverseEntry>,
+    ) -> DevRenderInner {
+        DevRenderInner {
+            routes: std::sync::RwLock::new(DevRouteTables {
+                routes_by_source,
+                ssr_routes,
+            }),
+            renderer: Arc::new(Mutex::new(None)),
+            project_root: PathBuf::new(),
+            rebuild_inputs: DevRebuildInputs {
+                cfg: config::Config::default(),
+                v8_plugin_hooks: zfb_render::PluginRegistryHooks::default(),
+                plugin_alias_entries: Vec::new(),
+                plugin_virtual_modules: Vec::new(),
+            },
+        }
+    }
+
+    /// V8-off counterpart of [`stub_dev_inner`] — no `rebuild_inputs`
+    /// field exists when `embed_v8` is disabled.
+    #[cfg(not(feature = "embed_v8"))]
+    fn stub_dev_inner(
+        routes_by_source: HashMap<PathBuf, Vec<RouteUniverseEntry>>,
+        ssr_routes: Vec<RouteUniverseEntry>,
+    ) -> DevRenderInner {
+        DevRenderInner {
+            routes: std::sync::RwLock::new(DevRouteTables {
+                routes_by_source,
+                ssr_routes,
+            }),
+            renderer: Arc::new(Mutex::new(None)),
+            project_root: PathBuf::new(),
+        }
+    }
+
     #[test]
     fn default_watch_roots_includes_zfb_config_json() {
         assert!(DEFAULT_WATCH_ROOTS.contains(&"zfb.config.json"));
@@ -1796,12 +2153,7 @@ mod tests {
     #[test]
     fn render_callback_drops_unknown_pages_silently() {
         let session = DevRenderSession {
-            inner: Arc::new(DevRenderInner {
-                routes_by_source: HashMap::new(),
-                ssr_routes: Vec::new(),
-                renderer: Arc::new(Mutex::new(None)),
-                project_root: PathBuf::new(),
-            }),
+            inner: Arc::new(stub_dev_inner(HashMap::new(), Vec::new())),
         };
         let cb = make_render_callback(session, PathBuf::from("/tmp/dist"));
         // A source path not present in routes_by_source is still dropped.
@@ -1907,12 +2259,7 @@ mod tests {
             }],
         );
         let session = DevRenderSession {
-            inner: Arc::new(DevRenderInner {
-                routes_by_source: routes,
-                ssr_routes: Vec::new(),
-                renderer: Arc::new(Mutex::new(None)),
-                project_root: PathBuf::new(),
-            }),
+            inner: Arc::new(stub_dev_inner(routes, Vec::new())),
         };
         let cb = make_render_callback(session, PathBuf::from("/tmp/dist"));
         let pages = vec![PageId::new(PathBuf::from("pages/index.tsx"))];
@@ -1945,9 +2292,9 @@ mod tests {
     #[test]
     fn ssr_patterns_emit_bracket_grammar_for_dynamic_routes() {
         let session = DevRenderSession {
-            inner: Arc::new(DevRenderInner {
-                routes_by_source: HashMap::new(),
-                ssr_routes: vec![
+            inner: Arc::new(stub_dev_inner(
+                HashMap::new(),
+                vec![
                     RouteUniverseEntry {
                         url_path: "/blog/:slug".into(),
                         output_path: PathBuf::new(),
@@ -1963,9 +2310,7 @@ mod tests {
                         source_path: None,
                     },
                 ],
-                renderer: Arc::new(Mutex::new(None)),
-                project_root: PathBuf::new(),
-            }),
+            )),
         };
         let patterns = session.ssr_patterns();
         assert_eq!(patterns, vec!["/blog/[slug]".to_string(), "/api/x".to_string()]);

--- a/crates/zfb/src/config.rs
+++ b/crates/zfb/src/config.rs
@@ -1311,6 +1311,38 @@ async fn load_from_ts_file(
     parse_loader_envelope(&json, ts_path)
 }
 
+/// Spawn `cmd` and wait for output, bounded by `timeout`.
+///
+/// `Command::output()` reads stdout/stderr pipes to EOF, so any grandchild
+/// that inherits the pipe write-end (e.g. a detached node process) holds the
+/// call forever at low CPU — the same unbounded-output() hang class fixed for
+/// the post-dist vectors in #648 / #651. This helper bounds the wait and kills
+/// the child (via `.kill_on_drop(true)`) when the deadline is exceeded.
+///
+/// The inner `io::Result<Output>` is returned unwrapped so callers can
+/// inspect `io::ErrorKind` (e.g. `NotFound`) on their own code-path; only the
+/// timeout itself becomes the outer `Err`.
+async fn output_bounded(
+    cmd: &mut Command,
+    timeout: std::time::Duration,
+    name: &str,
+) -> Result<std::io::Result<std::process::Output>> {
+    cmd.kill_on_drop(true);
+    match tokio::time::timeout(timeout, cmd.output()).await {
+        Ok(res) => Ok(res),
+        Err(_) => bail!(
+            "config loader: {} did not exit within {}s — killed",
+            name,
+            timeout.as_secs()
+        ),
+    }
+}
+
+/// Generous backstop timeout for config-loader subprocesses. Mirrors the 300 s
+/// used by `run_capturing` in `zfb-build` (see #648/#651) — a wedge guard, not
+/// a performance bound.
+const CONFIG_SUBPROCESS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300);
+
 /// Bundle `ts_path` with esbuild (`--platform=neutral`) and evaluate it
 /// in-process using the embedded V8 isolate. Returns the same
 /// `{ config, plugins: [...resolved-specifiers...] }` envelope JSON that
@@ -1360,12 +1392,15 @@ async fn load_ts_via_inprocess_v8(
     cmd.arg(&outfile_arg);
     cmd.arg(ts_path);
 
-    let esbuild_out = cmd.output().await.with_context(|| {
-        format!(
-            "config loader: failed to spawn esbuild at {}",
-            esbuild.display()
-        )
-    })?;
+    // Bounded wait — guards against the unbounded-output() hang class (#648/#651).
+    let esbuild_out = output_bounded(&mut cmd, CONFIG_SUBPROCESS_TIMEOUT, "esbuild (neutral)")
+        .await?
+        .with_context(|| {
+            format!(
+                "config loader: failed to spawn esbuild at {}",
+                esbuild.display()
+            )
+        })?;
     if !esbuild_out.status.success() {
         let stderr = String::from_utf8_lossy(&esbuild_out.stderr);
         bail!(
@@ -1621,12 +1656,15 @@ async fn load_ts_via_subprocess(
     cmd.arg(&outfile_arg);
     cmd.arg(ts_path);
 
-    let esbuild_out = cmd.output().await.with_context(|| {
-        format!(
-            "config loader: failed to spawn esbuild at {}",
-            esbuild.display()
-        )
-    })?;
+    // Bounded wait — guards against the unbounded-output() hang class (#648/#651).
+    let esbuild_out = output_bounded(&mut cmd, CONFIG_SUBPROCESS_TIMEOUT, "esbuild (node)")
+        .await?
+        .with_context(|| {
+            format!(
+                "config loader: failed to spawn esbuild at {}",
+                esbuild.display()
+            )
+        })?;
     if !esbuild_out.status.success() {
         let stderr = String::from_utf8_lossy(&esbuild_out.stderr);
         bail!(
@@ -1652,7 +1690,8 @@ async fn load_ts_via_subprocess(
     // resolution and for bare-specifier `node_modules` lookup.
     node_cmd.arg(dir);
 
-    let node_out = match node_cmd.output().await {
+    // Bounded wait — guards against the unbounded-output() hang class (#648/#651).
+    let node_out = match output_bounded(&mut node_cmd, CONFIG_SUBPROCESS_TIMEOUT, "node").await? {
         Ok(o) => o,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             bail!(
@@ -3830,6 +3869,46 @@ mod tests {
         assert!(
             msg.contains("bogus") || msg.contains("unknown field"),
             "error must name the unknown field; got: {msg}"
+        );
+    }
+
+    // --- output_bounded tests ---------------------------------------------------
+
+    /// Verify that `output_bounded` returns a named timeout error promptly when
+    /// the spawned child keeps stdout open (via a backgrounded grandchild), which
+    /// would hang `Command::output()` indefinitely.
+    ///
+    /// Mirrors the intent of `run_capturing_returns_promptly_when_grandchild_holds_pipe_open`
+    /// in `crates/zfb-build/src/adapter.rs` (#648 / #651), adapted to the async path.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn output_bounded_returns_timeout_error_when_grandchild_holds_pipe_open() {
+        let mut cmd = tokio::process::Command::new("sh");
+        // `sleep 30 &` backgrounds a grandchild that inherits the pipe
+        // write-end; without the timeout this would block for 30 s.
+        cmd.arg("-c").arg("sleep 30 & exit 0");
+
+        // Short timeout so the test itself is fast.
+        let timeout = std::time::Duration::from_secs(2);
+
+        // Outer watchdog: if output_bounded itself hangs (regression), the
+        // test times out in 10 s and fails RED rather than hanging CI.
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(10),
+            output_bounded(&mut cmd, timeout, "test-stub"),
+        )
+        .await
+        .expect("output_bounded did not return within 10 s — pipe-EOF hang regression");
+
+        let err = result.expect_err("output_bounded should have returned a timeout error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("did not exit within"),
+            "error must name the timeout; got: {msg}"
+        );
+        assert!(
+            msg.contains("test-stub"),
+            "error must name the subprocess; got: {msg}"
         );
     }
 }


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/657

---

## Summary

Epic #657 — two independent build/dev robustness bugs, landed on `base/build-dev-robustness` across two dependency waves.

### Wave 1

**#658 — Bound config-loader subprocess waits** (`crates/zfb/src/config.rs`)
Three `tokio::process` `output().await` sites (config-loader esbuild `--platform=neutral`, esbuild `--platform=node`, and the `node` loader-eval) could hang forever at low CPU if a grandchild inherited and held a stdout/stderr pipe write-end open — the same unbounded-wait class as #648/#651, but pre-dist. New `output_bounded` helper wraps each call in `tokio::time::timeout` (300s wedge guard) with `kill_on_drop(true)`, failing fast with a diagnostic that **names the specific subprocess**. The `ErrorKind::NotFound` install-Node.js guidance and all non-zero-status paths are preserved. Async wedge test added.

**#659 — `zfb dev` live watch-add discovery** (`orchestrator.rs`, `commands/dev.rs`, tests)
Adding a new content file while `zfb dev` ran 404'd until restart (editing existing files hot-reloaded fine). Root cause resolved on the current tree: the affected route is a **dynamic `[slug]` route whose `paths()` walks a content collection**, and the defect was a **frozen `routes_by_source` table + stale SSR bundle snapshot** built once at boot. Fix: on a `Created` event under content/pages roots, re-bundle the snapshot, **reload the SSR/V8 host in place** (the `reload_renderer` callback was previously unimplemented — wiring it was the core of this work), re-expand `paths()`, rebuild the route tables, and upsert the new page into the dep graph. `ChangeKind` is carried via an **additive** `tick_with_kinds` path — the existing `plan_for_changes`/`tick` public signatures are untouched. Created-only; the edit path is behaviourally identical.

### Wave 2

**#660 — Confirm watch-add end-to-end + edit-path guard** (`zfb-watcher`, `zfb-server` test)
The confirm pass caught a **real production defect** the synthetic-tick test structurally could not: on macOS FSEvents a new-file write fires `Create`+`Modify` within the debounce window, and the debouncer's "keep latest kind" rule collapsed it to `Modified`, dropping the `Created` signal the discovery hook depends on — so #659's fix would have 404'd on new files on macOS in real use. Fixed with a priority merge (`Removed > Created > Modified`, sticky Created) + 6 unit tests. Added a **real-watcher end-to-end test** (`crates/zfb-server/tests/watch_add_confirm.rs`): a real file write → real `notify` watcher → orchestrator → discovery → render → `GET /blog/foo` returns 200, plus a 404-before baseline and an edit-path regression assertion.

### QA fix on the merged base
The real-watcher e2e ADD test was flaky (passed alone, failed under full-suite load). Root-caused to **macOS FSEvents stream startup latency** — events for a file created in the first window after stream registration are dropped wholesale. Replaced the fixed warmup sleep with a **deterministic watcher-live handshake** (writes fresh-named throwaway files until the hook observes one, proving the stream is live) and serialized the two real-watcher tests. No product code touched; deterministic.

## Verification
- `cargo test --workspace` green locally (macOS) and in CI (`health` job, Linux/inotify).
- `cargo clippy` clean; `build (no-v8)` green (config.rs change exercises both feature branches).
- `/gcoc-review` on the full diff: no actionable findings.

## Supersedes
Closes #656, #649 (closed as superseded by this epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)