### PR TITLE
fix(zfb-dev): refresh the renderer bundle on edit ticks; watch configured collection paths

### DIFF
--- a/crates/zfb-build/src/lib.rs
+++ b/crates/zfb-build/src/lib.rs
@@ -74,7 +74,7 @@ pub use head_inject::{
     css_link_tag, inject_prod_head_assets, island_module_script_tag, needs_html5_doctype,
     ProdHeadAssets, HTML5_DOCTYPE_PREFIX,
 };
-pub use orchestrator::{BuildOrchestrator, DiscoveryHook, OrchestratorConfig};
+pub use orchestrator::{BuildOrchestrator, DiscoveryHook, DiscoveryOutcome, OrchestratorConfig};
 pub use plugin_registries::{
     AliasEntry, AliasMap, InjectedRoute, InjectedRouteList, SetupCommand, SetupRegistries,
     SetupRegistryError, VirtualLoaderId, VirtualModuleEntry, VirtualModuleRegistry,
@@ -92,7 +92,7 @@ pub use pipeline::{
     ProductionEmitters, RelDistPath, RenderedPage, RendererReloader,
 };
 pub use plan::{PageSelection, RebuildPlan};
-pub use policy::{classify_change, GranularityPolicy, PathClass};
+pub use policy::{classify_change, classify_change_with_content_roots, GranularityPolicy, PathClass};
 pub use renderer::{
     render_all, render_one, reload, shutdown, start, Backend, EmbeddedV8Host,
     EmbeddedV8HostFactory, HttpResponseLike, RendererError, RendererInput, RendererOutput,

--- a/crates/zfb-build/src/orchestrator.rs
+++ b/crates/zfb-build/src/orchestrator.rs
@@ -50,7 +50,7 @@ use zfb_watcher::{Change, ChangeKind, Watcher};
 
 use crate::pipeline::{AssetPipeline, BuildContext, BuildOutcome};
 use crate::plan::{PageSelection, RebuildPlan};
-use crate::policy::{classify_change, GranularityPolicy, PathClass};
+use crate::policy::{classify_change_with_content_roots, GranularityPolicy, PathClass};
 
 /// Live watch-ADD discovery hook (issue #659).
 ///
@@ -67,17 +67,33 @@ use crate::policy::{classify_change, GranularityPolicy, PathClass};
 /// page-render path an edit tick uses.
 ///
 /// Why a separate hook rather than [`BuildContext::reload_renderer`]:
-/// `reload_renderer` fires on **every** page tick (including edits) and
-/// only reloads the host — it neither rebundles a new content snapshot
-/// nor rediscovers routes, so it cannot make a brand-new file appear.
-/// The Created path is distinct and additive: it leaves the edit path
-/// (which never calls this hook) behaviourally identical.
+/// the discovery hook additionally rediscovers routes and reports the
+/// newly-renderable pages back into the tick's plan — `reload_renderer`
+/// is a fire-and-forget refresh with no way to surface discovered pages.
+/// The two cooperate via [`DiscoveryOutcome::renderer_reloaded`] /
+/// [`crate::RebuildPlan::renderer_fresh`]: when the hook's re-bundle
+/// already refreshed the renderer this tick, the pipeline skips its own
+/// `reload_renderer` call instead of bundling twice.
 ///
-/// Returning an empty `Vec` (no created path mapped to a discoverable
+/// Returning an empty page set (no created path mapped to a discoverable
 /// page) folds into the tick as a no-op for discovery — the rest of the
 /// tick's changes are still planned normally.
 pub type DiscoveryHook =
-    std::sync::Arc<dyn Fn(&[PathBuf]) -> Result<Vec<PageId>> + Send + Sync + 'static>;
+    std::sync::Arc<dyn Fn(&[PathBuf]) -> Result<DiscoveryOutcome> + Send + Sync + 'static>;
+
+/// What a [`DiscoveryHook`] invocation did for this tick.
+#[derive(Debug, Clone, Default)]
+pub struct DiscoveryOutcome {
+    /// Source pages whose route set changed (newly renderable). Folded
+    /// into the tick's plan so they render this tick.
+    pub pages: Vec<PageId>,
+
+    /// True when the hook re-bundled and reloaded the renderer in
+    /// place. Propagated to [`crate::RebuildPlan::renderer_fresh`] so the
+    /// pipeline's per-tick `reload_renderer` call is skipped — one
+    /// bundle per tick.
+    pub renderer_reloaded: bool,
+}
 
 /// Construction-time configuration for [`BuildOrchestrator`].
 #[derive(Debug, Clone)]
@@ -213,7 +229,12 @@ impl<P: AssetPipeline> BuildOrchestrator<P> {
             let path: PathBuf = change.into();
             plan.record_trigger(path.clone());
 
-            let class = classify_change(&path, &self.config.project_root, |p| graph.is_global(p));
+            let class = classify_change_with_content_roots(
+                &path,
+                &self.config.project_root,
+                &self.config.policy.content_roots,
+                |p| graph.is_global(p),
+            );
 
             match class {
                 PathClass::Global => {
@@ -368,7 +389,7 @@ impl<P: AssetPipeline> BuildOrchestrator<P> {
         // the path-only fold would have produced an empty/no-op plan
         // (a brand-new content file has no reverse edge yet, exactly the
         // #659 symptom).
-        let discovered: Vec<PageId> = match discover {
+        let discovered: DiscoveryOutcome = match discover {
             Some(hook) => {
                 let created: Vec<PathBuf> = changes
                     .iter()
@@ -376,18 +397,21 @@ impl<P: AssetPipeline> BuildOrchestrator<P> {
                     .map(|(p, _)| p.clone())
                     .collect();
                 if created.is_empty() {
-                    Vec::new()
+                    DiscoveryOutcome::default()
                 } else {
                     hook(&created)?
                 }
             }
-            None => Vec::new(),
+            None => DiscoveryOutcome::default(),
         };
 
         let mut plan = self.plan_for_changes(changes.into_iter().map(|(p, _)| p));
 
-        if !discovered.is_empty() {
-            let set: std::collections::BTreeSet<PageId> = discovered.into_iter().collect();
+        if discovered.renderer_reloaded {
+            plan.mark_renderer_fresh();
+        }
+        if !discovered.pages.is_empty() {
+            let set: std::collections::BTreeSet<PageId> = discovered.pages.into_iter().collect();
             plan.mark_pages(PageSelection::Specific(set));
         }
 
@@ -426,6 +450,10 @@ impl<P: AssetPipeline> BuildOrchestrator<P> {
     pub fn initial_build(&self, ctx: &BuildContext) -> Result<Option<BuildOutcome>> {
         let mut plan = RebuildPlan::empty();
         plan.mark_pages(PageSelection::All);
+        // The dev command bundles eagerly at boot right before this
+        // call — the renderer is already bound to a fresh bundle, so the
+        // pipeline must not re-bundle again for the initial render.
+        plan.mark_renderer_fresh();
         self.resolve_all(&mut plan);
         if plan.pages.is_empty() {
             return Ok(None);

--- a/crates/zfb-build/src/pipeline/dev.rs
+++ b/crates/zfb-build/src/pipeline/dev.rs
@@ -104,11 +104,16 @@ impl AssetPipeline for DevAssetPipeline {
 
         if !pages.is_empty() {
             // Reload the SSR renderer (embedded V8 host) before rendering
-            // pages whenever the dirty set is non-empty. Errors abort the
+            // pages whenever the dirty set is non-empty — UNLESS the
+            // renderer bundle was already refreshed this tick (boot's
+            // eager initial render, or a watch-ADD discovery re-bundle;
+            // see `RebuildPlan::renderer_fresh`). Errors abort the
             // tick — the watcher stays alive and the previous renderer
             // state is preserved by the orchestrator.
-            if let Some(reload) = &ctx.reload_renderer {
-                reload()?;
+            if !plan.renderer_fresh {
+                if let Some(reload) = &ctx.reload_renderer {
+                    reload()?;
+                }
             }
 
             let rendered = (ctx.render_pages)(&pages)?;
@@ -315,6 +320,7 @@ mod tests {
             pages: PageSelection::Specific(sel),
             rerun_css: false,
             rerun_islands: false,
+            renderer_fresh: false,
             triggers: vec![],
         };
 
@@ -347,6 +353,7 @@ mod tests {
             pages: PageSelection::Specific(sel),
             rerun_css: false,
             rerun_islands: false,
+            renderer_fresh: false,
             triggers: vec![],
         };
 
@@ -380,6 +387,7 @@ mod tests {
             pages: PageSelection::none(),
             rerun_css: true,
             rerun_islands: false,
+            renderer_fresh: false,
             triggers: vec![],
         };
 
@@ -413,6 +421,7 @@ mod tests {
             pages: PageSelection::Specific(sel.clone()),
             rerun_css: false,
             rerun_islands: false,
+            renderer_fresh: false,
             triggers: vec![],
         };
         let first = pipeline.apply(&plan, &ctx_a).unwrap();
@@ -475,6 +484,7 @@ mod tests {
             pages: PageSelection::Specific(sel),
             rerun_css: false,
             rerun_islands: false,
+            renderer_fresh: false,
             triggers: vec![],
         };
         let first = pipeline.apply(&plan, &ctx).unwrap();
@@ -528,6 +538,7 @@ mod tests {
             pages: PageSelection::Specific(sel),
             rerun_css: false,
             rerun_islands: false,
+            renderer_fresh: false,
             triggers: vec![],
         };
         let first = pipeline.apply(&plan, &ctx1).unwrap();
@@ -611,6 +622,7 @@ mod tests {
             pages: PageSelection::All,
             rerun_css: false,
             rerun_islands: false,
+            renderer_fresh: false,
             triggers: vec![],
         };
         assert!(pipeline.apply(&plan, &ctx).is_err());
@@ -641,6 +653,7 @@ mod tests {
             pages: PageSelection::none(),
             rerun_css: true,
             rerun_islands: true,
+            renderer_fresh: false,
             triggers: vec![],
         };
         let outcome = pipeline.apply(&plan, &ctx).unwrap();

--- a/crates/zfb-build/src/pipeline/orchestrator.rs
+++ b/crates/zfb-build/src/pipeline/orchestrator.rs
@@ -199,6 +199,9 @@ pub fn apply_prod_asset_pipeline(
         pages: PageSelection::Specific(selection),
         rerun_css: true,
         rerun_islands: true,
+        // One-shot production build: the render session is constructed
+        // against the bundle that was just built — nothing to reload.
+        renderer_fresh: true,
         triggers: vec![],
     };
 

--- a/crates/zfb-build/src/pipeline/prod.rs
+++ b/crates/zfb-build/src/pipeline/prod.rs
@@ -634,6 +634,7 @@ mod tests {
             pages: PageSelection::Specific(sel),
             rerun_css: true,
             rerun_islands: true,
+            renderer_fresh: false,
             triggers: vec![],
         }
     }
@@ -888,6 +889,7 @@ mod tests {
             pages: PageSelection::All,
             rerun_css: false,
             rerun_islands: false,
+            renderer_fresh: false,
             triggers: vec![],
         };
         assert!(pipeline.apply(&plan, &ctx).is_err());

--- a/crates/zfb-build/src/plan.rs
+++ b/crates/zfb-build/src/plan.rs
@@ -29,6 +29,13 @@ pub struct RebuildPlan {
     /// Whether the islands bundler should run again.
     pub rerun_islands: bool,
 
+    /// True when the renderer's bundle was already refreshed for this
+    /// tick — by the boot bundle (initial render) or by the watch-ADD
+    /// discovery hook's re-bundle + host reload. The pipeline consults
+    /// this to skip its own `reload_renderer` call so a single tick
+    /// never bundles twice.
+    pub renderer_fresh: bool,
+
     /// The raw paths that triggered this plan, kept around purely for
     /// diagnostics. Not consumed by the pipeline.
     pub triggers: Vec<PathBuf>,
@@ -92,6 +99,7 @@ impl RebuildPlan {
             pages: PageSelection::none(),
             rerun_css: false,
             rerun_islands: false,
+            renderer_fresh: false,
             triggers: Vec::new(),
         }
     }
@@ -102,8 +110,15 @@ impl RebuildPlan {
             pages: PageSelection::All,
             rerun_css: true,
             rerun_islands: true,
+            renderer_fresh: false,
             triggers: Vec::new(),
         }
+    }
+
+    /// Mark the renderer bundle as already refreshed for this tick (see
+    /// [`RebuildPlan::renderer_fresh`]).
+    pub fn mark_renderer_fresh(&mut self) {
+        self.renderer_fresh = true;
     }
 
     /// Add `path` to the diagnostics trigger list.

--- a/crates/zfb-build/src/policy.rs
+++ b/crates/zfb-build/src/policy.rs
@@ -124,8 +124,40 @@ pub fn classify_change(
     project_root: &Path,
     is_global: impl FnOnce(&Path) -> bool,
 ) -> PathClass {
+    classify_change_with_content_roots(path, project_root, &[], is_global)
+}
+
+/// Like [`classify_change`], but consults `content_roots` (project-relative
+/// roots of configured content collections, e.g. `src/mdx/notes` from a
+/// consumer's `zfb.config.ts`) **before** the standard root-segment walk.
+///
+/// Without this, a collection configured outside `content/` misclassifies:
+/// `src/mdx/notes/foo.mdx` matches the `src` segment in the walk and comes
+/// back as [`PathClass::Module`] — which both misses the content semantics
+/// and wastefully triggers an islands re-bundle (`src` is a default islands
+/// root). The global check still wins (a globally-registered file under a
+/// collection root must stay nuclear).
+pub fn classify_change_with_content_roots(
+    path: &Path,
+    project_root: &Path,
+    content_roots: &[PathBuf],
+    is_global: impl FnOnce(&Path) -> bool,
+) -> PathClass {
     if is_global(path) {
         return PathClass::Global;
+    }
+
+    if !content_roots.is_empty() {
+        // Match against the project-relative form when the event path is
+        // inside the root; fall back to a direct prefix match so an
+        // absolute (out-of-tree) collection root still classifies.
+        let rel = path.strip_prefix(project_root).ok();
+        let under_content_root = content_roots.iter().any(|root| {
+            rel.map(|r| r.starts_with(root)).unwrap_or(false) || path.starts_with(root)
+        });
+        if under_content_root {
+            return PathClass::Content;
+        }
     }
 
     let lower_ext = path
@@ -232,12 +264,22 @@ pub struct GranularityPolicy {
     /// the islands re-bundle. Defaults to `["components", "src"]` —
     /// callers can override with [`GranularityPolicy::with_islands_roots`].
     pub islands_roots: Vec<PathBuf>,
+
+    /// Project-relative roots of configured content collections (each
+    /// `collections[].path` from the consumer config). Changes under
+    /// these roots classify as [`PathClass::Content`] ahead of the
+    /// standard root-segment walk — see
+    /// [`classify_change_with_content_roots`]. Empty by default (the
+    /// hardcoded `content/` root in the walk keeps covering the
+    /// conventional layout).
+    pub content_roots: Vec<PathBuf>,
 }
 
 impl Default for GranularityPolicy {
     fn default() -> Self {
         Self {
             islands_roots: vec![PathBuf::from("components"), PathBuf::from("src")],
+            content_roots: Vec::new(),
         }
     }
 }
@@ -251,6 +293,17 @@ impl GranularityPolicy {
         P: Into<PathBuf>,
     {
         self.islands_roots = roots.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Set the configured content-collection roots (chainable). See
+    /// [`GranularityPolicy::content_roots`].
+    pub fn with_content_roots<I, P>(mut self, roots: I) -> Self
+    where
+        I: IntoIterator<Item = P>,
+        P: Into<PathBuf>,
+    {
+        self.content_roots = roots.into_iter().map(Into::into).collect();
         self
     }
 
@@ -306,6 +359,79 @@ mod tests {
 
     fn proj() -> &'static Path {
         Path::new("/proj")
+    }
+
+    /// Regression: a collection configured under `src/` (e.g.
+    /// `src/mdx/notes` in a consumer's `zfb.config.ts`) classified as
+    /// `Module` because the root-segment walk matched `src` — missing
+    /// the content semantics and (since `src` is a default islands
+    /// root) wastefully re-bundling islands on every entry edit.
+    #[test]
+    fn configured_content_root_wins_over_module_segment_walk() {
+        let roots = vec![PathBuf::from("src/mdx/notes")];
+        assert_eq!(
+            classify_change_with_content_roots(
+                Path::new("/proj/src/mdx/notes/foo.mdx"),
+                proj(),
+                &roots,
+                never_global,
+            ),
+            PathClass::Content
+        );
+        // A sibling module file outside the collection root keeps the
+        // normal Module classification.
+        assert_eq!(
+            classify_change_with_content_roots(
+                Path::new("/proj/src/components/button.tsx"),
+                proj(),
+                &roots,
+                never_global,
+            ),
+            PathClass::Module
+        );
+    }
+
+    /// The global check must stay ahead of the content-root check — a
+    /// globally-registered file under a collection root is still
+    /// nuclear.
+    #[test]
+    fn global_check_wins_over_configured_content_root() {
+        let roots = vec![PathBuf::from("src/mdx")];
+        assert_eq!(
+            classify_change_with_content_roots(
+                Path::new("/proj/src/mdx/zfb.config.ts"),
+                proj(),
+                &roots,
+                |_| true,
+            ),
+            PathClass::Global
+        );
+    }
+
+    /// An absolute (out-of-tree) collection root still classifies via
+    /// the direct prefix fallback.
+    #[test]
+    fn absolute_content_root_classifies_via_prefix_fallback() {
+        let roots = vec![PathBuf::from("/srv/shared/posts")];
+        assert_eq!(
+            classify_change_with_content_roots(
+                Path::new("/srv/shared/posts/a.mdx"),
+                proj(),
+                &roots,
+                never_global,
+            ),
+            PathClass::Content
+        );
+    }
+
+    /// `classify_change` (no content roots) keeps its exact legacy
+    /// behaviour — `src/**.mdx` still walks to `Module`.
+    #[test]
+    fn no_content_roots_preserves_legacy_module_walk() {
+        assert_eq!(
+            classify_change(Path::new("/proj/src/mdx/notes/foo.mdx"), proj(), never_global),
+            PathClass::Module
+        );
     }
 
     #[test]

--- a/crates/zfb-build/src/policy.rs
+++ b/crates/zfb-build/src/policy.rs
@@ -137,6 +137,14 @@ pub fn classify_change(
 /// and wastefully triggers an islands re-bundle (`src` is a default islands
 /// root). The global check still wins (a globally-registered file under a
 /// collection root must stay nuclear).
+///
+/// The content-root override is **gated on content-shaped extensions**
+/// (`md` / `mdx` — the same set [`classify_by_extension`] maps to
+/// [`PathClass::Content`]). A co-located non-entry file under a collection
+/// root — e.g. an islands `Counter.tsx` or a `theme.css` — must NOT be
+/// swept up as `Content`; it falls through to the normal root-segment walk
+/// so it keeps classifying as [`PathClass::Module`] (preserving islands
+/// invalidation) or [`PathClass::Style`] (preserving the CSS rerun).
 pub fn classify_change_with_content_roots(
     path: &Path,
     project_root: &Path,
@@ -147,7 +155,17 @@ pub fn classify_change_with_content_roots(
         return PathClass::Global;
     }
 
-    if !content_roots.is_empty() {
+    let lower_ext = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase());
+
+    // Only redirect content-shaped files (md / mdx) under a configured
+    // collection root to `Content`. Co-located `.tsx` / `.css` / other
+    // files must fall through to the normal root-segment walk so islands
+    // re-bundling and CSS reruns still fire.
+    let is_content_shaped = matches!(lower_ext.as_deref(), Some("md") | Some("mdx"));
+    if is_content_shaped && !content_roots.is_empty() {
         // Match against the project-relative form when the event path is
         // inside the root; fall back to a direct prefix match so an
         // absolute (out-of-tree) collection root still classifies.
@@ -159,11 +177,6 @@ pub fn classify_change_with_content_roots(
             return PathClass::Content;
         }
     }
-
-    let lower_ext = path
-        .extension()
-        .and_then(|e| e.to_str())
-        .map(|e| e.to_ascii_lowercase());
 
     // Out-of-root paths (the `extraWatchPaths` channel — issue #368)
     // must NOT walk their absolute components looking for in-tree root
@@ -388,6 +401,43 @@ mod tests {
                 never_global,
             ),
             PathClass::Module
+        );
+    }
+
+    /// A co-located islands `.tsx` INSIDE the collection root must NOT be
+    /// swept up as `Content` by the content-root override — the override is
+    /// gated on content-shaped extensions (md / mdx). Otherwise the islands
+    /// re-bundle the default `src` islands root would trigger gets skipped
+    /// and the client bundle goes stale.
+    #[test]
+    fn content_root_does_not_swallow_colocated_tsx() {
+        let roots = vec![PathBuf::from("src/mdx/notes")];
+        assert_eq!(
+            classify_change_with_content_roots(
+                Path::new("/proj/src/mdx/notes/Counter.tsx"),
+                proj(),
+                &roots,
+                never_global,
+            ),
+            PathClass::Module
+        );
+    }
+
+    /// A co-located `.css` INSIDE the collection root must fall through to
+    /// the normal root-segment walk and classify as `Style`, not `Content`
+    /// — otherwise the CSS rerun for an edit to it is skipped and the
+    /// styles go stale.
+    #[test]
+    fn content_root_does_not_swallow_colocated_css() {
+        let roots = vec![PathBuf::from("src/mdx/notes")];
+        assert_eq!(
+            classify_change_with_content_roots(
+                Path::new("/proj/src/mdx/notes/theme.css"),
+                proj(),
+                &roots,
+                never_global,
+            ),
+            PathClass::Style
         );
     }
 

--- a/crates/zfb-build/tests/integration_dev_loop.rs
+++ b/crates/zfb-build/tests/integration_dev_loop.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use tempfile::tempdir;
 use zfb_build::{
     AssetPipeline, BuildContext, BuildOrchestrator, DevAssetPipeline, DiscoveryHook,
-    OrchestratorConfig, PageSelection, RebuildPlan, RelDistPath, RenderedPage,
+    DiscoveryOutcome, OrchestratorConfig, PageSelection, RebuildPlan, RelDistPath, RenderedPage,
 };
 use zfb_graph::{DepKind, DependencyGraph, PageDeps, PageId};
 use zfb_watcher::{ChangeKind, Watcher};
@@ -580,7 +580,10 @@ fn fake_blog_discovery_hook(
                 out.push(page);
             }
         }
-        Ok(out)
+        Ok(DiscoveryOutcome {
+            pages: out,
+            renderer_reloaded: true,
+        })
     })
 }
 
@@ -745,3 +748,242 @@ fn modified_content_file_does_not_invoke_discovery_and_still_hot_reloads() {
 
 #[allow(dead_code)]
 fn _ensure_unused_imports_used(_: PageSelection) {}
+
+// ---------------------------------------------------------------------------
+// Per-tick renderer reload (`BuildContext::reload_renderer` ×
+// `RebuildPlan::renderer_fresh`).
+//
+// The content snapshot and page modules are baked into the SSR bundle, so
+// an EDIT tick that only re-renders against the boot-time bundle emits
+// byte-identical stale HTML — the dev server never reflected in-place
+// saves until restart. The pipeline must therefore invoke
+// `reload_renderer` before rendering on a normal edit tick, and must NOT
+// invoke it when the tick's bundle is already fresh (boot initial render,
+// or a watch-ADD discovery re-bundle in the same tick).
+// ---------------------------------------------------------------------------
+
+/// Shared scaffolding for the reload tests: one md page fixture, a
+/// recording reload hook, and a recording renderer.
+struct ReloadProbe {
+    events: Arc<Mutex<Vec<&'static str>>>,
+}
+
+impl ReloadProbe {
+    fn new() -> Self {
+        Self {
+            events: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn ctx(&self, project: &std::path::Path) -> BuildContext {
+        let render_events = self.events.clone();
+        let reload_events = self.events.clone();
+        BuildContext {
+            dist_root: project.join("dist"),
+            render_pages: Arc::new(move |pages: &[PageId]| {
+                render_events.lock().unwrap().push("render");
+                Ok(pages
+                    .iter()
+                    .map(|p| RenderedPage {
+                        page: p.clone(),
+                        output_path: RelDistPath::new(format!(
+                            "{}.html",
+                            p.path().file_stem().unwrap().to_string_lossy()
+                        ))
+                        .expect("test stem is a relative html path"),
+                        html: "<p>x</p>".into(),
+                        content_type: None,
+                    })
+                    .collect())
+            }),
+            run_css: None,
+            run_islands: None,
+            reload_renderer: Some(Arc::new(move || {
+                reload_events.lock().unwrap().push("reload");
+                Ok(())
+            })),
+        }
+    }
+
+    fn events(&self) -> Vec<&'static str> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+fn md_page_fixture(project: &std::path::Path) -> Arc<Mutex<DependencyGraph>> {
+    std::fs::create_dir_all(project.join("pages")).unwrap();
+    std::fs::create_dir_all(project.join("content")).unwrap();
+    std::fs::write(project.join("pages/post.tsx"), "// page\n").unwrap();
+    std::fs::write(project.join("content/post.md"), "# hello\n").unwrap();
+    std::fs::create_dir_all(project.join("dist")).unwrap();
+    make_graph_with_md_page(project)
+}
+
+/// An in-place EDIT (`Modified`) must reload the renderer BEFORE
+/// rendering — otherwise the render runs against the stale boot bundle
+/// and the output is byte-identical to the previous tick.
+#[test]
+fn modified_content_tick_reloads_renderer_before_render() {
+    let dir = tempdir().unwrap();
+    let project = dir.path();
+    let graph = md_page_fixture(project);
+
+    let orch = BuildOrchestrator::new(
+        OrchestratorConfig::new(project, vec![PathBuf::from("content")]),
+        graph,
+        DevAssetPipeline::new(),
+    );
+    let probe = ReloadProbe::new();
+    let ctx = probe.ctx(project);
+
+    orch.tick_with_kinds(
+        vec![(project.join("content/post.md"), ChangeKind::Modified)],
+        &ctx,
+        None,
+    )
+    .expect("tick succeeded")
+    .expect("non-noop");
+
+    assert_eq!(
+        probe.events(),
+        vec!["reload", "render"],
+        "edit tick must reload the renderer exactly once, before rendering"
+    );
+}
+
+/// A Created tick whose discovery hook already re-bundled + reloaded
+/// (`DiscoveryOutcome::renderer_reloaded == true`) must NOT trigger the
+/// pipeline's own reload — one bundle per tick.
+#[test]
+fn discovery_reload_suppresses_pipeline_reload_in_same_tick() {
+    let dir = tempdir().unwrap();
+    let project = dir.path();
+    let graph = md_page_fixture(project);
+
+    let orch = BuildOrchestrator::new(
+        OrchestratorConfig::new(project, vec![PathBuf::from("content")]),
+        graph,
+        DevAssetPipeline::new(),
+    );
+    let probe = ReloadProbe::new();
+    let ctx = probe.ctx(project);
+
+    let new_post = project.join("content/new-post.md");
+    std::fs::write(&new_post, "# new\n").unwrap();
+
+    let hook_pages = vec![pid(project.join("pages/post.tsx"))];
+    let hook: DiscoveryHook = Arc::new(move |_created: &[PathBuf]| {
+        Ok(DiscoveryOutcome {
+            pages: hook_pages.clone(),
+            renderer_reloaded: true,
+        })
+    });
+
+    orch.tick_with_kinds(
+        vec![(new_post.clone(), ChangeKind::Created)],
+        &ctx,
+        Some(&hook),
+    )
+    .expect("tick succeeded")
+    .expect("non-noop");
+
+    assert_eq!(
+        probe.events(),
+        vec!["render"],
+        "discovery already refreshed the bundle — the pipeline must not reload again"
+    );
+}
+
+/// Boot's eager initial render runs right after the boot bundle — the
+/// renderer is already fresh, so `initial_build` must not reload.
+#[test]
+fn initial_build_does_not_reload_renderer() {
+    let dir = tempdir().unwrap();
+    let project = dir.path();
+    let graph = md_page_fixture(project);
+
+    let orch = BuildOrchestrator::new(
+        OrchestratorConfig::new(project, vec![PathBuf::from("content")]),
+        graph,
+        DevAssetPipeline::new(),
+    );
+    let probe = ReloadProbe::new();
+    let ctx = probe.ctx(project);
+
+    orch.initial_build(&ctx)
+        .expect("initial build succeeded")
+        .expect("non-empty graph renders");
+
+    assert_eq!(
+        probe.events(),
+        vec!["render"],
+        "initial render must reuse the boot bundle, not re-bundle"
+    );
+}
+
+/// A collection configured under a custom root (`src/mdx/notes`) plans a
+/// Content rebuild — pages re-render, islands do NOT re-bundle (before
+/// the `content_roots` policy, the `src` segment classified the entry as
+/// Module and re-bundled islands on every edit).
+#[test]
+fn modified_entry_under_custom_collection_root_skips_islands() {
+    let dir = tempdir().unwrap();
+    let project = dir.path();
+
+    std::fs::create_dir_all(project.join("pages")).unwrap();
+    std::fs::create_dir_all(project.join("src/mdx/notes")).unwrap();
+    std::fs::write(project.join("pages/post.tsx"), "// page\n").unwrap();
+    std::fs::write(project.join("src/mdx/notes/foo.mdx"), "# hi\n").unwrap();
+    std::fs::create_dir_all(project.join("dist")).unwrap();
+
+    let mut g = DependencyGraph::new();
+    g.upsert(PageDeps::new(
+        pid(project.join("pages/post.tsx")),
+        vec![(project.join("src/mdx/notes/foo.mdx"), DepKind::Content)],
+    ));
+    let graph = Arc::new(Mutex::new(g));
+
+    let islands_runs = Arc::new(AtomicUsize::new(0));
+    let islands_runs_cb = islands_runs.clone();
+
+    let orch = BuildOrchestrator::new(
+        OrchestratorConfig::new(
+            project,
+            vec![PathBuf::from("pages"), PathBuf::from("src/mdx/notes")],
+        )
+        .with_policy(
+            zfb_build::GranularityPolicy::default()
+                .with_content_roots(vec![PathBuf::from("src/mdx/notes")]),
+        ),
+        graph,
+        DevAssetPipeline::new(),
+    );
+
+    let probe = ReloadProbe::new();
+    let mut ctx = probe.ctx(project);
+    ctx.run_islands = Some(Arc::new(move || {
+        islands_runs_cb.fetch_add(1, Ordering::SeqCst);
+        Ok(None)
+    }));
+
+    let outcome = orch
+        .tick_with_kinds(
+            vec![(project.join("src/mdx/notes/foo.mdx"), ChangeKind::Modified)],
+            &ctx,
+            None,
+        )
+        .expect("tick succeeded")
+        .expect("non-noop");
+
+    assert_eq!(outcome.pages_rendered, 1, "consumer page re-rendered");
+    assert!(
+        !outcome.islands_rerun,
+        "a content entry under a configured collection root must not re-bundle islands"
+    );
+    assert_eq!(islands_runs.load(Ordering::SeqCst), 0);
+    assert_eq!(
+        probe.events(),
+        vec!["reload", "render"],
+        "content edit still refreshes the renderer bundle"
+    );
+}

--- a/crates/zfb-server/tests/watch_add_confirm.rs
+++ b/crates/zfb-server/tests/watch_add_confirm.rs
@@ -80,7 +80,8 @@ use std::time::Duration;
 use tokio::net::TcpListener;
 use tokio::sync::broadcast;
 use zfb_build::{
-    BuildContext, BuildOrchestrator, DevAssetPipeline, DiscoveryHook, OrchestratorConfig,
+    BuildContext, BuildOrchestrator, DevAssetPipeline, DiscoveryHook, DiscoveryOutcome,
+    OrchestratorConfig,
     RelDistPath, RenderedPage,
 };
 use zfb_graph::{DepKind, DependencyGraph, PageDeps, PageId};
@@ -228,7 +229,10 @@ fn make_discovery_hook(
                 out.push(pid(slug_src.clone()));
             }
         }
-        Ok(out)
+        Ok(DiscoveryOutcome {
+            pages: out,
+            renderer_reloaded: true,
+        })
     })
 }
 
@@ -622,6 +626,209 @@ async fn real_watcher_edit_existing_file_still_hot_reloads() {
     // ----------------------------------------------------------------
     // 5. Teardown
     // ----------------------------------------------------------------
+    orch_task.abort();
+    server.abort();
+}
+
+/// Real-watcher confirmation for the per-tick renderer reload
+/// (`BuildContext::reload_renderer` wiring).
+///
+/// ## Why this test exists
+///
+/// The content snapshot and page modules are baked into the SSR bundle.
+/// Before the reload wiring, an IN-PLACE save (`ChangeKind::Modified` —
+/// what VS Code and most editors emit) re-rendered against the
+/// boot-time bundle, so the re-rendered HTML was byte-identical to the
+/// stale boot output: edits never reached the browser until a dev-server
+/// restart. (Rename-replace saves worked by accident via the watch-ADD
+/// discovery path.) Discovered during usage in a consumer project.
+///
+/// ## How the staleness is modelled
+///
+/// The real staleness lives in the V8 bundle, which crate-level tests
+/// can't reach. The stub here mirrors the semantics exactly:
+///
+/// - `snapshot` (an `Arc<Mutex<String>>`) plays the role of the baked
+///   content snapshot: it is read ONCE at "boot".
+/// - `render_pages` renders from `snapshot`, NOT from disk — like the
+///   real renderer, it cannot see an edit until the bundle refreshes.
+/// - `reload_renderer` re-reads `hello.mdx` from disk into `snapshot` —
+///   like the real re-bundle + host swap.
+///
+/// With `reload_renderer: None` (the pre-fix wiring) the served body
+/// stays at v1 forever and this test fails its marker assertion — the
+/// falsifiable encoding of the user-visible bug.
+#[tokio::test]
+async fn real_watcher_inplace_edit_reaches_served_html_via_reload() {
+    let _serial = SERIAL.lock().await;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let project = tmp.path().canonicalize().expect("canonicalize project");
+
+    setup_fixture(&project);
+
+    let routes = seed_route_table(&project);
+    let graph = seed_graph(&project);
+
+    let html_root = project.join("dist");
+    let hello_src = project.join("content/blog/hello.mdx");
+
+    // "Boot bundle": the snapshot reads the source once, up front.
+    let snapshot: Arc<Mutex<String>> = Arc::new(Mutex::new(
+        std::fs::read_to_string(&hello_src).expect("read hello.mdx at boot"),
+    ));
+
+    let reload_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+    let ctx = {
+        let routes = routes.clone();
+        let snapshot_for_render = snapshot.clone();
+        let snapshot_for_reload = snapshot.clone();
+        let hello_for_reload = hello_src.clone();
+        let reload_count = reload_count.clone();
+        BuildContext {
+            dist_root: html_root.clone(),
+            render_pages: Arc::new(move |pages: &[PageId]| {
+                let table = routes.lock().unwrap();
+                let body = snapshot_for_render.lock().unwrap().clone();
+                let mut out = Vec::new();
+                for p in pages {
+                    for output in table.get(p.path()).into_iter().flatten() {
+                        let html = format!("<html><body><p>{body}</p></body></html>");
+                        let output_path = RelDistPath::new(output.clone())
+                            .expect("test output is a relative path");
+                        out.push(RenderedPage {
+                            page: PageId::new(PathBuf::from(output)),
+                            output_path,
+                            html,
+                            content_type: None,
+                        });
+                    }
+                }
+                Ok(out)
+            }),
+            run_css: None,
+            run_islands: None,
+            reload_renderer: Some(Arc::new(move || {
+                let fresh = std::fs::read_to_string(&hello_for_reload)?;
+                *snapshot_for_reload.lock().unwrap() = fresh;
+                reload_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                Ok(())
+            })),
+        }
+    };
+
+    let debounce = Duration::from_millis(200);
+    let orch = BuildOrchestrator::new(
+        OrchestratorConfig::new(project.clone(), vec![PathBuf::from("content")])
+            .with_debounce(debounce),
+        graph.clone(),
+        DevAssetPipeline::new(),
+    );
+
+    // Pre-render the hello route from the boot snapshot so the server
+    // serves v1 at boot.
+    {
+        let hello_dir = html_root.join("blog/hello");
+        std::fs::create_dir_all(&hello_dir).unwrap();
+        let body = snapshot.lock().unwrap().clone();
+        std::fs::write(
+            hello_dir.join("index.html"),
+            format!("<html><body><p>{body}</p></body></html>"),
+        )
+        .unwrap();
+    }
+
+    let (listener, addr) = bind_ephemeral().await;
+    let (tx, _rx) = broadcast::channel::<ReloadEvent>(8);
+    let opts = ServeOpts {
+        project_root: project.clone(),
+        dist_root: html_root.clone(),
+        html_root: html_root.clone(),
+        public_root: project.join("public"),
+        addr,
+        pages: PageCache::new(),
+        broadcast: tx,
+        plugins: None,
+        injected_routes: None,
+        ssr_routes: None,
+        base: None,
+        trailing_slash: false,
+        mode: zfb_server::ServerMode::Dev,
+        islands_bundle_url: None,
+        css_bundle_url: None,
+    };
+    let server = tokio::spawn(async move {
+        serve_with_listener(opts, listener, std::future::pending::<()>()).await
+    });
+    tokio::task::yield_now().await;
+
+    let client = reqwest::Client::new();
+    let r0 = client
+        .get(format!("http://{addr}/blog/hello"))
+        .send()
+        .await
+        .expect("GET /blog/hello initial");
+    assert_eq!(r0.status().as_u16(), 200);
+    assert!(
+        !r0.text().await.unwrap().contains("V2-MARKER"),
+        "marker must not be present before the edit"
+    );
+
+    // No discovery hook: the per-tick reload is the only refresh path,
+    // exactly the EDIT scenario under test.
+    let orch_task = tokio::spawn(async move { orch.run(ctx, None, |_outcome| {}).await });
+
+    // Watcher-live handshake (same FSEvents dead-window mitigation as the
+    // ADD test, but probed through the reload counter since there is no
+    // discovery hook here): write fresh-named throwaway files under
+    // content/blog/ until a tick lands.
+    {
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
+        let mut i = 0;
+        while reload_count.load(std::sync::atomic::Ordering::SeqCst) == 0 {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "watcher-live handshake timed out (no tick within 15s)"
+            );
+            std::fs::write(
+                project.join(format!("content/blog/.warmup-{i}.md")),
+                "warmup\n",
+            )
+            .unwrap();
+            i += 1;
+            tokio::time::sleep(Duration::from_millis(300)).await;
+        }
+    }
+
+    // The actual in-place EDIT: same path, same inode, truncate + write.
+    std::fs::write(&hello_src, "---\ntitle: Hello\n---\nV2-MARKER content\n")
+        .expect("in-place edit hello.mdx");
+
+    // Poll until the SERVED body carries the new content.
+    let deadline = std::time::Instant::now() + Duration::from_secs(30);
+    let mut served_fresh = false;
+    while std::time::Instant::now() < deadline {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        if let Ok(resp) = client.get(format!("http://{addr}/blog/hello")).send().await {
+            if resp.status().as_u16() == 200 {
+                if let Ok(body) = resp.text().await {
+                    if body.contains("V2-MARKER") {
+                        served_fresh = true;
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(
+        served_fresh,
+        "an in-place edit must reach the served HTML via the per-tick renderer \
+         reload within 30s (stale-bundle regression: without reload_renderer the \
+         body stays at v1 forever)",
+    );
+
     orch_task.abort();
     server.abort();
 }

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -74,12 +74,12 @@ use anyhow::{Context, Result};
 use tokio::sync::broadcast;
 use zfb_build::bundler::{bundle, BundleMode, BundlerInput, BundlerOutput};
 use zfb_build::renderer::{
-    reload, render_one, shutdown, start, Backend, RendererStartInput, RendererState,
-    RouteUniverseEntry,
+    render_one, shutdown, start, Backend, RendererStartInput, RendererState, RouteUniverseEntry,
 };
 use zfb_build::{
-    BuildContext, BuildOrchestrator, BuildOutcome, CssRunner, DevAssetPipeline, IslandsBundleInfo,
-    IslandsRunner, OrchestratorConfig, PageRenderer, RelDistPath, RenderedPage,
+    BuildContext, BuildOrchestrator, BuildOutcome, CssRunner, DevAssetPipeline, DiscoveryOutcome,
+    IslandsBundleInfo, IslandsRunner, OrchestratorConfig, PageRenderer, RelDistPath, RenderedPage,
+    RendererReloader,
 };
 use zfb_graph::persist::{load_from_disk, save_to_disk, ManifestDigest};
 use zfb_graph::{DependencyGraph, PageDeps, PageId};
@@ -111,6 +111,52 @@ const DEFAULT_WATCH_ROOTS: &[&str] = &[
     "zfb.config.json",
     "zfb.config.ts",
 ];
+
+/// Strip `.` components so `./src/mdx` and `src/mdx` compare equal in
+/// the dedupe / coverage checks below.
+fn normalize_relative(path: &Path) -> PathBuf {
+    path.components()
+        .filter(|c| !matches!(c, std::path::Component::CurDir))
+        .collect()
+}
+
+/// The dev watcher's source roots: [`DEFAULT_WATCH_ROOTS`] plus each
+/// configured collection's `path`.
+///
+/// Collections may live anywhere in the project (`CollectionDef::path`
+/// is project-root-relative, e.g. `src/mdx/notes`) — only watching the
+/// fixed default roots means edits under such a collection never produce
+/// a watcher event and the dev server serves stale HTML until restart.
+///
+/// Rules:
+/// - paths are normalized (leading `./` stripped) before comparison;
+/// - a collection path already covered by an earlier root is skipped
+///   (`content/blog` is inside the default `content` root; nested
+///   collections dedupe against each other after the shallow-first
+///   sort), avoiding double event delivery from overlapping recursive
+///   watches;
+/// - missing directories are tolerated downstream — the watcher warns
+///   and skips them at registration.
+fn derive_watch_roots(cfg: &config::Config) -> Vec<PathBuf> {
+    let mut roots: Vec<PathBuf> = DEFAULT_WATCH_ROOTS.iter().map(PathBuf::from).collect();
+    let mut collection_paths: Vec<PathBuf> = cfg
+        .collections
+        .iter()
+        .map(|c| normalize_relative(&c.path))
+        .filter(|p| !p.as_os_str().is_empty())
+        .collect();
+    // Shallow-first so a parent collection root lands before its
+    // children and the coverage check below collapses the family to
+    // the parent.
+    collection_paths.sort_by_key(|p| p.components().count());
+    for p in collection_paths {
+        let covered = roots.iter().any(|r| p.starts_with(r));
+        if !covered {
+            roots.push(p);
+        }
+    }
+    roots
+}
 
 /// Entry point for `zfb dev`.
 ///
@@ -340,7 +386,10 @@ pub async fn run(args: &DevArgs) -> Result<()> {
     // matches the current project layout, deserialise and reuse —
     // otherwise build fresh and save the new graph back so the
     // *next* cold start is fast.
-    let watch_roots: Vec<PathBuf> = DEFAULT_WATCH_ROOTS.iter().map(PathBuf::from).collect();
+    // Includes configured collection paths (e.g. `src/mdx/notes`) so
+    // edits there produce watcher events; the manifest digest below
+    // covers them automatically since it walks the same roots.
+    let watch_roots: Vec<PathBuf> = derive_watch_roots(&cfg);
     let graph_cache_path = project_root.join(".zfb").join("graph.bin");
     let manifest_digest = compute_manifest_digest(&project_root, &watch_roots);
     let initial_graph = load_persisted_graph(&graph_cache_path, manifest_digest.as_ref());
@@ -375,8 +424,21 @@ pub async fn run(args: &DevArgs) -> Result<()> {
     let graph_for_save = Arc::clone(&graph);
     let pipeline = DevAssetPipeline::new();
     let extra_watch_paths = resolve_extra_watch_paths(&cfg.extra_watch_paths);
+    // Configured collection roots classify as Content ahead of the
+    // standard root-segment walk — without this, a collection under
+    // `src/` (e.g. `src/mdx/notes`) classifies as Module and wastefully
+    // re-bundles islands on every entry edit.
+    let content_roots: Vec<PathBuf> = cfg
+        .collections
+        .iter()
+        .map(|c| normalize_relative(&c.path))
+        .filter(|p| !p.as_os_str().is_empty())
+        .collect();
     let orch_config = OrchestratorConfig::new(&project_root, watch_roots.clone())
-        .with_extra_watch_paths(extra_watch_paths);
+        .with_extra_watch_paths(extra_watch_paths)
+        .with_policy(
+            zfb_build::GranularityPolicy::default().with_content_roots(content_roots),
+        );
     let orchestrator = BuildOrchestrator::new(orch_config, graph, pipeline);
 
     let render_pages: PageRenderer = match dev_session.as_ref() {
@@ -641,6 +703,31 @@ pub async fn run(args: &DevArgs) -> Result<()> {
         }))
     };
 
+    // Per-tick bundle refresh for EDIT ticks. Without this the renderer
+    // stays bound to the boot-time bundle: the content snapshot and page
+    // modules are baked in at bundle time, so an in-place save
+    // (`ChangeKind::Modified` — what VS Code and most editors emit)
+    // re-rendered byte-identical stale HTML forever. Only rename-replace
+    // saves worked, by accident, through the watch-ADD discovery path.
+    // The pipeline skips this when the tick's plan is already
+    // renderer-fresh (boot initial render, watch-ADD discovery
+    // re-bundle), so each tick bundles at most once.
+    let reload_renderer: Option<RendererReloader> = dev_session.as_ref().map(|session| {
+        let session = session.clone();
+        Arc::new(move || {
+            let changed = session
+                .refresh_bundle_and_routes()
+                .context("edit-tick bundle refresh failed")?;
+            if !changed.is_empty() {
+                tracing::debug!(
+                    count = changed.len(),
+                    "edit-tick refresh changed route sets"
+                );
+            }
+            Ok(())
+        }) as RendererReloader
+    });
+
     let ctx = BuildContext {
         // Issue #534 — `DevAssetPipeline::apply` writes
         // `RenderedPage.html` to `<ctx.dist_root>/<output_path>` on every
@@ -657,12 +744,7 @@ pub async fn run(args: &DevArgs) -> Result<()> {
         render_pages,
         run_css,
         run_islands,
-        // The bundle-rebuild + renderer-reload wiring lands
-        // here once the dev-mode bundler is available on a per-tick
-        // basis; for now leave the hook empty so existing behaviour
-        // is preserved (the renderer state stays bound to the
-        // boot-time bundle).
-        reload_renderer: None,
+        reload_renderer,
     };
 
     // 3b. Eager initial render (zfb#642 / #644).
@@ -1195,39 +1277,62 @@ impl DevRenderSession {
 
     /// Discover content files CREATED after dev-server boot (issue #659).
     ///
-    /// This is the load-bearing fix. A content file like
-    /// `content/blog/foo.mdx` is reached through a dynamic
-    /// `pages/blog/[slug].tsx` page whose `paths()` walks the `blog`
-    /// collection. The collection snapshot is baked into the SSR bundle at
-    /// boot, and `routes_by_source` is frozen at boot — so a file created
-    /// afterwards is invisible to the running V8 host and never appears in
-    /// the route table, 404ing until restart.
-    ///
-    /// On a `Created` tick we therefore:
-    /// 1. re-bundle the SSR worker (recomputes the content snapshot from
-    ///    disk, so `getCollection` will see the new file),
-    /// 2. reload the embedded V8 host **in place** — `take()` the
-    ///    `Option<RendererState>` out of the SAME `Arc<Mutex<…>>` the
-    ///    render callback and SSR adapter hold, `reload()` it against the
-    ///    new bundle, and put it back, so the running server sees the new
-    ///    host (NOT a fresh `DevRenderSession` it never reads),
-    /// 3. re-scan the router + re-expand `paths()` through the reloaded
-    ///    host to rebuild `routes_by_source` (now the new `/blog/foo` URL
-    ///    is present),
-    /// 4. swap the rebuilt tables in under the route `RwLock`.
-    ///
-    /// Returns the source [`PageId`]s whose route set changed (the dynamic
-    /// `[slug]` page), so the orchestrator renders them and writes the new
-    /// URL to `dist/`. EDIT ticks never call this (the discovery hook only
-    /// sees `Created` paths), so the edit path is untouched.
-    ///
-    /// `embed_v8`-gated like `boot_dev_renderer` — the reload + `paths()`
-    /// runtime eval need the embedded V8 host.
+    /// Thin gate over [`Self::refresh_bundle_and_routes`] — see there for
+    /// what the refresh does. Kept as a named entry point so the
+    /// discovery hook's intent stays explicit at the call site.
     #[cfg(feature = "embed_v8")]
     fn discover_created(&self, created: &[PathBuf]) -> Result<Vec<PageId>> {
         if created.is_empty() {
             return Ok(Vec::new());
         }
+        self.refresh_bundle_and_routes()
+    }
+
+    /// Re-bundle the SSR worker, swap in a freshly-started embedded V8
+    /// host, and rebuild the route tables — the dev server's "make the
+    /// running renderer see the source tree as it is NOW" primitive.
+    ///
+    /// The collection snapshot and every page module are baked into the
+    /// SSR bundle, and `routes_by_source` is frozen, at whatever point
+    /// this was last run (boot, or a previous refresh). Two paths call
+    /// it:
+    ///
+    /// - the watch-ADD discovery hook (issue #659) — a content file like
+    ///   `content/blog/foo.mdx` CREATED after boot is invisible to the
+    ///   running host (404 until restart) without a refresh;
+    /// - the per-tick `BuildContext::reload_renderer` — an in-place EDIT
+    ///   (`ChangeKind::Modified`) re-renders pages, but against the
+    ///   stale bundle the render output is byte-identical to the boot
+    ///   render, so saves from in-place-writing editors (VS Code et al.)
+    ///   never showed up. Rename-replace saves only worked by accident,
+    ///   via the Created path above.
+    ///
+    /// Steps:
+    /// 1. re-scan the router (cheap; picks up brand-new `pages/` files),
+    /// 2. re-bundle with a fresh content snapshot from disk,
+    /// 3. START a new embedded V8 host against the new bundle, swap it
+    ///    into the SAME `Arc<Mutex<…>>` the render callback and SSR
+    ///    adapter hold, and shut the old host down AFTER the swap.
+    ///    Start-before-swap is deliberate: the old take→reload→put
+    ///    order consumed the previous state up front, so a host-start
+    ///    failure left the slot `None` and every later render broke
+    ///    until restart. Acceptable when only rare watch-ADDs hit the
+    ///    path; fatal now that every edit tick does. (Bundle errors —
+    ///    the common failure, e.g. saving a syntax error — abort in
+    ///    step 2 before the renderer is touched either way.)
+    /// 4. re-expand `paths()` through the new host and swap the rebuilt
+    ///    route tables in under the route `RwLock`. Rebuilding on EDIT
+    ///    ticks too (not just Created) means frontmatter edits that
+    ///    change a dynamic route's `paths()` output surface without a
+    ///    restart.
+    ///
+    /// Returns the source [`PageId`]s whose route set changed (empty for
+    /// a plain content edit).
+    ///
+    /// `embed_v8`-gated like `boot_dev_renderer` — the host start +
+    /// `paths()` runtime eval need the embedded V8 host.
+    #[cfg(feature = "embed_v8")]
+    fn refresh_bundle_and_routes(&self) -> Result<Vec<PageId>> {
         let project_root = &self.inner.project_root;
         let inputs = &self.inner.rebuild_inputs;
 
@@ -1240,51 +1345,61 @@ impl DevRenderSession {
         let router = zfb_router::Router::scan(&pages_dir).map_err(anyhow::Error::from)?;
         let plan = build_route_universe(router.routes());
 
-        // 1. Re-bundle with a fresh content snapshot (reads content/ from
-        //    disk, so the created file is now in the snapshot).
+        // 1. Re-bundle with a fresh content snapshot (reads every
+        //    configured collection from disk, so created AND edited
+        //    entries are in the snapshot).
         let bundler_out = assemble_and_bundle_dev(
             project_root,
             &inputs.cfg,
             inputs.plugin_alias_entries.clone(),
             inputs.plugin_virtual_modules.clone(),
         )
-        .context("watch-add re-bundle failed")?;
+        .context("dev refresh: re-bundle failed")?;
 
-        // 2. Reload the embedded V8 host IN PLACE so the running server's
-        //    render callback + SSR adapter (which share this exact Arc)
-        //    see the rebuilt bundle. Take/reload/put on the existing mutex
-        //    — do NOT construct a fresh session.
+        // 2. Start a NEW embedded V8 host against the rebuilt bundle,
+        //    swap it into the existing mutex (the render callback + SSR
+        //    adapter share this exact Arc), and shut the old host down
+        //    only after the swap — a host-start failure must leave the
+        //    previous renderer serving (see the method docs).
         {
-            let mut lock = self.inner.renderer.lock().unwrap_or_else(|p| {
-                tracing::warn!(site = "discover_created", "renderer mutex poisoned, recovered");
-                p.into_inner()
-            });
-            let previous = lock
-                .take()
-                .ok_or_else(|| anyhow::anyhow!("renderer not started for watch-add reload"))?;
-            let reloaded = reload(
-                previous,
-                RendererStartInput {
-                    bundle_path: bundler_out.bundle_path.clone(),
-                    sourcemap_path: bundler_out.sourcemap_path.clone(),
-                    backend: Backend::EmbeddedV8 {
-                        host_factory: crate::v8_host_adapter::make_v8_host_factory_with_hooks(
-                            inputs.v8_plugin_hooks.clone(),
-                        ),
-                    },
-                    request_timeout: None,
+            let started = start(RendererStartInput {
+                bundle_path: bundler_out.bundle_path.clone(),
+                sourcemap_path: bundler_out.sourcemap_path.clone(),
+                backend: Backend::EmbeddedV8 {
+                    host_factory: crate::v8_host_adapter::make_v8_host_factory_with_hooks(
+                        inputs.v8_plugin_hooks.clone(),
+                    ),
                 },
-            )
+                request_timeout: None,
+            })
             .map_err(anyhow::Error::from)
-            .context("watch-add renderer reload failed")?;
-            *lock = Some(reloaded);
+            .context("dev refresh: renderer start failed (previous renderer kept serving)")?;
+            let previous = {
+                let mut lock = self.inner.renderer.lock().unwrap_or_else(|p| {
+                    tracing::warn!(
+                        site = "refresh_bundle_and_routes",
+                        "renderer mutex poisoned, recovered"
+                    );
+                    p.into_inner()
+                });
+                lock.replace(started)
+            };
+            if let Some(prev) = previous {
+                if let Err(err) = shutdown(prev) {
+                    tracing::warn!(
+                        site = "refresh_bundle_and_routes",
+                        error = %err,
+                        "old renderer shutdown failed; continuing with new host"
+                    );
+                }
+            }
         }
 
         // 3. Rebuild the route tables through the reloaded host (re-expands
         //    `paths()`, so the dynamic source now resolves the new URL).
         let (new_routes_by_source, new_ssr_routes) =
             build_dev_route_tables(&router, &plan, project_root, &self.inner.renderer)
-                .context("watch-add route-table rebuild failed")?;
+                .context("dev refresh: route-table rebuild failed")?;
 
         // 4. Diff against the frozen table to find which source pages
         //    gained/changed entries, then swap the new tables in.
@@ -1933,17 +2048,22 @@ fn make_render_callback(session: DevRenderSession, dist_dir: PathBuf) -> PageRen
 ///
 /// The orchestrator invokes it with the `Created` subset of a tick's
 /// changed paths. We restrict the expensive re-bundle to files created
-/// under `content/` or `pages/` (the roots that feed the SSR bundle and
-/// the route table); a file created elsewhere — `styles/`, `public/` —
-/// can never add a content-collection route, so we skip discovery for it
-/// and let the normal tick handle it.
+/// under `content/`, `pages/`, or any configured collection root (the
+/// roots that feed the SSR bundle and the route table — collections may
+/// live anywhere, e.g. `src/mdx/notes`); a file created elsewhere —
+/// `styles/`, `public/` — can never add a content-collection route, so
+/// we skip discovery for it and let the normal tick handle it.
 ///
 /// On a relevant create we delegate to
-/// [`DevRenderSession::discover_created`] (re-bundle → reload host in
-/// place → rebuild route tables) and then upsert the new file into the
+/// [`DevRenderSession::discover_created`] (re-bundle → swap in a fresh
+/// host → rebuild route tables) and then upsert the new file into the
 /// dependency graph as a content dep of each rediscovered source page, so
 /// a LATER edit of that same file hot-reloads its consumer exactly like a
 /// pre-existing post does.
+///
+/// The returned [`DiscoveryOutcome`] reports `renderer_reloaded: true`
+/// whenever the refresh ran, so the pipeline's per-tick
+/// `reload_renderer` is skipped and the tick bundles exactly once.
 ///
 /// `embed_v8`-gated: discovery needs the embedded V8 host.
 #[cfg(feature = "embed_v8")]
@@ -1951,18 +2071,27 @@ fn make_discovery_hook(
     session: DevRenderSession,
     graph: Arc<Mutex<DependencyGraph>>,
 ) -> zfb_build::DiscoveryHook {
-    let content_root = session.inner.project_root.join("content");
-    let pages_root = session.inner.project_root.join("pages");
+    let mut relevant_roots: Vec<PathBuf> = vec![
+        session.inner.project_root.join("content"),
+        session.inner.project_root.join("pages"),
+    ];
+    for collection in &session.inner.rebuild_inputs.cfg.collections {
+        let root = session.inner.project_root.join(&collection.path);
+        if !relevant_roots.contains(&root) {
+            relevant_roots.push(root);
+        }
+    }
     Arc::new(move |created: &[PathBuf]| {
-        // Only created files under content/ or pages/ can introduce a new
-        // content-collection route; skip the re-bundle otherwise.
+        // Only created files under content/, pages/, or a collection
+        // root can introduce a new content-collection route; skip the
+        // re-bundle otherwise.
         let relevant: Vec<PathBuf> = created
             .iter()
-            .filter(|p| p.starts_with(&content_root) || p.starts_with(&pages_root))
+            .filter(|p| relevant_roots.iter().any(|root| p.starts_with(root)))
             .cloned()
             .collect();
         if relevant.is_empty() {
-            return Ok(Vec::new());
+            return Ok(DiscoveryOutcome::default());
         }
 
         let changed = session.discover_created(&relevant)?;
@@ -1984,7 +2113,10 @@ fn make_discovery_hook(
             }
         }
 
-        Ok(changed)
+        Ok(DiscoveryOutcome {
+            pages: changed,
+            renderer_reloaded: true,
+        })
     })
 }
 
@@ -1998,11 +2130,14 @@ fn make_discovery_hook(
 /// over the same renderer mutex the SSG callback uses, so the V8 host
 /// is shared across build-time and request-time dispatches.
 ///
-/// Live-reload of SSR page sources: editing a `prerender = false` page
-/// during a `zfb dev` session does NOT currently re-evaluate the bundle
-/// inside the running V8 host — `BuildContext::reload_renderer` is
-/// `None` in dev today. The next dev-server restart picks up the new
-/// code. Wiring `reload_renderer` is a follow-up for a future sub-task.
+/// Live-reload of SSR page sources: `BuildContext::reload_renderer` is
+/// wired in dev, so any tick that re-renders SSG pages also swaps in a
+/// freshly-bundled host — the SSR adapter shares that host, so SSR
+/// routes serve the new code from the next request. The remaining gap
+/// is an SSR-ONLY project (or an edit whose tick dirties no SSG page):
+/// no SSG dirty set means no reload, and this `SsrRouteSet` itself is
+/// static after boot, so added/removed `prerender = false` routes still
+/// need a dev-server restart. Follow-up for a future sub-task.
 ///
 /// Compiled in only when the `embed_v8` feature is on (issue #371,
 /// sub-task 4.1a) — the SSR adapter requires the V8 host.
@@ -2118,6 +2253,74 @@ mod tests {
     fn default_watch_roots_includes_zfb_config_json() {
         assert!(DEFAULT_WATCH_ROOTS.contains(&"zfb.config.json"));
         assert!(DEFAULT_WATCH_ROOTS.contains(&"zfb.config.ts"));
+    }
+
+    fn cfg_with_collections(paths: &[&str]) -> config::Config {
+        let mut cfg = config::Config::default();
+        cfg.collections = paths
+            .iter()
+            .map(|p| config::CollectionDef {
+                name: p.replace('/', "-"),
+                path: PathBuf::from(p),
+                schema: None,
+                include: None,
+                exclude: None,
+                id_strip_suffix: None,
+            })
+            .collect();
+        cfg
+    }
+
+    /// Regression: a collection configured outside the default watch
+    /// roots (e.g. `src/mdx/notes`) was never watched, so edits there
+    /// produced no rebuild and the dev server served stale HTML until
+    /// restart. Discovered during usage in a consumer project with
+    /// custom collection paths.
+    #[test]
+    fn derive_watch_roots_appends_custom_collection_paths() {
+        let cfg = cfg_with_collections(&["src/mdx/notes", "src/mdx/guides"]);
+        let roots = derive_watch_roots(&cfg);
+        assert!(roots.contains(&PathBuf::from("src/mdx/notes")));
+        assert!(roots.contains(&PathBuf::from("src/mdx/guides")));
+        // Defaults are preserved in front.
+        assert!(roots.contains(&PathBuf::from("pages")));
+        assert!(roots.contains(&PathBuf::from("content")));
+    }
+
+    /// A collection under the default `content/` root must NOT be
+    /// re-registered — overlapping recursive watches deliver duplicate
+    /// events for the same write.
+    #[test]
+    fn derive_watch_roots_skips_paths_covered_by_default_roots() {
+        let cfg = cfg_with_collections(&["content/blog"]);
+        let roots = derive_watch_roots(&cfg);
+        assert!(!roots.contains(&PathBuf::from("content/blog")));
+        assert_eq!(
+            roots.len(),
+            DEFAULT_WATCH_ROOTS.len(),
+            "covered collection path must not add a watch root"
+        );
+    }
+
+    /// Nested collections collapse to the shallowest ancestor regardless
+    /// of declaration order, and duplicates dedupe.
+    #[test]
+    fn derive_watch_roots_collapses_nested_and_duplicate_collections() {
+        let cfg = cfg_with_collections(&["src/mdx/notes", "src/mdx", "src/mdx/notes"]);
+        let roots = derive_watch_roots(&cfg);
+        assert!(roots.contains(&PathBuf::from("src/mdx")));
+        assert!(!roots.contains(&PathBuf::from("src/mdx/notes")));
+        assert_eq!(roots.len(), DEFAULT_WATCH_ROOTS.len() + 1);
+    }
+
+    /// Leading `./` is normalized away so `./src/mdx` and `src/mdx`
+    /// compare equal in the dedupe/coverage checks.
+    #[test]
+    fn derive_watch_roots_normalizes_leading_curdir() {
+        let cfg = cfg_with_collections(&["./src/mdx", "src/mdx"]);
+        let roots = derive_watch_roots(&cfg);
+        assert!(roots.contains(&PathBuf::from("src/mdx")));
+        assert_eq!(roots.len(), DEFAULT_WATCH_ROOTS.len() + 1);
     }
 
     /// Issue #534 regression — dev's per-route HTML output dir must live

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -2256,19 +2256,20 @@ mod tests {
     }
 
     fn cfg_with_collections(paths: &[&str]) -> config::Config {
-        let mut cfg = config::Config::default();
-        cfg.collections = paths
-            .iter()
-            .map(|p| config::CollectionDef {
-                name: p.replace('/', "-"),
-                path: PathBuf::from(p),
-                schema: None,
-                include: None,
-                exclude: None,
-                id_strip_suffix: None,
-            })
-            .collect();
-        cfg
+        config::Config {
+            collections: paths
+                .iter()
+                .map(|p| config::CollectionDef {
+                    name: p.replace('/', "-"),
+                    path: PathBuf::from(p),
+                    schema: None,
+                    include: None,
+                    exclude: None,
+                    id_strip_suffix: None,
+                })
+                .collect(),
+            ..config::Config::default()
+        }
     }
 
     /// Regression: a collection configured outside the default watch


### PR DESCRIPTION
## Summary

`zfb dev` never reflected in-place file edits: the content snapshot and page modules are baked into the SSR bundle at boot, and the per-tick `BuildContext::reload_renderer` hook was never wired (`reload_renderer: None` with a deferred-TODO comment), so every edit tick re-rendered against the boot-time bundle and produced byte-identical stale HTML until a dev-server restart. Saves from in-place-writing editors (VS Code et al., `ChangeKind::Modified`) never showed up; rename-replace saves only worked by accident through the watch-ADD discovery re-bundle (#659).

Additionally, content collections configured at custom paths in `zfb.config.ts` (e.g. `path: 'src/mdx/notes'`) were invisible to the watcher entirely: `DEFAULT_WATCH_ROOTS` is hardcoded, the discovery hook filtered to `content/` + `pages/` only, and the classifier mapped such paths to `Module` (triggering wasteful islands re-bundles once watched).

Discovered during usage in a consumer project with custom collection paths.

## Changes

### Edit-tick bundle refresh (the core fix)
- Extract the re-bundle + host-reload steps from `DevRenderSession::discover_created` into `refresh_bundle_and_routes()` and wire it as `BuildContext::reload_renderer` — every tick that re-renders pages now re-bundles (fresh content snapshot + page modules) and swaps in a freshly-started embedded V8 host first.
- **Start-then-swap**: the new host is started *before* the old one is taken out of the shared mutex, so a host-start failure keeps the previous renderer serving (the old take→reload→put order left the slot empty on failure — tolerable for rare watch-ADDs, fatal once every edit tick hits the path). Bundle errors (e.g. saving a syntax error) abort before the renderer is touched.
- Route tables now rebuild on edit ticks too, so frontmatter edits that change a dynamic route's `paths()` output surface without a restart.
- New `RebuildPlan::renderer_fresh` + `DiscoveryOutcome.renderer_reloaded` coordinate the pipeline and the watch-ADD discovery hook so each tick bundles **at most once** (boot's eager initial render also skips the reload).

### Custom collection paths
- `derive_watch_roots()`: watch roots = `DEFAULT_WATCH_ROOTS` + each configured collection path (normalized, shallow-first, paths covered by an existing root skipped to avoid duplicate event delivery).
- Discovery-hook filter accepts `Created` files under any configured collection root.
- `GranularityPolicy::content_roots`: entries under a configured collection root classify as `Content` ahead of the root-segment walk — no more islands re-bundles for every mdx edit under `src/`. Gated on content-shaped extensions (`md`/`mdx`) so co-located `.tsx`/`.css` files keep their `Module`/`Style` classification (review finding).
- The graph-cache manifest digest covers collection paths automatically (they're part of the watch roots it walks).

## Test Plan

- [x] Unit: watch-root derivation (append/covered-skip/nested-collapse/`./`-normalization), content-root classification (incl. co-located `.tsx`/`.css`, absolute roots, global precedence)
- [x] Integration (`integration_dev_loop.rs`): edit tick reloads renderer before render; discovery re-bundle suppresses the pipeline reload in the same tick; `initial_build` never reloads; content edit under a custom collection root re-renders without islands re-bundle
- [x] Real-watcher e2e (`watch_add_confirm.rs`): in-place edit reaches the served HTML via the per-tick reload, with the baked-snapshot staleness modelled in the stub — **falsifiability verified**: the test fails with the reload wiring removed
- [x] `cargo test --workspace` green; `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Live verification with the built binary: in-place mdx edits now reach the served HTML in ~3s on a scaffolded `content/blog` project, a `src/mdx/*` custom-path fixture (edit + new-file route discovery), and a large real consumer project (~5s)

## Follow-ups (raised as issues)

- #796 — stale HTML / page cache not pruned when a route disappears or renames
- #797 — SSR-only projects never reload the host; `SsrRouteSet` static after boot
- #798 — `→ ready` banner prints before the listener binds

🤖 Generated with [Claude Code](https://claude.com/claude-code)