### PR TITLE
review-sweep: fix 25 adversarially-verified review findings

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -88,11 +88,12 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    env:
+      IFTTT_PROD_NOTIFY: ${{ secrets.IFTTT_PROD_NOTIFY }}
     steps:
       - name: Notify via IFTTT
         if: env.IFTTT_PROD_NOTIFY != ''
         env:
-          IFTTT_PROD_NOTIFY: ${{ secrets.IFTTT_PROD_NOTIFY }}
           RAW_COMMIT_MSG: ${{ github.event.head_commit.message }}
           BUILD_RESULT: ${{ needs.build.result }}
           DEPLOY_RESULT: ${{ needs.deploy.result }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -432,10 +432,11 @@ jobs:
           # Determine prerelease flag from the tag name.
           TAG="${GITHUB_REF#refs/tags/}"
           if [[ "$TAG" =~ -next\. ]] || [[ "$TAG" =~ -beta\. ]] || [[ "$TAG" =~ -rc\. ]]; then
-            echo "IS_PRERELEASE=true" >> "$GITHUB_ENV"
+            IS_PRERELEASE=true
           else
-            echo "IS_PRERELEASE=false" >> "$GITHUB_ENV"
+            IS_PRERELEASE=false
           fi
+          echo "IS_PRERELEASE=$IS_PRERELEASE" >> "$GITHUB_ENV"
           echo "Tag: $TAG | semver: $ZFB_SEMVER | prerelease: $IS_PRERELEASE"
 
       - name: Download all archives

--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -2050,7 +2050,14 @@ fn materialise_shadow(
             }
         }
         // Negate static_count so higher static count → lower (earlier) key.
