### PR TITLE
feat(bundler): add bundle.mainFields / bundle.external knobs for the page/SSR pass (#676)

### DIFF
--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -314,6 +314,19 @@ pub struct BundlerInput {
     /// runtime SSR adapter (T2) provides at embedded V8 host load time. An
     /// empty vec means "bundle everything from node_modules".
     pub external: Vec<String>,
+    /// Explicit esbuild `--main-fields` list for the `--platform=neutral`
+    /// page/SSR pass. Under `neutral` esbuild's main-fields list is EMPTY by
+    /// default, so a dep resolved purely via `package.json` `main`/`module`
+    /// (no `exports` map) fails with `The "main" field here was ignored. Main
+    /// fields must be configured explicitly when using the "neutral"
+    /// platform.` Setting e.g. `["main", "module"]` lets such CJS-main-only
+    /// deps resolve (#676 -- `msw` -> `path-to-regexp@6`).
+    ///
+    /// Empty (the default) -> no `--main-fields` is emitted EXCEPT the existing
+    /// React-only `main,module` shim, so a non-React bundle stays
+    /// byte-identical to a build without this knob. When non-empty it applies
+    /// to every framework and takes precedence over the React shim.
+    pub main_fields: Vec<String>,
     /// Where the final `bundle.mjs` (and its `.map`) is written.
     pub outdir: PathBuf,
     /// Production / development mode (drives `import.meta.env.{PROD,DEV}`).
@@ -718,6 +731,7 @@ impl BundlerInput {
             define_vars: Default::default(),
             tsconfig_paths: Default::default(),
             external: Vec::new(),
+            main_fields: Vec::new(),
             outdir,
             mode,
             minify: false,
@@ -3912,28 +3926,31 @@ fn run_esbuild(input: &BundlerInput, shadow: &Path, bundle_path: &Path) -> Resul
         cmd.arg("--conditions=worker");
     }
 
-    // React-only: set `--main-fields=main,module` so esbuild can resolve
-    // main-only CJS packages that have NO `exports` map. Under
-    // `--platform=neutral` esbuild's main-fields list is EMPTY by default,
-    // so a package resolved purely via `package.json` `main`/`module`
-    // (rather than an `exports` map) fails with
-    // `Could not resolve "<pkg>" … The "main" field here was ignored.
-    // Main fields must be configured explicitly when using the "neutral"
-    // platform.` This bites the React UI-library chain — e.g.
-    // `@headlessui/react` → `@floating-ui/react` → `tabbable`, where
-    // `tabbable` ships `main`/`module` and no `exports` — which the T6
-    // configurator depends on. `--conditions=worker` cannot help here
-    // because it only steers `exports`-map resolution.
+    // Main-fields for the `--platform=neutral` page/SSR pass. Under `neutral`
+    // esbuild's main-fields list is EMPTY by default, so a package resolved
+    // purely via `package.json` `main`/`module` (no `exports` map) fails with
+    // `Could not resolve "<pkg>" ... The "main" field here was ignored. Main
+    // fields must be configured explicitly when using the "neutral" platform.`
     //
-    // Safe to scope to React (and would be safe unconditionally):
-    // `--main-fields` only affects packages WITHOUT an `exports` map.
-    // `exports` always takes precedence, so react/react-dom/preact and any
-    // exports-based dep are untouched. The flag can only turn a currently
-    // *failing* main-only resolution into a success, never alter a working
-    // one. It is React-gated to mirror `--conditions=worker` and keep the
-    // Preact bundle's arg set byte-identical (zero regression). `main,module`
-    // matches esbuild's own node-platform default ordering.
-    if matches!(input.framework, Framework::React) {
+    // Resolution order:
+    // 1. An explicit `bundle.mainFields` (input.main_fields) wins for EVERY
+    //    framework -- the #676 host knob (e.g. a Preact project hitting
+    //    `msw` -> `path-to-regexp@6` sets `["main", "module"]`).
+    // 2. Otherwise React keeps its historical `main,module` default (the
+    //    `@headlessui/react` -> `@floating-ui/react` -> `tabbable` chain the T6
+    //    configurator depends on; `tabbable` ships `main`/`module`, no
+    //    `exports`). `--conditions=worker` cannot help -- it only steers
+    //    `exports`-map resolution.
+    // 3. Otherwise (non-React, no knob) NO `--main-fields` is emitted, keeping
+    //    the Preact bundle's arg set byte-identical (zero regression).
+    //
+    // Safe in all cases: `--main-fields` only affects packages WITHOUT an
+    // `exports` map (`exports` always takes precedence), so it can only turn a
+    // currently *failing* main-only resolution into a success, never alter a
+    // working one. `main,module` matches esbuild's node-platform default order.
+    if !input.main_fields.is_empty() {
+        cmd.arg(format!("--main-fields={}", input.main_fields.join(",")));
+    } else if matches!(input.framework, Framework::React) {
         cmd.arg("--main-fields=main,module");
     }
 
@@ -4340,6 +4357,7 @@ mod tests {
             define_vars: HashMap::new(),
             tsconfig_paths: BTreeMap::new(),
             external: vec![],
+            main_fields: Vec::new(),
             outdir: root.join("dist"),
             mode: BundleMode::Production,
             minify: false,
@@ -5614,6 +5632,7 @@ mod tests {
             define_vars: defs,
             tsconfig_paths: BTreeMap::new(),
             external: vec!["preact".into()],
+            main_fields: Vec::new(),
             outdir: root.join("dist"),
             mode: BundleMode::Production,
             minify: false,

--- a/crates/zfb-build/tests/bundler_css_modules.rs
+++ b/crates/zfb-build/tests/bundler_css_modules.rs
@@ -34,6 +34,7 @@ fn make_input(
 ) -> BundlerInput {
     main_fields: Vec::new(),
     BundlerInput {
+        main_fields: Vec::new(),
         project_root: root.to_path_buf(),
         pages_dir: PathBuf::from("pages"),
         content_dir: PathBuf::from("content"),

--- a/crates/zfb-build/tests/bundler_css_modules.rs
+++ b/crates/zfb-build/tests/bundler_css_modules.rs
@@ -32,6 +32,7 @@ fn make_input(
     esbuild: PathBuf,
     class_maps: HashMap<PathBuf, HashMap<String, String>>,
 ) -> BundlerInput {
+    main_fields: Vec::new(),
     BundlerInput {
         project_root: root.to_path_buf(),
         pages_dir: PathBuf::from("pages"),

--- a/crates/zfb-build/tests/bundler_default_plugins.rs
+++ b/crates/zfb-build/tests/bundler_default_plugins.rs
@@ -329,6 +329,7 @@ fn make_input(
     esbuild: &std::path::Path,
     outdir_name: &str,
 ) -> BundlerInput {
+    main_fields: Vec::new(),
     BundlerInput {
         project_root: root.to_path_buf(),
         pages_dir: PathBuf::from("pages"),

--- a/crates/zfb-build/tests/bundler_default_plugins.rs
+++ b/crates/zfb-build/tests/bundler_default_plugins.rs
@@ -331,6 +331,7 @@ fn make_input(
 ) -> BundlerInput {
     main_fields: Vec::new(),
     BundlerInput {
+        main_fields: Vec::new(),
         project_root: root.to_path_buf(),
         pages_dir: PathBuf::from("pages"),
         content_dir: PathBuf::from("content"),

--- a/crates/zfb-build/tests/bundler_exact_match_resolution.rs
+++ b/crates/zfb-build/tests/bundler_exact_match_resolution.rs
@@ -72,6 +72,7 @@ fn make_input(
     plugin_alias_entries: Vec<(String, String)>,
     plugin_virtual_modules: Vec<(String, String)>,
 ) -> BundlerInput {
+    main_fields: Vec::new(),
     BundlerInput {
         project_root: root.to_path_buf(),
         pages_dir: PathBuf::from("pages"),

--- a/crates/zfb-build/tests/bundler_exact_match_resolution.rs
+++ b/crates/zfb-build/tests/bundler_exact_match_resolution.rs
@@ -74,6 +74,7 @@ fn make_input(
 ) -> BundlerInput {
     main_fields: Vec::new(),
     BundlerInput {
+        main_fields: Vec::new(),
         project_root: root.to_path_buf(),
         pages_dir: PathBuf::from("pages"),
         content_dir: PathBuf::from("content"),

--- a/crates/zfb-build/tests/bundler_exclude_glob.rs
+++ b/crates/zfb-build/tests/bundler_exclude_glob.rs
@@ -88,6 +88,7 @@ fn make_input(
     esbuild: std::path::PathBuf,
     bundle_exclude: Vec<String>,
 ) -> BundlerInput {
+    main_fields: Vec::new(),
     let mut input = BundlerInput::for_project(
         root.to_path_buf(),
         Framework::Preact,

--- a/crates/zfb-build/tests/bundler_integration.rs
+++ b/crates/zfb-build/tests/bundler_integration.rs
@@ -138,6 +138,7 @@ fn end_to_end_bundles_aliases_mdx_islands_and_define() {
     paths.insert("@/components/*".into(), vec!["./components/*".into()]);
 
     let input = BundlerInput {
+        main_fields: Vec::new(),
         project_root: root.clone(),
         pages_dir: PathBuf::from("pages"),
         content_dir: PathBuf::from("content"),
@@ -338,6 +339,7 @@ fn import_meta_glob_eager_is_expanded_before_esbuild() {
     .unwrap();
 
     let input = BundlerInput {
+        main_fields: Vec::new(),
         project_root: root.clone(),
         pages_dir: PathBuf::from("pages"),
         content_dir: PathBuf::from("content"),

--- a/crates/zfb-build/tests/bundler_main_fields.rs
+++ b/crates/zfb-build/tests/bundler_main_fields.rs
@@ -101,6 +101,7 @@ fn make_input(
     main_fields: Vec<String>,
     extra_external: Vec<String>,
 ) -> BundlerInput {
+    main_fields: Vec::new(),
     let mut input = BundlerInput::for_project(
         root.to_path_buf(),
         Framework::Preact,

--- a/crates/zfb-build/tests/bundler_main_fields.rs
+++ b/crates/zfb-build/tests/bundler_main_fields.rs
@@ -1,0 +1,224 @@
+//! Integration test for `bundle.mainFields` / `bundle.external` (#676).
+//!
+//! ## What is being proven
+//!
+//! The page/SSR bundler runs esbuild with `--platform=neutral`, whose
+//! main-fields list is EMPTY by default. A dependency resolved purely via
+//! `package.json` `main`/`module` (no `exports` map) — the shape of
+//! `path-to-regexp@6`, the transitive dep `msw` pulls in — is therefore
+//! REJECTED:
+//!
+//! ```text
+//! Could not resolve "<pkg>" … The "main" field here was ignored. Main
+//! fields must be configured explicitly when using the "neutral" platform.
+//! ```
+//!
+//! #676 adds two host knobs to fix this WITHOUT excluding the file:
+//! - `bundle.mainFields` → `BundlerInput::main_fields` → esbuild
+//!   `--main-fields=…`, so the CJS-main-only dep RESOLVES and is bundled.
+//! - `bundle.external` → appended to `BundlerInput::external` → esbuild
+//!   `--external:…`, so the dep is left unresolved (the other escape hatch).
+//!
+//! ## Negative control (load-bearing)
+//!
+//! Each test builds the SAME tree twice: once WITHOUT the knob (must FAIL —
+//! proving the bad import really is reached and rejected under neutral) and
+//! once WITH it (must PASS). A with-only assertion would pass even with no
+//! implementation, so the fail-without half is what gives these tests teeth.
+//!
+//! ## Faithfulness, not literalness
+//!
+//! A hermetic Rust test cannot `npm install msw`, so the fixture hand-rolls a
+//! `main` + `module` / no-`exports` package mirroring the `--platform=neutral`
+//! CJS-rejection *mechanism* (the same approach as `bundler_exclude_glob.rs`
+//! and `bundler_workspace_pkg_alias.rs`). The faithfulness is to the
+//! resolution failure, not to the literal `msw`/`path-to-regexp`.
+
+use std::fs;
+
+use zfb_build::{bundle, BundleMode, BundlerInput};
+use zfb_render::adapters::Framework;
+use zfb_test_utils::locate_esbuild;
+
+/// Write a hand-rolled CJS-only package into `<root>/node_modules/<name>`.
+///
+/// The `package.json` carries `main` (CJS) + `module` (an ESM-ish sibling) and
+/// deliberately NO `exports` map — the literal `path-to-regexp@6` shape. Under
+/// `--platform=neutral` esbuild's main-fields list is empty, so this package
+/// fails to resolve unless `--main-fields` is configured (or it is marked
+/// external), reproducing the `msw` → `path-to-regexp@6` worker-bundle failure
+/// without a real npm install.
+fn write_cjs_only_package(root: &std::path::Path, name: &str) {
+    let pkg = root.join("node_modules").join(name);
+    fs::create_dir_all(pkg.join("dist")).unwrap();
+    fs::create_dir_all(pkg.join("dist.es2015")).unwrap();
+    fs::write(
+        pkg.join("package.json"),
+        format!(
+            r#"{{ "name": "{name}", "version": "6.3.0", "main": "dist/index.js", "module": "dist.es2015/index.js" }}"#
+        ),
+    )
+    .unwrap();
+    // CJS body — top-level module.exports.
+    fs::write(
+        pkg.join("dist/index.js"),
+        "function http() { return \"http-cjs\"; }\nmodule.exports = { http: http };\n",
+    )
+    .unwrap();
+    // ESM sibling the `module` field points at.
+    fs::write(
+        pkg.join("dist.es2015/index.js"),
+        "export function http() { return \"http-esm\"; }\n",
+    )
+    .unwrap();
+}
+
+/// Standard source dirs plus a page that STATICALLY imports `dep`, so the bad
+/// import is reached directly from the synthetic entry (no glob needed).
+fn scaffold_project_importing(root: &std::path::Path, dep: &str) {
+    for d in ["pages", "components", "layouts", "content"] {
+        fs::create_dir_all(root.join(d)).unwrap();
+    }
+    fs::write(
+        root.join("pages/index.tsx"),
+        format!(
+            r#"
+                import {{ http }} from "{dep}";
+                export default function Home() {{ return http(); }}
+            "#
+        ),
+    )
+    .unwrap();
+}
+
+/// Preact + neutral worker bundle (the failing combination): node_modules
+/// adjacent to the project so the hand-rolled package is resolvable, and
+/// preact/runtime bare specifiers marked external so the synthetic `entry.mjs`
+/// itself bundles. `main_fields` / extra `external` are the knobs under test.
+fn make_input(
+    root: &std::path::Path,
+    esbuild: std::path::PathBuf,
+    main_fields: Vec<String>,
+    extra_external: Vec<String>,
+) -> BundlerInput {
+    let mut input = BundlerInput::for_project(
+        root.to_path_buf(),
+        Framework::Preact,
+        BundleMode::Production,
+        root.join("dist"),
+        None,
+    );
+    input.external = vec![
+        "preact".into(),
+        "preact-render-to-string".into(),
+        "@takazudo/zfb-runtime".into(),
+    ];
+    input.external.extend(extra_external);
+    input.main_fields = main_fields;
+    input.esbuild_binary = Some(esbuild);
+    input.node_modules_dir = Some(root.join("node_modules"));
+    input
+}
+
+/// Core proof: a Preact/neutral bundle whose page imports a CJS-main-only dep
+/// FAILS without `bundle.mainFields` and PASSES (with the dep actually
+/// resolved + inlined) when `main_fields = ["main", "module"]`.
+#[test]
+fn main_fields_knob_resolves_cjs_main_only_dep_fails_without_passes_with() {
+    let Some(esbuild) = locate_esbuild() else {
+        eprintln!("[bundler_main_fields] no esbuild binary; skipping.");
+        return;
+    };
+
+    // --- Negative control: NO main_fields → must FAIL. ---
+    let tmp_fail = tempfile::tempdir().expect("tempdir");
+    scaffold_project_importing(tmp_fail.path(), "badcjs");
+    write_cjs_only_package(tmp_fail.path(), "badcjs");
+    let fail = bundle(make_input(
+        tmp_fail.path(),
+        esbuild.clone(),
+        Vec::new(),
+        Vec::new(),
+    ));
+    assert!(
+        fail.is_err(),
+        "WITHOUT bundle.mainFields the Preact/neutral pass has an empty \
+         main-fields list and must reject the CJS-main-only dep. A green build \
+         here means the negative control is broken."
+    );
+    let msg = format!("{:?}", fail.unwrap_err());
+    assert!(
+        msg.contains("esbuild") || msg.to_lowercase().contains("resolve") || msg.contains("badcjs"),
+        "failure should originate from esbuild's resolution of the CJS-only \
+         package; got: {msg}"
+    );
+
+    // --- With main_fields = [main, module] → must PASS and bundle the dep. ---
+    let tmp_pass = tempfile::tempdir().expect("tempdir");
+    scaffold_project_importing(tmp_pass.path(), "badcjs");
+    write_cjs_only_package(tmp_pass.path(), "badcjs");
+    let out = bundle(make_input(
+        tmp_pass.path(),
+        esbuild,
+        vec!["main".to_string(), "module".to_string()],
+        Vec::new(),
+    ))
+    .expect("WITH bundle.mainFields the CJS-main-only dep must resolve → green build");
+    assert!(out.bundle_path.exists(), "bundle.mjs should exist");
+    let body = fs::read_to_string(&out.bundle_path).expect("read bundle");
+    // The dep was actually RESOLVED and inlined (not externalised): one of its
+    // two entry bodies is present.
+    assert!(
+        body.contains("http-cjs") || body.contains("http-esm"),
+        "the resolved CJS-main-only dep should be inlined into the bundle"
+    );
+}
+
+/// The other #676 escape hatch: `bundle.external` lets the build go green by
+/// leaving the CJS-main-only dep unresolved (a bare import in the bundle)
+/// instead of resolving it.
+#[test]
+fn external_knob_lets_build_skip_cjs_main_only_dep() {
+    let Some(esbuild) = locate_esbuild() else {
+        eprintln!("[bundler_main_fields] no esbuild binary; skipping.");
+        return;
+    };
+
+    // --- Negative control: NO external → must FAIL. ---
+    let tmp_fail = tempfile::tempdir().expect("tempdir");
+    scaffold_project_importing(tmp_fail.path(), "badcjs");
+    write_cjs_only_package(tmp_fail.path(), "badcjs");
+    let fail = bundle(make_input(
+        tmp_fail.path(),
+        esbuild.clone(),
+        Vec::new(),
+        Vec::new(),
+    ));
+    assert!(
+        fail.is_err(),
+        "negative control: must fail without any knob"
+    );
+
+    // --- With external = [badcjs] → must PASS, dep left unresolved. ---
+    let tmp_pass = tempfile::tempdir().expect("tempdir");
+    scaffold_project_importing(tmp_pass.path(), "badcjs");
+    write_cjs_only_package(tmp_pass.path(), "badcjs");
+    let out = bundle(make_input(
+        tmp_pass.path(),
+        esbuild,
+        Vec::new(),
+        vec!["badcjs".to_string()],
+    ))
+    .expect("WITH bundle.external the dep is left external → green build");
+    assert!(out.bundle_path.exists(), "bundle.mjs should exist");
+    let body = fs::read_to_string(&out.bundle_path).expect("read bundle");
+    // Externalised: the import is preserved as a bare specifier, not inlined.
+    assert!(
+        body.contains("badcjs"),
+        "externalised dep should remain a bare import in the bundle"
+    );
+    assert!(
+        !body.contains("http-cjs") && !body.contains("http-esm"),
+        "externalised dep body must NOT be inlined into the bundle"
+    );
+}

--- a/crates/zfb-build/tests/bundler_md_pages.rs
+++ b/crates/zfb-build/tests/bundler_md_pages.rs
@@ -20,6 +20,7 @@ use zfb_test_utils::locate_esbuild;
 
 /// Build a minimal `BundlerInput` for an isolated test project.
 fn make_input(root: &std::path::Path, esbuild: PathBuf) -> BundlerInput {
+    main_fields: Vec::new(),
     BundlerInput {
         project_root: root.to_path_buf(),
         pages_dir: PathBuf::from("pages"),

--- a/crates/zfb-build/tests/bundler_md_pages.rs
+++ b/crates/zfb-build/tests/bundler_md_pages.rs
@@ -22,6 +22,7 @@ use zfb_test_utils::locate_esbuild;
 fn make_input(root: &std::path::Path, esbuild: PathBuf) -> BundlerInput {
     main_fields: Vec::new(),
     BundlerInput {
+        main_fields: Vec::new(),
         project_root: root.to_path_buf(),
         pages_dir: PathBuf::from("pages"),
         content_dir: PathBuf::from("content"),

--- a/crates/zfb-build/tests/bundler_resolve_links.rs
+++ b/crates/zfb-build/tests/bundler_resolve_links.rs
@@ -92,6 +92,7 @@ fn make_input_with_resolve(
     outdir_name: &str,
     on_broken_links: OnBrokenLinks,
 ) -> BundlerInput {
+    main_fields: Vec::new(),
     BundlerInput {
         project_root: root.to_path_buf(),
         pages_dir: PathBuf::from("pages"),
@@ -152,6 +153,7 @@ fn make_input_without_resolve(
     esbuild: &std::path::Path,
     outdir_name: &str,
 ) -> BundlerInput {
+    main_fields: Vec::new(),
     BundlerInput {
         project_root: root.to_path_buf(),
         pages_dir: PathBuf::from("pages"),

--- a/crates/zfb-build/tests/bundler_resolve_links.rs
+++ b/crates/zfb-build/tests/bundler_resolve_links.rs
@@ -94,6 +94,7 @@ fn make_input_with_resolve(
 ) -> BundlerInput {
     main_fields: Vec::new(),
     BundlerInput {
+        main_fields: Vec::new(),
         project_root: root.to_path_buf(),
         pages_dir: PathBuf::from("pages"),
         content_dir: PathBuf::from("content"),
@@ -155,6 +156,7 @@ fn make_input_without_resolve(
 ) -> BundlerInput {
     main_fields: Vec::new(),
     BundlerInput {
+        main_fields: Vec::new(),
         project_root: root.to_path_buf(),
         pages_dir: PathBuf::from("pages"),
         content_dir: PathBuf::from("content"),

--- a/crates/zfb-build/tests/bundler_strip_md_ext.rs
+++ b/crates/zfb-build/tests/bundler_strip_md_ext.rs
@@ -78,6 +78,7 @@ fn make_input(
 ) -> BundlerInput {
     main_fields: Vec::new(),
     BundlerInput {
+        main_fields: Vec::new(),
         project_root: root.to_path_buf(),
         pages_dir: PathBuf::from("pages"),
         content_dir: PathBuf::from("content"),

--- a/crates/zfb-build/tests/bundler_strip_md_ext.rs
+++ b/crates/zfb-build/tests/bundler_strip_md_ext.rs
@@ -76,6 +76,7 @@ fn make_input(
     outdir_name: &str,
     strip_md_ext: bool,
 ) -> BundlerInput {
+    main_fields: Vec::new(),
     BundlerInput {
         project_root: root.to_path_buf(),
         pages_dir: PathBuf::from("pages"),

--- a/crates/zfb-build/tests/bundler_transform_compose.rs
+++ b/crates/zfb-build/tests/bundler_transform_compose.rs
@@ -66,6 +66,7 @@ fn branch4_input(
     tsconfig_paths: BTreeMap<String, Vec<String>>,
     class_maps: HashMap<PathBuf, HashMap<String, String>>,
 ) -> BundlerInput {
+    main_fields: Vec::new(),
     let mut input = BundlerInput::for_project(
         root.to_path_buf(),
         Framework::Preact,

--- a/crates/zfb-build/tests/embedded_v8_snapshot_e2e.rs
+++ b/crates/zfb-build/tests/embedded_v8_snapshot_e2e.rs
@@ -64,6 +64,7 @@ fn write_blog_fixture(dir: &std::path::Path) -> PathBuf {
 /// the test doesn't need a real esbuild binary. The mock output satisfies
 /// the bundler's post-processing expectations (routes export + hydrateIsland).
 fn make_mock_input(tmp: &tempfile::TempDir, snapshot_json: Option<String>) -> BundlerInput {
+    main_fields: Vec::new(),
     let root = tmp.path().to_path_buf();
     fs::create_dir_all(root.join("pages")).unwrap();
     fs::create_dir_all(root.join("content")).unwrap();
@@ -645,6 +646,7 @@ async fn embedded_v8_renders_page_with_snapshot_data() {
     let dist_tmp = tempfile::tempdir().expect("dist tempdir");
 
     let input = BundlerInput {
+        main_fields: Vec::new(),
         project_root: project_root.clone(),
         pages_dir: PathBuf::from("pages"),
         content_dir: PathBuf::from("content"),
@@ -833,6 +835,7 @@ async fn embedded_v8_md_page_renders_to_html() {
     let dist_tmp = tempfile::tempdir().expect("dist tempdir");
 
     let input = BundlerInput {
+        main_fields: Vec::new(),
         project_root: project_root.to_path_buf(),
         pages_dir: PathBuf::from("pages"),
         content_dir: PathBuf::from("content"),
@@ -1292,6 +1295,7 @@ async fn paths_worker_resolves_collection_across_dual_zfb_instances() {
     let dist_tmp = tempfile::tempdir().expect("dist tempdir");
 
     let input = BundlerInput {
+        main_fields: Vec::new(),
         project_root: project_root.to_path_buf(),
         pages_dir: PathBuf::from("pages"),
         content_dir: PathBuf::from("content"),

--- a/crates/zfb-build/tests/embedded_v8_snapshot_e2e.rs
+++ b/crates/zfb-build/tests/embedded_v8_snapshot_e2e.rs
@@ -76,6 +76,7 @@ fn make_mock_input(tmp: &tempfile::TempDir, snapshot_json: Option<String>) -> Bu
     )
     .unwrap();
     BundlerInput {
+        main_fields: Vec::new(),
         project_root: root.clone(),
         pages_dir: PathBuf::from("pages"),
         content_dir: PathBuf::from("content"),

--- a/crates/zfb-build/tests/integration_e2e_routing_rendering.rs
+++ b/crates/zfb-build/tests/integration_e2e_routing_rendering.rs
@@ -284,6 +284,7 @@ fn build_bundle(
     let node_modules = make_test_node_modules();
 
     let input = BundlerInput {
+        main_fields: Vec::new(),
         project_root: fixture_root.to_path_buf(),
         pages_dir: PathBuf::from("pages"),
         content_dir: PathBuf::from("content"),

--- a/crates/zfb-build/tests/migration_fixes_integration_confirm.rs
+++ b/crates/zfb-build/tests/migration_fixes_integration_confirm.rs
@@ -411,6 +411,7 @@ fn make_full_fixture_input(
 ) -> BundlerInput {
     main_fields: Vec::new(),
     BundlerInput {
+        main_fields: Vec::new(),
         project_root: root.to_path_buf(),
         pages_dir: PathBuf::from("pages"),
         content_dir: PathBuf::from("content"),

--- a/crates/zfb-build/tests/migration_fixes_integration_confirm.rs
+++ b/crates/zfb-build/tests/migration_fixes_integration_confirm.rs
@@ -409,6 +409,7 @@ fn make_full_fixture_input(
     root: &std::path::Path,
     esbuild: &std::path::Path,
 ) -> BundlerInput {
+    main_fields: Vec::new(),
     BundlerInput {
         project_root: root.to_path_buf(),
         pages_dir: PathBuf::from("pages"),

--- a/crates/zfb-build/tests/worker_only_routes_filter.rs
+++ b/crates/zfb-build/tests/worker_only_routes_filter.rs
@@ -84,6 +84,7 @@ fn ssr_catchall_survives_worker_only_routes_filter() {
     worker_only.insert("/api/admin/:adminPath{.+}".into());
 
     let input = BundlerInput {
+        main_fields: Vec::new(),
         project_root: root.clone(),
         pages_dir: PathBuf::from("pages"),
         content_dir: PathBuf::from("content"),

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -1512,6 +1512,16 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
     // copy and the #665 import.meta.glob expansion). Empty → skip nothing.
     bundler_input.bundle_exclude =
         crate::config::resolve_bundle_exclude(config.bundle.as_ref());
+    // #676 -- thread `bundle.mainFields` / `bundle.external` so hosts can make
+    // the `--platform=neutral` page/SSR pass resolve (or externalize)
+    // CJS-main-only deps (e.g. `msw` -> `path-to-regexp@6`). main_fields
+    // applies to every framework when set; external is APPENDED so any
+    // framework-required externals are preserved. Empty -> byte-identical.
+    bundler_input.main_fields =
+        crate::config::resolve_bundle_main_fields(config.bundle.as_ref());
+    bundler_input
+        .external
+        .extend(crate::config::resolve_bundle_external(config.bundle.as_ref()));
     // #586 — thread `markdown.features` into the bundler so opt-in feature
     // plugins (mermaid, …) fire per the configured toggles.
     // `None` keeps the legacy always-on chain, byte-identical to today.

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -1527,6 +1527,14 @@ fn assemble_and_bundle_dev(
     // Empty → skip nothing. Mirrors `commands/build.rs`.
     bundler_input.bundle_exclude =
         crate::config::resolve_bundle_exclude(cfg.bundle.as_ref());
+    // #676 -- mirror commands/build.rs: thread `bundle.mainFields` /
+    // `bundle.external` so dev's page/SSR bundle resolves (or externalizes)
+    // CJS-main-only deps identically to the production build.
+    bundler_input.main_fields =
+        crate::config::resolve_bundle_main_fields(cfg.bundle.as_ref());
+    bundler_input
+        .external
+        .extend(crate::config::resolve_bundle_external(cfg.bundle.as_ref()));
     // #586 — thread `markdown.features` so dev rendering honours the opt-in
     // feature plugins, matching the production build. Mirrors
     // `commands/build.rs`. `None` keeps the legacy always-on chain.

--- a/crates/zfb/src/config.rs
+++ b/crates/zfb/src/config.rs
@@ -661,6 +661,30 @@ pub struct BundleConfig {
     /// (collections / i18n locale filtering).
     #[serde(default)]
     pub exclude: Option<Vec<String>>,
+
+    /// Explicit esbuild `main-fields` list for the `--platform=neutral`
+    /// page/SSR pass. Under `neutral` esbuild's main-fields list is EMPTY by
+    /// default, so a dep resolved purely via `package.json` `main`/`module`
+    /// (no `exports` map) fails with `The "main" field here was ignored. Main
+    /// fields must be configured explicitly when using the "neutral"
+    /// platform.` Setting e.g. `["main", "module"]` lets such CJS-main-only
+    /// deps resolve (#676 -- `msw` -> `path-to-regexp@6`). Applies to every
+    /// framework; absent/empty -> byte-identical to a build without the knob
+    /// (the React-only `main,module` shim still applies).
+    ///
+    /// Mirrors `BundleConfig.mainFields` in `packages/zfb/src/config.ts`.
+    #[serde(default)]
+    pub main_fields: Option<Vec<String>>,
+
+    /// Bare specifiers to mark `--external` in the `--platform=neutral`
+    /// page/SSR pass, so esbuild leaves them unbundled instead of resolving
+    /// them (the other #676 escape hatch -- externalize a CJS-only dep rather
+    /// than resolving it). Appended to the framework-provided externals.
+    /// Absent/empty -> no extra externals.
+    ///
+    /// Mirrors `BundleConfig.external` in `packages/zfb/src/config.ts`.
+    #[serde(default)]
+    pub external: Option<Vec<String>>,
 }
 
 /// Syntect-based code-highlight options.
@@ -1115,6 +1139,30 @@ pub fn resolve_hard_breaks(markdown: Option<&MarkdownConfig>) -> bool {
 pub fn resolve_bundle_exclude(bundle: Option<&BundleConfig>) -> Vec<String> {
     match bundle {
         Some(b) => b.exclude.clone().unwrap_or_default(),
+        None => Vec::new(),
+    }
+}
+
+/// Resolve `bundle.mainFields` into the esbuild `--main-fields` list for the
+/// page/SSR pass. Empty when `bundle` is absent or `bundle.mainFields` is
+/// `None`, so callers can thread the result straight into
+/// `BundlerInput::main_fields` and an empty vec means "emit no
+/// `--main-fields`" (byte-identical to a build without the knob; #676).
+#[must_use]
+pub fn resolve_bundle_main_fields(bundle: Option<&BundleConfig>) -> Vec<String> {
+    match bundle {
+        Some(b) => b.main_fields.clone().unwrap_or_default(),
+        None => Vec::new(),
+    }
+}
+
+/// Resolve `bundle.external` into the extra `--external` specifiers appended
+/// to the page/SSR pass's externals. Empty when `bundle` is absent or
+/// `bundle.external` is `None` (#676).
+#[must_use]
+pub fn resolve_bundle_external(bundle: Option<&BundleConfig>) -> Vec<String> {
+    match bundle {
+        Some(b) => b.external.clone().unwrap_or_default(),
         None => Vec::new(),
     }
 }
@@ -3537,6 +3585,37 @@ mod tests {
         let cfg: Config = serde_json::from_value(serde_json::json!({ "bundle": {} }))
             .expect("bundle:{} deserialises");
         assert!(resolve_bundle_exclude(cfg.bundle.as_ref()).is_empty());
+    }
+
+    // --- bundle.mainFields / bundle.external tests (#676) ------------------
+
+    #[test]
+    fn bundle_main_fields_and_external_deserialise_from_camel_case() {
+        let cfg: Config = serde_json::from_value(serde_json::json!({
+            "bundle": { "mainFields": ["main", "module"], "external": ["path-to-regexp"] }
+        }))
+        .expect("bundle.mainFields / bundle.external deserialise");
+        assert_eq!(
+            resolve_bundle_main_fields(cfg.bundle.as_ref()),
+            vec!["main".to_string(), "module".to_string()]
+        );
+        assert_eq!(
+            resolve_bundle_external(cfg.bundle.as_ref()),
+            vec!["path-to-regexp".to_string()]
+        );
+    }
+
+    #[test]
+    fn bundle_absent_resolves_to_empty_main_fields_and_external() {
+        let cfg: Config = serde_json::from_value(serde_json::json!({}))
+            .expect("empty config deserialises");
+        assert!(resolve_bundle_main_fields(cfg.bundle.as_ref()).is_empty());
+        assert!(resolve_bundle_external(cfg.bundle.as_ref()).is_empty());
+
+        let cfg: Config = serde_json::from_value(serde_json::json!({ "bundle": {} }))
+            .expect("bundle:{} deserialises");
+        assert!(resolve_bundle_main_fields(cfg.bundle.as_ref()).is_empty());
+        assert!(resolve_bundle_external(cfg.bundle.as_ref()).is_empty());
     }
 
     // --- OutputMode tests (sub-task 4.1b / issue #373) ---------------------

--- a/crates/zfb/tests/framework_packages_no_pnpm.rs
+++ b/crates/zfb/tests/framework_packages_no_pnpm.rs
@@ -123,6 +123,7 @@ fn embedded_extraction_resolves_framework_imports_with_no_consumer_node_modules(
     // external — every framework import must resolve from the extraction)
     // and `node_modules_dir = Some(nm_path)` pointing at the extraction.
     let input = BundlerInput {
+        main_fields: Vec::new(),
         project_root: root.clone(),
         pages_dir: PathBuf::from("pages"),
         content_dir: PathBuf::from("content"),

--- a/packages/zfb/src/config.ts
+++ b/packages/zfb/src/config.ts
@@ -103,6 +103,32 @@ export type BundleConfig = {
    * Mirrors `Config::bundle` in crates/zfb/src/config.rs.
    */
   exclude?: string[];
+
+  /**
+   * Explicit esbuild `main-fields` list for the `--platform=neutral` page/SSR
+   * pass. Under `neutral` esbuild's main-fields list is EMPTY by default, so a
+   * dep resolved purely via `package.json` `main`/`module` (no `exports` map)
+   * is rejected ("The "main" field here was ignored. Main fields must be
+   * configured explicitly when using the neutral platform."). Set e.g.
+   * `["main", "module"]` to let such CJS-main-only deps resolve (#676 —
+   * `msw` → `path-to-regexp@6`). Applies to every framework; unset/empty →
+   * byte-identical to a build without the knob (the React-only `main,module`
+   * shim still applies).
+   *
+   * Mirrors `BundleConfig::main_fields` in `crates/zfb/src/config.rs`.
+   */
+  mainFields?: string[];
+
+  /**
+   * Bare specifiers to mark external in the `--platform=neutral` page/SSR
+   * pass, so esbuild leaves them unbundled instead of resolving them (the
+   * other #676 escape hatch — externalize a CJS-only dep rather than
+   * resolving it). Appended to the framework-provided externals. Unset/empty
+   * → no extra externals.
+   *
+   * Mirrors `BundleConfig::external` in `crates/zfb/src/config.rs`.
+   */
+  external?: string[];
 };
 
 /**


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/676

---

## Summary

The page/SSR bundler runs esbuild with `--platform=neutral`, whose `mainFields` list is **empty** by default. A dependency resolved purely via `package.json` `main`/`module` (no `exports` map) — e.g. `path-to-regexp@6`, reached transitively via `msw` — therefore fails:

```
✘ Could not resolve "path-to-regexp"
  The "main" field here was ignored. Main fields must be configured explicitly when using the "neutral" platform.
```

The pre-existing `--main-fields=main,module` shim was **React-only**, so Preact projects (e.g. zzmod styleguide-v2) had no way to resolve such deps short of excluding the importing file via `bundle.exclude`.

This implements **requested fix option 1** from #676: expose `mainFields` / `external` knobs for the page/SSR bundler.

## Changes

Two opt-in host config knobs under `bundle`, threaded through **both** `zfb build` and `zfb dev`:

- **`bundle.mainFields`** → `BundlerInput::main_fields` → esbuild `--main-fields=…`. Applies to **every framework** when set (takes precedence over the React shim); resolves CJS-main-only deps.
- **`bundle.external`** → **appended** to `BundlerInput::external` → esbuild `--external:…`. The other escape hatch: externalize a CJS-only dep instead of resolving it.

Mirrors the existing `bundle.exclude` pattern: Rust `BundleConfig` fields + `resolve_bundle_main_fields` / `resolve_bundle_external` helpers + camelCase TS type in `packages/zfb/src/config.ts`.

### Zero-regression / opt-in

- `mainFields` unset → esbuild args **byte-identical** to before for both React (keeps `main,module`) and Preact (emits nothing). esbuild's `--main-fields` only affects packages **without** an `exports` map, so it can only turn a currently-failing resolution into success.
- `external` is **appended** (`extend`), never overwriting framework-required externals.

## Test plan

- New `crates/zfb-build/tests/bundler_main_fields.rs`: negative-control integration tests (hand-rolled CJS-main-only package, the `path-to-regexp@6` shape). Both knobs **fail-without / pass-with**, asserting the dep is actually inlined (`mainFields`) or left as a bare external import (`external`). ✅ 2 passed (real esbuild).
- `crates/zfb/src/config.rs`: deserialization + resolver unit tests. ✅ 11 passed.
- Existing `bundler_exclude_glob` / `migration_fixes_integration_confirm` regression tests still green (opt-in design preserves the Preact-fails-without-knob behavior they assert).
- `cargo check --all-targets`, `cargo clippy -- -D warnings`, `cargo check --no-default-features -p zfb --tests`, `prettier --check` — all clean.

> Note: `zfb check`'s generated config-type shim does not yet include `bundle.*` at all — a pre-existing gap tracked separately as #678, intentionally out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)