### PR TITLE
Admonition Directives: :::caution preset + configurable extraDirectives/extendDefaults (#681)

### DIFF
--- a/crates/zfb-content/src/lib.rs
+++ b/crates/zfb-content/src/lib.rs
@@ -29,7 +29,11 @@ pub use plugins::toc::TocConfig;
 // depend on `zfb-content` (e.g. `zfb-build`, `zfb-render`) can name them when
 // threading `markdown.features` into the feature-aware pipeline constructor,
 // without taking a direct dependency on `zfb-md-ast` / `zfb-md-extras`.
-pub use zfb_md_extras::{FeatureToggle, MarkdownFeaturesConfig};
+pub use zfb_md_extras::{
+    admonitions_preset_enabled, AdmonitionDirectiveFullSpec, AdmonitionDirectiveKind,
+    AdmonitionDirectiveSpec, AdmonitionsPresetFeature, AdmonitionsPresetOptions, FeatureToggle,
+    MarkdownFeaturesConfig, into_directive_def,
+};
 
 pub use frontmatter::{FrontmatterError, UnifiedFrontmatter};
 pub use mdx_jsx_emit::{

--- a/crates/zfb-content/src/pipeline.rs
+++ b/crates/zfb-content/src/pipeline.rs
@@ -958,7 +958,7 @@ pub fn register_features(
     //   HeadingLinksPlugin. Since HeadingLinksPlugin was added first in the
     //   caller's hast chain, any hast visitor appended here runs after it.
 
-    use zfb_md_ast::{feature_enabled, heading_marker_toc_enabled};
+    use zfb_md_ast::{admonitions_preset_enabled, feature_enabled, heading_marker_toc_enabled};
 
     // ── mdast phase ────────────────────────────────────────────────────────
     // transclude MUST run FIRST in the mdast phase — before code_tabs,
@@ -1007,12 +1007,22 @@ pub fn register_features(
         p.add_mdast_visitor(Box::new(zfb_md_extras::ruby::RubyPlugin::new()));
     }
 
-    if feature_enabled(&features.admonitions_preset) {
+    if admonitions_preset_enabled(&features.admonitions_preset) {
         use crate::plugins::directives::DirectiveRegistry;
+        use zfb_md_ast::into_directive_def;
         use zfb_md_extras::admonitions_preset::default_admonition_directives;
+        let opts = features.admonitions_preset.as_ref().unwrap().options();
+        let extend = opts.extend_defaults.unwrap_or(true);
         let mut registry = DirectiveRegistry::new();
-        for def in default_admonition_directives() {
-            registry.register(def);
+        if extend {
+            for def in default_admonition_directives() {
+                registry.register(def);
+            }
+        }
+        if let Some(extra) = &opts.extra_directives {
+            for (name, spec) in extra {
+                registry.register(into_directive_def(name, spec));
+            }
         }
         p.add_mdast_visitor(registry.into_visitor());
     }

--- a/crates/zfb-content/src/plugins/admonitions.rs
+++ b/crates/zfb-content/src/plugins/admonitions.rs
@@ -7,7 +7,7 @@
 //! registry. This file exports:
 //!
 //! - [`AdmonitionsPlugin`] — backwards-compatible visitor that wires up
-//!   the six built-in admonitions, equivalent to constructing
+//!   the seven built-in admonitions, equivalent to constructing
 //!   [`DirectiveRegistry::with_defaults`] and using it as the visitor.
 //!   New code should prefer the registry directly so it can register
 //!   additional directives such as `:::card`, `:::badge`, etc.
@@ -28,7 +28,7 @@ use crate::pipeline::MdastVisitor;
 
 use super::directives::{DirectiveDef, DirectiveRegistry};
 
-/// The six built-in admonition directives.
+/// The seven built-in admonition directives.
 ///
 /// Delegates to [`zfb_md_extras::admonitions_preset::default_admonition_directives`]
 /// which owns the canonical definition since Wave 3 (#570). Kept here for
@@ -39,7 +39,7 @@ pub fn default_admonition_directives() -> Vec<DirectiveDef> {
 }
 
 /// Visitor that converts `:::kind … :::` paragraph runs into
-/// `<Kind>…</Kind>` MDX flow elements for the six built-in admonitions.
+/// `<Kind>…</Kind>` MDX flow elements for the seven built-in admonitions.
 ///
 /// Backwards-compatible facade over
 /// [`DirectiveRegistry::with_defaults`]. New code should prefer using
@@ -78,7 +78,7 @@ pub struct AdmonitionsPlugin {
 }
 
 impl AdmonitionsPlugin {
-    /// New plugin preloaded with the six built-in admonitions.
+    /// New plugin preloaded with the seven built-in admonitions.
     #[must_use]
     pub fn new() -> Self {
         Self {
@@ -249,7 +249,7 @@ mod tests {
 
     #[test]
     fn all_kinds_accept_label_as_title() {
-        // Verify all six built-in admonitions promote [label] → title="…".
+        // Verify all seven built-in admonitions promote [label] → title="…".
         for (key, tag) in [
             ("note", "Note"),
             ("tip", "Tip"),
@@ -257,6 +257,7 @@ mod tests {
             ("danger", "Danger"),
             ("info", "Info"),
             ("details", "Details"),
+            ("caution", "Caution"),
         ] {
             let root = run_root(vec![
                 text_para(&format!(":::{key}[My Label]")),

--- a/crates/zfb-content/src/plugins/directives.rs
+++ b/crates/zfb-content/src/plugins/directives.rs
@@ -97,7 +97,7 @@ impl DirectiveRegistry {
         self.defs.insert(def.name.clone(), def);
     }
 
-    /// Registry preloaded with the six built-in admonitions.
+    /// Registry preloaded with the seven built-in admonitions.
     #[must_use]
     pub fn with_defaults() -> Self {
         let mut r = Self::new();

--- a/crates/zfb-content/tests/directives_typed_attrs.rs
+++ b/crates/zfb-content/tests/directives_typed_attrs.rs
@@ -581,7 +581,7 @@ fn existing_directives_without_schema_compile_and_expand_unchanged() {
 
 #[test]
 fn default_admonitions_no_schema_still_work() {
-    // Guard: the six built-in admonitions (no schema) must still expand
+    // Guard: the seven built-in admonitions (no schema) must still expand
     // without diagnostics after the typed-attrs change.
     let mut reg = DirectiveRegistry::with_defaults();
     let out = run_registry(

--- a/crates/zfb-md-ast/src/features_config.rs
+++ b/crates/zfb-md-ast/src/features_config.rs
@@ -10,7 +10,11 @@
 //! Mirrored 1:1 by `MarkdownFeaturesConfig` and `FeatureToggle` in
 //! `packages/zfb/src/config.ts` for the TypeScript loader.
 
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
+
+use crate::directives::{DirectiveDef, DirectiveKind};
 
 /// Per-feature toggle: `bool` shorthand or a feature-options object.
 ///
@@ -289,6 +293,158 @@ pub fn heading_marker_toc_enabled(toggle: &Option<HeadingMarkerTocFeature>) -> b
     toggle.as_ref().is_some_and(HeadingMarkerTocFeature::is_enabled)
 }
 
+/// Directive kind for user-defined admonition directives.
+///
+/// Maps to [`crate::directives::DirectiveKind`]. A separate serde DTO is
+/// needed because `DirectiveKind` carries no serde derives.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum AdmonitionDirectiveKind {
+    /// Block-level container directive (default).
+    Container,
+    /// Self-closing leaf directive.
+    Leaf,
+    /// Inline text directive.
+    Text,
+}
+
+impl From<AdmonitionDirectiveKind> for DirectiveKind {
+    fn from(k: AdmonitionDirectiveKind) -> Self {
+        match k {
+            AdmonitionDirectiveKind::Container => DirectiveKind::Container,
+            AdmonitionDirectiveKind::Leaf => DirectiveKind::Leaf,
+            AdmonitionDirectiveKind::Text => DirectiveKind::Text,
+        }
+    }
+}
+
+/// Full object form for a user-defined admonition directive.
+///
+/// `deny_unknown_fields` is critical: without it a typo'd field inside the
+/// untagged `AdmonitionDirectiveSpec` enum would silently fall back to
+/// `Short(String)` instead of surfacing the error.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AdmonitionDirectiveFullSpec {
+    /// JSX component identifier (e.g. `"Spoiler"`, `"Kbd"`).
+    pub component: String,
+    /// Container/leaf/text shape. Defaults to `Container` when absent.
+    #[serde(default)]
+    pub kind: Option<AdmonitionDirectiveKind>,
+    /// Whether the bracketed `[label]` is promoted to a `title="…"` attribute.
+    /// Defaults to `true` when absent.
+    #[serde(default)]
+    pub title_from_label: Option<bool>,
+}
+
+/// Spec for one user-defined admonition directive: either a bare component
+/// name string or a full options object.
+///
+/// `serde(untagged)` with `Full` listed first ensures serde tries the object
+/// form before the string — same ordering discipline as [`FeatureToggle`].
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum AdmonitionDirectiveSpec {
+    /// Full options object — kind, title_from_label, component.
+    Full(AdmonitionDirectiveFullSpec),
+    /// Bare component name shorthand (`"Spoiler"`, `"Kbd"`, etc.).
+    Short(String),
+}
+
+/// Options object for the `admonitionsPreset` feature.
+///
+/// `deny_unknown_fields` ensures a typo like `extraDirectivez` is rejected
+/// rather than silently activating the feature with default options.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct AdmonitionsPresetOptions {
+    /// Additional `:::name` → component mappings to register. Registered
+    /// after the standard set (when `extend_defaults` is true) so last-wins
+    /// gives user override on collision.
+    #[serde(default)]
+    pub extra_directives: Option<HashMap<String, AdmonitionDirectiveSpec>>,
+    /// Seed the standard seven directives before `extra_directives`.
+    /// Defaults to `true` when absent.
+    #[serde(default)]
+    pub extend_defaults: Option<bool>,
+}
+
+/// `admonitionsPreset` feature value: either a `bool` shorthand or a full
+/// [`AdmonitionsPresetOptions`] object.
+///
+/// `serde(untagged)` with `Options` listed first ensures serde tries the
+/// object form before the bool — same pattern as [`HeadingMarkerTocFeature`].
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum AdmonitionsPresetFeature {
+    /// Full options object.
+    Options(AdmonitionsPresetOptions),
+    /// Shorthand: `true` = enabled with defaults, `false` = disabled.
+    Bool(bool),
+}
+
+impl AdmonitionsPresetFeature {
+    /// True when the feature should be wired into the pipeline. `Bool(false)`
+    /// is treated as disabled even though it deserialises to `Some(...)`.
+    #[must_use]
+    pub fn is_enabled(&self) -> bool {
+        match self {
+            AdmonitionsPresetFeature::Bool(b) => *b,
+            AdmonitionsPresetFeature::Options(_) => true,
+        }
+    }
+
+    /// Resolve to a concrete [`AdmonitionsPresetOptions`]. `Bool(true)` and
+    /// `Bool(false)` both fall back to defaults; the caller must gate on
+    /// [`Self::is_enabled`] first.
+    #[must_use]
+    pub fn options(&self) -> AdmonitionsPresetOptions {
+        match self {
+            AdmonitionsPresetFeature::Options(opts) => opts.clone(),
+            AdmonitionsPresetFeature::Bool(_) => AdmonitionsPresetOptions::default(),
+        }
+    }
+}
+
+/// Same as [`feature_enabled`] but for the admonitions-preset feature, which
+/// accepts the rich `AdmonitionsPresetOptions` shape via
+/// [`AdmonitionsPresetFeature`].
+#[must_use]
+pub fn admonitions_preset_enabled(toggle: &Option<AdmonitionsPresetFeature>) -> bool {
+    toggle.as_ref().is_some_and(AdmonitionsPresetFeature::is_enabled)
+}
+
+/// Convert a user-supplied [`AdmonitionDirectiveSpec`] into a
+/// [`DirectiveDef`] ready for registration.
+///
+/// - `Short(name)` → Container, `title_from_label = true`.
+/// - `Full { ... }` → kind defaults to Container, `title_from_label`
+///   defaults to `true`. `attrs` is empty in this phase (attrs-via-config
+///   is deferred).
+#[must_use]
+pub fn into_directive_def(name: &str, spec: &AdmonitionDirectiveSpec) -> DirectiveDef {
+    match spec {
+        AdmonitionDirectiveSpec::Short(component) => DirectiveDef {
+            name: name.to_string(),
+            kind: DirectiveKind::Container,
+            component_name: component.clone(),
+            title_from_label: true,
+            attrs: Vec::new(),
+        },
+        AdmonitionDirectiveSpec::Full(full) => DirectiveDef {
+            name: name.to_string(),
+            kind: full
+                .kind
+                .clone()
+                .map(DirectiveKind::from)
+                .unwrap_or(DirectiveKind::Container),
+            component_name: full.component.clone(),
+            title_from_label: full.title_from_label.unwrap_or(true),
+            attrs: Vec::new(),
+        },
+    }
+}
+
 /// Per-feature markdown pipeline configuration.
 ///
 /// Each field corresponds to one pluggable markdown feature. All fields are
@@ -347,8 +503,10 @@ pub struct MarkdownFeaturesConfig {
     pub transclude: Option<TranscludeConfig>,
 
     /// Framework admonitions preset (maps `:::note` etc. to components).
+    /// Accepts `true`/`false` or a full [`AdmonitionsPresetOptions`] object —
+    /// see [`AdmonitionsPresetFeature`].
     #[serde(default)]
-    pub admonitions_preset: Option<FeatureToggle>,
+    pub admonitions_preset: Option<AdmonitionsPresetFeature>,
 
     /// Mermaid diagram rendering.
     #[serde(default)]

--- a/crates/zfb-md-ast/src/lib.rs
+++ b/crates/zfb-md-ast/src/lib.rs
@@ -29,9 +29,12 @@ pub use directives::{
     ValidatedAttrValue,
 };
 pub use features_config::{
-    feature_enabled, heading_marker_toc_enabled, CodeEnrichmentConfig, FeatureOptions,
+    admonitions_preset_enabled, feature_enabled, heading_marker_toc_enabled,
+    AdmonitionDirectiveFullSpec, AdmonitionDirectiveKind, AdmonitionDirectiveSpec,
+    AdmonitionsPresetFeature, AdmonitionsPresetOptions, CodeEnrichmentConfig, FeatureOptions,
     FeatureToggle, GithubAutolinksConfig, HeadingMarkerTocFeature, ImageDimensionsConfig,
     LinkValidationConfig, MarkdownFeaturesConfig, TocConfig, TocExportConfig, TranscludeConfig,
+    into_directive_def,
 };
 pub use hast_text::extract_text;
 

--- a/crates/zfb-md-extras/src/admonitions_preset.rs
+++ b/crates/zfb-md-extras/src/admonitions_preset.rs
@@ -1,8 +1,8 @@
-//! Admonitions preset — the six built-in directive definitions.
+//! Admonitions preset — the seven built-in directive definitions.
 //!
 //! This module owns the *preset list* only: it returns a `Vec<DirectiveDef>`
-//! that registers `note`, `tip`, `warning`, `danger`, `info`, and `details`
-//! as container directives. The actual MDX expansion engine
+//! that registers `note`, `tip`, `warning`, `danger`, `info`, `details`, and
+//! `caution` as container directives. The actual MDX expansion engine
 //! (`DirectiveRegistry` / `AdmonitionsPlugin`) stays in `zfb-content`; this
 //! crate simply produces the preset configuration.
 //!
@@ -25,11 +25,11 @@
 
 use zfb_md_ast::{AttrSchema, AttrType, DirectiveDef, DirectiveKind};
 
-/// The six built-in admonition directives.
+/// The seven built-in admonition directives.
 ///
 /// Returned in the historical match order (`note`, `tip`, `warning`,
-/// `danger`, `info`, `details`) so callers building a registry from
-/// these get a deterministic order. All six have `title_from_label = true`
+/// `danger`, `info`, `details`, `caution`) so callers building a registry
+/// from these get a deterministic order. All seven have `title_from_label = true`
 /// so `:::note[Custom Title]` promotes the bracketed label to a
 /// `title="…"` attribute — matching Docusaurus/Starlight behaviour.
 /// Each one also declares a `title` attr of type `AttrType::String` via
@@ -96,6 +96,14 @@ pub fn default_admonition_directives() -> Vec<DirectiveDef> {
             attrs: Vec::new(),
         }
         .with_attrs(vec![title_attr()]),
+        DirectiveDef {
+            name: "caution".to_string(),
+            kind: DirectiveKind::Container,
+            component_name: "Caution".to_string(),
+            title_from_label: true,
+            attrs: Vec::new(),
+        }
+        .with_attrs(vec![title_attr()]),
     ]
 }
 
@@ -104,9 +112,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn returns_six_directives() {
+    fn returns_seven_directives() {
         let defs = default_admonition_directives();
-        assert_eq!(defs.len(), 6);
+        assert_eq!(defs.len(), 7);
     }
 
     #[test]
@@ -143,7 +151,7 @@ mod tests {
         let names: Vec<&str> = defs.iter().map(|d| d.name.as_str()).collect();
         assert_eq!(
             names,
-            vec!["note", "tip", "warning", "danger", "info", "details"]
+            vec!["note", "tip", "warning", "danger", "info", "details", "caution"]
         );
     }
 }

--- a/crates/zfb-md-extras/src/lib.rs
+++ b/crates/zfb-md-extras/src/lib.rs
@@ -35,8 +35,8 @@ pub mod test_harness;
 
 // ── Wave 3 feature modules (moved from zfb-content in #570) ────────────────
 
-/// Admonitions preset — the six built-in directive definitions (`note`,
-/// `tip`, `warning`, `danger`, `info`, `details`).
+/// Admonitions preset — the seven built-in directive definitions (`note`,
+/// `tip`, `warning`, `danger`, `info`, `details`, `caution`).
 /// Wire via `features.admonitionsPreset = true` in `zfb.config.ts`.
 pub mod admonitions_preset;
 

--- a/crates/zfb-md-extras/src/lib.rs
+++ b/crates/zfb-md-extras/src/lib.rs
@@ -19,9 +19,12 @@
 // in the natural location (this is the "features" crate, after all) without
 // reaching past it for the type.
 pub use zfb_md_ast::{
-    feature_enabled, heading_marker_toc_enabled, CodeEnrichmentConfig, FeatureOptions,
+    admonitions_preset_enabled, feature_enabled, heading_marker_toc_enabled,
+    AdmonitionDirectiveFullSpec, AdmonitionDirectiveKind, AdmonitionDirectiveSpec,
+    AdmonitionsPresetFeature, AdmonitionsPresetOptions, CodeEnrichmentConfig, FeatureOptions,
     FeatureToggle, GithubAutolinksConfig, HeadingMarkerTocFeature, ImageDimensionsConfig,
     LinkValidationConfig, MarkdownFeaturesConfig, TocConfig, TocExportConfig, TranscludeConfig,
+    into_directive_def,
 };
 
 /// Test harness module — `run_fixture` and helpers for fixture-based

--- a/crates/zfb-md-extras/tests/cross_feature_integration.rs
+++ b/crates/zfb-md-extras/tests/cross_feature_integration.rs
@@ -29,9 +29,9 @@ use std::path::PathBuf;
 use zfb_content::pipeline::Pipeline;
 use zfb_content::serializer::serialize;
 use zfb_md_ast::{
-    BuildContext, CodeEnrichmentConfig, FeatureToggle, GithubAutolinksConfig, HeadingMarkerTocFeature,
-    ImageDimensionsConfig, LinkValidationConfig, MarkdownFeaturesConfig, TocConfig, TocExportConfig,
-    TranscludeConfig,
+    AdmonitionsPresetFeature, BuildContext, CodeEnrichmentConfig, FeatureToggle,
+    GithubAutolinksConfig, HeadingMarkerTocFeature, ImageDimensionsConfig, LinkValidationConfig,
+    MarkdownFeaturesConfig, TocConfig, TocExportConfig, TranscludeConfig,
     diagnostics::{CollectingSink, DiagnosticSeverity, MarkdownDiagnostic},
     heading_registry::HeadingRegistry,
 };
@@ -213,7 +213,7 @@ fn image_dimensions_injects_width_and_height() {
 #[test]
 fn admonitions_preset_and_github_alerts_coexist() {
     let features = MarkdownFeaturesConfig {
-        admonitions_preset: Some(FeatureToggle::Bool(true)),
+        admonitions_preset: Some(AdmonitionsPresetFeature::Bool(true)),
         github_alerts: Some(FeatureToggle::Bool(true)),
         ..Default::default()
     };
@@ -390,7 +390,7 @@ fn transclude_cycle_produces_generic_not_broken_link() {
 fn ruby_outside_admonition_works_with_admonitions_enabled() {
     let features = MarkdownFeaturesConfig {
         ruby: Some(FeatureToggle::Bool(true)),
-        admonitions_preset: Some(FeatureToggle::Bool(true)),
+        admonitions_preset: Some(AdmonitionsPresetFeature::Bool(true)),
         ..Default::default()
     };
     let mut pipeline = Pipeline::with_defaults_and_features(&features);
@@ -479,7 +479,7 @@ fn all_features_on_does_not_crash() {
 
     let features = MarkdownFeaturesConfig {
         mermaid: Some(FeatureToggle::Bool(true)),
-        admonitions_preset: Some(FeatureToggle::Bool(true)),
+        admonitions_preset: Some(AdmonitionsPresetFeature::Bool(true)),
         heading_marker_toc: Some(HeadingMarkerTocFeature::Config(TocConfig {
             heading: "TOC".to_string(),
             max_depth: 2,

--- a/crates/zfb-md-extras/tests/cross_feature_integration.rs
+++ b/crates/zfb-md-extras/tests/cross_feature_integration.rs
@@ -23,15 +23,32 @@
 //!    survives wrapping by other plugins.
 //! 8. All 14 features on simultaneously — build must not crash; output must
 //!    contain plausible HTML markers.
+//!
+//! # Configurable admonitions confirm gate (per spec #684)
+//!
+//! 9.  Custom container — `extraDirectives: { spoiler: "Spoiler" }` + `:::spoiler[Hidden]`
+//!     emits `<Spoiler title="Hidden">…</Spoiler>`.
+//! 10. Override (last-wins) — `extraDirectives: { caution: "MyCaution" }` →
+//!     `:::caution` emits `<MyCaution>` (user spec wins on collision).
+//! 11. `extendDefaults: false` — only `extraDirectives` set is active; the
+//!     standard six are dropped, unknown directives produce diagnostics.
+//! 12. Leaf/text via kind — `{ component: "Kbd", kind: "text", titleFromLabel: false }`
+//!     → inline `:kbd[Ctrl+S]` emits `<Kbd>`.
+//! 13. Back-compat — `admonitionsPreset: true` rewrites the original six
+//!     byte-for-byte identically AND `:::caution` → `<Caution>`;
+//!     an unknown directive `:::nope` still yields an unknown-directive diagnostic.
 
+use std::collections::HashMap;
 use std::path::PathBuf;
 
 use zfb_content::pipeline::Pipeline;
+use zfb_content::plugins::DirectiveRegistry;
 use zfb_content::serializer::serialize;
 use zfb_md_ast::{
-    AdmonitionsPresetFeature, BuildContext, CodeEnrichmentConfig, FeatureToggle,
-    GithubAutolinksConfig, HeadingMarkerTocFeature, ImageDimensionsConfig, LinkValidationConfig,
-    MarkdownFeaturesConfig, TocConfig, TocExportConfig, TranscludeConfig,
+    AdmonitionDirectiveFullSpec, AdmonitionDirectiveKind, AdmonitionDirectiveSpec,
+    AdmonitionsPresetFeature, AdmonitionsPresetOptions, BuildContext, CodeEnrichmentConfig,
+    FeatureToggle, GithubAutolinksConfig, HeadingMarkerTocFeature, ImageDimensionsConfig,
+    LinkValidationConfig, MarkdownFeaturesConfig, TocConfig, TocExportConfig, TranscludeConfig,
     diagnostics::{CollectingSink, DiagnosticSeverity, MarkdownDiagnostic},
     heading_registry::HeadingRegistry,
 };
@@ -562,5 +579,287 @@ fn all_features_on_does_not_crash() {
     assert!(
         errors.is_empty(),
         "all-features pipeline must not produce Error diagnostics: {errors:?}"
+    );
+}
+
+// ── Case 9: custom container via extraDirectives ─────────────────────────────
+
+/// `extraDirectives: { spoiler: "Spoiler" }` registers a new container
+/// directive.  `:::spoiler[Hidden]` must emit `<Spoiler title="Hidden">…</Spoiler>`
+/// (Container kind; bracket label promoted to `title`).
+#[test]
+fn admonitions_extra_directive_custom_container() {
+    let mut extra = HashMap::new();
+    extra.insert(
+        "spoiler".to_string(),
+        AdmonitionDirectiveSpec::Short("Spoiler".to_string()),
+    );
+
+    let features = MarkdownFeaturesConfig {
+        admonitions_preset: Some(AdmonitionsPresetFeature::Options(
+            AdmonitionsPresetOptions {
+                extra_directives: Some(extra),
+                extend_defaults: None, // defaults to true
+            },
+        )),
+        ..Default::default()
+    };
+    let mut pipeline = Pipeline::with_defaults_and_features(&features);
+
+    let input = ":::spoiler[Hidden]\n\nSecret content.\n\n:::\n";
+    let hast = pipeline.run(input).expect("pipeline must not fail");
+    let html = serialize(&hast);
+
+    // The custom container must produce the Spoiler JSX component.
+    assert!(
+        html.contains("Spoiler"),
+        "extraDirectives must register Spoiler component: {html}"
+    );
+    // The bracket label must be promoted to the title attribute.
+    assert!(
+        html.contains("title=\"Hidden\""),
+        "bracket label [Hidden] must become title attribute: {html}"
+    );
+    // The body content must appear inside the component.
+    assert!(
+        html.contains("Secret content"),
+        "body content must be preserved inside custom directive: {html}"
+    );
+}
+
+// ── Case 10: override (last-wins) via extraDirectives ────────────────────────
+
+/// When `extraDirectives` includes a key that already exists in the default
+/// preset (e.g. `caution`), the extra definition wins.  `:::caution` must
+/// emit `<MyCaution>` instead of `<Caution>` (user spec overwrites preset).
+#[test]
+fn admonitions_extra_directive_overrides_preset() {
+    let mut extra = HashMap::new();
+    extra.insert(
+        "caution".to_string(),
+        AdmonitionDirectiveSpec::Short("MyCaution".to_string()),
+    );
+
+    let features = MarkdownFeaturesConfig {
+        admonitions_preset: Some(AdmonitionsPresetFeature::Options(
+            AdmonitionsPresetOptions {
+                extra_directives: Some(extra),
+                extend_defaults: None, // defaults to true; preset registers "caution → Caution" first
+            },
+        )),
+        ..Default::default()
+    };
+    let mut pipeline = Pipeline::with_defaults_and_features(&features);
+
+    let input = ":::caution\n\nContent.\n\n:::\n";
+    let hast = pipeline.run(input).expect("pipeline must not fail");
+    let html = serialize(&hast);
+
+    // extraDirectives-provided component must win (last-wins over preset).
+    assert!(
+        html.contains("MyCaution"),
+        "extraDirectives must override preset for caution; expected MyCaution: {html}"
+    );
+    // The OLD preset component must NOT appear — it has been replaced.
+    assert!(
+        !html.contains("<Caution"),
+        "preset Caution component must be replaced by MyCaution: {html}"
+    );
+}
+
+// ── Case 11: extendDefaults:false drops the standard set ─────────────────────
+
+/// With `extendDefaults: false` only the user-supplied `extraDirectives` are
+/// active.  The standard six (`note`, etc.) are NOT rewritten; `:::spoiler`
+/// IS rewritten.
+#[test]
+fn admonitions_extend_defaults_false_drops_standard_set() {
+    let mut extra = HashMap::new();
+    extra.insert(
+        "spoiler".to_string(),
+        AdmonitionDirectiveSpec::Short("Spoiler".to_string()),
+    );
+
+    let features = MarkdownFeaturesConfig {
+        admonitions_preset: Some(AdmonitionsPresetFeature::Options(
+            AdmonitionsPresetOptions {
+                extra_directives: Some(extra),
+                extend_defaults: Some(false), // standard set dropped
+            },
+        )),
+        ..Default::default()
+    };
+    let mut pipeline = Pipeline::with_defaults_and_features(&features);
+
+    // Both a standard directive and the custom one.
+    let input = ":::note\n\nStandard.\n\n:::\n\n:::spoiler\n\nCustom.\n\n:::\n";
+    let hast = pipeline.run(input).expect("pipeline must not fail");
+    let html = serialize(&hast);
+
+    // :::note must NOT be rewritten (standard set dropped).
+    assert!(
+        !html.contains("<Note"),
+        ":::note must NOT be rewritten when extendDefaults=false: {html}"
+    );
+    // Raw :::note paragraph text must be present (not consumed by the registry).
+    assert!(
+        html.contains(":::note"),
+        ":::note text must remain as raw paragraph when extendDefaults=false: {html}"
+    );
+
+    // :::spoiler MUST be rewritten via extraDirectives.
+    assert!(
+        html.contains("Spoiler"),
+        ":::spoiler must be rewritten when it is the only registered directive: {html}"
+    );
+    assert!(
+        html.contains("Custom"),
+        "spoiler body must appear in output: {html}"
+    );
+}
+
+// ── Case 12: Leaf/text via kind ──────────────────────────────────────────────
+
+/// An `extraDirectives` entry with `kind: "text"` and
+/// `titleFromLabel: false` registers an inline text directive.
+/// `:kbd[Ctrl+S]` must emit `<Kbd>Ctrl+S</Kbd>`.
+#[test]
+fn admonitions_extra_directive_text_kind() {
+    let mut extra = HashMap::new();
+    extra.insert(
+        "kbd".to_string(),
+        AdmonitionDirectiveSpec::Full(AdmonitionDirectiveFullSpec {
+            component: "Kbd".to_string(),
+            kind: Some(AdmonitionDirectiveKind::Text),
+            title_from_label: Some(false),
+        }),
+    );
+
+    let features = MarkdownFeaturesConfig {
+        admonitions_preset: Some(AdmonitionsPresetFeature::Options(
+            AdmonitionsPresetOptions {
+                extra_directives: Some(extra),
+                extend_defaults: None,
+            },
+        )),
+        ..Default::default()
+    };
+    let mut pipeline = Pipeline::with_defaults_and_features(&features);
+
+    // Inline text directive — :kbd[Ctrl+S] within a paragraph.
+    let input = "Press :kbd[Ctrl+S] to save.\n";
+    let hast = pipeline.run(input).expect("pipeline must not fail");
+    let html = serialize(&hast);
+
+    // The Kbd JSX element must appear in the output.
+    assert!(
+        html.contains("Kbd"),
+        "text-kind directive must emit Kbd component: {html}"
+    );
+    // The label text must appear as the element's content.
+    assert!(
+        html.contains("Ctrl+S"),
+        "directive label must appear as inner content: {html}"
+    );
+    // The raw :kbd[…] syntax must not leak through.
+    assert!(
+        !html.contains(":kbd["),
+        "raw :kbd[ syntax must not appear in output: {html}"
+    );
+}
+
+// ── Case 13: Back-compat — admonitionsPreset: true ───────────────────────────
+
+/// With `admonitionsPreset: true`:
+/// - The original six (`note`/`tip`/`warning`/`danger`/`info`/`details`)
+///   must be rewritten byte-for-byte identically to the pre-Phase-2 output.
+/// - `:::caution` must resolve to `<Caution>` (the #682 fix is preserved).
+/// - An unknown directive `:::nope` must still yield an unknown-directive
+///   diagnostic from `DirectiveRegistry` (the engine property we kept).
+///
+/// To assert the "six unchanged" direction we run the same document through
+/// both `Pipeline::with_defaults` (the old path) and
+/// `Pipeline::with_defaults_and_features` (the new path) and compare
+/// byte-for-byte.  The `:::caution` assertion is separate.
+#[test]
+fn admonitions_true_back_compat_six_unchanged_caution_works_unknown_diagnostic() {
+    // ── Part A: the original six are byte-for-byte identical ──────────────
+    let six_input = concat!(
+        ":::note\n\nNote body.\n\n:::\n\n",
+        ":::tip\n\nTip body.\n\n:::\n\n",
+        ":::warning\n\nWarning body.\n\n:::\n\n",
+        ":::danger\n\nDanger body.\n\n:::\n\n",
+        ":::info\n\nInfo body.\n\n:::\n\n",
+        ":::details\n\nDetails body.\n\n:::\n",
+    );
+
+    let mut old_pipeline = Pipeline::with_defaults();
+    let old_hast = old_pipeline.run(six_input).expect("old pipeline must not fail");
+    let old_html = serialize(&old_hast);
+
+    let features = MarkdownFeaturesConfig {
+        admonitions_preset: Some(AdmonitionsPresetFeature::Bool(true)),
+        ..Default::default()
+    };
+    let mut new_pipeline = Pipeline::with_defaults_and_features(&features);
+    let new_hast = new_pipeline.run(six_input).expect("new pipeline must not fail");
+    let new_html = serialize(&new_hast);
+
+    assert_eq!(
+        old_html, new_html,
+        "admonitionsPreset=true must be byte-for-byte identical to with_defaults for the \
+         original six directives.\n--- old ---\n{old_html}\n--- new ---\n{new_html}"
+    );
+
+    // Sanity: the six components are actually present in the output.
+    for component in ["Note", "Tip", "Warning", "Danger", "Info", "Details"] {
+        assert!(
+            new_html.contains(component),
+            "admonitionsPreset=true must emit <{component}>: {new_html}"
+        );
+    }
+
+    // ── Part B: :::caution resolves to <Caution> ──────────────────────────
+    let caution_input = ":::caution\n\nCaution content.\n\n:::\n";
+    let hast = new_pipeline.run(caution_input).expect("pipeline must not fail for caution");
+    let caution_html = serialize(&hast);
+
+    assert!(
+        caution_html.contains("Caution"),
+        ":::caution must resolve to <Caution> with admonitionsPreset=true: {caution_html}"
+    );
+    assert!(
+        caution_html.contains("Caution content"),
+        "caution body must be preserved: {caution_html}"
+    );
+
+    // ── Part C: unknown directive :::nope yields a DirectiveDiagnostic ────
+    //
+    // The `DirectiveRegistry` is boxed inside the pipeline and diagnostics are
+    // not surfaced via `Pipeline::run`. We verify this at the registry level
+    // directly, which is the canonical API for diagnostic inspection.
+    let mut registry = DirectiveRegistry::with_defaults();
+    // Use markdown-rs to parse the nope directive, then run the registry visit.
+    let nope_input = ":::nope\n\nUnknown body.\n\n:::\n";
+    let parse_opts = markdown::ParseOptions::mdx();
+    let mut mdast = markdown::to_mdast(nope_input, &parse_opts)
+        .expect("markdown parse must not fail");
+    use zfb_content::pipeline::MdastVisitor;
+    registry.visit(&mut mdast);
+
+    let diags = registry.take_diagnostics();
+    let unknown_diags: Vec<_> = diags
+        .iter()
+        .filter(|d| d.message.contains("nope"))
+        .collect();
+    assert!(
+        !unknown_diags.is_empty(),
+        "DirectiveRegistry must emit an unknown-directive diagnostic for :::nope; \
+         got diags: {diags:?}"
+    );
+    assert!(
+        unknown_diags[0].message.contains("unknown directive"),
+        "diagnostic message must say 'unknown directive'; got: {:?}",
+        unknown_diags[0].message
     );
 }

--- a/crates/zfb-md-extras/tests/github_alerts.rs
+++ b/crates/zfb-md-extras/tests/github_alerts.rs
@@ -12,7 +12,7 @@
 
 use zfb_content::pipeline::Pipeline;
 use zfb_content::serializer::serialize;
-use zfb_md_ast::FeatureToggle;
+use zfb_md_ast::{AdmonitionsPresetFeature, FeatureToggle};
 use zfb_md_extras::{test_harness::run_fixture, MarkdownFeaturesConfig};
 
 /// Build a pipeline with `githubAlerts` set to the given toggle.
@@ -114,7 +114,7 @@ fn disabled_leaves_blockquote_unchanged() {
 fn both_features_on_alert_renders_correctly() {
     let features = MarkdownFeaturesConfig {
         github_alerts: Some(FeatureToggle::Bool(true)),
-        admonitions_preset: Some(FeatureToggle::Bool(true)),
+        admonitions_preset: Some(AdmonitionsPresetFeature::Bool(true)),
         ..Default::default()
     };
     let mut p = Pipeline::with_defaults_and_features(&features);
@@ -135,7 +135,7 @@ fn both_features_on_alert_renders_correctly() {
 #[test]
 fn parity_with_admonitions_single_paragraph() {
     let adm_features = MarkdownFeaturesConfig {
-        admonitions_preset: Some(FeatureToggle::Bool(true)),
+        admonitions_preset: Some(AdmonitionsPresetFeature::Bool(true)),
         ..Default::default()
     };
     let alert_features = MarkdownFeaturesConfig {
@@ -163,7 +163,7 @@ fn parity_with_admonitions_single_paragraph() {
 #[test]
 fn parity_with_admonitions_multiple_paragraphs() {
     let adm_features = MarkdownFeaturesConfig {
-        admonitions_preset: Some(FeatureToggle::Bool(true)),
+        admonitions_preset: Some(AdmonitionsPresetFeature::Bool(true)),
         ..Default::default()
     };
     let alert_features = MarkdownFeaturesConfig {

--- a/crates/zfb-render/tests/mdx_loader.rs
+++ b/crates/zfb-render/tests/mdx_loader.rs
@@ -137,7 +137,7 @@ fn malformed_mdx_yields_compile_error_with_specifier_and_message() {
 #[test]
 fn mdx_admonition_directive_runs_through_pipeline() {
     let features = zfb_content::MarkdownFeaturesConfig {
-        admonitions_preset: Some(zfb_content::FeatureToggle::Bool(true)),
+        admonitions_preset: Some(zfb_content::AdmonitionsPresetFeature::Bool(true)),
         ..Default::default()
     };
     let mut loader = ModuleLoader::with_strip_md_ext_and_gfm_and_cjk_and_features(

--- a/crates/zfb/src/config.rs
+++ b/crates/zfb/src/config.rs
@@ -942,9 +942,11 @@ pub struct MarkdownConfig {
 // like `zfb::config::{MarkdownFeaturesConfig, FeatureToggle, ...}` and
 // `zfb::config::TocConfig` continue to resolve.
 pub use zfb_md_ast::{
-    CodeEnrichmentConfig, FeatureOptions, FeatureToggle, GithubAutolinksConfig,
-    HeadingMarkerTocFeature, ImageDimensionsConfig, LinkValidationConfig, MarkdownFeaturesConfig,
-    TocConfig, TocExportConfig, TranscludeConfig,
+    admonitions_preset_enabled, into_directive_def, AdmonitionDirectiveFullSpec,
+    AdmonitionDirectiveKind, AdmonitionDirectiveSpec, AdmonitionsPresetFeature,
+    AdmonitionsPresetOptions, CodeEnrichmentConfig, FeatureOptions, FeatureToggle,
+    GithubAutolinksConfig, HeadingMarkerTocFeature, ImageDimensionsConfig, LinkValidationConfig,
+    MarkdownFeaturesConfig, TocConfig, TocExportConfig, TranscludeConfig,
 };
 
 /// Options for the `rehype-external-links` port.
@@ -4127,6 +4129,219 @@ mod tests {
             msg.contains("bogus") || msg.contains("unknown field"),
             "error must name the unknown field; got: {msg}"
         );
+    }
+
+    // --- admonitionsPreset round-trip tests ------------------------------------
+
+    // `admonitionsPreset: true` → `AdmonitionsPresetFeature::Bool(true)`.
+    #[test]
+    fn admonitions_preset_bool_true() {
+        let cfg: MarkdownConfig = serde_json::from_value(serde_json::json!({
+            "features": { "admonitionsPreset": true }
+        }))
+        .expect("admonitionsPreset: true deserialises");
+        let features = cfg.features.expect("features present");
+        assert_eq!(
+            features.admonitions_preset,
+            Some(AdmonitionsPresetFeature::Bool(true))
+        );
+    }
+
+    // `admonitionsPreset: false` → `AdmonitionsPresetFeature::Bool(false)`.
+    #[test]
+    fn admonitions_preset_bool_false() {
+        let cfg: MarkdownConfig = serde_json::from_value(serde_json::json!({
+            "features": { "admonitionsPreset": false }
+        }))
+        .expect("admonitionsPreset: false deserialises");
+        let features = cfg.features.expect("features present");
+        assert_eq!(
+            features.admonitions_preset,
+            Some(AdmonitionsPresetFeature::Bool(false))
+        );
+    }
+
+    // `admonitionsPreset: {}` → `Options(AdmonitionsPresetOptions::default())`.
+    #[test]
+    fn admonitions_preset_empty_object() {
+        let cfg: MarkdownConfig = serde_json::from_value(serde_json::json!({
+            "features": { "admonitionsPreset": {} }
+        }))
+        .expect("admonitionsPreset: {} deserialises");
+        let features = cfg.features.expect("features present");
+        assert_eq!(
+            features.admonitions_preset,
+            Some(AdmonitionsPresetFeature::Options(
+                AdmonitionsPresetOptions::default()
+            ))
+        );
+    }
+
+    // `admonitionsPreset: { extraDirectives: {} }` → Options with empty extras.
+    #[test]
+    fn admonitions_preset_object_empty_extra_directives() {
+        let cfg: MarkdownConfig = serde_json::from_value(serde_json::json!({
+            "features": { "admonitionsPreset": { "extraDirectives": {} } }
+        }))
+        .expect("admonitionsPreset: { extraDirectives: {} } deserialises");
+        let features = cfg.features.expect("features present");
+        let opts = match features.admonitions_preset.expect("admonitions_preset present") {
+            AdmonitionsPresetFeature::Options(o) => o,
+            AdmonitionsPresetFeature::Bool(_) => panic!("expected Options variant"),
+        };
+        assert_eq!(
+            opts.extra_directives.as_ref().map(|m| m.len()),
+            Some(0)
+        );
+    }
+
+    // Short-form extra directive: `{ extraDirectives: { caution: "Caution" } }`.
+    #[test]
+    fn admonitions_preset_extra_directive_short_form() {
+        let cfg: MarkdownConfig = serde_json::from_value(serde_json::json!({
+            "features": {
+                "admonitionsPreset": {
+                    "extraDirectives": { "caution": "Caution" }
+                }
+            }
+        }))
+        .expect("short-form extra directive deserialises");
+        let features = cfg.features.expect("features present");
+        let opts = match features.admonitions_preset.expect("admonitions_preset present") {
+            AdmonitionsPresetFeature::Options(o) => o,
+            AdmonitionsPresetFeature::Bool(_) => panic!("expected Options variant"),
+        };
+        let extra = opts.extra_directives.expect("extra_directives present");
+        let spec = extra.get("caution").expect("caution entry present");
+        assert_eq!(
+            spec,
+            &AdmonitionDirectiveSpec::Short("Caution".to_string())
+        );
+    }
+
+    // Full-form extra directive: `{ extraDirectives: { kbd: { component: "Kbd", kind: "text", titleFromLabel: false } } }`.
+    #[test]
+    fn admonitions_preset_extra_directive_full_form() {
+        let cfg: MarkdownConfig = serde_json::from_value(serde_json::json!({
+            "features": {
+                "admonitionsPreset": {
+                    "extraDirectives": {
+                        "kbd": {
+                            "component": "Kbd",
+                            "kind": "text",
+                            "titleFromLabel": false
+                        }
+                    }
+                }
+            }
+        }))
+        .expect("full-form extra directive deserialises");
+        let features = cfg.features.expect("features present");
+        let opts = match features.admonitions_preset.expect("admonitions_preset present") {
+            AdmonitionsPresetFeature::Options(o) => o,
+            AdmonitionsPresetFeature::Bool(_) => panic!("expected Options variant"),
+        };
+        let extra = opts.extra_directives.expect("extra_directives present");
+        let spec = extra.get("kbd").expect("kbd entry present");
+        assert_eq!(
+            spec,
+            &AdmonitionDirectiveSpec::Full(AdmonitionDirectiveFullSpec {
+                component: "Kbd".to_string(),
+                kind: Some(AdmonitionDirectiveKind::Text),
+                title_from_label: Some(false),
+            })
+        );
+    }
+
+    // `deny_unknown_fields` on `AdmonitionsPresetOptions` must reject typo'd
+    // field names like `extraDirectivez`.
+    #[test]
+    fn admonitions_preset_unknown_field_rejected() {
+        let err = serde_json::from_value::<MarkdownConfig>(serde_json::json!({
+            "features": { "admonitionsPreset": { "extraDirectivez": {} } }
+        }))
+        .expect_err("typo'd field in admonitionsPreset options must be rejected");
+        let msg = err.to_string();
+        // With untagged enum serde reports "did not match any variant" for the
+        // outer AdmonitionsPresetFeature; the field-name detail is swallowed.
+        assert!(
+            msg.contains("extraDirectivez")
+                || msg.contains("unknown field")
+                || msg.contains("variant")
+                || msg.contains("AdmonitionsPreset"),
+            "error must indicate a rejection of the typo'd field; got: {msg}"
+        );
+    }
+
+    // Untagged ordering: an object must parse as Options(...), not Bool(_).
+    #[test]
+    fn admonitions_preset_untagged_object_is_options_variant() {
+        let feature: AdmonitionsPresetFeature =
+            serde_json::from_value(serde_json::json!({})).expect("empty object deserialises");
+        assert!(
+            matches!(feature, AdmonitionsPresetFeature::Options(_)),
+            "empty object must parse as Options variant"
+        );
+    }
+
+    // Untagged ordering: a bare bool must parse as Bool(_).
+    #[test]
+    fn admonitions_preset_untagged_bool_is_bool_variant() {
+        let feature: AdmonitionsPresetFeature =
+            serde_json::from_value(serde_json::json!(true)).expect("bool deserialises");
+        assert!(
+            matches!(feature, AdmonitionsPresetFeature::Bool(true)),
+            "bool must parse as Bool variant"
+        );
+    }
+
+    // `into_directive_def` conversion — Short form.
+    #[test]
+    fn into_directive_def_short_form() {
+        use zfb_md_ast::{into_directive_def, AdmonitionDirectiveSpec, DirectiveKind};
+        let spec = AdmonitionDirectiveSpec::Short("Spoiler".to_string());
+        let def = into_directive_def("spoiler", &spec);
+        assert_eq!(def.name, "spoiler");
+        assert_eq!(def.component_name, "Spoiler");
+        assert_eq!(def.kind, DirectiveKind::Container);
+        assert!(def.title_from_label);
+        assert!(def.attrs.is_empty());
+    }
+
+    // `into_directive_def` conversion — Full form with explicit kind + titleFromLabel.
+    #[test]
+    fn into_directive_def_full_form() {
+        use zfb_md_ast::{
+            into_directive_def, AdmonitionDirectiveFullSpec, AdmonitionDirectiveKind,
+            AdmonitionDirectiveSpec, DirectiveKind,
+        };
+        let spec = AdmonitionDirectiveSpec::Full(AdmonitionDirectiveFullSpec {
+            component: "Kbd".to_string(),
+            kind: Some(AdmonitionDirectiveKind::Text),
+            title_from_label: Some(false),
+        });
+        let def = into_directive_def("kbd", &spec);
+        assert_eq!(def.name, "kbd");
+        assert_eq!(def.component_name, "Kbd");
+        assert_eq!(def.kind, DirectiveKind::Text);
+        assert!(!def.title_from_label);
+        assert!(def.attrs.is_empty());
+    }
+
+    // `into_directive_def` conversion — Full form with defaults (no kind, no titleFromLabel).
+    #[test]
+    fn into_directive_def_full_form_defaults() {
+        use zfb_md_ast::{
+            into_directive_def, AdmonitionDirectiveFullSpec, AdmonitionDirectiveSpec, DirectiveKind,
+        };
+        let spec = AdmonitionDirectiveSpec::Full(AdmonitionDirectiveFullSpec {
+            component: "MyBlock".to_string(),
+            kind: None,
+            title_from_label: None,
+        });
+        let def = into_directive_def("my-block", &spec);
+        assert_eq!(def.kind, DirectiveKind::Container);
+        assert!(def.title_from_label); // default true
     }
 
     // --- output_bounded tests ---------------------------------------------------

--- a/docs/src/content/docs/concepts/custom-directives.mdx
+++ b/docs/src/content/docs/concepts/custom-directives.mdx
@@ -22,11 +22,11 @@ a JSX component, and the pipeline rewrites matching paragraphs into
 
 The shapes follow the
 [CommonMark Directives proposal](https://talk.commonmark.org/t/generic-directives-plugins-syntax/444):
-container, leaf, and text. zfb's six built-in admonitions
+container, leaf, and text. zfb's seven built-in admonitions
 (`:::note`, `:::tip`, `:::info`, `:::warning`, `:::danger`,
-`:::details`) are themselves registered through the same registry
-via `Pipeline::with_defaults()` — the registry is the only mechanism,
-and the defaults aren't privileged.
+`:::details`, `:::caution`) are themselves registered through the same
+registry via `Pipeline::with_defaults()` — the registry is the only
+mechanism, and the defaults aren't privileged.
 
 ## The three directive shapes
 
@@ -127,7 +127,7 @@ ordinary MDX-component plumbing.
 <Note>
 
 `Pipeline::with_defaults()` is your starting point — it pre-registers
-the six built-in admonitions and wires the standard plugin set
+the seven built-in admonitions and wires the standard plugin set
 (syntect highlighting, heading links, etc.). You can also start from
 `DirectiveRegistry::new()` if you want a clean slate, but the
 defaults are designed to be additive, not opinionated.
@@ -291,7 +291,7 @@ identically.
   The engine validates against the `AttrSchema` you declare (type + enum
   values). TypeScript typing on the JSX component side is still your
   responsibility.
-- **Provide a default directive set beyond the six admonitions.** No
+- **Provide a default directive set beyond the seven admonitions.** No
   built-in `:::callout`, `:::card`, `::youtube`, etc. — every framework
   picks its own.
 - **Auto-import the JSX components.** You're responsible for making

--- a/docs/src/content/docs/markdown-features/admonitions-preset.mdx
+++ b/docs/src/content/docs/markdown-features/admonitions-preset.mdx
@@ -1,10 +1,10 @@
 ---
 title: Admonitions preset
-description: Enable the six built-in admonition directive types (note, tip, warning, danger, info, details).
+description: Enable the seven built-in admonition directive types (note, tip, warning, danger, info, details, caution) and register your own.
 tier: Opt-in
 ---
 
-The `admonitionsPreset` feature registers the six built-in admonition directive types: `note`, `tip`, `warning`, `danger`, `info`, and `details`.
+The `admonitionsPreset` feature registers the seven built-in admonition directive types: `note`, `tip`, `warning`, `danger`, `info`, `details`, and `caution`. It also accepts an object form to register project-specific directives and optionally suppress the defaults.
 
 ## Enable
 
@@ -43,7 +43,7 @@ Warning body text.
 :::
 ```
 
-All six kinds: `note`, `tip`, `warning`, `danger`, `info`, `details`.
+All seven kinds: `note`, `tip`, `warning`, `danger`, `info`, `details`, `caution`.
 
 The bracketed `[label]` is promoted to a `title="…"` attribute on the emitted JSX element:
 
@@ -65,6 +65,121 @@ Hidden content.
 
 Each fence line (`:::note` and the closing `:::`) **must** be separated from surrounding content by blank lines so the Markdown parser treats them as separate paragraphs. Without blank lines the content is not recognised as a directive and a warning diagnostic is emitted at build time.
 
-## Custom directives
+## Registering your own directives
 
-To register additional directives (e.g. `:::card`) or override the built-ins, use `DirectiveRegistry` directly via the pipeline API instead of this preset.
+Pass an options object instead of `true` to add project-specific `:::name` directives or replace built-ins.
+
+### Short form — bare component name
+
+The simplest entry maps a directive name to a component identifier string. The directive is registered as a container with `title_from_label: true` (the `[label]` becomes a `title="…"` attribute).
+
+```ts
+// zfb.config.ts
+export default defineConfig({
+  markdown: {
+    features: {
+      admonitionsPreset: {
+        extraDirectives: {
+          spoiler: "Spoiler",
+        },
+      },
+    },
+  },
+});
+```
+
+`:::spoiler` in Markdown now emits `<Spoiler>`.
+
+### Object value form — full spec
+
+Use an object value to control the directive shape (`container`, `leaf`, or `text`) and whether the bracketed label becomes a `title` attribute.
+
+```ts
+// zfb.config.ts
+export default defineConfig({
+  markdown: {
+    features: {
+      admonitionsPreset: {
+        extraDirectives: {
+          kbd: {
+            component: "Kbd",
+            kind: "text",
+            titleFromLabel: false,
+          },
+        },
+      },
+    },
+  },
+});
+```
+
+`:kbd[Ctrl+C]` in Markdown emits `<Kbd>Ctrl+C</Kbd>`.
+
+### Overriding a built-in
+
+`extraDirectives` entries are registered after the standard seven, so a name collision replaces the built-in:
+
+```ts
+// zfb.config.ts
+export default defineConfig({
+  markdown: {
+    features: {
+      admonitionsPreset: {
+        extraDirectives: {
+          caution: "MyCaution",
+        },
+      },
+    },
+  },
+});
+```
+
+`:::caution` now emits `<MyCaution>` instead of `<Caution>`.
+
+### Suppressing the built-ins entirely
+
+Set `extendDefaults: false` to skip the standard seven and register only what you declare:
+
+```ts
+// zfb.config.ts
+export default defineConfig({
+  markdown: {
+    features: {
+      admonitionsPreset: {
+        extendDefaults: false,
+        extraDirectives: {
+          callout: "Callout",
+          aside: "Aside",
+        },
+      },
+    },
+  },
+});
+```
+
+Only `:::callout` and `:::aside` are registered. None of the standard seven kinds work.
+
+### Important: registering a directive does not provide a component
+
+zfb is framework-agnostic and ships no admonition React (or other) components. Registering a directive only tells the pipeline to emit `<ComponentName>` in compiled MDX. You must:
+
+1. Author the component yourself (e.g. in `_mdx-components.ts`).
+2. Add it to your project's [MDX components map](/concepts/mdx-components).
+3. Style it with your own CSS.
+
+### Casing and verbatim emit
+
+The value you supply (`"Spoiler"`, `"MyCaution"`, `"Kbd"`) is the JSX component identifier emitted verbatim — there is no auto-PascalCasing and no validation. `caution: "Caution"` emits `<Caution>`; `caution: "my-caution"` emits `<my-caution>` (a DOM element, likely not what you want).
+
+The directive-name key follows the directive grammar `[A-Za-z_][A-Za-z0-9_-]*`. A key that does not match this pattern will simply never match any `:::name` in source.
+
+<Note>
+
+The object value form (`{ component, kind, titleFromLabel }`) is forward-compatible with a planned top-level generic `directives` feature that will unify all directive registrations in one place. No migration will be needed.
+
+</Note>
+
+## See also
+
+- [Directives registry](/markdown-features/directives-registry) — the underlying Core primitive.
+- [Custom Directives](/concepts/custom-directives) — register directives via the Rust pipeline API.

--- a/docs/src/content/docs/markdown-features/directives-registry.mdx
+++ b/docs/src/content/docs/markdown-features/directives-registry.mdx
@@ -14,9 +14,9 @@ It is always active. You interact with it in two ways:
 - **Consuming the registry** — register your own directive names from a
   project-side config without writing Rust. See
   [Custom Directives](/concepts/custom-directives).
-- **Using the built-in preset** — enable the six bundled admonition
-  directive types (`note`, `tip`, `warning`, `danger`, `info`, `details`)
-  via the opt-in `admonitionsPreset` feature described below.
+- **Using the built-in preset** — enable the seven bundled admonition
+  directive types (`note`, `tip`, `warning`, `danger`, `info`, `details`,
+  `caution`) via the opt-in `admonitionsPreset` feature described below.
 
 ## Directive shapes
 
@@ -30,7 +30,7 @@ The registry handles three directive shapes:
 
 ## Admonitions preset
 
-The six built-in admonition types are opt-in — they are not registered by
+The seven built-in admonition types are opt-in — they are not registered by
 default. Enable them in `zfb.config.ts`:
 
 ```ts title="zfb.config.ts"
@@ -74,6 +74,6 @@ that does not require writing Rust.
 - [Custom Directives](/concepts/custom-directives) — register new
   `:::name` / `::name` / `:name` directive names.
 - [Admonitions preset](/markdown-features/admonitions-preset) — opt-in
-  preset of six built-in admonition types.
+  preset of seven built-in admonition types.
 - [Extending the Markdown Pipeline](/guides/extending-the-markdown-pipeline)
   — engine-side extension surface.

--- a/docs/src/content/docs/markdown-features/index.mdx
+++ b/docs/src/content/docs/markdown-features/index.mdx
@@ -68,7 +68,7 @@ These always-on plugins ship as part of `zfb-content`'s default pipeline.
 
 Enable each in `markdown.features.*`. All live in `zfb-md-extras`.
 
-- [Admonitions preset](/markdown-features/admonitions-preset) — the six built-in admonition directive types (`note`, `tip`, `warning`, `danger`, `info`, `details`).
+- [Admonitions preset](/markdown-features/admonitions-preset) — the seven built-in admonition directive types (`note`, `tip`, `warning`, `danger`, `info`, `details`, `caution`) plus project-specific directives.
 - [Mermaid diagrams](/markdown-features/mermaid) — renders Mermaid flowcharts from fenced code blocks.
 - [Heading-marker TOC](/markdown-features/heading-marker-toc) — auto-inserts a table of contents after a designated heading.
 - [GitHub alerts](/markdown-features/github-alerts) — renders `> [!NOTE]` / `> [!WARNING]` blockquotes as styled components.

--- a/packages/zfb/src/config.ts
+++ b/packages/zfb/src/config.ts
@@ -714,8 +714,14 @@ export type MarkdownFeaturesConfig = {
   /** Transclusion of other MDX files (`![[path]]` syntax). */
   transclude?: TranscludeConfig;
 
-  /** Framework admonitions preset (maps `:::note` etc. to components). */
-  admonitionsPreset?: FeatureToggle;
+  /**
+   * Framework admonitions preset (maps `:::note` etc. to components). Accepts
+   * a `boolean` shorthand (`true` = enable with the standard seven directives,
+   * `false` = disable) or a full {@link AdmonitionsPresetOptions} object to
+   * register custom `:::name` → component mappings and optionally suppress the
+   * standard set via `extendDefaults: false`.
+   */
+  admonitionsPreset?: AdmonitionsPresetFeature;
 
   /** Mermaid diagram rendering. */
   mermaid?: FeatureToggle;
@@ -736,6 +742,50 @@ export type MarkdownFeaturesConfig = {
  * Mirrors `HeadingMarkerTocFeature` in crates/zfb-md-ast/src/features_config.rs.
  */
 export type HeadingMarkerTocFeature = boolean | TocConfig;
+
+/**
+ * Spec for one user-defined admonition directive: either a bare component
+ * name string or a full options object.
+ *
+ * Mirrors `AdmonitionDirectiveSpec` in crates/zfb-md-ast/src/features_config.rs.
+ */
+export type AdmonitionDirectiveSpec =
+  | string
+  | {
+      /** JSX component identifier (e.g. `"Spoiler"`, `"Kbd"`). */
+      component: string;
+      /** Container/leaf/text shape. Defaults to `"container"` when absent. */
+      kind?: "container" | "leaf" | "text";
+      /** Whether the bracketed `[label]` becomes a `title` attribute. Defaults to `true`. */
+      titleFromLabel?: boolean;
+    };
+
+/**
+ * Options object for the `admonitionsPreset` feature.
+ *
+ * Mirrors `AdmonitionsPresetOptions` in crates/zfb-md-ast/src/features_config.rs.
+ */
+export type AdmonitionsPresetOptions = {
+  /**
+   * Additional `:::name` → component mappings to register. Registered after
+   * the standard set (when `extendDefaults` is `true`) so user entries win
+   * on name collision.
+   */
+  extraDirectives?: Record<string, AdmonitionDirectiveSpec>;
+  /**
+   * Seed the standard seven directives before `extraDirectives`.
+   * Defaults to `true` when absent.
+   */
+  extendDefaults?: boolean;
+};
+
+/**
+ * `admonitionsPreset` feature value: either a `boolean` shorthand or a
+ * full {@link AdmonitionsPresetOptions} object.
+ *
+ * Mirrors `AdmonitionsPresetFeature` in crates/zfb-md-ast/src/features_config.rs.
+ */
+export type AdmonitionsPresetFeature = boolean | AdmonitionsPresetOptions;
 
 /**
  * Options for the external-link rewriter (port of `rehype-external-links`).


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/681

---

## Summary

Makes zfb's markdown admonition directives **user-extensible** instead of a fixed set of six. Implements epic #681 (origin: upstream-tracking zudolab/zudo-doc#1831). Two phases compose through the same `DirectiveRegistry`.

### Phase 1 — `:::caution` → `<Caution>` (#682)
- Adds a 7th built-in admonition directive (`caution` → `Caution`, Container, `title_from_label=true`) to `default_admonition_directives()`, mirroring the existing six.
- Closes the literal upstream bug (`:::caution` rendered as raw text) and fixes the asymmetry where `githubAlerts` already mapped `> [!CAUTION]` → `<Caution>` but the directive did not.

### Phase 2 — configurable `admonitionsPreset` (#683)
- `markdown.features.admonitionsPreset` changes from on/off-only (`FeatureToggle`) to a `bool | object` feature (`AdmonitionsPresetFeature`), modeled byte-for-byte on the existing `HeadingMarkerTocFeature` (untagged serde enum, `Options` variant first, `deny_unknown_fields`).
- Object form carries `extraDirectives` (a `name → component` map; value is either a bare component string or `{ component, kind?, titleFromLabel? }`) and `extendDefaults` (default `true`).
- Wired presets-first → `extraDirectives`-second into one registry, so `register()`'s last-wins semantics give **user-override-on-collision** for free.
- Decisions baked in: override standard set = yes; validation = permissive (component names emitted verbatim, no lint); leaf/text via `kind` = yes; typed-attrs-via-config and a generic top-level `directives` feature = **deferred** (the object value form is forward-compatible into them).
- Updated all three re-export surfaces + the 7 struct-literal test sites for the field-type swap; TS config types mirror the Rust serde shape 1:1.

### Phase 2 — confirm (#684) + docs (#685)
- 5 new pipeline integration tests (custom container, last-wins override, `extendDefaults:false`, text-`kind` inline, and explicit back-compat: the original six unchanged + `caution` now resolves + unknown-directive diagnostics preserved).
- Docs updated across `admonitions-preset.mdx`, `directives-registry.mdx`, `custom-directives.mdx`, `index.mdx` (seven built-ins + the configurable form, plus the "registering a directive ≠ providing a component" and verbatim-casing notes).

## Test plan
- `cargo test` green across `zfb-md-ast`, `zfb-md-extras` (incl. 13 `cross_feature_integration` cases), `zfb-content`, `zfb-render`, `zfb` (12 new serde/conversion tests).
- `cargo build -p zfb` clean; `packages/zfb` TS typecheck (`tsc --noEmit`) passes.
- Astro docs site build clean (205 pages).
- CI green on this PR (binary builds, docs site, preview deploy, no-v8 build, health, audit).

## Back-compat
`admonitionsPreset: true` behaves identically for the original six; only addition is `caution`. The field-type change is contained (no external API breakage beyond the in-repo call sites updated here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)