-        (-static_count, dynamic_count, catchall_count)
+        // Add catchall_count into the dynamic bucket so catchall segments sort
+        // after plain dynamic at equal static depth (e.g. /docs/[...slug] after
+        // /docs/[id]), preserving the invariant documented at line 2022.
+        (
+            -static_count,
+            dynamic_count + catchall_count,
+            catchall_count,
+        )
     }
     routes.sort_by(|a, b| {
         let ka = route_sort_key(&a.route);
@@ -5906,6 +5913,63 @@ mod tests {
         assert!(
             idx("/docs/[...slug]") < idx("/[lang]/[slug]"),
             "/docs/[...slug] should be before /[lang]/[slug]"
+        );
+    }
+
+    #[test]
+    fn route_sort_catchall_after_plain_dynamic_at_equal_static_depth() {
+        use std::collections::BTreeMap;
+        use tempfile::TempDir;
+
+        // Verify that a plain dynamic segment sorts before a catchall at the
+        // same static depth — i.e. /docs/[id] before /docs/[...slug].
+        // This is the invariant documented in route_sort_key ("Catchall (rest)
+        // segments always sort after plain dynamic ones").
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let pages = root.join("pages");
+        for d in ["pages", "pages/docs"] {
+            fs::create_dir_all(root.join(d)).unwrap();
+        }
+        let stub = "export default function P() { return null; }\n";
+        for f in ["pages/docs/[id].tsx", "pages/docs/[...slug].tsx"] {
+            fs::write(root.join(f), stub).unwrap();
+        }
+        let mut routes = Vec::new();
+        let shadow_pages_dest = root.join("shadow").join("pages");
+        materialise_shadow(
+            &pages,
+            &shadow_pages_dest,
+            &mut routes,
+            &root,
+            false,
+            None,
+            None,
+            None,
+            zfb_content::ResolvedGfmConstructs::default(),
+            None,
+            None,
+            true,
+            false,
+            None,
+            &no_bundle_exclude(),
+            false,
+            &mut Vec::new(),
+        )
+        .unwrap();
+
+        let order: BTreeMap<&str, usize> = routes
+            .iter()
+            .enumerate()
+            .map(|(i, r)| (r.route.as_str(), i))
+            .collect();
+
+        let idx = |r: &str| *order.get(r).unwrap_or_else(|| panic!("missing route {r}"));
+
+        // Plain dynamic must come before catchall at equal static depth.
+        assert!(
+            idx("/docs/[id]") < idx("/docs/[...slug]"),
+            "/docs/[id] should be registered before /docs/[...slug]"
         );
     }
 

--- a/crates/zfb-build/tests/integration_dev_loop.rs
+++ b/crates/zfb-build/tests/integration_dev_loop.rs
@@ -384,12 +384,11 @@ async fn touching_md_via_real_watcher_triggers_one_page_rebuild() {
     assert!(html_path.exists());
     assert_eq!(std::fs::read_to_string(&html_path).unwrap(), "<h1>v2</h1>");
 
-    // Drop the watcher to stop the OS-level watch. We deliberately do
-    // not call `Watcher::shutdown` here — that path awaits the bridge
-    // task which will not exit until `_notify` itself is dropped, so
-    // the test would hang. Drop is the path used in production
-    // (`BuildOrchestrator::run` ends by dropping its watcher), so this
-    // also matches the real shutdown ordering.
+    // Drop the watcher to stop the OS-level watch. `Watcher::shutdown` is
+    // now safe to call (the circular-wait deadlock was fixed in #708/#759
+    // and is covered by a timeout-guarded test in zfb-watcher), but we keep
+    // `drop` here because it matches the production shutdown path
+    // (`BuildOrchestrator::run` ends by dropping its watcher).
     drop(watcher);
 }
 

--- a/crates/zfb-content/src/plugins/cjk_friendly.rs
+++ b/crates/zfb-content/src/plugins/cjk_friendly.rs
@@ -734,10 +734,8 @@ mod tests {
         }
         fn walk_inner(n: &MdastNode, found: &mut bool) {
             match n {
-                MdastNode::Text(t) => {
-                    if t.value.contains("**重要。**") {
-                        *found = true;
-                    }
+                MdastNode::Text(t) if t.value.contains("**重要。**") => {
+                    *found = true;
                 }
                 MdastNode::Paragraph(p) => {
                     for c in &p.children {

--- a/crates/zfb-css/src/engine.rs
+++ b/crates/zfb-css/src/engine.rs
@@ -238,11 +238,7 @@ impl TailwindSubprocessConfig {
     /// `handle` is wrapped in [`Arc`] so the surrounding
     /// `#[derive(Clone)]` keeps working — `tempfile::TempDir` is not
     /// itself `Clone`.
-    pub fn with_embedded_binary(
-        mut self,
-        handle: tempfile::TempDir,
-        path: PathBuf,
-    ) -> Self {
+    pub fn with_embedded_binary(mut self, handle: tempfile::TempDir, path: PathBuf) -> Self {
         if std::env::var_os("ZFB_TAILWIND_BIN").is_some() {
             // Env tier already won — drop the handle on the floor and
             // leave `binary_path` pointing at the env value.
@@ -253,6 +249,93 @@ impl TailwindSubprocessConfig {
         self._embedded_handle = Some(Arc::new(handle));
         self
     }
+}
+
+/// Append a single `@source "<escaped_value>";\n` directive to `out`.
+///
+/// Only `"` and `\` need escaping in a CSS string literal; glob
+/// metacharacters (`*`, `{`, `}`, etc.) are left untouched because
+/// Tailwind v4 interprets them as glob syntax inside the `@source`
+/// value — escaping them would break pattern expansion.
+fn push_escaped_source(out: &mut String, value: &str) {
+    out.push_str("@source \"");
+    for c in value.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            _ => out.push(c),
+        }
+    }
+    out.push_str("\";\n");
+}
+
+/// Strip CSS block comments (`/* … */`) and line comments (`//…`) from
+/// `text` so that import-detection is not fooled by commented-out directives.
+///
+/// The algorithm is a byte state machine matching the one in
+/// `scanner.rs::extract_module_css_specifiers`: string literals (delimited
+/// by `"`, `'`, or `` ` ``) take precedence over comment scanning so that
+/// `/*` inside a string is treated as literal text, not a comment start.
+/// Only the "active" (uncommented) characters are returned.
+fn strip_css_comments(text: &str) -> String {
+    let bytes = text.as_bytes();
+    let mut out = String::with_capacity(text.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        // String literals: copy verbatim so `/*` inside a string isn't
+        // mistaken for a comment open.
+        if b == b'"' || b == b'\'' || b == b'`' {
+            let quote = b;
+            out.push(b as char);
+            i += 1;
+            while i < bytes.len() {
+                let c = bytes[i];
+                out.push(c as char);
+                if c == b'\\' && i + 1 < bytes.len() {
+                    i += 1;
+                    out.push(bytes[i] as char);
+                    i += 1;
+                    continue;
+                }
+                if c == b'\n' || c == quote {
+                    i += 1;
+                    break;
+                }
+                i += 1;
+            }
+        } else if b == b'/' && i + 1 < bytes.len() {
+            let next = bytes[i + 1];
+            if next == b'/' {
+                // Line comment: skip until newline (keep the newline so
+                // line numbers are preserved for any downstream tool).
+                i += 2;
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+            } else if next == b'*' {
+                // Block comment: skip until `*/`.
+                i += 2;
+                while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                    // Preserve newlines so multiline comments don't collapse
+                    // adjacent lines together (prevents false `@import`
+                    // detection across line boundaries).
+                    if bytes[i] == b'\n' {
+                        out.push('\n');
+                    }
+                    i += 1;
+                }
+                i = i.saturating_add(2); // consume `*/`
+            } else {
+                out.push(b as char);
+                i += 1;
+            }
+        } else {
+            out.push(b as char);
+            i += 1;
+        }
+    }
+    out
 }
 
 /// Build the synthesised entry CSS that the engine hands to Tailwind v4.
@@ -284,17 +367,22 @@ pub fn build_synthesised_entry_css(
     let mut out = String::new();
     let mut emitted_import = false;
 
-    // Detect a leading `@import "tailwindcss";` (full bundle) *or* any
-    // split-import sub-path (`@import "tailwindcss/preflight"`, etc.) in
-    // the user CSS so we don't prepend the full bundle on top and leak the
-    // default palette tokens. The split-import pattern is the deliberate
-    // way users opt out of the full default theme.
+    // Strip block/line comments before scanning for the tailwind import so
+    // that a commented-out `@import "tailwindcss";` inside a `/* … */`
+    // block does not suppress the real synthesised import. The stripped text
+    // is used only for detection; the original bytes are written to the
+    // output unchanged.
     let user_has_import = input_css_text
-        .map(|t| t.lines().any(|l| {
-            let t = l.trim();
-            t.starts_with("@import \"tailwindcss\"") || t.starts_with("@import 'tailwindcss'")
-                || t.starts_with("@import \"tailwindcss/") || t.starts_with("@import 'tailwindcss/")
-        }))
+        .map(|t| {
+            let stripped = strip_css_comments(t);
+            stripped.lines().any(|l| {
+                let t = l.trim();
+                t.starts_with("@import \"tailwindcss\"")
+                    || t.starts_with("@import 'tailwindcss'")
+                    || t.starts_with("@import \"tailwindcss/")
+                    || t.starts_with("@import 'tailwindcss/")
+            })
+        })
         .unwrap_or(false);
 
     if !user_has_import {
@@ -304,11 +392,11 @@ pub fn build_synthesised_entry_css(
 
     // User-project content globs first.
     for g in &cfg.content_globs {
-        out.push_str(&format!("@source \"{g}\";\n"));
+        push_escaped_source(&mut out, g);
     }
     // Then framework packages.
     for g in &cfg.framework_package_globs {
-        out.push_str(&format!("@source \"{g}\";\n"));
+        push_escaped_source(&mut out, g);
     }
 
     if emitted_import || !cfg.content_globs.is_empty() || !cfg.framework_package_globs.is_empty() {
@@ -364,10 +452,7 @@ impl Clone for TailwindSubprocessEngine {
         Self {
             config: self.config.clone(),
             last_entry_css: std::sync::Mutex::new(
-                self.last_entry_css
-                    .lock()
-                    .ok()
-                    .and_then(|g| g.clone()),
+                self.last_entry_css.lock().ok().and_then(|g| g.clone()),
             ),
         }
     }
@@ -407,12 +492,10 @@ impl CssEngine for TailwindSubprocessEngine {
         // failure to read is fatal because the user explicitly asked for
         // it.
         let user_text = match &self.config.input_css {
-            Some(p) => Some(std::fs::read_to_string(p).with_context(|| {
-                format!(
-                    "failed to read user input CSS at {}",
-                    p.display()
-                )
-            })?),
+            Some(p) => Some(
+                std::fs::read_to_string(p)
+                    .with_context(|| format!("failed to read user input CSS at {}", p.display()))?,
+            ),
             None => None,
         };
         let entry_css = build_synthesised_entry_css(&self.config, user_text.as_deref());
@@ -519,18 +602,10 @@ pub fn default_source_directives(project_root: &Path) -> String {
     let mut out = String::new();
     for root in DEFAULT_CONTENT_ROOTS {
         let full = project_root.join(root);
-        // Escape `"` and `\` so a project root containing those bytes
-        // (legal on Linux/macOS) still emits a well-formed
-        // `@source "..."` directive that Tailwind can parse.
-        out.push_str("@source \"");
-        for c in full.display().to_string().chars() {
-            match c {
-                '"' => out.push_str("\\\""),
-                '\\' => out.push_str("\\\\"),
-                _ => out.push(c),
-            }
-        }
-        out.push_str("\";\n");
+        // push_escaped_source escapes `"` and `\` so a project root
+        // containing those bytes (legal on Linux/macOS) still emits a
+        // well-formed `@source "..."` directive that Tailwind can parse.
+        push_escaped_source(&mut out, &full.display().to_string());
     }
     out
 }
@@ -600,12 +675,10 @@ mod tests {
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&bin_path, std::fs::Permissions::from_mode(0o755))
-                .unwrap();
+            std::fs::set_permissions(&bin_path, std::fs::Permissions::from_mode(0o755)).unwrap();
         }
 
-        let cfg = TailwindSubprocessConfig::default()
-            .with_embedded_binary(dir, bin_path.clone());
+        let cfg = TailwindSubprocessConfig::default().with_embedded_binary(dir, bin_path.clone());
         assert_eq!(
             cfg.binary_path, bin_path,
             "no env override → embedded path should win over the workspace fallback"
@@ -650,5 +723,139 @@ mod tests {
         );
 
         // _guard drops here, restoring the previous ZFB_TAILWIND_BIN value.
+    }
+
+    // -----------------------------------------------------------------------
+    // Sub #706 — escaped @source globs
+    // -----------------------------------------------------------------------
+
+    /// A glob value containing a double-quote must be escaped so the emitted
+    /// `@source "..."` directive is well-formed CSS.
+    #[test]
+    fn push_escaped_source_escapes_double_quote() {
+        let mut out = String::new();
+        push_escaped_source(&mut out, r#"pages/"odd"/**"#);
+        assert_eq!(out, r#"@source "pages/\"odd\"/**";"#.to_string() + "\n");
+    }
+
+    /// A glob value containing a backslash (common on Windows paths) must be
+    /// double-escaped so the CSS parser sees a single `\`.
+    #[test]
+    fn push_escaped_source_escapes_backslash() {
+        let mut out = String::new();
+        push_escaped_source(&mut out, r"C:\project\pages");
+        assert_eq!(out, "@source \"C:\\\\project\\\\pages\";\n");
+    }
+
+    /// Glob metacharacters (`*`, `{`, `}`, `?`) must pass through untouched
+    /// — Tailwind v4 needs them as-is for pattern expansion.
+    #[test]
+    fn push_escaped_source_leaves_glob_chars_untouched() {
+        let mut out = String::new();
+        push_escaped_source(&mut out, "pages/**/*.{tsx,jsx}");
+        assert_eq!(out, "@source \"pages/**/*.{tsx,jsx}\";\n");
+    }
+
+    /// `build_synthesised_entry_css` must escape `"` in content_globs and
+    /// framework_package_globs (the pre-existing `default_source_directives`
+    /// path was already correct; this test covers the newly-fixed paths).
+    #[test]
+    fn synthesised_css_escapes_quotes_in_globs() {
+        let cfg = TailwindSubprocessConfig::default()
+            .with_mock_output(String::new())
+            .with_content_globs([r#"pages/"special"/**"#])
+            .with_framework_package_globs([r#"packages/"fw"/**"#]);
+        let css = build_synthesised_entry_css(&cfg, None);
+        assert!(
+            css.contains(r#"@source "pages/\"special\"/**";"#),
+            "content_globs quote not escaped; got:\n{css}"
+        );
+        assert!(
+            css.contains(r#"@source "packages/\"fw\"/**";"#),
+            "framework_package_globs quote not escaped; got:\n{css}"
+        );
+    }
+
+    /// `default_source_directives` must escape a `"` in the project root.
+    #[test]
+    fn default_source_directives_escapes_quotes_in_root() {
+        let root = std::path::PathBuf::from(r#"/pro"ject"#);
+        let out = default_source_directives(&root);
+        // Every content root entry should have the quote escaped.
+        assert!(
+            out.contains(r#"@source "/pro\"ject/"#),
+            "quote in project root not escaped; got:\n{out}"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Sub #739 — comment-aware tailwind import detection
+    // -----------------------------------------------------------------------
+
+    /// A `@import "tailwindcss";` that appears only inside a `/* … */` block
+    /// comment must NOT suppress the synthesised prepended import — it is not
+    /// an active directive, so the real `@import "tailwindcss";\n` should
+    /// appear at the top of the output.
+    #[test]
+    fn block_comment_import_does_not_suppress_synthesised_import() {
+        let input_css = r#"
+/*
+ * Old import — kept for reference but commented out.
+ * @import "tailwindcss";
+ */
+
+@layer base {
+  body { margin: 0; }
+}
+"#;
+        let cfg = TailwindSubprocessConfig::default().with_mock_output(String::new());
+        let css = build_synthesised_entry_css(&cfg, Some(input_css));
+        assert!(
+            css.starts_with("@import \"tailwindcss\";\n"),
+            "synthesised import must be prepended when the real import is inside a block comment;\
+             \ngot:\n{css}"
+        );
+    }
+
+    /// An active (uncommented) `@import "tailwindcss";` must still suppress
+    /// the synthesised prepended import (regression guard).
+    #[test]
+    fn real_import_suppresses_synthesised_import() {
+        let input_css = "@import \"tailwindcss\";\n\n@layer base { body { margin: 0; } }\n";
+        let cfg = TailwindSubprocessConfig::default().with_mock_output(String::new());
+        let css = build_synthesised_entry_css(&cfg, Some(input_css));
+        // The synthesised "@import ..." must NOT appear; the user's own line
+        // is already in the output as part of input_css_text.
+        let import_count = css.matches("@import \"tailwindcss\"").count();
+        assert_eq!(
+            import_count, 1,
+            "only the user's own import should appear (count=1); got:\n{css}"
+        );
+    }
+
+    /// A `@import "tailwindcss";` inside a line comment (`//`) must also not
+    /// suppress the synthesised import.
+    #[test]
+    fn line_comment_import_does_not_suppress_synthesised_import() {
+        let input_css = "// @import \"tailwindcss\";\n@layer base {}\n";
+        let cfg = TailwindSubprocessConfig::default().with_mock_output(String::new());
+        let css = build_synthesised_entry_css(&cfg, Some(input_css));
+        assert!(
+            css.starts_with("@import \"tailwindcss\";\n"),
+            "synthesised import must be prepended when the real import is inside a line comment;\
+             \ngot:\n{css}"
+        );
+    }
+
+    /// `strip_css_comments` must not mangle an active import on a line
+    /// adjacent to a multi-line block comment.
+    #[test]
+    fn strip_css_comments_preserves_active_imports_adjacent_to_block_comment() {
+        let text = "/* comment */\n@import \"tailwindcss\";\n";
+        let stripped = strip_css_comments(text);
+        assert!(
+            stripped.contains("@import \"tailwindcss\";"),
+            "active import after block comment must survive stripping; got:\n{stripped}"
+        );
     }
 }

--- a/crates/zfb-css/src/engine.rs
+++ b/crates/zfb-css/src/engine.rs
@@ -277,6 +277,11 @@ fn push_escaped_source(out: &mut String, value: &str) {
 /// by `"`, `'`, or `` ` ``) take precedence over comment scanning so that
 /// `/*` inside a string is treated as literal text, not a comment start.
 /// Only the "active" (uncommented) characters are returned.
+///
+/// Caveat: bytes are pushed via `b as char`, so multi-byte UTF-8 sequences
+/// are mangled in the returned text. Harmless here — the result is a
+/// detection-only scratch copy (the original bytes are what get emitted),
+/// and the `@import "tailwindcss"` needle is pure ASCII.
 fn strip_css_comments(text: &str) -> String {
     let bytes = text.as_bytes();
     let mut out = String::with_capacity(text.len());

--- a/crates/zfb-css/src/lib.rs
+++ b/crates/zfb-css/src/lib.rs
@@ -85,13 +85,11 @@ pub mod scanner;
 
 pub use emitter::{css_relative_path, CssEmitterOutput, CssProductionEmitter};
 pub use engine::{
-    build_synthesised_entry_css, CssEngine, TailwindSubprocessConfig,
-    TailwindSubprocessEngine,
+    build_synthesised_entry_css, CssEngine, TailwindSubprocessConfig, TailwindSubprocessEngine,
 };
 pub use modules::{CssModulesOutput, CssModulesProcessor};
 pub use native_engine::NativeRustEngine;
 pub use pipeline::{link_href, CssPipeline, CssPipelineConfig, CssPipelineOutput};
 pub use scanner::{
-    scan_css_module_imports, scan_css_module_imports_in_memory, ModuleImportScan,
-    SourceModuleUsage,
+    scan_css_module_imports, scan_css_module_imports_in_memory, ModuleImportScan, SourceModuleUsage,
 };

--- a/crates/zfb-css/src/modules.rs
+++ b/crates/zfb-css/src/modules.rs
@@ -111,11 +111,7 @@ impl CssModulesProcessor {
         self.process_one(path, source)
     }
 
-    fn process_one(
-        &self,
-        path: &Path,
-        source: &str,
-    ) -> Result<(String, HashMap<String, String>)> {
+    fn process_one(&self, path: &Path, source: &str) -> Result<(String, HashMap<String, String>)> {
         let pattern = self
             .config
             .pattern
@@ -139,24 +135,15 @@ impl CssModulesProcessor {
             ..ParserOptions::default()
         };
 
-        let stylesheet = StyleSheet::parse(source, parser_opts).map_err(|e| {
-            anyhow::anyhow!(
-                "lightningcss failed to parse {}: {e}",
-                path.display()
-            )
-        })?;
+        let stylesheet = StyleSheet::parse(source, parser_opts)
+            .map_err(|e| anyhow::anyhow!("lightningcss failed to parse {}: {e}", path.display()))?;
 
         let printed = stylesheet
             .to_css(PrinterOptions {
                 minify: !self.config.dev,
                 ..PrinterOptions::default()
             })
-            .map_err(|e| {
-                anyhow::anyhow!(
-                    "lightningcss failed to print {}: {e}",
-                    path.display()
-                )
-            })?;
+            .map_err(|e| anyhow::anyhow!("lightningcss failed to print {}: {e}", path.display()))?;
 
         // Translate the lightningcss `exports` map (Option<CssModuleExports>)
         // into a plain HashMap<String, String> of original→scoped names.

--- a/crates/zfb-css/src/pipeline.rs
+++ b/crates/zfb-css/src/pipeline.rs
@@ -238,9 +238,7 @@ impl<E: CssEngine> CssPipeline<E> {
         let mut files: Vec<PathBuf> = self.config.css_modules.clone();
         let mut seen: std::collections::HashSet<PathBuf> = files.iter().cloned().collect();
 
-        let per_source = if self.config.auto_discover_modules
-            && !self.config.sources.is_empty()
-        {
+        let per_source = if self.config.auto_discover_modules && !self.config.sources.is_empty() {
             let scan: ModuleImportScan = scan_css_module_imports(&self.config.sources)
                 .context("CSS Modules import scan failed")?;
             for m in &scan.modules {

--- a/crates/zfb-css/src/scanner.rs
+++ b/crates/zfb-css/src/scanner.rs
@@ -130,9 +130,7 @@ pub fn scan_css_module_imports(sources: &[PathBuf]) -> Result<ModuleImportScan> 
 }
 
 /// In-memory variant — the caller already has the source text.
-pub fn scan_css_module_imports_in_memory(
-    sources: &[(PathBuf, String)],
-) -> ModuleImportScan {
+pub fn scan_css_module_imports_in_memory(sources: &[(PathBuf, String)]) -> ModuleImportScan {
     let mut all: BTreeSet<PathBuf> = BTreeSet::new();
     let mut per_source: Vec<SourceModuleUsage> = Vec::with_capacity(sources.len());
     for (src, text) in sources {
@@ -261,10 +259,7 @@ fn normalise_path(p: &Path) -> PathBuf {
         match comp {
             Component::CurDir => {}
             Component::ParentDir => {
-                if matches!(
-                    out.last(),
-                    Some(Component::Normal(_))
-                ) {
+                if matches!(out.last(), Some(Component::Normal(_))) {
                     out.pop();
                 } else {
                     // RootDir / Prefix / nothing — leave it as-is so

--- a/crates/zfb-css/tests/integration.rs
+++ b/crates/zfb-css/tests/integration.rs
@@ -10,8 +10,8 @@
 use std::path::{Path, PathBuf};
 
 use zfb_css::{
-    build_synthesised_entry_css, link_href, scan_css_module_imports, CssEngine, CssPipeline,
-    CssPipelineConfig, CssModulesOutput, CssModulesProcessor, NativeRustEngine,
+    build_synthesised_entry_css, link_href, scan_css_module_imports, CssEngine, CssModulesOutput,
+    CssModulesProcessor, CssPipeline, CssPipelineConfig, NativeRustEngine,
     TailwindSubprocessConfig, TailwindSubprocessEngine,
 };
 
@@ -32,8 +32,8 @@ fn native_engine_returns_not_implemented_error() {
 fn subprocess_engine_mock_short_circuits_command() {
     // Use the mock-output escape hatch so this test does not require the
     // tailwindcss binary to be present.
-    let cfg = TailwindSubprocessConfig::default()
-        .with_mock_output(".mock-utility { color: red; }\n");
+    let cfg =
+        TailwindSubprocessConfig::default().with_mock_output(".mock-utility { color: red; }\n");
     let engine = TailwindSubprocessEngine::new(cfg);
     let css = engine
         .produce_utility_css(&[PathBuf::from("pages/index.tsx")])
@@ -105,8 +105,7 @@ fn pipeline_writes_hashed_asset_with_mock_engine() {
     let output_root = tmp.path().to_path_buf();
 
     let engine = TailwindSubprocessEngine::new(
-        TailwindSubprocessConfig::default()
-            .with_mock_output(".u-text-red { color: red; }\n"),
+        TailwindSubprocessConfig::default().with_mock_output(".u-text-red { color: red; }\n"),
     );
     let cfg = CssPipelineConfig {
         sources: vec![PathBuf::from("pages/index.tsx")],
@@ -235,26 +234,20 @@ export function DocShell() {
     )
     .unwrap();
     let fw_module = fw_components.join("shell.module.css");
-    std::fs::write(
-        &fw_module,
-        ".shell { padding: 1rem; }\n",
-    )
-    .unwrap();
+    std::fs::write(&fw_module, ".shell { padding: 1rem; }\n").unwrap();
 
     // ---- Tailwind engine config (mocked subprocess) ----
     // We feed a mock output that simulates the real binary scanning
     // both @source globs and emitting utilities for both pages —
     // including the framework-only `prose-zfb-only` class.
-    let mock_tailwind = ".flex{display:flex}.items-center{align-items:center}.prose-zfb-only{max-width:65ch}\n";
+    let mock_tailwind =
+        ".flex{display:flex}.items-center{align-items:center}.prose-zfb-only{max-width:65ch}\n";
 
     let tw_cfg = TailwindSubprocessConfig::default()
         .with_working_dir(&user_proj)
         .with_input_css(&user_global_css_file)
         .with_content_globs(vec!["pages/**/*.{tsx,jsx,ts,js}"])
-        .with_framework_package_globs(vec![format!(
-            "{}/**/*.{{tsx,jsx,ts,js}}",
-            fw_pkg.display()
-        )])
+        .with_framework_package_globs(vec![format!("{}/**/*.{{tsx,jsx,ts,js}}", fw_pkg.display())])
         .with_theme_block("@theme inline {\n  --font-display: 'Inter';\n}\n")
         .with_mock_output(mock_tailwind);
     let engine = TailwindSubprocessEngine::new(tw_cfg);
@@ -377,12 +370,14 @@ export function DocShell() {
             json_path.display(),
             class_map_dir.display()
         );
-        assert!(json_path.exists(), "json {} must exist", json_path.display());
+        assert!(
+            json_path.exists(),
+            "json {} must exist",
+            json_path.display()
+        );
         let body = std::fs::read_to_string(json_path).unwrap();
-        let parsed: std::collections::BTreeMap<String, String> =
-            serde_json::from_str(&body).unwrap_or_else(|e| {
-                panic!("invalid JSON for {}: {e}\n{body}", module_path.display())
-            });
+        let parsed: std::collections::BTreeMap<String, String> = serde_json::from_str(&body)
+            .unwrap_or_else(|e| panic!("invalid JSON for {}: {e}\n{body}", module_path.display()));
         // Each map must contain at least one binding.
         assert!(!parsed.is_empty());
     }
@@ -395,8 +390,7 @@ export function DocShell() {
 
 #[test]
 fn synthesised_entry_drops_duplicate_tailwind_import_from_user_css() {
-    let cfg = TailwindSubprocessConfig::default()
-        .with_content_globs(vec!["pages/**/*.tsx"]);
+    let cfg = TailwindSubprocessConfig::default().with_content_globs(vec!["pages/**/*.tsx"]);
     let user = "@import \"tailwindcss\";\n.foo { color: red; }\n";
     let out = build_synthesised_entry_css(&cfg, Some(user));
     let occurrences = out.matches("@import \"tailwindcss\"").count();
@@ -423,8 +417,7 @@ fn synthesised_entry_drops_duplicate_tailwind_import_from_user_css() {
 
 #[test]
 fn synthesised_entry_omits_full_import_when_user_css_has_split_import() {
-    let cfg = TailwindSubprocessConfig::default()
-        .with_content_globs(vec!["pages/**/*.tsx"]);
+    let cfg = TailwindSubprocessConfig::default().with_content_globs(vec!["pages/**/*.tsx"]);
 
     // User CSS uses split imports — the deliberate way to opt out of the
     // full default Tailwind theme.
@@ -491,9 +484,7 @@ fn scanner_finds_module_imports_in_real_tsx_file() {
     let scan = scan_css_module_imports(std::slice::from_ref(&tsx)).expect("scan");
     assert_eq!(scan.modules.len(), 2);
     assert!(
-        scan.modules
-            .iter()
-            .any(|p| p.ends_with("local.module.css")),
+        scan.modules.iter().any(|p| p.ends_with("local.module.css")),
         "scan: {scan:?}"
     );
     assert!(
@@ -518,8 +509,7 @@ fn build_emitter_returns_bytes_and_stable_url_without_writing_asset() {
     let output_root = tmp.path().to_path_buf();
 
     let engine = TailwindSubprocessEngine::new(
-        TailwindSubprocessConfig::default()
-            .with_mock_output(".u-text-red { color: red; }\n"),
+        TailwindSubprocessConfig::default().with_mock_output(".u-text-red { color: red; }\n"),
     );
     let cfg = CssPipelineConfig {
         sources: vec![PathBuf::from("pages/index.tsx")],
@@ -572,9 +562,7 @@ fn build_emitter_bytes_match_build_output_for_same_inputs() {
         ..CssPipelineConfig::default()
     };
     let p1 = CssPipeline::new(
-        TailwindSubprocessEngine::new(
-            TailwindSubprocessConfig::default().with_mock_output(mock),
-        ),
+        TailwindSubprocessEngine::new(TailwindSubprocessConfig::default().with_mock_output(mock)),
         cfg1,
     );
     let built = p1.build().expect("build");
@@ -586,9 +574,7 @@ fn build_emitter_bytes_match_build_output_for_same_inputs() {
         ..CssPipelineConfig::default()
     };
     let p2 = CssPipeline::new(
-        TailwindSubprocessEngine::new(
-            TailwindSubprocessConfig::default().with_mock_output(mock),
-        ),
+        TailwindSubprocessEngine::new(TailwindSubprocessConfig::default().with_mock_output(mock)),
         cfg2,
     );
     let emitted = p2.build_emitter().expect("build_emitter");
@@ -620,9 +606,8 @@ fn build_emitter_still_writes_class_map_jsons_when_configured() {
         class_map_dir: Some(class_map_dir.clone()),
         ..CssPipelineConfig::default()
     };
-    let engine = TailwindSubprocessEngine::new(
-        TailwindSubprocessConfig::default().with_mock_output(""),
-    );
+    let engine =
+        TailwindSubprocessEngine::new(TailwindSubprocessConfig::default().with_mock_output(""));
     let pipeline = CssPipeline::new(engine, cfg);
     let _ = pipeline.build_emitter().expect("build_emitter");
 
@@ -631,7 +616,9 @@ fn build_emitter_still_writes_class_map_jsons_when_configured() {
         .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
         .collect();
     assert!(
-        entries.iter().any(|n| n.ends_with("button.module.css.classes.json")),
+        entries
+            .iter()
+            .any(|n| n.ends_with("button.module.css.classes.json")),
         "expected button class-map json, got entries: {entries:?}"
     );
 

--- a/crates/zfb-diagnostics/src/lib.rs
+++ b/crates/zfb-diagnostics/src/lib.rs
@@ -147,7 +147,10 @@ pub fn render_framed(diag: &Diagnostic) -> String {
     out.push_str(&format!("{label_error}: {}\n", diag.message));
 
     let arrow = "-->".if_supports_color(Stream::Stderr, |t| t.cyan().to_string());
-    out.push_str(&format!(" {arrow} {}:{}:{}\n", diag.file, diag.line, diag.col));
+    out.push_str(&format!(
+        " {arrow} {}:{}:{}\n",
+        diag.file, diag.line, diag.col
+    ));
 
     if let Some(src) = &diag.source {
         let lines: Vec<&str> = src.split('\n').collect();
@@ -184,8 +187,7 @@ pub fn render_framed(diag: &Diagnostic) -> String {
                 // Caret line. Render a single `^` under `col` (1-based).
                 let caret_offset = diag.col.saturating_sub(1);
                 let pad = " ".repeat(caret_offset);
-                let caret =
-                    "^".if_supports_color(Stream::Stderr, |t| t.red().bold().to_string());
+                let caret = "^".if_supports_color(Stream::Stderr, |t| t.red().bold().to_string());
                 out.push_str(&format!(
                     "{:>w$} {bar} {pad}{caret}\n",
                     "",
@@ -260,14 +262,16 @@ where
                 Some(root) if raw.is_relative() => {
                     let bundle_dir = bundle_path.parent().unwrap_or(Path::new(""));
                     let candidate = bundle_dir.join(&raw);
-                    candidate.canonicalize().unwrap_or(candidate)
+                    candidate
+                        .canonicalize()
+                        .unwrap_or(candidate)
                         .strip_prefix(root)
                         .map(|p| p.to_path_buf())
                         .unwrap_or_else(|_| raw.clone())
                 }
                 _ => raw.clone(),
             };
-            let display_path = project_relative(&abs, None);
+            let display_path = project_relative(&abs, project_root);
             let mut diag = Diagnostic::new(display_path, decoded.line(), decoded.col(), message);
             if let Some(content) = decoded.source_content() {
                 diag.source = Some(content);
@@ -429,6 +433,63 @@ mod tests {
         // strip_prefix fails; falls back to absolute
         let result = project_relative(file, Some(root));
         assert!(result.contains("project"), "got: {result}");
+    }
+
+    /// A minimal [`DecodedPosition`] stub for tests.
+    struct FakeDecoded {
+        file: &'static str,
+        line: usize,
+        col: usize,
+        source_content: Option<String>,
+    }
+    impl DecodedPosition for FakeDecoded {
+        fn file(&self) -> &str {
+            self.file
+        }
+        fn line(&self) -> usize {
+            self.line
+        }
+        fn col(&self) -> usize {
+            self.col
+        }
+        fn source_content(&self) -> Option<String> {
+            self.source_content.clone()
+        }
+    }
+
+    #[test]
+    fn absolute_sourcemap_path_is_stripped_against_project_root() {
+        // esbuild can emit absolute paths in `sources`; previously the call
+        // site passed `None` so project_root was ignored and the full
+        // on-disk path leaked into the diagnostic.  After the fix,
+        // project_root is forwarded and the path is made project-relative.
+        let project_root = Path::new("/home/alice/proj");
+        let bundle_path = Path::new("/home/alice/proj/.zfb/bundle.js");
+
+        let diag = from_js_runtime_error_with_decoder(
+            bundle_path,
+            "// bundle",
+            1,
+            1,
+            "oops",
+            Some("ignored"),
+            Some(project_root),
+            |_map, _line, _col| {
+                Some(FakeDecoded {
+                    file: "/home/alice/proj/src/pages/index.tsx",
+                    line: 3,
+                    col: 5,
+                    source_content: Some("// src".into()),
+                })
+            },
+        );
+
+        // Must be project-relative, not the full on-disk absolute path.
+        assert_eq!(
+            diag.file, "src/pages/index.tsx",
+            "expected project-relative path, got: {}",
+            diag.file
+        );
     }
 
     #[test]

--- a/crates/zfb-graph/src/error.rs
+++ b/crates/zfb-graph/src/error.rs
@@ -24,6 +24,8 @@ pub enum GraphError {
     /// On-disk file did not start with the expected magic / version
     /// header. Treated as "not a graph file we can read" and surfaced
     /// so callers can decide whether to discard and rebuild.
-    #[error("graph persistence: invalid file header (not a zfb-graph snapshot, or version mismatch)")]
+    #[error(
+        "graph persistence: invalid file header (not a zfb-graph snapshot, or version mismatch)"
+    )]
     BadHeader,
 }

--- a/crates/zfb-graph/src/lib.rs
+++ b/crates/zfb-graph/src/lib.rs
@@ -365,8 +365,10 @@ impl DependencyGraph {
 
     /// Remove a node from the graph and return its former consumers.
     ///
-    /// - If `path` was a page, the page is dropped and its reverse-index
-    ///   entries are cleaned up. The returned set contains just that page id.
+    /// - If `path` was a page, the page is dropped and its own forward edges
+    ///   are cleaned up. The returned set includes that page id AND any other
+    ///   pages that depended on it (a page can also be a dep of other pages,
+    ///   e.g. `/pages/b.tsx` imported by `/pages/a.tsx`).
     /// - If `path` was a non-page dep, every page that depended on it loses
     ///   that edge. The returned set is the former consumer list — these
     ///   pages should be rebuilt.
@@ -378,7 +380,10 @@ impl DependencyGraph {
     pub fn remove_node(&mut self, path: &Path) -> BTreeSet<PageId> {
         let mut affected: BTreeSet<PageId> = BTreeSet::new();
 
-        // Case 1: removing a page.
+        // Case 1: removing a page. Tear down page-specific state, then fall
+        // through to Case 2 so any OTHER pages that imported this page (it may
+        // be both a page and a dep) are collected into `affected` and have their
+        // forward edges cleaned up.
         let page_id = PageId::new(path.to_path_buf());
         if self.pages.remove(&page_id) {
             if let Some(deps) = self.forward.remove(&page_id) {
@@ -396,10 +401,14 @@ impl DependencyGraph {
             // consumer on subsequent queries.
             self.clear_assets_for_page(&page_id);
             affected.insert(page_id);
-            return affected;
+            // Do NOT return here: fall through to Case 2 so consumers of this
+            // page (recorded in the reverse index under `path`) are also
+            // collected into `affected` and their forward edges are cleaned.
         }
 
-        // Case 2: removing a non-page dep. Collect consumers, clear edges.
+        // Case 2: drain reverse-index consumers of `path`. For a plain dep
+        // this is the primary branch; for a page that is also a dep this
+        // collects the OTHER pages that imported it.
         if let Some(consumers) = self.reverse.remove(path) {
             for page in &consumers {
                 if let Some(forward_deps) = self.forward.get_mut(page) {
@@ -612,11 +621,7 @@ impl DependencyGraph {
     /// Lookup helper: every recorded dep of a page (kind included), sorted by
     /// path. Returns an empty `Vec` for unknown pages.
     pub fn deps_of(&self, page: &PageId) -> Vec<(PathBuf, DepKind)> {
-        let mut v = self
-            .forward
-            .get(page)
-            .cloned()
-            .unwrap_or_default();
+        let mut v = self.forward.get(page).cloned().unwrap_or_default();
         v.sort_by(|a, b| a.0.cmp(&b.0));
         v
     }
@@ -819,6 +824,56 @@ mod tests {
         assert!(removed.is_empty());
     }
 
+    /// Regression test for the "page that is also a dep" bug (issue #758 / finding #707).
+    ///
+    /// A imports /pages/b.tsx as a dep. After removing B, A must appear in
+    /// `affected` so the build orchestrator knows to rebuild it. A subsequent
+    /// `dirty_pages(/pages/b.tsx)` must NOT resurface A (the reverse entry
+    /// should have been drained by `remove_node`).
+    #[test]
+    fn remove_node_page_that_is_also_dep_includes_consumers_in_affected() {
+        let mut g = DependencyGraph::new();
+        // Page A imports page B (a page can be a dep of another page).
+        g.upsert(PageDeps::new(
+            pid("/pages/a.tsx"),
+            vec![(p("/pages/b.tsx"), DepKind::Module)],
+        ));
+        g.upsert(PageDeps::new(pid("/pages/b.tsx"), vec![]));
+
+        // Sanity: both pages are registered.
+        assert_eq!(g.page_count(), 2);
+
+        // Remove page B — it is both a page and a dep of A.
+        let affected = g.remove_node(&p("/pages/b.tsx"));
+
+        // B itself must be in affected (it is the removed page).
+        assert!(
+            affected.contains(&pid("/pages/b.tsx")),
+            "removed page must be in affected"
+        );
+        // A must also be in affected (it was a consumer of B via reverse index).
+        assert!(
+            affected.contains(&pid("/pages/a.tsx")),
+            "consumer of removed page must be in affected; got: {affected:?}"
+        );
+
+        // Subsequent dirty_pages for the deleted path must return empty —
+        // the reverse entry should have been drained.
+        let d = g.dirty_pages(&p("/pages/b.tsx"));
+        assert_eq!(
+            d.as_pages().unwrap(),
+            Vec::<PageId>::new(),
+            "dirty_pages after remove_node must return empty (no stale reverse entry)"
+        );
+
+        // A's forward edges must no longer reference B.
+        let a_deps = g.deps_of(&pid("/pages/a.tsx"));
+        assert!(
+            !a_deps.iter().any(|(dep, _)| dep == &p("/pages/b.tsx")),
+            "A's forward edges must not reference deleted B"
+        );
+    }
+
     #[test]
     fn add_node_is_idempotent_for_known_paths() {
         let mut g = DependencyGraph::new();
@@ -842,7 +897,11 @@ mod tests {
         g.upsert(PageDeps::new(pid("/pages/b.tsx"), vec![]));
         assert_eq!(
             g.pages(),
-            vec![pid("/pages/a.tsx"), pid("/pages/b.tsx"), pid("/pages/c.tsx")]
+            vec![
+                pid("/pages/a.tsx"),
+                pid("/pages/b.tsx"),
+                pid("/pages/c.tsx")
+            ]
         );
     }
 
@@ -932,7 +991,10 @@ mod tests {
             pid("/pages/b.tsx"),
             AssetDeps::new(
                 [],
-                [p("/styles/header.module.css"), p("/styles/footer.module.css")],
+                [
+                    p("/styles/header.module.css"),
+                    p("/styles/footer.module.css"),
+                ],
             ),
         );
         assert_eq!(
@@ -959,10 +1021,7 @@ mod tests {
             AssetDeps::new(["New".to_string()], [p("/styles/new.module.css")]),
         );
         assert!(g.pages_using_island("Old").is_empty());
-        assert_eq!(
-            g.pages_using_island("New"),
-            vec![pid("/pages/a.tsx")],
-        );
+        assert_eq!(g.pages_using_island("New"), vec![pid("/pages/a.tsx")],);
         assert!(g
             .pages_using_css_module(&p("/styles/old.module.css"))
             .is_empty());
@@ -994,7 +1053,10 @@ mod tests {
         let mut g = DependencyGraph::new();
         g.set_assets_for_page(
             pid("/pages/a.tsx"),
-            AssetDeps::new(["Z".to_string(), "A".to_string()], [p("/y.css"), p("/x.css")]),
+            AssetDeps::new(
+                ["Z".to_string(), "A".to_string()],
+                [p("/y.css"), p("/x.css")],
+            ),
         );
         g.set_assets_for_page(
             pid("/pages/b.tsx"),
@@ -1080,8 +1142,12 @@ mod tests {
         let a = g.dirty_pages(&p("/shared.tsx"));
         let b = g.dirty_pages(&p("/other.tsx"));
         let mut union: BTreeSet<PageId> = BTreeSet::new();
-        if let DirtySet::Specific(s) = a { union.extend(s); }
-        if let DirtySet::Specific(s) = b { union.extend(s); }
+        if let DirtySet::Specific(s) = a {
+            union.extend(s);
+        }
+        if let DirtySet::Specific(s) = b {
+            union.extend(s);
+        }
         assert_eq!(batch_pages, union.into_iter().collect::<Vec<_>>());
     }
 

--- a/crates/zfb-islands/src/bundler.rs
+++ b/crates/zfb-islands/src/bundler.rs
@@ -625,7 +625,10 @@ mod tests {
         // esbuild flag and the emitted glue). Round-trip both variants and
         // confirm the default fallback for unknown sources.
         for fw in [FrameworkKind::Preact, FrameworkKind::React] {
-            assert_eq!(FrameworkKind::from_jsx_import_source(fw.jsx_import_source()), fw);
+            assert_eq!(
+                FrameworkKind::from_jsx_import_source(fw.jsx_import_source()),
+                fw
+            );
         }
         assert_eq!(
             FrameworkKind::from_jsx_import_source("react"),

--- a/crates/zfb-islands/src/esbuild.rs
+++ b/crates/zfb-islands/src/esbuild.rs
@@ -56,33 +56,45 @@ pub const EXPECTED_ESBUILD_VERSION: &str = "0.25.12";
 pub const EXPECTED_ESBUILD_SHA256: &str = {
     // Linux x86_64
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-    { "bab29b2ca7a9e89b67cf720b77b2d743f9f31f5cf0d5bd74ee8c8de30ced7014" }
+    {
+        "bab29b2ca7a9e89b67cf720b77b2d743f9f31f5cf0d5bd74ee8c8de30ced7014"
+    }
 
     // Linux aarch64
     #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
-    { "840ad255d6fd587b126d8b2d59ab506d8562785b9bc76249dc3b0e1bdd2ca449" }
+    {
+        "840ad255d6fd587b126d8b2d59ab506d8562785b9bc76249dc3b0e1bdd2ca449"
+    }
 
     // macOS aarch64 (Apple Silicon)
     #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-    { "3e030ee2aa86ad3c33e5e95ae0e53bb03de40e0da35c9b1180a67de4a497cae5" }
+    {
+        "3e030ee2aa86ad3c33e5e95ae0e53bb03de40e0da35c9b1180a67de4a497cae5"
+    }
 
     // macOS x86_64 (Intel)
     #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
-    { "bd09e65a6a1a903c40269d3a4ae23ffc6139f691703728c1faf25f62e48baa40" }
+    {
+        "bd09e65a6a1a903c40269d3a4ae23ffc6139f691703728c1faf25f62e48baa40"
+    }
 
     // Windows x86_64
     #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
-    { "cae1bbc86f4df800b01d99e28aea0a154b02243de6797e98f48a9b88a64a7be0" }
+    {
+        "cae1bbc86f4df800b01d99e28aea0a154b02243de6797e98f48a9b88a64a7be0"
+    }
 
     // Fallback for unsupported platforms: skip checksum gate.
     #[cfg(not(any(
-        all(target_os = "linux",   target_arch = "x86_64"),
-        all(target_os = "linux",   target_arch = "aarch64"),
-        all(target_os = "macos",   target_arch = "aarch64"),
-        all(target_os = "macos",   target_arch = "x86_64"),
+        all(target_os = "linux", target_arch = "x86_64"),
+        all(target_os = "linux", target_arch = "aarch64"),
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "macos", target_arch = "x86_64"),
         all(target_os = "windows", target_arch = "x86_64"),
     )))]
-    { "" }
+    {
+        ""
+    }
 };
 
 /// One-time cache of `(binary_path → outcome)` for the version + checksum
@@ -369,11 +381,7 @@ impl EsbuildSubprocessConfig {
     /// subprocess (chainable). Most useful for `NODE_PATH=<path>` so
     /// esbuild resolves bare imports against an externally-staged
     /// `node_modules` tree.
-    pub fn with_extra_env(
-        mut self,
-        key: impl Into<OsString>,
-        value: impl Into<OsString>,
-    ) -> Self {
+    pub fn with_extra_env(mut self, key: impl Into<OsString>, value: impl Into<OsString>) -> Self {
         self.env_vars.push((key.into(), value.into()));
         self
     }
@@ -849,8 +857,12 @@ pub(crate) fn build_esbuild_args(
         FrameworkKind::from_jsx_import_source(&config.jsx_import_source),
         FrameworkKind::Preact
     ) {
-        args.push(OsString::from("--alias:react/jsx-runtime=preact/jsx-runtime"));
-        args.push(OsString::from("--alias:react/jsx-dev-runtime=preact/jsx-dev-runtime"));
+        args.push(OsString::from(
+            "--alias:react/jsx-runtime=preact/jsx-runtime",
+        ));
+        args.push(OsString::from(
+            "--alias:react/jsx-dev-runtime=preact/jsx-dev-runtime",
+        ));
     }
     if config.minify {
         args.push(OsString::from("--minify"));
@@ -858,10 +870,7 @@ pub(crate) fn build_esbuild_args(
     if config.sourcemap {
         args.push(OsString::from("--sourcemap=linked"));
     }
-    args.push(OsString::from(format!(
-        "--outfile={}",
-        out_path.display()
-    )));
+    args.push(OsString::from(format!("--outfile={}", out_path.display())));
     // Inline NODE_ENV so React/Preact pick their production build
     // when minifying. esbuild expects the define value to be a JS
     // literal, hence the embedded quotes.
@@ -2078,11 +2087,13 @@ mod tests {
         let cfg = BundleConfig::default().with_minify(true);
         let args = args_as_strings(&cfg);
         assert!(
-            args.iter().any(|a| a == "--define:import.meta.env.PROD=true"),
+            args.iter()
+                .any(|a| a == "--define:import.meta.env.PROD=true"),
             "missing --define:import.meta.env.PROD=true in args: {args:?}"
         );
         assert!(
-            args.iter().any(|a| a == "--define:import.meta.env.DEV=false"),
+            args.iter()
+                .any(|a| a == "--define:import.meta.env.DEV=false"),
             "missing --define:import.meta.env.DEV=false in args: {args:?}"
         );
     }
@@ -2097,11 +2108,13 @@ mod tests {
         assert!(!cfg.minify, "default BundleConfig must be dev mode");
         let args = args_as_strings(&cfg);
         assert!(
-            args.iter().any(|a| a == "--define:import.meta.env.PROD=false"),
+            args.iter()
+                .any(|a| a == "--define:import.meta.env.PROD=false"),
             "missing --define:import.meta.env.PROD=false in args: {args:?}"
         );
         assert!(
-            args.iter().any(|a| a == "--define:import.meta.env.DEV=true"),
+            args.iter()
+                .any(|a| a == "--define:import.meta.env.DEV=true"),
             "missing --define:import.meta.env.DEV=true in args: {args:?}"
         );
     }
@@ -2145,11 +2158,13 @@ mod tests {
         assert_eq!(cfg.jsx_import_source, "preact", "default must be Preact");
         let args = args_as_strings(&cfg);
         assert!(
-            args.iter().any(|a| a == "--alias:react/jsx-runtime=preact/jsx-runtime"),
+            args.iter()
+                .any(|a| a == "--alias:react/jsx-runtime=preact/jsx-runtime"),
             "missing --alias:react/jsx-runtime=preact/jsx-runtime in args: {args:?}"
         );
         assert!(
-            args.iter().any(|a| a == "--alias:react/jsx-dev-runtime=preact/jsx-dev-runtime"),
+            args.iter()
+                .any(|a| a == "--alias:react/jsx-dev-runtime=preact/jsx-dev-runtime"),
             "missing --alias:react/jsx-dev-runtime=preact/jsx-dev-runtime in args: {args:?}"
         );
     }
@@ -2163,11 +2178,15 @@ mod tests {
         let cfg = BundleConfig::default().with_jsx_import_source("react");
         let args = args_as_strings(&cfg);
         assert!(
-            !args.iter().any(|a| a == "--alias:react/jsx-runtime=preact/jsx-runtime"),
+            !args
+                .iter()
+                .any(|a| a == "--alias:react/jsx-runtime=preact/jsx-runtime"),
             "react path must not alias react/jsx-runtime: {args:?}"
         );
         assert!(
-            !args.iter().any(|a| a == "--alias:react/jsx-dev-runtime=preact/jsx-dev-runtime"),
+            !args
+                .iter()
+                .any(|a| a == "--alias:react/jsx-dev-runtime=preact/jsx-dev-runtime"),
             "react path must not alias react/jsx-dev-runtime: {args:?}"
         );
     }
@@ -2183,8 +2202,14 @@ mod tests {
     #[test]
     fn zero_registrations_produce_no_alias_flags_in_config() {
         let cfg = EsbuildSubprocessConfig::default();
-        assert!(cfg.alias_entries.is_empty(), "alias_entries must default to empty");
-        assert!(cfg.virtual_modules.is_empty(), "virtual_modules must default to empty");
+        assert!(
+            cfg.alias_entries.is_empty(),
+            "alias_entries must default to empty"
+        );
+        assert!(
+            cfg.virtual_modules.is_empty(),
+            "virtual_modules must default to empty"
+        );
     }
 
     /// `with_alias_entries` stores the pairs and overwrites the previous list.
@@ -2201,9 +2226,10 @@ mod tests {
     /// `with_virtual_modules` stores the pairs and overwrites the previous list.
     #[test]
     fn with_virtual_modules_stores_pairs() {
-        let vms = vec![
-            ("virtual:my-data".to_string(), "export const x = 1;".to_string()),
-        ];
+        let vms = vec![(
+            "virtual:my-data".to_string(),
+            "export const x = 1;".to_string(),
+        )];
         let cfg = EsbuildSubprocessConfig::default().with_virtual_modules(vms.clone());
         assert_eq!(cfg.virtual_modules, vms);
     }
@@ -2255,12 +2281,14 @@ mod tests {
     #[test]
     fn builder_methods_are_chainable() {
         let cfg = EsbuildSubprocessConfig::default()
-            .with_alias_entries(vec![
-                ("@/components".to_string(), "/abs/src/components".to_string()),
-            ])
-            .with_virtual_modules(vec![
-                ("virtual:meta".to_string(), "export const v = 1;".to_string()),
-            ]);
+            .with_alias_entries(vec![(
+                "@/components".to_string(),
+                "/abs/src/components".to_string(),
+            )])
+            .with_virtual_modules(vec![(
+                "virtual:meta".to_string(),
+                "export const v = 1;".to_string(),
+            )]);
         assert_eq!(cfg.alias_entries.len(), 1);
         assert_eq!(cfg.virtual_modules.len(), 1);
         assert_eq!(cfg.alias_entries[0].0, "@/components");
@@ -2282,6 +2310,10 @@ mod tests {
         let cfg = EsbuildSubprocessConfig::default()
             .with_virtual_modules(vec![("virtual:data".to_string(), source.to_string())]);
         let retrieved = &cfg.virtual_modules[0].1;
-        assert_eq!(retrieved.as_str(), source, "source must survive config round-trip unchanged");
+        assert_eq!(
+            retrieved.as_str(),
+            source,
+            "source must survive config round-trip unchanged"
+        );
     }
 }

--- a/crates/zfb-islands/src/hydration.rs
+++ b/crates/zfb-islands/src/hydration.rs
@@ -57,7 +57,7 @@ use std::cell::Cell;
 use std::rc::Rc;
 
 use lol_html::html_content::{ContentType, Element};
-use lol_html::{ElementContentHandlers, RewriteStrSettings, Selector, doc_comments};
+use lol_html::{doc_comments, ElementContentHandlers, RewriteStrSettings, Selector};
 use serde::Serialize;
 use serde_json::Value as JsonValue;
 use thiserror::Error;
@@ -321,18 +321,16 @@ fn rewrite_single_island(
         let close_seen_c = Rc::clone(&close_seen);
 
         let settings: RewriteStrSettings<'_, '_> = RewriteStrSettings {
-            document_content_handlers: vec![
-                doc_comments!(move |c| {
-                    let text = c.text().to_string();
-                    if text == open_text {
-                        open_seen_c.set(true);
-                    }
-                    if text == close_text {
-                        close_seen_c.set(true);
-                    }
-                    Ok(())
-                }),
-            ],
+            document_content_handlers: vec![doc_comments!(move |c| {
+                let text = c.text().to_string();
+                if text == open_text {
+                    open_seen_c.set(true);
+                }
+                if text == close_text {
+                    close_seen_c.set(true);
+                }
+                Ok(())
+            })],
             ..RewriteStrSettings::new()
         };
 
@@ -361,12 +359,12 @@ fn rewrite_single_island(
     let close_str = format!("<!--/zfb-island:{}-->", d.marker_key);
 
     let html = &tree.html;
-    let open_idx = html.find(&open_str).ok_or_else(|| {
-        IslandRewriteError::OpenMarkerMissing {
+    let open_idx = html
+        .find(&open_str)
+        .ok_or_else(|| IslandRewriteError::OpenMarkerMissing {
             component: d.component_name.clone(),
             key: d.marker_key.clone(),
-        }
-    })?;
+        })?;
     let after_open = open_idx + open_str.len();
     let close_rel = html[after_open..].find(&close_str).ok_or_else(|| {
         IslandRewriteError::CloseMarkerMissing {
@@ -568,8 +566,8 @@ pub fn inject_runtime_script_into_head(tree: &mut HtmlTree, runtime_url: &str) {
 fn render_wrapper(d: &IslandDescriptor, inner: &str) -> String {
     // Serialise props. `serde_json::to_string` on a `Value` is infallible
     // for any valid `Value` (all variants produce valid JSON).
-    let props_json = serde_json::to_string(&d.props)
-        .expect("serde_json::Value always serialises to valid JSON");
+    let props_json =
+        serde_json::to_string(&d.props).expect("serde_json::Value always serialises to valid JSON");
 
     let mut s = String::with_capacity(inner.len() + props_json.len() + 96);
     s.push_str("<div data-zfb-island=\"");
@@ -725,10 +723,9 @@ mod tests {
         let d = IslandDescriptor::new("Foo", json!({}), "k")
             .with_when(WhenHint::Media("(min-width: 600px)".into()));
         rewrite_islands(&mut tree, &[d]).unwrap();
-        assert!(
-            tree.serialize()
-                .contains(r#"data-when="media((min-width: 600px))""#)
-        );
+        assert!(tree
+            .serialize()
+            .contains(r#"data-when="media((min-width: 600px))""#));
     }
 
     #[test]
@@ -786,11 +783,7 @@ mod tests {
         let inner = wrap_with_markers("k", "<i>x</i>");
         let mut tree = page_with(&inner);
         // The JSON value has a string field containing HTML-special characters.
-        let d = IslandDescriptor::new(
-            "My&Comp",
-            json!({"text": "<a & \"b\">"}),
-            "k",
-        );
+        let d = IslandDescriptor::new("My&Comp", json!({"text": "<a & \"b\">"}), "k");
         rewrite_islands(&mut tree, &[d]).unwrap();
         let out = tree.serialize();
         assert!(out.contains(r#"data-zfb-island="My&amp;Comp""#));
@@ -873,7 +866,9 @@ mod tests {
 
     #[test]
     fn no_descriptors_is_a_no_op() {
-        let html_str = "<html><body><h1>Page</h1><span>plain</span><footer>fin</footer></body></html>".to_string();
+        let html_str =
+            "<html><body><h1>Page</h1><span>plain</span><footer>fin</footer></body></html>"
+                .to_string();
         let mut tree = HtmlTree::parse(html_str.clone());
         rewrite_islands(&mut tree, &[]).unwrap();
         assert_eq!(tree.serialize(), html_str);

--- a/crates/zfb-islands/src/manifest.rs
+++ b/crates/zfb-islands/src/manifest.rs
@@ -349,8 +349,14 @@ mod tests {
         let collected: Vec<(&str, &Path)> = m.iter().collect();
         assert_eq!(collected[0].0, "Counter");
         assert_eq!(collected[1].0, "Tabs");
-        assert_eq!(m.get("Counter").unwrap(), Path::new("/proj/components/counter.tsx"));
-        assert_eq!(m.get("Tabs").unwrap(), Path::new("/proj/components/tabs.tsx"));
+        assert_eq!(
+            m.get("Counter").unwrap(),
+            Path::new("/proj/components/counter.tsx")
+        );
+        assert_eq!(
+            m.get("Tabs").unwrap(),
+            Path::new("/proj/components/tabs.tsx")
+        );
     }
 
     #[test]
@@ -360,8 +366,14 @@ mod tests {
             island("Tabs", "/proj/components/nested/tabs.tsx"),
         ];
         let m = Manifest::from_islands(&set).relative_to(Path::new("/proj"));
-        assert_eq!(m.get("Counter").unwrap(), Path::new("components/counter.tsx"));
-        assert_eq!(m.get("Tabs").unwrap(), Path::new("components/nested/tabs.tsx"));
+        assert_eq!(
+            m.get("Counter").unwrap(),
+            Path::new("components/counter.tsx")
+        );
+        assert_eq!(
+            m.get("Tabs").unwrap(),
+            Path::new("components/nested/tabs.tsx")
+        );
     }
 
     #[test]
@@ -369,7 +381,10 @@ mod tests {
         let set = vec![island("Counter", "/proj/components/counter.tsx")];
         let m = Manifest::from_islands(&set).relative_to(Path::new("/elsewhere"));
         // Different root prefix → original path is kept.
-        assert_eq!(m.get("Counter").unwrap(), Path::new("/proj/components/counter.tsx"));
+        assert_eq!(
+            m.get("Counter").unwrap(),
+            Path::new("/proj/components/counter.tsx")
+        );
     }
 
     #[test]

--- a/crates/zfb-islands/src/scanner.rs
+++ b/crates/zfb-islands/src/scanner.rs
@@ -1316,9 +1316,8 @@ pub fn scan_islands_with_meta<R: Resolver>(
         // Gathered for every reachable module, not just `"use client"`
         // files — the import typically lives in an SSR-only layout that
         // carries no directive.
-        let cr_facts = collect_client_router_facts(&module, |spec| {
-            resolver.resolve(&importer_dir, spec)
-        });
+        let cr_facts =
+            collect_client_router_facts(&module, |spec| resolver.resolve(&importer_dir, spec));
 
         if has_use_client_directive(&module) {
             for record in exported_island_records(&module) {
@@ -1610,8 +1609,7 @@ fn resolve_client_router_usage(facts: &HashMap<PathBuf, ClientRouterFacts>) -> b
             if proxies.contains(path) {
                 continue;
             }
-            if f
-                .star_reexport_targets
+            if f.star_reexport_targets
                 .iter()
                 .any(|target| proxies.contains(target))
             {
@@ -1739,14 +1737,29 @@ fn collect_import_specifiers(module: &Module) -> Vec<String> {
         };
         match decl {
             ModuleDecl::Import(import_decl) => {
+                // `import type { … }` is erased at compile time — the module
+                // is never loaded at runtime, so it must not become a DFS edge.
+                if import_decl.type_only {
+                    continue;
+                }
                 out.push(atom_to_string(&import_decl.src.value));
             }
             ModuleDecl::ExportNamed(named) => {
+                // `export type { … } from "…"` is compile-time-erased — not a
+                // runtime pull, so it must not become a DFS edge.
+                if named.type_only {
+                    continue;
+                }
                 if let Some(src) = &named.src {
                     out.push(atom_to_string(&src.value));
                 }
             }
             ModuleDecl::ExportAll(all) => {
+                // `export type * from "…"` is compile-time-erased — not a
+                // runtime pull, so it must not become a DFS edge.
+                if all.type_only {
+                    continue;
+                }
                 out.push(atom_to_string(&all.src.value));
             }
             _ => {}
@@ -5233,5 +5246,131 @@ mod tests {
             "marker_name must default to the export name when no \
              renderSsrSkipPlaceholder call is present"
         );
+    }
+
+    // --- type-only import/export edges must not reach "use client" islands ---
+    // Regression tests for collect_import_specifiers: declaration-level
+    // type_only guards prevent phantom islands when the only path to a
+    // "use client" module is a compile-time-erased edge.
+
+    #[test]
+    fn island_not_emitted_when_reachable_only_via_import_type() {
+        // `import type { Counter } from "…"` is compile-time-erased.
+        // The "use client" module is reachable ONLY through this edge;
+        // it must NOT appear as an island.
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import type { Counter } from "../components/counter";
+                export default function Home() {}
+                "#,
+            )
+            .with_file(
+                root().join("components/counter.tsx"),
+                r#""use client";
+                export function Counter() {}
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert!(
+            islands.is_empty(),
+            "a 'use client' module reachable only via `import type` must not \
+             be emitted as an island; got {islands:?}"
+        );
+    }
+
+    #[test]
+    fn island_not_emitted_when_reachable_only_via_export_type_named() {
+        // `export type { Counter } from "…"` is compile-time-erased.
+        // A barrel re-exports the island with a type-only named re-export;
+        // the "use client" module must NOT appear as an island.
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import { Counter } from "../components/index";
+                export default function Home() {}
+                "#,
+            )
+            .with_file(
+                root().join("components/index.tsx"),
+                r#"export type { Counter } from "./counter";
+                "#,
+            )
+            .with_file(
+                root().join("components/counter.tsx"),
+                r#""use client";
+                export function Counter() {}
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert!(
+            islands.is_empty(),
+            "a 'use client' module reachable only via `export type {{ }}` must \
+             not be emitted as an island; got {islands:?}"
+        );
+    }
+
+    #[test]
+    fn island_not_emitted_when_reachable_only_via_export_type_star() {
+        // `export type * from "…"` is compile-time-erased.
+        // A barrel re-exports the island with a type-only star re-export;
+        // the "use client" module must NOT appear as an island.
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import { Counter } from "../components/index";
+                export default function Home() {}
+                "#,
+            )
+            .with_file(
+                root().join("components/index.tsx"),
+                r#"export type * from "./counter";
+                "#,
+            )
+            .with_file(
+                root().join("components/counter.tsx"),
+                r#""use client";
+                export function Counter() {}
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert!(
+            islands.is_empty(),
+            "a 'use client' module reachable only via `export type *` must \
+             not be emitted as an island; got {islands:?}"
+        );
+    }
+
+    #[test]
+    fn island_still_emitted_when_also_reachable_via_runtime_import() {
+        // Control: the same "use client" module is imported both with
+        // `import type` AND via a plain runtime import from another barrel.
+        // The runtime path must still emit the island.
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import type { Counter } from "../components/counter";
+                import { Counter as CounterImpl } from "../components/counter";
+                export default function Home() { return <CounterImpl/>; }
+                "#,
+            )
+            .with_file(
+                root().join("components/counter.tsx"),
+                r#""use client";
+                export function Counter() {}
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert_eq!(
+            islands.len(),
+            1,
+            "a module with both a type-only and a runtime import must still \
+             emit the island; got {islands:?}"
+        );
+        assert_eq!(islands[0].component_name, "Counter");
     }
 }

--- a/crates/zfb-md-extras/src/heading_marker_toc.rs
+++ b/crates/zfb-md-extras/src/heading_marker_toc.rs
@@ -29,7 +29,9 @@
 //! Wire via `features.headingMarkerToc = { heading: "TOC", maxDepth: 2 }`
 //! in `zfb.config.ts`.
 
-use zfb_md_ast::{HastNode, HastVisitor, TocConfig, extract_text};
+use zfb_md_ast::{HastNode, HastVisitor, TocConfig};
+
+use crate::toc_common::{heading_level, heading_text_without_hash_link};
 
 /// Hast visitor that inserts a `<ul>/<li>` table of contents after the
 /// TOC anchor heading.
@@ -96,7 +98,7 @@ fn find_anchor(children: &[HastNode], cfg: &TocConfig) -> Option<usize> {
         if !is_heading_tag(tag) {
             continue;
         }
-        let text = heading_text_without_anchor(node);
+        let text = heading_text_without_hash_link(node);
         if text.trim().to_lowercase() == target {
             return Some(i);
         }
@@ -126,51 +128,15 @@ fn heading_entry(node: &HastNode, max_level: u8) -> Option<TocEntry> {
     if id.is_empty() {
         return None;
     }
-    let text = heading_text_without_anchor(node);
+    let text = heading_text_without_hash_link(node);
     if text.is_empty() {
         return None;
     }
     Some(TocEntry { level, text, id })
 }
 
-fn heading_text_without_anchor(node: &HastNode) -> String {
-    let HastNode::Element { children, .. } = node else {
-        return extract_text(node);
-    };
-    let filtered: Vec<&HastNode> = children
-        .iter()
-        .filter(|c| !is_hash_link(c))
-        .collect();
-    let mut out = String::new();
-    for c in filtered {
-        out.push_str(&extract_text(c));
-    }
-    out
-}
-
-fn is_hash_link(node: &HastNode) -> bool {
-    let HastNode::Element { tag, attrs, children, .. } = node else {
-        return false;
-    };
-    tag == "a"
-        && children.is_empty()
-        && attrs.iter().any(|(k, v)| k == "class" && v == "hash-link")
-}
-
 fn is_heading_tag(tag: &str) -> bool {
     matches!(tag, "h1" | "h2" | "h3" | "h4" | "h5" | "h6")
-}
-
-fn heading_level(tag: &str) -> Option<u8> {
-    match tag {
-        "h1" => Some(1),
-        "h2" => Some(2),
-        "h3" => Some(3),
-        "h4" => Some(4),
-        "h5" => Some(5),
-        "h6" => Some(6),
-        _ => None,
-    }
 }
 
 fn build_nested_list(entries: &[TocEntry], base_level: u8) -> HastNode {
@@ -272,7 +238,13 @@ mod tests {
     }
 
     fn collect_hrefs_inner(node: &HastNode, out: &mut Vec<String>) {
-        if let HastNode::Element { tag, attrs, children, .. } = node {
+        if let HastNode::Element {
+            tag,
+            attrs,
+            children,
+            ..
+        } = node
+        {
             if tag == "a" {
                 if let Some((_, v)) = attrs.iter().find(|(k, _)| k == "href") {
                     out.push(v.clone());
@@ -303,7 +275,12 @@ mod tests {
         let children = root_children(&tree);
         assert_eq!(children.len(), 4, "TOC list must be inserted");
         let toc_list = &children[1];
-        let HastNode::Element { tag, children: ul_children, .. } = toc_list else {
+        let HastNode::Element {
+            tag,
+            children: ul_children,
+            ..
+        } = toc_list
+        else {
             panic!("expected <ul>");
         };
         assert_eq!(tag, "ul");
@@ -352,15 +329,27 @@ mod tests {
 
         let children = root_children(&tree);
         let toc_list = &children[1];
-        let HastNode::Element { children: ul_children, .. } = toc_list else {
+        let HastNode::Element {
+            children: ul_children,
+            ..
+        } = toc_list
+        else {
             panic!("expected <ul>");
         };
         assert_eq!(ul_children.len(), 2, "two top-level items");
 
-        let HastNode::Element { children: li1_children, .. } = &ul_children[0] else {
+        let HastNode::Element {
+            children: li1_children,
+            ..
+        } = &ul_children[0]
+        else {
             panic!("expected <li>");
         };
-        assert_eq!(li1_children.len(), 2, "alpha <li> must have link + nested ul");
+        assert_eq!(
+            li1_children.len(),
+            2,
+            "alpha <li> must have link + nested ul"
+        );
         let hrefs = collect_hrefs(&li1_children[1]);
         assert_eq!(hrefs, vec!["#sub"]);
     }

--- a/crates/zfb-md-extras/src/image_dimensions.rs
+++ b/crates/zfb-md-extras/src/image_dimensions.rs
@@ -42,8 +42,10 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 
-use zfb_md_ast::{BuildContext, HastNode, HastVisitor, ImageDimensionsConfig};
 use zfb_md_ast::diagnostics::MarkdownDiagnostic;
+use zfb_md_ast::{BuildContext, HastNode, HastVisitor, ImageDimensionsConfig};
+
+use crate::link_validation::normalize_path;
 
 /// Cached entry: `(mtime, width, height)`.
 type CacheEntry = (SystemTime, u32, u32);
@@ -151,9 +153,7 @@ fn try_inject_dimensions(
 
     // Skip remote URLs when `skipRemote` is true (the default).
     if should_skip_remote(config)
-        && (src.starts_with("http://")
-            || src.starts_with("https://")
-            || src.starts_with("//"))
+        && (src.starts_with("http://") || src.starts_with("https://") || src.starts_with("//"))
     {
         return;
     }
@@ -170,11 +170,35 @@ fn try_inject_dimensions(
         None => {
             emit_warning(
                 ctx,
-                format!("imageDimensions: could not resolve src '{src}' — no source path available"),
+                format!(
+                    "imageDimensions: could not resolve src '{src}' — no source path available"
+                ),
             );
             return;
         }
     };
+
+    // Containment guard: reject paths that escape the expected root directory.
+    // Absolute `/…` srcs are resolved into `public_dir`; relative srcs into
+    // `project_root`. Lexically normalize to collapse any `..` components
+    // injected via crafted src values (e.g. `../../etc/hosts`).
+    let is_absolute_src = src.starts_with('/');
+    let expected_root = if is_absolute_src {
+        &ctx.public_dir
+    } else {
+        &ctx.project_root
+    };
+    let normalized = normalize_path(&abs_path);
+    if !normalized.starts_with(expected_root) {
+        emit_warning(
+            ctx,
+            format!(
+                "imageDimensions: src '{src}' resolves outside the expected root '{}' — skipping",
+                expected_root.display()
+            ),
+        );
+        return;
+    }
 
     // Probe dimensions (from cache or disk).
     match probe_dimensions(&abs_path, cache, read_count) {
@@ -278,8 +302,13 @@ mod tests {
     }
 
     fn get_attr<'a>(node: &'a HastNode, name: &str) -> Option<&'a str> {
-        let HastNode::Element { attrs, .. } = node else { return None; };
-        attrs.iter().find(|(k, _)| k == name).map(|(_, v)| v.as_str())
+        let HastNode::Element { attrs, .. } = node else {
+            return None;
+        };
+        attrs
+            .iter()
+            .find(|(k, _)| k == name)
+            .map(|(_, v)| v.as_str())
     }
 
     #[test]
@@ -310,33 +339,21 @@ mod tests {
 
     #[test]
     fn resolve_src_absolute_uses_public_dir() {
-        let ctx = BuildContext::for_paths(
-            "/project/src/page.mdx",
-            "/project",
-            "/project/public",
-        );
+        let ctx = BuildContext::for_paths("/project/src/page.mdx", "/project", "/project/public");
         let resolved = resolve_src("/img/foo.png", &ctx);
         assert_eq!(resolved, Some(PathBuf::from("/project/public/img/foo.png")));
     }
 
     #[test]
     fn resolve_src_relative_uses_source_dir() {
-        let ctx = BuildContext::for_paths(
-            "/project/src/page.mdx",
-            "/project",
-            "/project/public",
-        );
+        let ctx = BuildContext::for_paths("/project/src/page.mdx", "/project", "/project/public");
         let resolved = resolve_src("./assets/foo.png", &ctx);
         assert_eq!(resolved, Some(PathBuf::from("/project/src/assets/foo.png")));
     }
 
     #[test]
     fn resolve_src_relative_no_leading_dot() {
-        let ctx = BuildContext::for_paths(
-            "/project/src/page.mdx",
-            "/project",
-            "/project/public",
-        );
+        let ctx = BuildContext::for_paths("/project/src/page.mdx", "/project", "/project/public");
         let resolved = resolve_src("assets/foo.png", &ctx);
         assert_eq!(resolved, Some(PathBuf::from("/project/src/assets/foo.png")));
     }
@@ -362,13 +379,17 @@ mod tests {
 
     #[test]
     fn should_skip_remote_explicit_true() {
-        let cfg = ImageDimensionsConfig { skip_remote: Some(true) };
+        let cfg = ImageDimensionsConfig {
+            skip_remote: Some(true),
+        };
         assert!(should_skip_remote(&cfg));
     }
 
     #[test]
     fn should_skip_remote_explicit_false() {
-        let cfg = ImageDimensionsConfig { skip_remote: Some(false) };
+        let cfg = ImageDimensionsConfig {
+            skip_remote: Some(false),
+        };
         assert!(!should_skip_remote(&cfg));
     }
 
@@ -392,5 +413,86 @@ mod tests {
         assert_eq!(get_attr(&node, "src"), Some("foo.png"));
         assert_eq!(get_attr(&node, "alt"), Some("desc"));
         assert_eq!(get_attr(&node, "width"), None);
+    }
+
+    // ── Fix #703: containment guard tests ────────────────────────────────────
+
+    /// Helper: run `try_inject_dimensions` for a given src and return collected warnings.
+    fn collect_warnings_for_src(
+        src: &str,
+        project_root: &str,
+        public_dir: &str,
+        source_path: &str,
+    ) -> Vec<String> {
+        use zfb_md_ast::diagnostics::CollectingSink;
+
+        let mut node = img(&[("src", src)]);
+        let cache = Arc::new(Mutex::new(HashMap::new()));
+        let read_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let config = ImageDimensionsConfig::default();
+
+        let mut sink = CollectingSink::new();
+        let mut ctx = zfb_md_ast::BuildContext {
+            source_path: Some(PathBuf::from(source_path)),
+            project_root: PathBuf::from(project_root),
+            public_dir: PathBuf::from(public_dir),
+            heading_registry: None,
+            diagnostics: Some(&mut sink),
+        };
+        try_inject_dimensions(&mut node, &mut ctx, &config, &cache, &read_count);
+        sink.take()
+            .into_iter()
+            .filter_map(|d| match d {
+                zfb_md_ast::diagnostics::MarkdownDiagnostic::Generic { message, .. } => {
+                    Some(message)
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// A relative src that escapes the project root via `../../` must be rejected
+    /// with a containment warning and must NOT trigger a disk probe.
+    #[test]
+    fn relative_path_traversal_rejected_with_warning() {
+        // `../../etc/hosts` resolves outside project_root → containment warning.
+        let warnings = collect_warnings_for_src(
+            "../../etc/hosts",
+            "/project",
+            "/project/public",
+            "/project/src/page.mdx",
+        );
+        assert!(
+            !warnings.is_empty(),
+            "expected a containment warning for path-traversal src"
+        );
+        assert!(
+            warnings[0].contains("resolves outside the expected root"),
+            "warning should mention containment: {:?}",
+            warnings[0]
+        );
+    }
+
+    /// An absolute src that escapes `public_dir` via `/../../` must be rejected.
+    #[test]
+    fn absolute_path_traversal_rejected_with_warning() {
+        // `/../../etc/hosts` → join public_dir `/project/public` →
+        // `/project/public/../../etc/hosts` → normalizes to `/etc/hosts`
+        // → not under `/project/public` → containment warning.
+        let warnings = collect_warnings_for_src(
+            "/../../etc/hosts",
+            "/project",
+            "/project/public",
+            "/project/src/page.mdx",
+        );
+        assert!(
+            !warnings.is_empty(),
+            "expected a containment warning for absolute path-traversal src"
+        );
+        assert!(
+            warnings[0].contains("resolves outside the expected root"),
+            "warning should mention containment: {:?}",
+            warnings[0]
+        );
     }
 }

--- a/crates/zfb-md-extras/src/lib.rs
+++ b/crates/zfb-md-extras/src/lib.rs
@@ -19,10 +19,10 @@
 // in the natural location (this is the "features" crate, after all) without
 // reaching past it for the type.
 pub use zfb_md_ast::{
-    directives_enabled, feature_enabled, heading_marker_toc_enabled, CodeEnrichmentConfig,
-    DirectiveFullSpec, DirectiveSpec, DirectiveSpecKind, FeatureOptions, FeatureToggle,
-    GithubAutolinksConfig, HeadingMarkerTocFeature, ImageDimensionsConfig, LinkValidationConfig,
-    MarkdownFeaturesConfig, TocConfig, TocExportConfig, TranscludeConfig, into_directive_def,
+    directives_enabled, feature_enabled, heading_marker_toc_enabled, into_directive_def,
+    CodeEnrichmentConfig, DirectiveFullSpec, DirectiveSpec, DirectiveSpecKind, FeatureOptions,
+    FeatureToggle, GithubAutolinksConfig, HeadingMarkerTocFeature, ImageDimensionsConfig,
+    LinkValidationConfig, MarkdownFeaturesConfig, TocConfig, TocExportConfig, TranscludeConfig,
 };
 
 /// Test harness module — `run_fixture` and helpers for fixture-based
@@ -33,6 +33,9 @@ pub use zfb_md_ast::{
 ///   `zfb-md-extras = { path = "...", features = ["test-utils"] }`
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_harness;
+
+// ── Crate-private shared utilities ─────────────────────────────────────────
+mod toc_common;
 
 // ── Wave 3 feature modules (moved from zfb-content in #570) ────────────────
 

--- a/crates/zfb-md-extras/src/link_validation.rs
+++ b/crates/zfb-md-extras/src/link_validation.rs
@@ -44,8 +44,8 @@
 use std::path::{Path, PathBuf};
 
 use zfb_md_ast::{
-    BuildContext, HastNode, HastVisitor, LinkValidationConfig,
     diagnostics::{DiagnosticSeverity, MarkdownDiagnostic, SourceLocation},
+    BuildContext, HastNode, HastVisitor, LinkValidationConfig,
 };
 
 // ── External URL detection ────────────────────────────────────────────────────
@@ -130,7 +130,10 @@ fn resolve_relative(source_path: &Path, file_ref: &str) -> Option<PathBuf> {
 /// Algorithm: iterate components and maintain a stack; `..` pops the last
 /// component (unless the stack is empty or the last component is also `..`),
 /// `.` is dropped, and everything else is pushed.
-fn normalize_path(path: &Path) -> PathBuf {
+///
+/// `pub(crate)` so sibling modules (e.g. `image_dimensions`) can share it
+/// without duplicating logic or adding a new module.
+pub(crate) fn normalize_path(path: &Path) -> PathBuf {
     use std::path::Component;
     let mut components: Vec<std::ffi::OsString> = Vec::new();
     let mut has_root = false;
@@ -229,7 +232,14 @@ impl HastVisitor for LinkValidationPlugin {
         let severity = self.severity();
         let allow_external = self.allow_external();
         let project_root = ctx.project_root.clone();
-        collect_diagnostics(node, &source_path, &project_root, ctx, severity, allow_external);
+        collect_diagnostics(
+            node,
+            &source_path,
+            &project_root,
+            ctx,
+            severity,
+            allow_external,
+        );
     }
 }
 
@@ -245,14 +255,34 @@ fn collect_diagnostics(
     allow_external: bool,
 ) {
     match node {
-        HastNode::Element { tag, attrs, children, .. } => {
+        HastNode::Element {
+            tag,
+            attrs,
+            children,
+            ..
+        } => {
             // Extract the link target: href for <a>, src for <img>.
-            let href_opt = if tag == "a" {
-                attrs.iter().find(|(k, _)| k == "href").map(|(_, v)| v.clone())
+            // Track whether the element is an <img> so fragment validation
+            // can be skipped — images use fragment syntax for SVG sprites
+            // (e.g. sprite.svg#icon-x) which are not heading anchors.
+            let (href_opt, is_img) = if tag == "a" {
+                (
+                    attrs
+                        .iter()
+                        .find(|(k, _)| k == "href")
+                        .map(|(_, v)| v.clone()),
+                    false,
+                )
             } else if tag == "img" {
-                attrs.iter().find(|(k, _)| k == "src").map(|(_, v)| v.clone())
+                (
+                    attrs
+                        .iter()
+                        .find(|(k, _)| k == "src")
+                        .map(|(_, v)| v.clone()),
+                    true,
+                )
             } else {
-                None
+                (None, false)
             };
 
             if let Some(href) = href_opt {
@@ -263,17 +293,32 @@ fn collect_diagnostics(
                     ctx,
                     severity,
                     allow_external,
+                    is_img,
                 );
             }
 
             // Recurse into children.
             for child in children {
-                collect_diagnostics(child, source_path, project_root, ctx, severity, allow_external);
+                collect_diagnostics(
+                    child,
+                    source_path,
+                    project_root,
+                    ctx,
+                    severity,
+                    allow_external,
+                );
             }
         }
         HastNode::Root { children } => {
             for child in children {
-                collect_diagnostics(child, source_path, project_root, ctx, severity, allow_external);
+                collect_diagnostics(
+                    child,
+                    source_path,
+                    project_root,
+                    ctx,
+                    severity,
+                    allow_external,
+                );
             }
         }
         // Leaf nodes.
@@ -282,6 +327,11 @@ fn collect_diagnostics(
 }
 
 /// Validate a single link `href` and emit a diagnostic if broken.
+///
+/// `is_img` must be `true` when the link comes from an `<img src>` attribute.
+/// Images support fragment syntax for SVG sprites (e.g. `sprite.svg#icon-x`),
+/// so `FileWithFragment` and `BareFragment` skip heading-anchor validation and
+/// only confirm file existence (or skip bare fragments entirely).
 fn validate_link(
     href: &str,
     source_path: &Path,
@@ -289,6 +339,7 @@ fn validate_link(
     ctx: &mut BuildContext<'_>,
     severity: DiagnosticSeverity,
     allow_external: bool,
+    is_img: bool,
 ) {
     let parsed = parse_link(href);
     match parsed {
@@ -298,8 +349,14 @@ fn validate_link(
             let _ = allow_external;
         }
         ParsedLink::BareFragment(fragment) => {
-            // Check fragment against the current file's heading entries.
-            validate_fragment_in_file(href, &fragment, source_path, ctx, severity);
+            if is_img {
+                // Bare fragment on an <img> (e.g. `#icon`) — no file to check,
+                // no heading registry applies; skip silently.
+                let _ = fragment;
+            } else {
+                // Check fragment against the current file's heading entries.
+                validate_fragment_in_file(href, &fragment, source_path, ctx, severity);
+            }
         }
         ParsedLink::FilePath(path) => {
             // Check that the file exists on disk relative to source_path,
@@ -307,8 +364,22 @@ fn validate_link(
             validate_file_exists(href, &path, source_path, project_root, ctx, severity);
         }
         ParsedLink::FileWithFragment { path, fragment } => {
-            // Resolve the target file, then check the fragment in that file.
-            validate_file_with_fragment(href, &path, &fragment, source_path, project_root, ctx, severity);
+            if is_img {
+                // For <img>, fragments are SVG sprite IDs — not heading anchors.
+                // Only validate file existence; ignore the fragment part.
+                validate_file_exists(href, &path, source_path, project_root, ctx, severity);
+            } else {
+                // Resolve the target file, then check the fragment in that file.
+                validate_file_with_fragment(
+                    href,
+                    &path,
+                    &fragment,
+                    source_path,
+                    project_root,
+                    ctx,
+                    severity,
+                );
+            }
         }
     }
 }
@@ -441,7 +512,10 @@ mod tests {
 
     #[test]
     fn parse_bare_fragment() {
-        assert_eq!(parse_link("#intro"), ParsedLink::BareFragment("intro".to_string()));
+        assert_eq!(
+            parse_link("#intro"),
+            ParsedLink::BareFragment("intro".to_string())
+        );
         assert_eq!(parse_link("#"), ParsedLink::BareFragment(String::new()));
     }
 
@@ -505,5 +579,50 @@ mod tests {
     fn normalize_path_double_parent() {
         let p = PathBuf::from("/a/b/c/../../d");
         assert_eq!(normalize_path(&p), PathBuf::from("/a/d"));
+    }
+
+    // ── Fix #733: img-src fragment should not trigger heading-anchor check ────
+
+    /// An `<img src="sprite.svg#icon-x">` where the file exists must NOT emit a
+    /// BrokenLink diagnostic even when `icon-x` is not a heading in any registry.
+    #[test]
+    fn img_src_with_svg_sprite_fragment_no_broken_link() {
+        use tempdir::TempDir;
+        use zfb_md_ast::{diagnostics::CollectingSink, HastVisitor};
+
+        let dir = TempDir::new("link_val_img_fragment").unwrap();
+        let sprite_path = dir.path().join("sprite.svg");
+        // File must exist so validate_file_exists passes.
+        std::fs::write(&sprite_path, "<svg/>").unwrap();
+        let source_path = dir.path().join("page.mdx");
+        std::fs::write(&source_path, "").unwrap();
+
+        // Build a hast tree: <img src="sprite.svg#icon-x">
+        let img_node = HastNode::Element {
+            tag: "img".to_string(),
+            attrs: vec![("src".to_string(), "sprite.svg#icon-x".to_string())],
+            children: vec![],
+            void: true,
+        };
+        let mut root = HastNode::Root {
+            children: vec![img_node],
+        };
+
+        let mut sink = CollectingSink::new();
+        let mut ctx = BuildContext {
+            source_path: Some(source_path),
+            project_root: dir.path().to_path_buf(),
+            public_dir: dir.path().to_path_buf(),
+            heading_registry: None, // no headings registered → fragment would fail if checked
+            diagnostics: Some(&mut sink),
+        };
+        let mut plugin = LinkValidationPlugin::new(LinkValidationConfig::default());
+        plugin.visit_with_context(&mut root, &mut ctx);
+
+        let diags = sink.take();
+        assert!(
+            diags.is_empty(),
+            "img src with svg sprite fragment must not emit BrokenLink: {diags:?}"
+        );
     }
 }

--- a/crates/zfb-md-extras/src/toc_common.rs
+++ b/crates/zfb-md-extras/src/toc_common.rs
@@ -1,0 +1,49 @@
+//! Shared pure helpers used by both `toc_export` and `heading_marker_toc`.
+//!
+//! These three functions are logically identical in both visitors; they live
+//! here to avoid byte-for-byte duplication (source finding #704).
+
+use zfb_md_ast::{extract_text, HastNode};
+
+/// Return `true` if `node` is the empty `<a class="hash-link">` anchor
+/// appended by `HeadingLinksPlugin`.
+pub(crate) fn is_hash_link(node: &HastNode) -> bool {
+    let HastNode::Element {
+        tag,
+        attrs,
+        children,
+        ..
+    } = node
+    else {
+        return false;
+    };
+    tag == "a" && children.is_empty() && attrs.iter().any(|(k, v)| k == "class" && v == "hash-link")
+}
+
+/// Map an HTML heading tag name (`"h1"`…`"h6"`) to its numeric depth.
+/// Returns `None` for any other tag.
+pub(crate) fn heading_level(tag: &str) -> Option<u8> {
+    match tag {
+        "h1" => Some(1),
+        "h2" => Some(2),
+        "h3" => Some(3),
+        "h4" => Some(4),
+        "h5" => Some(5),
+        "h6" => Some(6),
+        _ => None,
+    }
+}
+
+/// Strip the hash-link anchor appended by `HeadingLinksPlugin` and return
+/// the heading's plain-text content.
+pub(crate) fn heading_text_without_hash_link(node: &HastNode) -> String {
+    let HastNode::Element { children, .. } = node else {
+        return extract_text(node);
+    };
+    let filtered: Vec<&HastNode> = children.iter().filter(|c| !is_hash_link(c)).collect();
+    let mut out = String::new();
+    for c in filtered {
+        out.push_str(&extract_text(c));
+    }
+    out
+}

--- a/crates/zfb-md-extras/src/toc_export.rs
+++ b/crates/zfb-md-extras/src/toc_export.rs
@@ -46,7 +46,9 @@
 //! Ported in Wave 5 (#578). Separate from `heading_marker_toc.rs` (#570)
 //! so users can enable data-export without the in-body heading-marker insertion.
 
-use zfb_md_ast::{HastNode, HastVisitor, TocExportConfig, extract_text};
+use zfb_md_ast::{HastNode, HastVisitor, TocExportConfig};
+
+use crate::toc_common::{heading_level, heading_text_without_hash_link};
 
 /// Hast visitor that injects `export const toc = [...]` at the top of the
 /// document root.
@@ -136,45 +138,6 @@ fn flat_entry(node: &HastNode, max_depth: u8) -> Option<FlatEntry> {
         return None;
     }
     Some(FlatEntry { depth, id, text })
-}
-
-/// Strip the hash-link anchor appended by `HeadingLinksPlugin` and return
-/// the heading's plain-text content. Mirrors the same helper in
-/// `heading_marker_toc.rs`.
-fn heading_text_without_hash_link(node: &HastNode) -> String {
-    let HastNode::Element { children, .. } = node else {
-        return extract_text(node);
-    };
-    let filtered: Vec<&HastNode> = children
-        .iter()
-        .filter(|c| !is_hash_link(c))
-        .collect();
-    let mut out = String::new();
-    for c in filtered {
-        out.push_str(&extract_text(c));
-    }
-    out
-}
-
-fn is_hash_link(node: &HastNode) -> bool {
-    let HastNode::Element { tag, attrs, children, .. } = node else {
-        return false;
-    };
-    tag == "a"
-        && children.is_empty()
-        && attrs.iter().any(|(k, v)| k == "class" && v == "hash-link")
-}
-
-fn heading_level(tag: &str) -> Option<u8> {
-    match tag {
-        "h1" => Some(1),
-        "h2" => Some(2),
-        "h3" => Some(3),
-        "h4" => Some(4),
-        "h5" => Some(5),
-        "h6" => Some(6),
-        _ => None,
-    }
 }
 
 /// Build a nested `TocEntry` tree from a flat list, grouping children of
@@ -395,7 +358,10 @@ mod tests {
         );
         let export = extract_export(&tree);
         // Double-quote must be escaped; angle brackets are safe in JSON strings.
-        assert!(export.contains(r#"\"hello\""#), "quotes must be escaped: {export}");
+        assert!(
+            export.contains(r#"\"hello\""#),
+            "quotes must be escaped: {export}"
+        );
     }
 
     #[test]
@@ -407,7 +373,10 @@ mod tests {
             TocExportConfig::default(),
         );
         let export = extract_export(&tree);
-        assert!(export.contains("\"text\":\"Clean\""), "text must be clean: {export}");
+        assert!(
+            export.contains("\"text\":\"Clean\""),
+            "text must be clean: {export}"
+        );
     }
 
     #[test]

--- a/crates/zfb-server/src/inject.rs
+++ b/crates/zfb-server/src/inject.rs
@@ -88,9 +88,11 @@ pub fn livereload_tag(base_prefix: &str) -> String {
 /// - When no `<body>` element is found (HTML fragments, partials,
 ///   malformed input) the tag is appended to the end of the document,
 ///   matching the previous fallback behaviour.
-///
-/// The function never errors; the worst case is a fragment getting an
-/// extra script tag at the end, which is harmless in dev mode.
+/// - On a `lol_html` rewriting error (e.g. `ParsingAmbiguityError` from
+///   strict-mode parsing of non-conforming markup) a warning is logged,
+///   the tree is left unmodified, and the no-body append fallback still
+///   runs — serving the original bytes with the script tag appended
+///   rather than panicking the handler task.
 pub fn inject_livereload_into_tree_with_prefix(tree: &mut HtmlTree, base_prefix: &str) {
     let tag = livereload_tag(base_prefix);
     let body_found = Rc::new(Cell::new(false));
@@ -113,11 +115,24 @@ pub fn inject_livereload_into_tree_with_prefix(tree: &mut HtmlTree, base_prefix:
         ..RewriteStrSettings::new()
     };
 
-    tree.rewrite(settings)
-        .expect("lol_html rewriting for livereload injection should not fail");
+    let rewrite_ok = if let Err(err) = tree.rewrite(settings) {
+        // Graceful degradation in dev mode: lol_html should not fail on
+        // well-formed HTML, but non-conforming markup (e.g. <select><xmp>…)
+        // can trigger a ParsingAmbiguityError in strict mode. HtmlTree::rewrite
+        // leaves self.html unmodified on Err. Reset body_found so the append
+        // fallback below still runs — mirroring the contract in routes.rs
+        // ~1585: serve the original bytes rather than 500ing the page.
+        tracing::warn!(
+            err = %err,
+            "livereload injection: lol_html rewrite failed; falling back to append"
+        );
+        false
+    } else {
+        true
+    };
 
-    if !body_found.get() {
-        // Fragment / headerless: append the tag.
+    if !rewrite_ok || !body_found.get() {
+        // Fragment / headerless, or rewrite error: append the tag.
         tree.html_mut().push_str(&tag);
     }
 }
@@ -187,9 +202,8 @@ mod tests {
         // Japanese before/after, plus a 4-byte emoji literal.
         let html = "<html><body><h1>こんにちは🎉世界</h1></body></html>";
         let out = inject_livereload(html);
-        let expected = format!(
-            "<html><body><h1>こんにちは🎉世界</h1>{LIVERELOAD_TAG}</body></html>"
-        );
+        let expected =
+            format!("<html><body><h1>こんにちは🎉世界</h1>{LIVERELOAD_TAG}</body></html>");
         assert_eq!(out, expected);
         assert!(out.contains("こんにちは🎉世界"));
     }
@@ -278,5 +292,49 @@ mod tests {
         let with_empty_prefix = inject_livereload_with_prefix(html, "");
         let no_prefix = inject_livereload(html);
         assert_eq!(with_empty_prefix, no_prefix);
+    }
+
+    // ---- graceful degradation (issue #737) --------------------------------
+
+    /// Non-conforming markup that triggers lol_html's `ParsingAmbiguityError`
+    /// in strict mode: `<xmp>` inside `<select>` makes it ambiguous whether
+    /// `<script>` is parsed as raw text or element content.
+    ///
+    /// The function must not panic; it must serve *some* bytes that include
+    /// the original markup and the livereload script tag (via the append
+    /// fallback), rather than 500ing the request.
+    #[test]
+    fn rewrite_error_falls_back_to_append_without_panicking() {
+        // This markup is the canonical ParsingAmbiguityError trigger from
+        // the lol_html documentation: <xmp> inside <select> causes strict
+        // mode to reject the input rather than guess the parse context.
+        let ambiguous_html =
+            r#"<html><body><select><xmp><script>"use strict";</script></select></body></html>"#;
+        let mut tree = HtmlTree::parse(ambiguous_html);
+        // Must not panic regardless of whether lol_html rejects this input.
+        inject_livereload_into_tree_with_prefix(&mut tree, "");
+        let out = tree.serialize();
+        // The output must contain the livereload tag (via the append fallback).
+        assert!(
+            out.contains(LIVERELOAD_TAG),
+            "expected livereload tag in degraded output, got: {out}"
+        );
+        // The original markup must be preserved (no data loss).
+        assert!(
+            out.contains("use strict"),
+            "original content should be present in degraded output, got: {out}"
+        );
+    }
+
+    /// Confirm the no-body-found append fallback (fragment path) is
+    /// unaffected by the rewrite-error change — it still appends the tag.
+    #[test]
+    fn append_fallback_still_runs_on_normal_fragment() {
+        let html = "<p>just a paragraph</p>";
+        let out = inject_livereload(html);
+        assert!(
+            out.ends_with(LIVERELOAD_TAG),
+            "expected append fallback for fragment, got: {out}"
+        );
     }
 }

--- a/crates/zfb-test-utils/src/html_normalize.rs
+++ b/crates/zfb-test-utils/src/html_normalize.rs
@@ -104,23 +104,17 @@ pub fn normalize_html(html: &str) -> String {
     // <script> and <style> — are treated as body content and not hoisted
     // to <head>. parse_document would move <script>/<style> into <head>.
     let context_name = QualName::new(None, ns!(html), LocalName::from("body"));
-    let dom = parse_fragment(
-        RcDom::default(),
-        ParseOpts::default(),
-        context_name,
-        vec![],
-    )
-    .one(html.to_string());
+    let dom = parse_fragment(RcDom::default(), ParseOpts::default(), context_name, vec![])
+        .one(html.to_string());
 
     // Walk the DOM: sort attributes, normalize boolean attr values, and
     // collapse inter-element whitespace.
-    sort_attrs_and_collapse_whitespace(&dom.document);
+    sort_attrs_and_collapse_whitespace(&dom.document, false);
 
     // html5ever's fragment parse result has the structure:
     //   Document → html → body → [the actual fragment nodes]
     // We extract the body element and serialize its children directly.
-    let body = find_body(&dom.document)
-        .unwrap_or_else(|| dom.document.clone());
+    let body = find_body(&dom.document).unwrap_or_else(|| dom.document.clone());
 
     let mut output = Vec::new();
     let handle: SerializableHandle = body.clone().into();
@@ -163,8 +157,13 @@ fn find_body(node: &markup5ever_rcdom::Handle) -> Option<markup5ever_rcdom::Hand
 /// (pure-whitespace text nodes become a single newline).
 ///
 /// Raw-text contexts (`<pre>`, `<code>`, `<textarea>`, `<script>`, `<style>`)
-/// are preserved verbatim — their text-node children are not touched.
-fn sort_attrs_and_collapse_whitespace(node: &markup5ever_rcdom::Handle) {
+/// are preserved verbatim — their text-node descendants (including nested
+/// elements like `<pre><span>  </span></pre>`) are never touched.
+///
+/// `inside_raw` is `true` when any ancestor is already a raw-text element;
+/// the effective raw flag is the union of the ancestor state and the current
+/// node's own tag, propagated into every recursive call.
+fn sort_attrs_and_collapse_whitespace(node: &markup5ever_rcdom::Handle, inside_raw: bool) {
     // Determine if this node is a raw-text context (no whitespace collapse
     // inside it).
     let is_raw = match &node.data {
@@ -176,6 +175,9 @@ fn sort_attrs_and_collapse_whitespace(node: &markup5ever_rcdom::Handle) {
         }
         _ => false,
     };
+    // Combine ancestor state with current node: once inside a raw-text
+    // context, all descendants keep their whitespace untouched.
+    let effective_raw = inside_raw || is_raw;
 
     // Sort attributes on this element node and normalize boolean attr values.
     if let NodeData::Element { attrs, .. } = &node.data {
@@ -196,7 +198,7 @@ fn sort_attrs_and_collapse_whitespace(node: &markup5ever_rcdom::Handle) {
     // Process children.
     let children = node.children.borrow();
     for child in children.iter() {
-        if !is_raw {
+        if !effective_raw {
             // Collapse pure-whitespace text nodes to a single newline.
             if let NodeData::Text { contents } = &child.data {
                 let text = contents.borrow();
@@ -207,10 +209,9 @@ fn sort_attrs_and_collapse_whitespace(node: &markup5ever_rcdom::Handle) {
                 }
             }
         }
-        sort_attrs_and_collapse_whitespace(child);
+        sort_attrs_and_collapse_whitespace(child, effective_raw);
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -245,7 +246,10 @@ mod tests {
         let out = normalize_html(input);
         let href_pos = out.find("href=").unwrap();
         let rel_pos = out.find("rel=").unwrap();
-        assert!(href_pos < rel_pos, "normalize_html must sort attrs; got: {out}");
+        assert!(
+            href_pos < rel_pos,
+            "normalize_html must sort attrs; got: {out}"
+        );
     }
 
     // ── Entity encoding ───────────────────────────────────────────────────
@@ -326,7 +330,10 @@ mod tests {
         assert_eq!(a, b, "br vs br/ must normalize equal");
         assert_eq!(a, c, "br vs br-space-/ must normalize equal");
         // Output must not contain "/>" — HTML5 serializer never emits that.
-        assert!(!a.contains("/>"), "void elements must not have />; got: {a}");
+        assert!(
+            !a.contains("/>"),
+            "void elements must not have />; got: {a}"
+        );
     }
 
     #[test]
@@ -436,6 +443,21 @@ mod tests {
         assert!(
             !out.contains("   "),
             "pure-whitespace outside raw context must collapse; got: {out}"
+        );
+    }
+
+    #[test]
+    fn test_raw_context_nested_element_whitespace_preserved() {
+        // Regression: whitespace inside an element CHILD of a raw-text context
+        // (e.g. <span> inside <pre>, common in syntax-highlighted blocks) must
+        // NOT be collapsed — the `inside_raw` flag threads the raw-text context
+        // through recursion so that nested elements are also protected.
+        let input = "<pre><span>  </span></pre>";
+        let out = normalize_html(input);
+        // The two spaces inside <span> must survive verbatim.
+        assert!(
+            out.contains("<span>  </span>"),
+            "whitespace inside nested element within raw context must be preserved; got: {out}"
         );
     }
 

--- a/crates/zfb-test-utils/src/lib.rs
+++ b/crates/zfb-test-utils/src/lib.rs
@@ -53,9 +53,7 @@ pub fn locate_esbuild() -> Option<PathBuf> {
 
     if let Some(ref workspace) = workspace {
         // Step 2: workspace-local binary slot.
-        let slot = workspace
-            .join("crates/zfb/binaries/esbuild")
-            .join(binary);
+        let slot = workspace.join("crates/zfb/binaries/esbuild").join(binary);
         if slot.is_file() {
             return Some(slot);
         }

--- a/crates/zfb-watcher/src/lib.rs
+++ b/crates/zfb-watcher/src/lib.rs
@@ -330,7 +330,16 @@ async fn debouncer_task(
             // longer aborts the task — so this is the graceful-exit path.
             _ = &mut shutdown => {
                 flush_all(&mut pending, &out_tx).await;
-                break;
+                // Do NOT fall through to `let _ = bridge.await;` below: the
+                // bridge thread is parked in the synchronous `raw_rx.recv()`,
+                // which closes only after `_notify` drops — and `_notify`
+                // drops only when `Watcher::shutdown` RETURNS. Awaiting the
+                // bridge here is a circular wait (issue #708). abort() cannot
+                // cancel the parked thread, but it makes the JoinHandle return
+                // immediately; the detached thread then exits once `_notify`
+                // drops at the end of `shutdown()` and closes `raw_tx`.
+                bridge.abort();
+                return;
             }
 
             maybe_evt = bridge_rx.recv() => {
@@ -525,5 +534,24 @@ mod tests {
             merge(Some(ChangeKind::Modified), ChangeKind::Created),
             ChangeKind::Created,
         );
+    }
+
+    /// Regression test for the `Watcher::shutdown()` circular-wait deadlock
+    /// (issue #708 / sub-issue #759). Before the fix, the shutdown-signal
+    /// branch flushed then fell through to `let _ = bridge.await;`, but the
+    /// bridge `spawn_blocking` task is parked in `raw_rx.recv()`, which only
+    /// closes when `_notify` drops — and `_notify` drops only when `shutdown`
+    /// RETURNS. So `shutdown().await` could never complete. The timeout here
+    /// is the guard: it fails (rather than hangs the whole suite) if the
+    /// deadlock ever returns.
+    #[tokio::test]
+    async fn shutdown_returns_within_timeout() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let (watcher, _rx) =
+            Watcher::start(tmp.path(), std::iter::once(".")).expect("watcher start");
+
+        tokio::time::timeout(Duration::from_secs(3), watcher.shutdown())
+            .await
+            .expect("Watcher::shutdown() must complete (circular-wait deadlock regression)");
     }
 }

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -1104,12 +1104,14 @@ impl DevRenderSession {
             // *stable source id* whose output_path can flip across ticks (e.g.
             // sitemap.xml → sitemap.rss); output-path keying makes such a flip
             // produce two distinct keys, so the old artifact would orphan in
-            // dist/. Unreachable today because `routes_by_source` is built once
-            // at boot and never rebuilt during a session, so each entry's
-            // output_path is frozen. If live `paths()` re-expansion / router
-            // re-scan on watch ticks is added later (see the scope-guard
-            // follow-up below), restore source-path keying for static routes
-            // (or key dynamic entries on (source_path, output_path)).
+            // dist/. Still unreachable after #659 (which added live table
+            // rebuilding in `discover_created`): that function's diff gate
+            // (lines ~1289-1301) only re-renders sources whose entry COUNT
+            // changed (`prev.len() != entries.len()`), so an output_path flip
+            // on a stable-count source is never re-rendered/pruned and the
+            // orphan path is never triggered. If entry-count-stable output_path
+            // flips must be handled, restore source-path keying for static
+            // routes (or key dynamic entries on (source_path, output_path)).
             out.push(RenderedPage {
                 page: PageId::new(entry.output_path.clone()),
                 output_path,

--- a/crates/zfb/src/commands/plugins.rs
+++ b/crates/zfb/src/commands/plugins.rs
@@ -22,10 +22,12 @@ use zfb_server::{
 };
 
 /// Convert `Config.plugins` into the wire shape the plugin host wants.
-/// Drops entries without a resolved module specifier (the JSON-config
-/// path produces those, and there's no path-resolution context here to
-/// rescue them). Surfaces a warning so a typo in `zfb.config.json`
-/// doesn't fall on the floor silently.
+/// Drops entries without a resolved module specifier **silently** — the
+/// `filter_map` + `?` skips them with zero diagnostics. Upstream loaders
+/// (`resolve_json_plugin_modules` in config.rs and the TS evaluator) are
+/// responsible for hard-erroring on unresolvable plugins (#211), so a
+/// `None` resolved_module reaching here is effectively unreachable for
+/// config-declared plugins today.
 fn build_plugin_specs(config: &Config) -> Vec<PluginSpec> {
     config
         .plugins

--- a/crates/zfb/src/render_pipeline.rs
+++ b/crates/zfb/src/render_pipeline.rs
@@ -187,15 +187,17 @@ pub fn embedded_binary(name: &str) -> Result<(tempfile::TempDir, PathBuf)> {
         .unwrap_or_else(|| std::ffi::OsString::from(name));
     let dst = dir.path().join(&dst_name);
     std::fs::write(&dst, file.contents()).with_context(|| {
-        format!("failed to write embedded binary `{name}` to {}", dst.display())
+        format!(
+            "failed to write embedded binary `{name}` to {}",
+            dst.display()
+        )
     })?;
 
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&dst, std::fs::Permissions::from_mode(0o755)).with_context(
-            || format!("failed to set executable bit on {}", dst.display()),
-        )?;
+        std::fs::set_permissions(&dst, std::fs::Permissions::from_mode(0o755))
+            .with_context(|| format!("failed to set executable bit on {}", dst.display()))?;
     }
 
     Ok((dir, dst))
@@ -524,9 +526,8 @@ fn try_expand_one(
         .file_name()
         .map(|s| s.to_string_lossy().into_owned())
         .unwrap_or_else(|| route.source_path.display().to_string());
-    let source = std::fs::read_to_string(&abs).map_err(|e| {
-        TryExpandFailure::Other(format!("could not read {} ({e})", abs.display()))
-    })?;
+    let source = std::fs::read_to_string(&abs)
+        .map_err(|e| TryExpandFailure::Other(format!("could not read {} ({e})", abs.display())))?;
     let extraction = match extract_paths(&source, &file_name) {
         Ok(x) => x,
         Err(PathsExtractError::Parse { file, message }) => {
@@ -550,10 +551,38 @@ fn try_expand_one(
         }
     };
 
+    let segs: Vec<PathsSegment> = route.segments.to_vec();
+    let resolved = resolve_paths(cache, &route.template, &segs, &json).map_err(|e| {
+        TryExpandFailure::Other(format!("{}: {}", abs.display(), format_paths_error(&e)))
+    })?;
+    Ok(expand_resolved_urls(
+        &route.template,
+        &route.segments,
+        route.output_extension.as_deref(),
+        &route.source_path,
+        resolved,
+    ))
+}
+
+/// Shared post-`resolve_paths` tail: build `RouteUniverseEntry` and
+/// `DynamicResolvedEntry` vectors from a resolved-paths list.
+///
+/// Both [`try_expand_one`] (static extraction) and [`resolve_json_paths`]
+/// (runtime JSON) arrive at the same `Vec<ResolvedPath>` and then perform
+/// byte-identical processing. This helper owns that processing so neither
+/// call site can drift from the other.
+///
+/// `output_extension` is the route's override (None → `"html"`).
+fn expand_resolved_urls(
+    template: &str,
+    segments: &[Segment],
+    output_extension: Option<&str>,
+    source_path: &Path,
+    resolved: Vec<zfb_render::paths::ResolvedPath>,
+) -> (Vec<RouteUniverseEntry>, Vec<DynamicResolvedEntry>) {
     // Pre-compute which param names are catchall so we can split the
     // joined string back into a `Vec<String>` for the manifest (#262).
-    let catchall_names: std::collections::HashSet<&str> = route
-        .segments
+    let catchall_names: std::collections::HashSet<&str> = segments
         .iter()
         .filter_map(|seg| {
             if let Segment::Catchall(name) = seg {
@@ -564,24 +593,15 @@ fn try_expand_one(
         })
         .collect();
 
-    let segs: Vec<PathsSegment> = route.segments.to_vec();
-    let resolved = resolve_paths(cache, &route.template, &segs, &json).map_err(|e| {
-        TryExpandFailure::Other(format!("{}: {}", abs.display(), format_paths_error(&e)))
-    })?;
-    let extension = route
-        .output_extension
-        .as_deref()
-        .unwrap_or("html")
-        .to_string();
+    let extension = output_extension.unwrap_or("html").to_string();
     let mut universe_out = Vec::with_capacity(resolved.len());
     let mut manifest_out = Vec::with_capacity(resolved.len());
     for r in resolved {
-        let output_path =
-            build_output_path_for_resolved_url(&r.url, route.output_extension.as_deref());
+        let output_path = build_output_path_for_resolved_url(&r.url, output_extension);
         universe_out.push(RouteUniverseEntry {
             url_path: r.url.clone(),
             output_path: output_path.clone(),
-            route_key: route.template.clone(),
+            route_key: template.to_string(),
             static_html: false,
             source_path: None,
         });
@@ -603,13 +623,13 @@ fn try_expand_one(
         manifest_out.push(DynamicResolvedEntry {
             url_path: r.url,
             output_path,
-            source_path: route.source_path.clone(),
+            source_path: source_path.to_path_buf(),
             extension: extension.clone(),
-            route_key: route.template.clone(),
+            route_key: template.to_string(),
             params: ResolvedRouteParams { scalars, arrays },
         });
     }
-    Ok((universe_out, manifest_out))
+    (universe_out, manifest_out)
 }
 
 /// Compute the on-disk output path for a resolved dynamic URL, mirroring
@@ -981,61 +1001,15 @@ fn resolve_json_paths(
     cache: &mut PathsCache,
 ) -> Result<(Vec<RouteUniverseEntry>, Vec<DynamicResolvedEntry>), String> {
     let segs: Vec<PathsSegment> = route.segments.to_vec();
-
-    // Which param names are catchall (need array form in the manifest).
-    let catchall_names: std::collections::HashSet<&str> = route
-        .segments
-        .iter()
-        .filter_map(|seg| {
-            if let Segment::Catchall(name) = seg {
-                Some(name.as_str())
-            } else {
-                None
-            }
-        })
-        .collect();
-
     let resolved = resolve_paths(cache, &route.template, &segs, &json)
         .map_err(|e| format!("{}: {}", route.template, format_paths_error(&e)))?;
-
-    let extension = route
-        .output_extension
-        .as_deref()
-        .unwrap_or("html")
-        .to_string();
-    let mut universe_entries = Vec::with_capacity(resolved.len());
-    let mut manifest_entries = Vec::with_capacity(resolved.len());
-    for r in resolved {
-        let output_path =
-            build_output_path_for_resolved_url(&r.url, route.output_extension.as_deref());
-        universe_entries.push(RouteUniverseEntry {
-            url_path: r.url.clone(),
-            output_path: output_path.clone(),
-            route_key: route.template.clone(),
-            static_html: false,
-            source_path: None,
-        });
-
-        let mut scalars = BTreeMap::new();
-        let mut arrays: BTreeMap<String, Vec<String>> = BTreeMap::new();
-        for (k, v) in &r.params {
-            if catchall_names.contains(k.as_str()) {
-                let parts: Vec<String> = v.split('/').map(|s| s.to_string()).collect();
-                arrays.insert(k.clone(), parts);
-            } else {
-                scalars.insert(k.clone(), v.clone());
-            }
-        }
-        manifest_entries.push(DynamicResolvedEntry {
-            url_path: r.url,
-            output_path,
-            source_path: route.source_path.clone(),
-            extension: extension.clone(),
-            route_key: route.template.clone(),
-            params: ResolvedRouteParams { scalars, arrays },
-        });
-    }
-    Ok((universe_entries, manifest_entries))
+    Ok(expand_resolved_urls(
+        &route.template,
+        &route.segments,
+        route.output_extension.as_deref(),
+        &route.source_path,
+        resolved,
+    ))
 }
 
 // Keep the old `eval_one_deferred_path` name as a private alias so any
@@ -1497,8 +1471,7 @@ mod tests {
         // Drive the legacy on-disk-only branch so the error path remains
         // exercised even though the production `check_runtime_installed`
         // now short-circuits via the embedded vendor.
-        let err =
-            check_runtime_installed_with_overrides(dir.path(), None, false).unwrap_err();
+        let err = check_runtime_installed_with_overrides(dir.path(), None, false).unwrap_err();
         let msg = format!("{err:#}");
         assert!(msg.contains("@takazudo/zfb-runtime"), "{msg}");
         assert!(msg.contains("pnpm install"), "{msg}");

--- a/docs/astro.config.ts
+++ b/docs/astro.config.ts
@@ -88,7 +88,7 @@ export default defineConfig({
     rehypePlugins: [
       rehypeCodeTitle,
       rehypeHeadingLinks,
-      rehypeStripMdExtension,
+      [rehypeStripMdExtension, { trailingSlash: settings.trailingSlash }],
       ...(settings.mermaid ? [rehypeMermaid] : []),
     ],
   },

--- a/docs/src/integrations/claude-resources/generate.ts
+++ b/docs/src/integrations/claude-resources/generate.ts
@@ -14,6 +14,7 @@ interface ClaudeMdItem {
   displayPath: string;
   slug: string;
   relPath: string;
+  content: string;
 }
 
 interface CommandItem {
@@ -142,6 +143,7 @@ async function generateClaudemdDocs(config: ClaudeResourcesConfig): Promise<Clau
   ensureDir(outputDir);
   const items: ClaudeMdItem[] = [];
 
+  // First pass: collect items (retain file content for second pass)
   for (const filePath of files) {
     const content = fs.readFileSync(filePath, "utf8");
     const relPath = path.relative(projectRoot, filePath);
@@ -149,13 +151,23 @@ async function generateClaudemdDocs(config: ClaudeResourcesConfig): Promise<Clau
     const dirPart = path.dirname(relPath);
     const slug = dirPart === "." ? "root" : dirPart.replace(/\//g, "--");
 
-    items.push({ displayPath, slug, relPath });
+    items.push({ displayPath, slug, relPath, content });
+  }
 
-    const pos = items.length + 1;
+  // Sort: root first, then alphabetically
+  items.sort((a, b) => {
+    if (a.slug === "root") return -1;
+    if (b.slug === "root") return 1;
+    return a.displayPath.localeCompare(b.displayPath);
+  });
+
+  // Second pass: write each MDX with sidebar_position reflecting sort order (1-based)
+  for (let i = 0; i < items.length; i++) {
+    const { displayPath, slug, relPath, content } = items[i];
     const mdx = `---
 title: ${displayPath}
 description: CLAUDE.md at ${displayPath}
-sidebar_position: ${pos}
+sidebar_position: ${i + 1}
 sidebar_label: ${relPath}
 generated: true
 ---
@@ -166,13 +178,6 @@ ${escapeForMdx(content.trim())}
 `;
     await writeMdx(path.join(outputDir, `${slug}.mdx`), mdx);
   }
-
-  // Sort: root first, then alphabetically
-  items.sort((a, b) => {
-    if (a.slug === "root") return -1;
-    if (b.slug === "root") return 1;
-    return a.displayPath.localeCompare(b.displayPath);
-  });
 
   writeCategoryMeta(outputDir, "CLAUDE.md", 900, "Project-specific instructions");
   return items;

--- a/docs/src/plugins/rehype-strip-md-extension.ts
+++ b/docs/src/plugins/rehype-strip-md-extension.ts
@@ -2,18 +2,24 @@ import type { Root, Element } from "hast";
 import { visit } from "unist-util-visit";
 import { isExternal } from "./url-utils";
 
+export interface RehypeStripMdExtensionOptions {
+  /** Whether to append a trailing slash after stripping the extension. Mirrors the site-wide trailingSlash setting. */
+  trailingSlash: boolean;
+}
+
 /**
- * Rehype plugin that strips .md/.mdx extensions from relative link hrefs
- * and ensures they have a trailing slash for Astro's `trailingSlash: "always"` mode.
+ * Rehype plugin factory that strips .md/.mdx extensions from relative link hrefs.
+ * When `trailingSlash` is true, appends "/" after stripping the extension (and also
+ * adds a trailing slash to already-extensionless relative links that lack one).
+ * When `trailingSlash` is false, strips the extension only — no slash is appended —
+ * so in-content links match the slash-stripped nav/source-map URLs.
  *
  * Markdown authors often write links like `[Other doc](./other-doc.md)`.
- * In Astro's static output, the correct URL is `/docs/other-doc/` (no extension).
- *
- * Astro 5+ may strip .md extensions before rehype runs, so this plugin also
- * handles relative links that have already lost their extension by adding
- * a trailing slash when the last path segment has no file extension.
+ * In Astro's static output, the correct URL is `/docs/other-doc` (no extension, no slash)
+ * when trailingSlash is false, or `/docs/other-doc/` when trailingSlash is true.
  */
-export function rehypeStripMdExtension() {
+export function rehypeStripMdExtension(options: RehypeStripMdExtensionOptions) {
+  const { trailingSlash } = options;
   return (tree: Root) => {
     visit(tree, "element", (node: Element) => {
       if (node.tagName !== "a") return;
@@ -25,12 +31,23 @@ export function rehypeStripMdExtension() {
 
       let newHref = href;
 
-      // Strip .md or .mdx extension (with optional hash fragment)
-      newHref = newHref.replace(/\.mdx?(#.*)?$/, (_match, hash) => (hash ? "/" + hash : "/"));
+      // Strip .md or .mdx extension (with optional hash fragment).
+      // Append trailing slash only when trailingSlash is true.
+      newHref = newHref.replace(/\.mdx?(#.*)?$/, (_match, hash) => {
+        if (hash) {
+          return trailingSlash ? "/" + hash : hash;
+        }
+        return trailingSlash ? "/" : "";
+      });
 
       // For relative links where Astro already stripped .md:
-      // add trailing slash if missing and the last segment has no file extension
-      if (newHref === href && (newHref.startsWith("./") || newHref.startsWith("../"))) {
+      // add trailing slash if missing and the last segment has no file extension.
+      // Only applicable when trailingSlash is true — its sole purpose is appending slashes.
+      if (
+        trailingSlash &&
+        newHref === href &&
+        (newHref.startsWith("./") || newHref.startsWith("../"))
+      ) {
         // Split off query string and hash fragment
         const qIdx = newHref.indexOf("?");
         const hIdx = newHref.indexOf("#");

--- a/install.sh
+++ b/install.sh
@@ -114,8 +114,11 @@ resolve_tag() {
     return
   fi
 
-  # Specific tag — pass through as-is (caller supplied "v0.X.Y")
-  printf '%s' "$_version"
+  # Specific tag — must start with 'v' (mirrors install.ps1 rejection logic).
+  case "$_version" in
+    v*) printf '%s' "$_version" ;;
+    *) err "ZFB_VERSION must start with 'v' (e.g. v0.2.0). Got: $_version" ;;
+  esac
 }
 
 # ── Checksum helper ───────────────────────────────────────────────────────────

--- a/packages/create-zfb/bin/create-zfb.mjs
+++ b/packages/create-zfb/bin/create-zfb.mjs
@@ -55,27 +55,35 @@ try {
   const version = ownPkg.version;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 1500);
-  const res = await fetch("https://registry.npmjs.org/create-zfb/latest", {
-    signal: controller.signal,
-    headers: {
-      "User-Agent": `create-zfb/${version}`,
-      Accept: "application/json",
-    },
-  });
-  clearTimeout(timer);
-  if (res.ok) {
-    const data = await res.json();
-    const latest = data?.version;
-    if (typeof latest === "string" && typeof version === "string") {
-      if (compareSemver(version, latest) < 0) {
-        process.stderr.write(
-          `[create-zfb] You are running create-zfb@${version} but @latest is ${latest}.\n` +
-            `[create-zfb] pnpm 11's minimumReleaseAge may have downgraded the install.\n` +
-            `[create-zfb] Re-run with: pnpm create zfb@latest --config.minimumReleaseAge=0\n` +
-            `[create-zfb] Or use: npm create zfb@latest\n`,
-        );
+  let res;
+  try {
+    res = await fetch("https://registry.npmjs.org/create-zfb/latest", {
+      signal: controller.signal,
+      headers: {
+        "User-Agent": `create-zfb/${version}`,
+        Accept: "application/json",
+      },
+    });
+    if (res.ok) {
+      const data = await res.json();
+      const latest = data?.version;
+      if (typeof latest === "string" && typeof version === "string") {
+        if (compareSemver(version, latest) < 0) {
+          process.stderr.write(
+            `[create-zfb] You are running create-zfb@${version} but @latest is ${latest}.\n` +
+              `[create-zfb] pnpm 11's minimumReleaseAge may have downgraded the install.\n` +
+              `[create-zfb] Re-run with: pnpm create zfb@latest --config.minimumReleaseAge=0\n` +
+              `[create-zfb] Or use: npm create zfb@latest\n`,
+          );
+        }
       }
     }
+  } finally {
+    // Keep the abort signal armed across both the header and body reads.
+    // Only cancel the timer once the body has been fully consumed (or on
+    // any error path), so a proxy that stalls after headers cannot hang
+    // the scaffolder indefinitely.
+    clearTimeout(timer);
   }
 } catch {
   // silently skip on any error: network failure, timeout (AbortError), parse error, etc.

--- a/packages/zfb-adapter-cloudflare/bin/cli.mjs
+++ b/packages/zfb-adapter-cloudflare/bin/cli.mjs
@@ -15,9 +15,8 @@
 // no TypeScript loader required) so there is a single source of truth.
 // invariant: no runtime npm deps — see SECURITY-DEPS.md
 
-import { copyFile, mkdir, writeFile } from "node:fs/promises";
 import { realpathSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 // ---------------------------------------------------------------------------
@@ -27,18 +26,14 @@ import { fileURLToPath } from "node:url";
 import { WORKER_WRAPPER_SOURCE } from "../src/worker-wrapper.mjs";
 export { WORKER_WRAPPER_SOURCE };
 
+// ---------------------------------------------------------------------------
+// emitWorker — shared implementation, no runtime npm deps.
+// ---------------------------------------------------------------------------
+
+import { emitWorker as _emitWorker } from "../src/emit-worker.mjs";
+
 export async function emitWorker({ inputBundlePath, outdir }) {
-  const outdirAbs = resolve(outdir);
-  const inputAbs = resolve(inputBundlePath);
-
-  await mkdir(outdirAbs, { recursive: true });
-  const innerBundlePath = join(outdirAbs, "_zfb_inner.mjs");
-  await copyFile(inputAbs, innerBundlePath);
-
-  const workerPath = join(outdirAbs, "_worker.js");
-  await writeFile(workerPath, WORKER_WRAPPER_SOURCE, "utf8");
-
-  return { workerPath, innerBundlePath };
+  return _emitWorker({ inputBundlePath, outdir, workerWrapperSource: WORKER_WRAPPER_SOURCE });
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/zfb-adapter-cloudflare/src/__tests__/cli.test.ts
+++ b/packages/zfb-adapter-cloudflare/src/__tests__/cli.test.ts
@@ -27,8 +27,16 @@ import { emitWorker, WORKER_WRAPPER_SOURCE as TS_WRAPPER } from "../build.js";
 // a TS module), so we narrow the import shape ourselves and silence
 // TS's "no declaration file" complaint.
 // @ts-expect-error: bin/cli.mjs has no declaration file; we narrow below.
-import { WORKER_WRAPPER_SOURCE as MJS_WRAPPER_RAW } from "../../bin/cli.mjs";
+import {
+  WORKER_WRAPPER_SOURCE as MJS_WRAPPER_RAW,
+  emitWorker as cliEmitWorker,
+} from "../../bin/cli.mjs";
 const MJS_WRAPPER: string = MJS_WRAPPER_RAW as string;
+const CLI_EMIT_WORKER: (input: {
+  inputBundlePath: string;
+  outdir: string;
+}) => Promise<{ workerPath: string; innerBundlePath: string }> =
+  cliEmitWorker as typeof CLI_EMIT_WORKER;
 
 let scratchDirs: string[] = [];
 
@@ -418,5 +426,43 @@ export default {
     const response = await worker.default.fetch(request, env, ctx);
     expect(response.status).toBe(200);
     expect(await response.text()).toBe("inner only");
+  });
+
+  it("CLI's emitWorker (bin/cli.mjs) emits the same files as build.ts's emitWorker", async () => {
+    // Exercises the CLI's emitWorker export directly so the shared
+    // emit-worker.mjs refactor cannot drift silently. Both paths must
+    // produce identical _worker.js and _zfb_inner.mjs content.
+    const dir = await scratch();
+    const inputPath = join(dir, "bundle.mjs");
+    await writeFile(
+      inputPath,
+      `export default { fetch: async () => new Response("cli-test", { status: 200 }) };\n`,
+      "utf8",
+    );
+
+    const cliDir = join(dir, "cli-dist");
+    const tsDir = join(dir, "ts-dist");
+
+    const [cliOut, tsOut] = await Promise.all([
+      CLI_EMIT_WORKER({ inputBundlePath: inputPath, outdir: cliDir }),
+      emitWorker({ inputBundlePath: inputPath, outdir: tsDir }),
+    ]);
+
+    const [cliWorker, tsWorker] = await Promise.all([
+      readFile(cliOut.workerPath, "utf8"),
+      readFile(tsOut.workerPath, "utf8"),
+    ]);
+    const [cliInner, tsInner] = await Promise.all([
+      readFile(cliOut.innerBundlePath, "utf8"),
+      readFile(tsOut.innerBundlePath, "utf8"),
+    ]);
+
+    // Both paths must write the same wrapper and the same copied bundle.
+    expect(cliWorker).toBe(tsWorker);
+    expect(cliInner).toBe(tsInner);
+
+    // Returned path shapes are correct.
+    expect(cliOut.workerPath).toBe(join(cliDir, "_worker.js"));
+    expect(cliOut.innerBundlePath).toBe(join(cliDir, "_zfb_inner.mjs"));
   });
 });

--- a/packages/zfb-adapter-cloudflare/src/build.ts
+++ b/packages/zfb-adapter-cloudflare/src/build.ts
@@ -11,6 +11,9 @@
 // @ts-expect-error worker-wrapper.mjs has no declaration file; the export
 // shape is narrowed explicitly below.
 import { WORKER_WRAPPER_SOURCE as _wrapper } from "./worker-wrapper.mjs";
+// @ts-expect-error emit-worker.mjs has no declaration file; the export
+// shape is narrowed via EmitWorkerInput/EmitWorkerOutput below.
+import { emitWorker as _emitWorker } from "./emit-worker.mjs";
 
 /**
  * The wrapper source written to `_worker.js`. Imported from the single
@@ -67,18 +70,9 @@ export interface EmitWorkerOutput {
  * runtime — it is just `node:fs` glue.
  */
 export async function emitWorker(input: EmitWorkerInput): Promise<EmitWorkerOutput> {
-  const { mkdir, copyFile, writeFile } = await import("node:fs/promises");
-  const { resolve, join } = await import("node:path");
-
-  const outdir = resolve(input.outdir);
-  const inputBundle = resolve(input.inputBundlePath);
-
-  await mkdir(outdir, { recursive: true });
-  const innerBundlePath = join(outdir, "_zfb_inner.mjs");
-  await copyFile(inputBundle, innerBundlePath);
-
-  const workerPath = join(outdir, "_worker.js");
-  await writeFile(workerPath, WORKER_WRAPPER_SOURCE, "utf8");
-
-  return { workerPath, innerBundlePath };
+  return _emitWorker({
+    inputBundlePath: input.inputBundlePath,
+    outdir: input.outdir,
+    workerWrapperSource: WORKER_WRAPPER_SOURCE,
+  }) as Promise<EmitWorkerOutput>;
 }

--- a/packages/zfb-adapter-cloudflare/src/emit-worker.mjs
+++ b/packages/zfb-adapter-cloudflare/src/emit-worker.mjs
@@ -1,0 +1,38 @@
+// Shared, dependency-free implementation of `emitWorker`.
+//
+// Kept as a plain `.mjs` module (no TypeScript) so it can be imported from
+// both the typed TypeScript surface (`src/build.ts`) and the dependency-free
+// CLI binary (`bin/cli.mjs`) without needing a TypeScript loader.
+//
+// Do NOT duplicate this logic elsewhere. The two consumers always stay in
+// sync by importing from here.
+//
+// invariant: no runtime npm deps — see SECURITY-DEPS.md
+
+import { copyFile, mkdir, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+/**
+ * Emit a Cloudflare Pages `_worker.js` that wraps the zfb input bundle.
+ *
+ * Output shape (two files in `outdir`):
+ *
+ *   _worker.js       — entry imported by Cloudflare Pages advanced mode
+ *   _zfb_inner.mjs   — the input bundle, copied verbatim
+ *
+ * @param {{ inputBundlePath: string; outdir: string; workerWrapperSource: string }} input
+ * @returns {Promise<{ workerPath: string; innerBundlePath: string }>}
+ */
+export async function emitWorker({ inputBundlePath, outdir, workerWrapperSource }) {
+  const outdirAbs = resolve(outdir);
+  const inputAbs = resolve(inputBundlePath);
+
+  await mkdir(outdirAbs, { recursive: true });
+  const innerBundlePath = join(outdirAbs, "_zfb_inner.mjs");
+  await copyFile(inputAbs, innerBundlePath);
+
+  const workerPath = join(outdirAbs, "_worker.js");
+  await writeFile(workerPath, workerWrapperSource, "utf8");
+
+  return { workerPath, innerBundlePath };
+}

--- a/packages/zfb/src/__tests__/runtime.test.ts
+++ b/packages/zfb/src/__tests__/runtime.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
 
 import {
+  __hasPendingCancelForTests,
   __setIslandImporterForTests,
   mountIslands,
   scheduleHydrate,
@@ -183,6 +184,14 @@ describe("scheduleHydrate", () => {
       const fire = vi.fn();
       scheduleHydrate(target, "visible", fire);
       expect(fire).toHaveBeenCalledTimes(1);
+    });
+
+    it("public scheduleHydrate returns a plain function (not an object)", () => {
+      // Verify the public API contract: scheduleHydrate must keep returning
+      // a bare () => void cancel, regardless of changes to internal shape.
+      vi.stubGlobal("IntersectionObserver", undefined);
+      const cancel = scheduleHydrate(target, "visible", vi.fn());
+      expect(typeof cancel).toBe("function");
     });
   });
 
@@ -544,6 +553,58 @@ describe("scheduleHydrate", () => {
       await Promise.resolve();
 
       expect(mount).not.toHaveBeenCalled();
+    });
+
+    // -----------------------------------------------------------------------
+    // Stale-pendingCancels bug (#743): when IntersectionObserver is absent,
+    // scheduleVisible fires synchronously and returns noop — but the old code
+    // always called pendingCancels.set(element, noop) when when !== "load",
+    // leaving a permanent stale entry. The fix: only set pendingCancels when
+    // the scheduler did NOT fire synchronously (!fired).
+    // -----------------------------------------------------------------------
+
+    it("URL path: no stale pendingCancels entry when IO-less when=visible fires synchronously", () => {
+      // Remove IntersectionObserver so scheduleVisible fails open (sync fire).
+      vi.stubGlobal("IntersectionObserver", undefined);
+
+      document.body.innerHTML = `
+        <div data-zfb-island="Counter" data-props='{}' data-when="visible"></div>
+      `;
+
+      // Use an importer that resolves synchronously (via a resolved Promise)
+      // so console.error is not triggered. We just care about pendingCancels.
+      restoreImporter = __setIslandImporterForTests(() => Promise.resolve({ mount: vi.fn() }));
+
+      const el = document.querySelector("[data-zfb-island]")!;
+
+      mountIslands({ Counter: "/islands/Counter-abc.js" });
+
+      // The scheduler fired synchronously, so there must be NO stale entry
+      // in pendingCancels for this element. (#743)
+      expect(__hasPendingCancelForTests(el)).toBe(false);
+    });
+
+    it("fireInlineMount path: no stale pendingCancels entry when IO-less when=visible fires synchronously", () => {
+      // Remove IntersectionObserver so scheduleVisible fails open (sync fire).
+      vi.stubGlobal("IntersectionObserver", undefined);
+
+      document.body.innerHTML = `
+        <div data-zfb-island="Counter" data-props='{}' data-when="visible"></div>
+      `;
+
+      const mount = vi.fn();
+      restoreImporter = __setIslandImporterForTests(() => {
+        throw new Error("dynamic import must not be used for inline-module manifest entries");
+      });
+
+      const el = document.querySelector("[data-zfb-island]")!;
+
+      // Inline-module path (shared-bundle): mount is called directly.
+      mountIslands({ Counter: { mount } });
+
+      // The scheduler fired synchronously, so there must be NO stale entry
+      // in pendingCancels for this element. (#743)
+      expect(__hasPendingCancelForTests(el)).toBe(false);
     });
   });
 

--- a/packages/zfb/src/runtime.ts
+++ b/packages/zfb/src/runtime.ts
@@ -36,6 +36,31 @@ type SchedulerGlobal = typeof globalThis & {
 const g = globalThis as SchedulerGlobal;
 
 /**
+ * Internal variant of `scheduleHydrate` that also reports whether the fire
+ * callback was invoked synchronously. Unexported — call sites in this module
+ * use this to decide whether to register a `pendingCancels` entry.
+ */
+function scheduleHydrateInternal(
+  target: Element,
+  when: When | string | undefined,
+  fire: () => void,
+): { fired: boolean; cancel: () => void } {
+  const resolved = resolveWhen(when);
+
+  if (resolved === "load") {
+    fire();
+    return { fired: true, cancel: noop };
+  }
+
+  if (resolved === "idle") {
+    return { fired: false, cancel: scheduleIdle(fire) };
+  }
+
+  // "visible"
+  return scheduleVisible(target, fire);
+}
+
+/**
  * Schedule a hydration `fire` callback for `target` according to `when`.
  *
  * Returns a `cancel` function that aborts the scheduling if it has not
@@ -49,19 +74,7 @@ export function scheduleHydrate(
   when: When | string | undefined,
   fire: () => void,
 ): () => void {
-  const resolved = resolveWhen(when);
-
-  if (resolved === "load") {
-    fire();
-    return noop;
-  }
-
-  if (resolved === "idle") {
-    return scheduleIdle(fire);
-  }
-
-  // "visible"
-  return scheduleVisible(target, fire);
+  return scheduleHydrateInternal(target, when, fire).cancel;
 }
 
 function noop(): void {
@@ -114,14 +127,17 @@ function scheduleIdle(fire: () => void): () => void {
   };
 }
 
-function scheduleVisible(target: Element, fire: () => void): () => void {
+function scheduleVisible(
+  target: Element,
+  fire: () => void,
+): { fired: boolean; cancel: () => void } {
   const Observer = g.IntersectionObserver;
 
   // No IntersectionObserver (e.g. very old browsers, bare Node) — fail
   // open and hydrate immediately so the island is at least functional.
   if (typeof Observer !== "function") {
     fire();
-    return noop;
+    return { fired: true, cancel: noop };
   }
 
   const gate = oneShot(fire);
@@ -140,10 +156,13 @@ function scheduleVisible(target: Element, fire: () => void): () => void {
 
   observer.observe(target);
 
-  return () => {
-    const alreadyFired = gate.cancel();
-    if (alreadyFired) return;
-    observer.disconnect();
+  return {
+    fired: false,
+    cancel: () => {
+      const alreadyFired = gate.cancel();
+      if (alreadyFired) return;
+      observer.disconnect();
+    },
   };
 }
 
@@ -461,10 +480,14 @@ function scheduleMount(
     return;
   }
 
-  const cancel = scheduleHydrate(element, when, fire);
+  const { fired, cancel } = scheduleHydrateInternal(element, when, fire);
   // Track deferred-hydration cancel handle so cancelPendingIslands() can abort
   // idle / visibility callbacks before a body swap. (W1B §12.5)
-  if (when && when !== "load") {
+  // Only register when the scheduler did NOT fire synchronously — a synchronous
+  // fire means the island is already handling its import and there is no
+  // deferred callback to cancel. Registering noop after a sync fire would leave
+  // a stale pendingCancels entry for an already-handled element. (#743)
+  if (when && when !== "load" && !fired) {
     pendingCancels.set(element, cancel);
   }
 }
@@ -517,10 +540,14 @@ function fireInlineMount(
   }
 
   const when = element.getAttribute("data-when") ?? undefined;
-  const cancel = scheduleHydrate(element, when, fire);
+  const { fired, cancel } = scheduleHydrateInternal(element, when, fire);
   // Track deferred-hydration cancel handle so cancelPendingIslands() can abort
   // idle / visibility callbacks before a body swap. (W1B §12.5)
-  if (when && when !== "load") {
+  // Only register when the scheduler did NOT fire synchronously — a synchronous
+  // fire means the island is already handling its mount and there is no
+  // deferred callback to cancel. Registering noop after a sync fire would leave
+  // a stale pendingCancels entry for an already-handled element. (#743)
+  if (when && when !== "load" && !fired) {
     pendingCancels.set(element, cancel);
   }
 }
@@ -595,4 +622,13 @@ export function __setIslandImporterForTests(
   const prev = importImpl;
   importImpl = impl;
   return prev;
+}
+
+/**
+ * Test-only seam. Returns whether the given element has an entry in the
+ * module-private `pendingCancels` Map. Used to assert that a synchronous
+ * scheduler fire does not leave a stale entry behind. (#743)
+ */
+export function __hasPendingCancelForTests(element: Element): boolean {
+  return pendingCancels.has(element);
 }

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -18,17 +18,13 @@ set -e
 HOOK_MARKER="# x-wt-teams-push-guard v2"
 
 # Skip silently when not in a git repo (e.g. extracted tarball).
-GIT_COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null) || {
+# --path-format=absolute (git >= 2.31) returns an absolute path directly,
+# avoiding the mis-resolution that occurs when --git-common-dir is combined
+# with --show-toplevel to normalize a worktree-relative path.
+GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || {
   echo "install-git-hooks: not a git repo, skipping"
   exit 0
 }
-
-# Normalize to absolute path; git-common-dir is relative when run from a
-# regular checkout in some git versions.
-case "$GIT_COMMON_DIR" in
-  /*) ;;
-  *) GIT_COMMON_DIR="$(git rev-parse --show-toplevel)/$GIT_COMMON_DIR" ;;
-esac
 
 HOOKS_DIR="$GIT_COMMON_DIR/hooks"
 TARGET="$HOOKS_DIR/pre-push"

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -22,6 +22,13 @@ HOOK_MARKER="# x-wt-teams-push-guard v2"
 # avoiding the mis-resolution that occurs when --git-common-dir is combined
 # with --show-toplevel to normalize a worktree-relative path.
 GIT_COMMON_DIR=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null) || {
+  # Distinguish "not a git repo" from "git too old for --path-format".
+  # An old git would otherwise silently skip installing the push-guard
+  # behind a misleading "not a git repo" message.
+  if git rev-parse --git-dir >/dev/null 2>&1; then
+    echo "install-git-hooks: git >= 2.31 required (--path-format unsupported); push-guard NOT installed" >&2
+    exit 1
+  fi
   echo "install-git-hooks: not a git repo, skipping"
   exit 0
 }

--- a/scripts/update-homebrew-formula.sh
+++ b/scripts/update-homebrew-formula.sh
@@ -200,7 +200,11 @@ fi
 
 echo "==> Committing and pushing to tap ..."
 git -C "$tap_path" add Formula/zfb.rb
-git -C "$tap_path" commit -m "zfb ${semver}"
+if ! git -C "$tap_path" diff --cached --quiet; then
+  git -C "$tap_path" commit -m "zfb ${semver}"
+else
+  echo "    formula unchanged — skipping commit"
+fi
 git -C "$tap_path" push
 
 echo "==> Done — Formula/zfb.rb committed and pushed for zfb ${version_tag}"


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/750

---

## Summary

Fixes **25 adversarially-verified review findings** (sourced from the `/review-loop` deferred findings #698–#749) across the whole workspace, per epic #750. Every fix follows a single prescribed direction from its finding's verifier note — the 27 findings needing genuine design decisions were deliberately deferred and stay open.

### Rust crates

- **zfb**: stale doc comments corrected (plugins.rs silent-drop, dev.rs post-#659 invariant) (#698, #724); duplicated dynamic-route expansion tail extracted into `expand_resolved_urls` (#723)
- **zfb-build**: `route_sort_key` now sorts catchalls after plain dynamics at equal static depth, restoring the documented invariant (#726)
- **zfb-islands**: island DFS walk skips compile-time-erased type-only import/export edges (#729)
- **zfb-md-extras**: `image_dimensions` gets project-root/public-dir containment (security) (#703); `<img src>` fragments no longer validated as heading anchors (#733); byte-identical TOC helpers extracted to `toc_common` (#704)
- **zfb-css**: `@source` globs escaped via shared helper (#706); tailwind-import detection now strips CSS comments first (#739)
- **zfb-graph**: `remove_node` no longer early-returns for page-that-is-also-a-dep — consumers land in `affected` (#707)
- **zfb-watcher**: `Watcher::shutdown()` circular-wait deadlock fixed (`bridge.abort(); return;`), with a load-bearing timeout-guarded test (#708)
- **zfb-diagnostics**: absolute sourcemap paths stripped against project_root (#740)
- **zfb-test-utils**: raw-text context threads through normalize recursion; nested `<pre><span>` whitespace preserved (#741)
- **zfb-server**: livereload injection degrades gracefully instead of panicking on lol_html rewrite errors (#737)

### TS packages

- **packages/zfb**: schedulers report synchronous fire via internal `{fired, cancel}` variant; stale `pendingCancels` entries eliminated; public `scheduleHydrate` signature unchanged (#743)
- **create-zfb**: abort timer stays armed across the registry body read (#744)
- **zfb-adapter-cloudflare**: `emitWorker` extracted to shared dependency-free `emit-worker.mjs`, CLI drift-guard test added (#745)

### Docs + infra

- **docs**: CLAUDE.md pages get correct root-first/alphabetical `sidebar_position` (#746); `rehype-strip-md-extension` honors `settings.trailingSlash` (#747)
- **CI/scripts**: IFTTT prod-deploy notify actually fires (job-level env) (#716); release.yml prerelease log fixed (#719); Homebrew formula re-runs no longer abort on empty commit (#717); install.sh rejects non-`v` pinned versions like install.ps1 (#718); install-git-hooks.sh resolves the common dir absolutely with an old-git guard (#721)

### Post-merge review + validation

- 2-reviewer deep review on the full diff: no blocking findings; 2 minor fixes applied (`d6070e1`)
- Pre-existing clippy 1.95 lint in untouched zfb-content fixed to keep the workspace `-D warnings` gate green (`89b839b`)
- Full validation on merged base (see #767): `cargo test --workspace` ✅ · clippy workspace ✅ · vitest 154+102+16 ✅ · docs build (213 pages) ✅ · `bash -n` + hook-installer verification ✅

## Test plan

- CI: health (build/clippy/test --workspace), node-free smoke (amd64+arm64), docs build, actionlint, pnpm audit
- TS vitest suites are not in CI — validated locally (results in #767), each child also pasted suite output in its sub-issue

## Topic PRs

Topic branches were merged locally into the base and deleted (per the x-wt-teams flow); per-topic details live in sub-issues #751–#766.

🤖 Generated with [Claude Code](https://claude.com/claude-code)