### PR TITLE
ci(health): free runner disk before V8 build to prevent 'No space left on device' (#687)

### DIFF
--- a/.github/workflows/health.yml
+++ b/.github/workflows/health.yml
@@ -31,6 +31,30 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
+      # Free runner disk BEFORE the rust-cache restore + V8 first-compile (issue
+      # #687). rusty_v8 / deno_core produces a multi-GB target/; combined with the
+      # restored Swatinem cache it can exhaust the ~14 GB ubuntu-latest disk
+      # ("No space left on device", seen on 8a46936 during the #686 merge — infra
+      # flake, not a code regression). Reclaim ~15-20 GB by removing preinstalled
+      # toolchains this job never uses (Android SDK, .NET, Haskell, CodeQL) plus
+      # the Docker image cache. Done with plain `sudo rm -rf` rather than a
+      # third-party action to preserve this workflow's SHA-pinned-`uses` /
+      # least-privilege posture (see the pin-update header). Scoped to `health`
+      # only — the build-no-v8 job has no V8 to compile and stays light. Pure
+      # infra hardening: no build/test/lint behavior changes.
+      - name: Free disk space for V8 build (issue #687)
+        run: |
+          echo "Disk before cleanup:"
+          df -h /
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /opt/ghc /usr/local/.ghcup || true
+          sudo rm -rf /opt/hostedtoolcache/CodeQL || true
+          sudo docker image prune --all --force || true
+          sudo apt-get clean || true
+          echo "Disk after cleanup:"
+          df -h /
+
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/687

---

## Summary

The `health` job's `cargo build --workspace --all-targets` triggers the rusty_v8 / deno_core first-compile, whose multi-GB `target/` — combined with the restored Swatinem cache — can exhaust the ~14 GB ubuntu-latest runner disk, failing with `No space left on device`. This was observed once on `8a46936` during the #686 merge (an infra flake, not a code regression; `health` has been green on the 3 subsequent `main` commits). This PR hardens against that latent, recurring risk.

## Changes

- `.github/workflows/health.yml`: add a **"Free disk space for V8 build"** step to the `health` job, placed right after `actions/checkout` and **before** the Swatinem rust-cache restore + the heavy `cargo build`. It reclaims ~15–20 GB by removing preinstalled toolchains the job never uses — Android SDK (`/usr/local/lib/android`), .NET (`/usr/share/dotnet`), Haskell (`/opt/ghc`, `/usr/local/.ghcup`), and CodeQL (`/opt/hostedtoolcache/CodeQL`) — plus `docker image prune` and `apt-get clean`. Each removal is guarded with `|| true` and brackets with `df -h /` for log visibility.

### Design notes

- **No third-party action.** Implemented with plain `sudo rm -rf` to preserve this workflow's SHA-pinned-`uses` / least-privilege posture (see the file's pin-update header). A community `free-disk-space` action would add an unpinned dependency.
- **Only `/opt/hostedtoolcache/CodeQL` is removed, not the whole tool cache** — so `actions/setup-node`'s Node install (which lands elsewhere under the tool cache) is untouched.
- **Scoped to the `health` job only.** `build-no-v8` has no V8 to compile and stays light.
- Pure CI-infra hardening: **no build / test / lint behavior change.**

## Test Plan

- `actionlint` (runs in-job) validates the workflow YAML; locally confirmed the file parses and only the `health` job's step list changed.
- All PR checks (`health`, `build (no-v8)`, `actionlint`, docs, audits) must pass.
- The reclaimed headroom is verified at runtime by the bracketing `df -h /` output in the step log.

Closes #687