### PR TITLE
CI shell tests, honest x64 version fallback, embedded-V8 console logs

### DIFF
--- a/.github/workflows/health.yml
+++ b/.github/workflows/health.yml
@@ -31,6 +31,24 @@ jobs:
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
+      # Offline shell unit tests (issue #791). tests/unit/install-prerelease.sh
+      # pins install.sh's prerelease tag resolution (jq path + awk fallback +
+      # brace-injection fail-loud, added by #788) but was never executed by any
+      # workflow. Runs in <1s and needs only sh/awk/grep/sed, so it sits here as
+      # a fail-fast gate before any toolchain setup. The glob auto-wires future
+      # tests/unit/*.sh files — #791's root cause was a test that existed but
+      # was never wired. bash -n is a pure parse check (bash parses the POSIX-sh
+      # scripts fine) catching syntax errors in the otherwise untested scripts.
+      - name: Shell script syntax check + offline shell unit tests
+        run: |
+          for f in install.sh scripts/*.sh tests/unit/*.sh; do
+            bash -n "$f"
+          done
+          for t in tests/unit/*.sh; do
+            echo "+ sh $t"
+            sh "$t"
+          done
+
       # Free runner disk BEFORE the rust-cache restore + V8 first-compile (issue
       # #687). rusty_v8 / deno_core produces a multi-GB target/; combined with the
       # restored Swatinem cache it can exhaust the ~14 GB ubuntu-latest disk

--- a/crates/zfb-build/src/renderer.rs
+++ b/crates/zfb-build/src/renderer.rs
@@ -751,6 +751,14 @@ impl RendererState {
     /// Gated behind `embed_v8` (issue #371, sub-task 4.1a). When the
     /// feature is off the embedded V8 backend is unavailable and this
     /// accessor does not exist.
+    ///
+    /// Console-capture note (issue #700): dispatches made directly
+    /// through this accessor (the dev SSR seam, `paths()` evaluation)
+    /// accumulate worker console output in the host's capped buffer
+    /// until the next drain — [`render_one`] drains after every
+    /// dev-mode page render. Callers that dispatch heavily outside
+    /// `render_one` can call
+    /// [`EmbeddedV8Host::drain_console_logs`] themselves.
     #[cfg(feature = "embed_v8")]
     pub fn embedded_v8_host_mut(&mut self) -> Option<&mut dyn EmbeddedV8Host> {
         match &mut self.handle {
@@ -791,7 +799,7 @@ pub fn render_one(
         path: dist_dir.to_path_buf(),
         source: e,
     })?;
-    render_one_inner(
+    let result = render_one_inner(
         &mut state.handle,
         entry,
         dist_dir,
@@ -800,7 +808,18 @@ pub fn render_one(
         // Dev mode never injects prod head assets — see the
         // `prod_head_assets` field doc on `RendererInput`.
         None,
-    )
+    );
+    // Drain the console-capture buffer after every dev-mode render so a
+    // long-lived session does not pin stale logs at the buffer cap
+    // (which would silently stop capturing fresh ones — issue #700).
+    // The lines already reached stdout live via the host's console
+    // passthrough; on failure, surface them next to the error the same
+    // way `render_all` does.
+    let logs = state.handle.collect_logs();
+    if result.is_err() && !logs.trim().is_empty() {
+        eprintln!("[zfb] backend logs at render failure:\n{logs}");
+    }
+    result
 }
 
 /// Tear the dev-mode renderer down. Idempotent — calling on an
@@ -1597,6 +1616,28 @@ mod tests {
                 "render_all must drain the embedded host's console logs on \
                  the failure path (issue #700: this path never fired because \
                  collect_logs hard-coded an empty string)"
+            );
+        }
+
+        #[test]
+        fn dev_mode_render_one_drains_console_logs_each_render() {
+            let drained = Arc::new(AtomicBool::new(false));
+            let backend = embedded_backend(None, "[log] stale line", drained.clone());
+            let mut state = start(RendererStartInput {
+                bundle_path: PathBuf::from("/dev/null"),
+                sourcemap_path: PathBuf::from("/dev/null"),
+                backend,
+                request_timeout: None,
+            })
+            .expect("start");
+            let dist = tempfile::tempdir().unwrap();
+            let entry = single_route_universe().remove(0);
+            render_one(&mut state, &entry, dist.path(), Path::new(""))
+                .expect_err("dispatch failure must fail the render");
+            assert!(
+                drained.load(Ordering::SeqCst),
+                "render_one must drain the console buffer so a long-lived \
+                 dev session does not pin stale logs at the cap"
             );
         }
 

--- a/crates/zfb-build/src/renderer.rs
+++ b/crates/zfb-build/src/renderer.rs
@@ -207,6 +207,23 @@ pub trait EmbeddedV8Host: Send {
         let _ = (method, headers, body);
         self.dispatch_fetch(url_path)
     }
+
+    /// Drain worker console output buffered since the last drain
+    /// (issue #700).
+    ///
+    /// Returns the captured lines (each prefixed with its console
+    /// level, e.g. `[log] …`) joined with `\n`, and clears the
+    /// host-side buffer. The renderer calls this AFTER a render pass
+    /// completes or fails — never mid-dispatch — so implementations
+    /// may assume no render request is in flight.
+    ///
+    /// `&mut self` because a real drain mutates host state (clears
+    /// the buffer); the production `ThreadedV8Host` round-trips to
+    /// its pinned isolate thread. The default returns an empty
+    /// string so stub hosts and test doubles stay source-compatible.
+    fn drain_console_logs(&mut self) -> String {
+        String::new()
+    }
 }
 
 /// Factory type for constructing an [`EmbeddedV8Host`] from a bundle path.
@@ -384,7 +401,7 @@ impl BackendHandle {
         }
     }
 
-    fn collect_logs(&self) -> String {
+    fn collect_logs(&mut self) -> String {
         match self {
             BackendHandle::Http { .. } => String::new(),
             #[cfg(feature = "embed_v8")]
@@ -1108,17 +1125,15 @@ impl EmbeddedV8Guard {
         self.host.take();
     }
 
-    /// Collect diagnostic output from the host. The embedded V8 host
-    /// captures console output internally; this surfaces it as a string
-    /// for inclusion in error messages. Returns an empty string when the
-    /// host has already been terminated or when it produced no output.
-    fn collect_logs(&self) -> String {
-        // The embedded host captures console output through the V8
-        // console extension. The exact retrieval API is not yet
-        // defined; for now we return an empty string. Once the host
-        // exposes a `drain_console_logs() -> String` method on the
-        // trait, add it to `EmbeddedV8Host` and call it here.
-        String::new()
+    /// Collect diagnostic output from the host by draining its
+    /// console-capture buffer ([`EmbeddedV8Host::drain_console_logs`]).
+    /// Returns an empty string when the host has already been
+    /// terminated or when it produced no output.
+    fn collect_logs(&mut self) -> String {
+        match self.host.as_mut() {
+            Some(host) => host.drain_console_logs(),
+            None => String::new(),
+        }
     }
 }
 
@@ -1480,6 +1495,127 @@ mod tests {
                 assert!(body.contains("Error: boom"));
             }
             other => unreachable!("expected RenderFailed, got {other:?}"),
+        }
+    }
+
+    /// Console-log surfacing for the embedded V8 backend (issue #700).
+    ///
+    /// The bug fixed here: `EmbeddedV8Guard::collect_logs` hard-coded
+    /// `String::new()`, so the render-failure log-surfacing path in
+    /// [`render_all`] never fired for the production backend. These
+    /// tests pin the wiring with an in-process `EmbeddedV8Host` double
+    /// — the real console capture inside the V8 isolate is covered by
+    /// `zfb-render/tests/embedded_v8_console_logs.rs`.
+    #[cfg(feature = "embed_v8")]
+    mod embedded_v8_console_logs {
+        use super::*;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        /// Minimal `EmbeddedV8Host` double: serves a canned response
+        /// (or a dispatch error) and reports canned console logs via
+        /// `drain_console_logs`, recording that the drain happened.
+        struct LoggingHost {
+            /// `None` → every dispatch fails (render-failure path).
+            response: Option<HttpResponseLike>,
+            logs: String,
+            drained: Arc<AtomicBool>,
+        }
+
+        impl EmbeddedV8Host for LoggingHost {
+            fn dispatch_fetch(
+                &mut self,
+                _url_path: &str,
+            ) -> Result<HttpResponseLike, RendererError> {
+                match &self.response {
+                    Some(resp) => Ok(resp.clone()),
+                    None => Err(RendererError::EmbeddedV8("isolate exploded".into())),
+                }
+            }
+
+            fn drain_console_logs(&mut self) -> String {
+                self.drained.store(true, Ordering::SeqCst);
+                std::mem::take(&mut self.logs)
+            }
+        }
+
+        fn embedded_backend(
+            response: Option<HttpResponseLike>,
+            logs: &str,
+            drained: Arc<AtomicBool>,
+        ) -> Backend {
+            let logs = logs.to_string();
+            Backend::EmbeddedV8 {
+                host_factory: Arc::new(move |_bundle_path| {
+                    Ok(Box::new(LoggingHost {
+                        response: response.clone(),
+                        logs: logs.clone(),
+                        drained: drained.clone(),
+                    }))
+                }),
+            }
+        }
+
+        fn single_route_universe() -> Vec<RouteUniverseEntry> {
+            vec![RouteUniverseEntry {
+                url_path: "/".into(),
+                output_path: PathBuf::from("index.html"),
+                route_key: "/".into(),
+                static_html: false,
+                source_path: None,
+            }]
+        }
+
+        fn renderer_input(backend: Backend, dist_dir: PathBuf) -> RendererInput {
+            RendererInput {
+                bundle_path: PathBuf::from("/dev/null"),
+                sourcemap_path: PathBuf::from("/dev/null"),
+                manifest: dummy_manifest(),
+                dist_dir,
+                route_universe: single_route_universe(),
+                prerender_map: BTreeMap::new(),
+                backend,
+                request_timeout: None,
+                prod_head_assets: None,
+                project_root: PathBuf::new(),
+            }
+        }
+
+        #[test]
+        fn render_failure_drains_embedded_host_console_logs() {
+            let drained = Arc::new(AtomicBool::new(false));
+            let backend =
+                embedded_backend(None, "[error] worker exploded mid-render", drained.clone());
+            let dist = tempfile::tempdir().unwrap();
+            let err = render_all(renderer_input(backend, dist.path().to_path_buf()))
+                .expect_err("dispatch failure must fail the render");
+            assert!(
+                matches!(err, RendererError::EmbeddedV8(_)),
+                "expected EmbeddedV8 error, got {err:?}"
+            );
+            assert!(
+                drained.load(Ordering::SeqCst),
+                "render_all must drain the embedded host's console logs on \
+                 the failure path (issue #700: this path never fired because \
+                 collect_logs hard-coded an empty string)"
+            );
+        }
+
+        #[test]
+        fn green_render_surfaces_embedded_host_console_logs_as_runtime_logs() {
+            let drained = Arc::new(AtomicBool::new(false));
+            let backend = embedded_backend(
+                Some(html_ok("<html><body>ok</body></html>")),
+                "[log] hello from worker\n[warn] deprecation notice",
+                drained.clone(),
+            );
+            let dist = tempfile::tempdir().unwrap();
+            let out =
+                render_all(renderer_input(backend, dist.path().to_path_buf())).expect("render_all");
+            assert!(drained.load(Ordering::SeqCst));
+            assert_eq!(
+                out.runtime_logs, "[log] hello from worker\n[warn] deprecation notice",
+                "drained console logs must reach RendererOutput::runtime_logs"
+            );
         }
     }
 

--- a/crates/zfb-render/src/embedded_v8/js/globals_shim.js
+++ b/crates/zfb-render/src/embedded_v8/js/globals_shim.js
@@ -1,6 +1,6 @@
 // Host-bridge globals for the embedded V8 host.
 //
-// Installs `globalThis.__zfb` with two helpers the Rust side calls
+// Installs `globalThis.__zfb` with three helpers the Rust side calls
 // via `execute_script`:
 //
 // - `__zfb.setBundle(defaultExport)` — called once after the bundle
@@ -14,7 +14,14 @@
 //   loop until the Promise resolves, then unpacks the fields via v8
 //   property reads.
 //
-// Both helpers are pure JS; the host does not register any Rust ops
+// - `__zfb.drainConsoleLogs()` — returns the worker console output
+//   buffered by the console capture below (joined with `\n`, each
+//   line prefixed with its level) and clears the buffer. Called by
+//   the Rust side AFTER a render completes/fails — never
+//   mid-dispatch — so failed renders can surface what the worker
+//   printed (issue #700).
+//
+// All helpers are pure JS; the host does not register any Rust ops
 // for them. That keeps the deno_core op-version coupling out of this
 // crate's surface.
 
@@ -22,12 +29,135 @@ const __zfb_state = {
   bundle: null,
 };
 
+// Console capture (issue #700).
+//
+// The bare deno_core runtime installs a minimal `console` whose
+// levelled methods print straight to the zfb process's stdout via
+// `op_print`. That live passthrough is preserved (each patched method
+// forwards to the original binding), but every line is ALSO buffered
+// here so the Rust side can drain it and attach the worker's console
+// output to render-failure diagnostics — without the buffer, a failed
+// render surfaces only "Internal Server Error" with no context.
+//
+// Caps bound memory for noisy workers across a full render pass: once
+// either cap is hit, further lines are dropped and a single
+// truncation marker is recorded. Draining resets the caps.
+const __zfb_console_state = {
+  lines: [],
+  totalChars: 0,
+  truncated: false,
+};
+const __ZFB_CONSOLE_MAX_LINES = 1000;
+const __ZFB_CONSOLE_MAX_TOTAL_CHARS = 262144; // 256 KiB of UTF-16 units
+const __ZFB_CONSOLE_MAX_LINE_CHARS = 8192;
+
+function __zfb_consoleStringifyArg(arg) {
+  if (typeof arg === "string") {
+    return arg;
+  }
+  if (
+    arg === null ||
+    arg === undefined ||
+    typeof arg === "number" ||
+    typeof arg === "boolean" ||
+    typeof arg === "bigint" ||
+    typeof arg === "symbol" ||
+    typeof arg === "function"
+  ) {
+    return String(arg);
+  }
+  if (arg instanceof Error) {
+    return arg.stack || String(arg);
+  }
+  try {
+    const json = JSON.stringify(arg);
+    if (json !== undefined) {
+      return json;
+    }
+  } catch (_) {
+    // Circular structure etc. — fall through to String().
+  }
+  try {
+    return String(arg);
+  } catch (_) {
+    return "[unstringifiable value]";
+  }
+}
+
+function __zfb_captureConsoleLine(level, args) {
+  const st = __zfb_console_state;
+  if (
+    st.lines.length >= __ZFB_CONSOLE_MAX_LINES ||
+    st.totalChars >= __ZFB_CONSOLE_MAX_TOTAL_CHARS
+  ) {
+    if (!st.truncated) {
+      st.truncated = true;
+      st.lines.push("[zfb] (console capture truncated: buffer cap reached)");
+    }
+    return;
+  }
+  let line;
+  try {
+    line = `[${level}] ` + args.map(__zfb_consoleStringifyArg).join(" ");
+  } catch (_) {
+    line = `[${level}] [unstringifiable arguments]`;
+  }
+  if (line.length > __ZFB_CONSOLE_MAX_LINE_CHARS) {
+    line = line.slice(0, __ZFB_CONSOLE_MAX_LINE_CHARS) + " …(line truncated)";
+  }
+  st.lines.push(line);
+  st.totalChars += line.length;
+}
+
+// Patch the five levelled console methods in place (rather than
+// replacing the console object) so any extra members the runtime
+// installed — e.g. inspector-only APIs copied from V8's console —
+// survive untouched. Originals are snapshotted BEFORE patching so a
+// missing level's fallback (`console.info` does not exist on
+// deno_core's CoreConsole) forwards to the ORIGINAL `log`, not the
+// patched one (which would double-capture).
+(() => {
+  if (!globalThis.console || typeof globalThis.console !== "object") {
+    globalThis.console = {};
+  }
+  const c = globalThis.console;
+  const levels = ["log", "info", "warn", "error", "debug"];
+  const originals = {};
+  for (const level of levels) {
+    originals[level] = typeof c[level] === "function" ? c[level].bind(c) : null;
+  }
+  for (const level of levels) {
+    const forward = originals[level] || originals.log;
+    c[level] = (...args) => {
+      __zfb_captureConsoleLine(level, args);
+      if (forward) {
+        try {
+          forward(...args);
+        } catch (_) {
+          // Passthrough must never throw into worker code.
+        }
+      }
+    };
+  }
+})();
+
 globalThis.__zfb = {
   // ssrDebug: present only in the embedded build/dev V8 host, never in the
   // production Cloudflare Workers runtime — gates verbose SSR error output.
   ssrDebug: true,
   setBundle(defaultExport) {
     __zfb_state.bundle = defaultExport;
+  },
+  drainConsoleLogs() {
+    const st = __zfb_console_state;
+    if (st.lines.length === 0) {
+      return "";
+    }
+    const out = st.lines.join("\n");
+    st.lines = [];
+    st.totalChars = 0;
+    st.truncated = false;
+    return out;
   },
   async dispatch(urlStr, method, headersObj, bodyU8) {
     if (!__zfb_state.bundle || typeof __zfb_state.bundle.fetch !== "function") {

--- a/crates/zfb-render/src/embedded_v8/mod.rs
+++ b/crates/zfb-render/src/embedded_v8/mod.rs
@@ -53,6 +53,14 @@
 //!   `{ status, headers, body }` as a JS object. The Rust side
 //!   pulls those fields back out via `serde_v8` deserialisation.
 //!
+//! - Worker console output is captured by a shim installed at host
+//!   boot (part of `extensions::HOST_GLOBALS_SHIM_SRC`): the levelled
+//!   `console` methods are patched to buffer each line (capped) while
+//!   still forwarding to the runtime's original stdout printer.
+//!   [`EmbeddedV8RenderHost::drain_console_logs`] retrieves and clears
+//!   the buffer so render failures can surface what the worker
+//!   printed (issue #700).
+//!
 //! ## node:* stubs
 //!
 //! Five specifiers in the v1 list (`node:fs`, `node:fs/promises`,
@@ -404,6 +412,35 @@ impl EmbeddedV8RenderHost {
             .execute_script("zfb:dispatch", script)
             .map_err(|e| RenderError::Runtime(format_js_error(&e)))?;
         Ok(result)
+    }
+
+    /// Drain the worker console output buffered by the host shim's
+    /// console capture (see `js/globals_shim.js`) since the last
+    /// drain.
+    ///
+    /// Returns the buffered lines joined with `\n` — each line carries
+    /// a `[level]` prefix (`[log]`, `[warn]`, …) — and clears the
+    /// JS-side buffer. Returns an empty string when nothing was
+    /// logged, when the shim is missing, or when the drain script
+    /// itself fails: this is strictly best-effort diagnostics and
+    /// must never mask the render error the caller is about to
+    /// surface (issue #700).
+    ///
+    /// Re-entrancy rule: call only BETWEEN dispatches — after a render
+    /// (or module evaluation) completes or fails — never while a
+    /// dispatch is in flight on the isolate.
+    pub fn drain_console_logs(&mut self) -> String {
+        let result = match self.runtime.execute_script(
+            "zfb:drain_console_logs",
+            "globalThis.__zfb && typeof globalThis.__zfb.drainConsoleLogs === \"function\" \
+                 ? globalThis.__zfb.drainConsoleLogs() : \"\"",
+        ) {
+            Ok(v) => v,
+            Err(_) => return String::new(),
+        };
+        deno_core::scope!(scope, &mut self.runtime);
+        let local = v8::Local::new(scope, result);
+        local_to_string_if_string(scope, local).unwrap_or_default()
     }
 
     fn allocate_handle(&self, name: &str) -> ModuleHandle {

--- a/crates/zfb-render/tests/embedded_v8_console_logs.rs
+++ b/crates/zfb-render/tests/embedded_v8_console_logs.rs
@@ -1,0 +1,161 @@
+//! Console-capture tests for `EmbeddedV8RenderHost` (issue #700).
+//!
+//! What's exercised here:
+//!
+//! - **Logs then throws**: a workerd-shaped bundle whose `fetch`
+//!   console.logs at several levels and then throws. The dispatch
+//!   fails, and `drain_console_logs` must return the buffered lines
+//!   with their `[level]` prefixes — this is the exact render-failure
+//!   path `zfb-build::renderer::render_all` surfaces to the operator.
+//!
+//! - **Module-evaluation logs**: console output produced while the
+//!   bundle's top-level code runs (including when evaluation itself
+//!   throws) must be drainable too — the capture shim is installed at
+//!   host boot, before bundle execution.
+//!
+//! - **Drain semantics**: draining clears the buffer (second drain is
+//!   empty) and resets the truncation state.
+//!
+//! - **Buffer cap**: a worker that logs thousands of lines must not
+//!   grow the buffer unboundedly; the drained output carries a single
+//!   truncation marker instead.
+//!
+//! All tests are gated on the `embed_v8` feature.
+
+#![cfg(feature = "embed_v8")]
+
+use zfb_render::{EmbeddedV8RenderHost, HttpRequestLike, RenderHost};
+
+#[tokio::test]
+async fn drains_levelled_console_output_after_failed_dispatch() {
+    let mut host = EmbeddedV8RenderHost::new().expect("host boot");
+    // Nothing logged yet — a fresh host drains to empty.
+    assert_eq!(host.drain_console_logs(), "");
+
+    let bundle = r#"
+        export default {
+          fetch(request) {
+            console.log("plain line", 42);
+            console.info("info line");
+            console.warn("warn line");
+            console.error("error line");
+            console.debug({ detail: "structured" });
+            throw new Error("render exploded");
+          },
+        };
+    "#;
+    host.execute_module("bundle.mjs", bundle)
+        .await
+        .expect("execute bundle");
+    let err = host
+        .dispatch_fetch(HttpRequestLike::get("http://zfb.local/boom"))
+        .await
+        .expect_err("dispatch must fail when fetch throws");
+    assert!(
+        err.to_string().contains("render exploded"),
+        "dispatch error must carry the thrown message: {err}"
+    );
+
+    let logs = host.drain_console_logs();
+    assert!(
+        logs.contains("[log] plain line 42"),
+        "missing log line: {logs:?}"
+    );
+    assert!(
+        logs.contains("[info] info line"),
+        "missing info line: {logs:?}"
+    );
+    assert!(
+        logs.contains("[warn] warn line"),
+        "missing warn line: {logs:?}"
+    );
+    assert!(
+        logs.contains("[error] error line"),
+        "missing error line: {logs:?}"
+    );
+    assert!(
+        logs.contains(r#"[debug] {"detail":"structured"}"#),
+        "objects must JSON-stringify in the capture: {logs:?}"
+    );
+
+    // Draining clears the buffer.
+    assert_eq!(host.drain_console_logs(), "");
+}
+
+#[tokio::test]
+async fn captures_module_evaluation_logs_even_when_evaluation_fails() {
+    let mut host = EmbeddedV8RenderHost::new().expect("host boot");
+    let bundle = r#"
+        console.log("during module evaluation");
+        throw new Error("boot boom");
+    "#;
+    host.execute_module("bundle.mjs", bundle)
+        .await
+        .expect_err("module evaluation must fail");
+    let logs = host.drain_console_logs();
+    assert!(
+        logs.contains("[log] during module evaluation"),
+        "logs printed before a module-evaluation failure must be drainable: {logs:?}"
+    );
+}
+
+#[tokio::test]
+async fn caps_buffer_and_marks_truncation() {
+    let mut host = EmbeddedV8RenderHost::new().expect("host boot");
+    // 1500 lines blows past the 1000-entry cap (kept close to the
+    // cap so the live stdout passthrough does not spam test output). The noisy loop lives
+    // in `fetch` (not module top-level) so the same bundle can log
+    // again after the drain — a host loads only one main module.
+    let bundle = r#"
+        export default {
+          fetch(request) {
+            const url = new URL(request.url);
+            if (url.pathname === "/noisy") {
+              for (let i = 0; i < 1500; i++) {
+                console.log("line " + i);
+              }
+            } else {
+              console.log("fresh after drain");
+            }
+            return new Response("ok", { status: 200 });
+          },
+        };
+    "#;
+    host.execute_module("bundle.mjs", bundle)
+        .await
+        .expect("execute bundle");
+    host.dispatch_fetch(HttpRequestLike::get("http://zfb.local/noisy"))
+        .await
+        .expect("dispatch /noisy");
+    let logs = host.drain_console_logs();
+    let line_count = logs.lines().count();
+    assert!(
+        line_count <= 1001,
+        "buffer must be capped (got {line_count} lines)"
+    );
+    assert!(
+        logs.contains("[log] line 0"),
+        "early lines kept: {line_count} lines"
+    );
+    assert!(
+        !logs.contains("line 1499"),
+        "lines past the cap must be dropped"
+    );
+    assert!(
+        logs.contains("console capture truncated"),
+        "a truncation marker must record that lines were dropped"
+    );
+    // The marker appears exactly once, not per dropped line.
+    assert_eq!(logs.matches("console capture truncated").count(), 1);
+
+    // Draining resets the cap state: new logs are captured again.
+    host.dispatch_fetch(HttpRequestLike::get("http://zfb.local/quiet"))
+        .await
+        .expect("dispatch /quiet");
+    let fresh = host.drain_console_logs();
+    assert!(
+        fresh.contains("[log] fresh after drain"),
+        "capture must resume after a drain resets the cap: {fresh:?}"
+    );
+    assert!(!fresh.contains("truncated"));
+}

--- a/crates/zfb/src/v8_host_adapter.rs
+++ b/crates/zfb/src/v8_host_adapter.rs
@@ -31,6 +31,23 @@ use zfb_render::{
     BundleModuleLoader, EmbeddedV8RenderHost, HttpRequestLike, PluginRegistryHooks,
 };
 
+/// Message sent from the caller thread to the V8 host thread.
+///
+/// Both request kinds travel over the SAME rendezvous channel so the
+/// host thread serves strictly one at a time — this is what preserves
+/// the isolate-thread invariant AND the drain-after-render rule
+/// (issue #700): a `DrainConsoleLogs` can never interleave with an
+/// in-flight `Dispatch`.
+enum HostRequest {
+    /// Dispatch a synthetic HTTP request through the bundle's
+    /// `default.fetch`.
+    Dispatch(DispatchRequest),
+    /// Drain the worker console output buffered by the host's console
+    /// capture since the last drain. Replies with the joined lines
+    /// (empty when nothing was logged).
+    DrainConsoleLogs { reply: mpsc::SyncSender<String> },
+}
+
 /// Request sent from the caller thread to the V8 host thread.
 struct DispatchRequest {
     url_path: String,
@@ -60,7 +77,7 @@ pub struct ThreadedV8Host {
     /// Sender half of the request channel. Wrapped in `Option` so `Drop`
     /// can `take()` it (move it out of `self`) to close the channel
     /// before joining the thread.
-    tx: Option<mpsc::SyncSender<DispatchRequest>>,
+    tx: Option<mpsc::SyncSender<HostRequest>>,
     /// Join handle for clean shutdown on drop.
     thread: Option<thread::JoinHandle<()>>,
 }
@@ -115,7 +132,7 @@ impl ThreadedV8Host {
         // Use a rendezvous channel (bound = 0) so the request loop cannot
         // get more than one request ahead. This matches the single-threaded
         // contract of `BackendHandle::dispatch`.
-        let (tx, rx) = mpsc::sync_channel::<DispatchRequest>(0);
+        let (tx, rx) = mpsc::sync_channel::<HostRequest>(0);
 
         // Boot result channel: the spawned thread sends `Ok(())` once the
         // host is ready, or `Err(msg)` if boot fails.
@@ -171,7 +188,22 @@ impl ThreadedV8Host {
                         .unwrap_or("bundle.mjs");
                     use zfb_render::RenderHost as _;
                     if let Err(e) = host.execute_module(bundle_name, &bundle_src).await {
-                        let _ = boot_tx.send(Err(format!("bundle load failed: {e}")));
+                        // Module evaluation may have console.logged before
+                        // throwing — the console-capture shim is installed
+                        // at host boot, before bundle execution. The host
+                        // dies with this thread on a boot failure, so the
+                        // only way to surface those lines is to embed them
+                        // in the boot error itself (issue #700).
+                        let console_logs = host.drain_console_logs();
+                        let msg = if console_logs.trim().is_empty() {
+                            format!("bundle load failed: {e}")
+                        } else {
+                            format!(
+                                "bundle load failed: {e}\n\
+                                 worker console output during bundle load:\n{console_logs}"
+                            )
+                        };
+                        let _ = boot_tx.send(Err(msg));
                         return;
                     }
 
@@ -180,8 +212,19 @@ impl ThreadedV8Host {
                     // Drop boot_tx so the caller side's recv returns.
                     drop(boot_tx);
 
-                    // Request loop: serve one dispatch at a time.
-                    for req in rx {
+                    // Request loop: serve one request at a time.
+                    for host_req in rx {
+                        let req = match host_req {
+                            HostRequest::Dispatch(req) => req,
+                            HostRequest::DrainConsoleLogs { reply } => {
+                                // Runs on the isolate thread between
+                                // dispatches — the rendezvous channel
+                                // guarantees no render request is in
+                                // flight (issue #700's re-entrancy rule).
+                                let _ = reply.send(host.drain_console_logs());
+                                continue;
+                            }
+                        };
                         // Construct the request shape expected by
                         // dispatch_fetch. The legacy GET path keeps
                         // method = "GET" + empty headers/body via
@@ -294,6 +337,24 @@ impl EmbeddedV8Host for ThreadedV8Host {
             body.to_vec(),
         )
     }
+
+    fn drain_console_logs(&mut self) -> String {
+        // Best-effort: console logs are failure diagnostics. A host
+        // thread that is already gone (shut down, panicked) must
+        // surface as "no logs", not as an error that masks the render
+        // failure the caller is about to report.
+        let Some(tx) = self.tx.as_ref() else {
+            return String::new();
+        };
+        let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+        if tx
+            .send(HostRequest::DrainConsoleLogs { reply: reply_tx })
+            .is_err()
+        {
+            return String::new();
+        }
+        reply_rx.recv().unwrap_or_default()
+    }
 }
 
 impl ThreadedV8Host {
@@ -320,7 +381,7 @@ impl ThreadedV8Host {
             reply: reply_tx,
         };
         // Send the request; if the channel is broken the thread died.
-        tx.send(req).map_err(|_| {
+        tx.send(HostRequest::Dispatch(req)).map_err(|_| {
             RendererError::EmbeddedV8("V8 host thread has exited unexpectedly".into())
         })?;
         // Block until the reply arrives.
@@ -395,5 +456,82 @@ pub fn translate_setup_registries_to_hooks(
     PluginRegistryHooks {
         aliases,
         virtual_modules,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_bundle(dir: &tempfile::TempDir, source: &str) -> std::path::PathBuf {
+        let path = dir.path().join("bundle.mjs");
+        std::fs::write(&path, source).expect("write bundle");
+        path
+    }
+
+    /// End-to-end check of the drain request kind (issue #700): worker
+    /// console output produced on the pinned V8 thread — during both
+    /// bundle evaluation and a failing dispatch — round-trips back to
+    /// the caller thread through the shared request channel.
+    #[test]
+    fn drain_console_logs_round_trips_through_host_thread() {
+        let dir = tempfile::tempdir().unwrap();
+        let bundle_path = write_bundle(
+            &dir,
+            r#"
+            console.log("boot log");
+            export default {
+              fetch(request) {
+                console.warn("about to fail");
+                throw new Error("render exploded");
+              },
+            };
+            "#,
+        );
+        let mut host = ThreadedV8Host::new(&bundle_path).expect("host boot");
+        let err = host
+            .dispatch_fetch("/boom")
+            .expect_err("dispatch must fail when fetch throws");
+        assert!(
+            err.to_string().contains("render exploded"),
+            "dispatch error must carry the thrown message: {err}"
+        );
+        let logs = host.drain_console_logs();
+        assert!(
+            logs.contains("[log] boot log"),
+            "missing boot line: {logs:?}"
+        );
+        assert!(
+            logs.contains("[warn] about to fail"),
+            "missing dispatch-time line: {logs:?}"
+        );
+        // Draining clears the host-side buffer.
+        assert_eq!(host.drain_console_logs(), "");
+    }
+
+    /// A bundle that console.logs and then throws during module
+    /// evaluation never reaches the request loop — the host thread
+    /// dies at boot. The captured lines must still surface, embedded
+    /// in the boot error message (issue #700).
+    #[test]
+    fn boot_failure_embeds_console_output_in_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let bundle_path = write_bundle(
+            &dir,
+            r#"
+            console.log("pre-crash detail");
+            throw new Error("boot boom");
+            "#,
+        );
+        let err = ThreadedV8Host::new(&bundle_path)
+            .err()
+            .expect("boot must fail");
+        let msg = err.to_string();
+        assert!(msg.contains("boot boom"), "boot error kept: {msg}");
+        assert!(
+            msg.contains("[log] pre-crash detail"),
+            "console output from the failed bundle load must be embedded \
+             in the boot error: {msg}"
+        );
     }
 }

--- a/scripts/build-macos-x64-local.sh
+++ b/scripts/build-macos-x64-local.sh
@@ -164,10 +164,25 @@ if [[ ! -f "$built_binary" ]]; then
 fi
 
 # ── Assert --version equals release semver (mirrors release.yml:284-296) ──────
-# Catches a missed ZFB_RELEASE_VERSION injection before the binary is archived.
+# Rosetta path: run the binary and assert `--version` output equals
+# "zfb $semver" — the only STRONG check this script performs. It catches a
+# missed ZFB_RELEASE_VERSION injection before the binary is archived.
 # Fix (b): on Apple Silicon without Rosetta 2 the x86_64 binary cannot execute
-# (Bad CPU type in executable), so guard the runtime assertion behind a Rosetta
-# check and fall back to a static rodata grep when Rosetta is absent.
+# (Bad CPU type in executable), so fall back to a static rodata scan. That
+# fallback is ONE-WAY (issue #748): the semver being ABSENT proves the stamp
+# was never injected (hard fail), but its PRESENCE cannot prove a correct
+# stamp — so on a match the script only warns and continues; it does NOT
+# claim the version was verified.
+#
+# Empirical facts behind the one-way design (issue #748 — measured against a
+# real stamped x64 binary; do not re-attempt these disproved "fixes"):
+#   - clap stores the program name ("zfb") and the version as SEPARATE rodata
+#     strings: grep -aF "zfb $semver" NEVER matches even a correctly-stamped
+#     binary, so the contiguous literal cannot be asserted.
+#   - Bare-substring signals are noisy in BOTH directions: "0.0.0" appears
+#     ~32x (vendored package metadata), the real semver ~9x, and even "9.9.9"
+#     matches a rodata digit lookup table — so neither a positive bare-semver
+#     match nor a "0.0.0 placeholder absent" assertion is a reliable guard.
 # The version string is embedded via option_env!("ZFB_RELEASE_VERSION") in
 # crates/zfb/src/cli.rs and appears literally in the binary's read-only data.
 expected_version="zfb $semver"
@@ -182,16 +197,21 @@ if arch -x86_64 /usr/bin/true 2>/dev/null; then
     exit 1
   fi
 else
-  # No Rosetta — verify the version stamp statically by grepping rodata.
-  echo "==> Rosetta absent — verifying version stamp via static rodata grep"
-  echo "Expected: $expected_version"
-  if grep -aF "$semver" "$built_binary" >/dev/null 2>&1; then
-    echo "Actual:   $semver found in binary rodata — OK"
-  else
-    echo "ERROR: '$semver' not found in binary rodata." >&2
-    echo "       ZFB_RELEASE_VERSION injection likely failed." >&2
+  # No Rosetta — best-effort static scan (one-way; see comment block above).
+  echo "==> Rosetta absent — best-effort static scan for '$semver' (NOT a real verification)"
+  if ! grep -aF "$semver" "$built_binary" >/dev/null 2>&1; then
+    echo "ERROR: '$semver' not found anywhere in the binary." >&2
+    echo "       ZFB_RELEASE_VERSION injection definitely failed — the stamped" >&2
+    echo "       version would appear literally in the binary's rodata." >&2
     exit 1
   fi
+  echo "WARNING: version stamp NOT verified — only a best-effort substring scan ran." >&2
+  echo "         '$semver' appears somewhere in the binary, but a bare-substring" >&2
+  echo "         match cannot distinguish the injected version stamp from vendored" >&2
+  echo "         package metadata, nor '0.1.0' from '0.1.0-next.N' (issue #748)." >&2
+  echo "         For a real check: install Rosetta 2 (softwareupdate --install-rosetta)" >&2
+  echo "         and re-run, or rely on release CI's --version assertions" >&2
+  echo "         (.github/workflows/release.yml) for published artifacts." >&2
 fi
 
 # ── Place binary in the platform package (mirrors release.yml) ────────────────


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/792

---

## Summary

- **Closes #791** — `tests/unit/install-prerelease.sh` (offline fixture test pinning `install.sh`'s prerelease tag resolution) is now executed by CI: a fail-fast step in the `health` job globs `tests/unit/*.sh` (auto-wiring future shell tests) and `bash -n` parse-checks `install.sh` + `scripts/*.sh`.
- **Closes #748** — the no-Rosetta static fallback in `scripts/build-macos-x64-local.sh` no longer overclaims verification: semver **absent** in rodata stays a hard fail (proves a missed `ZFB_RELEASE_VERSION` stamp), semver **present** is now an explicit inconclusive WARNING (vendored metadata makes substring signals noisy both ways), with Rosetta named as the only strong local check. Empirical facts (clap stores name/version as separate rodata strings; `0.0.0` appears ~32×) are recorded in-script so disproved fixes aren't re-attempted.
- **Closes #700** — the embedded-V8 backend finally surfaces worker console output on render failure: a console shim in `globals_shim.js` buffers levelled `console.*` lines (capped 1000 lines / 256 KiB / 8 KiB-per-line with truncation marker) while preserving stdout passthrough; `drain_console_logs(&mut self)` threads from the `EmbeddedV8Host` trait through `ThreadedV8Host` (second request kind on the same rendezvous channel — drain always runs on the pinned isolate thread, never mid-dispatch) down to `EmbeddedV8Guard::collect_logs`. Boot/module-eval failures embed captured console output in the boot error; dev-mode `render_one` drains after every page render.

## Changes

| Area | Files |
|---|---|
| CI wiring (#791) | `.github/workflows/health.yml` |
| Version guard (#748) | `scripts/build-macos-x64-local.sh` |
| V8 console capture (#700) | `crates/zfb-render/src/embedded_v8/js/globals_shim.js`, `crates/zfb-render/src/embedded_v8/mod.rs`, `crates/zfb-render/tests/embedded_v8_console_logs.rs` (new), `crates/zfb/src/v8_host_adapter.rs`, `crates/zfb-build/src/renderer.rs` |

## Test Plan

- `sh tests/unit/install-prerelease.sh` — passes (3/3), now also enforced by CI on this very PR
- #748 fallback logic validated against a real stamped x64 binary: correct semver → warns + continues; never-stamped semver → hard fail
- `cargo test -p zfb-render --test embedded_v8_console_logs` (3 new), `cargo test -p zfb-build --lib renderer` (27 incl. 3 new), `cargo test -p zfb --lib v8_host_adapter` (2 new, real-V8 end-to-end incl. boot-failure embedding) — all green on the merged base; clippy clean on touched crates
- `/codex-review` vs `main`: no actionable findings

## Workflow

3-topic parallel `/x-wt-teams` run (tracking issue #792); topic branches merged locally into `base/fixes-791-748-700` and deleted after push. Codex 2nd opinion shaped the plan (health.yml placement; no fake negative-placeholder guard; `&mut self` trait method; channel-routed drain; buffer cap; boot-failure drain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)