### PR TITLE
feat: [[...slug]] optional-catchall routing + hono floor ^4.12.23

### DIFF
--- a/SECURITY-DEPS.md
+++ b/SECURITY-DEPS.md
@@ -26,7 +26,7 @@ users of the package.
 
 | Package | Version range | Rationale |
 | ------- | ------------- | --------- |
-| `hono`  | `^4.7.0`      | Hono is the page-router runtime — it is the entire point of this package. `zfb-runtime` wraps Hono's routing primitives to provide file-system-based page routing, content snapshots, and SSR for Cloudflare Workers. A Node built-in cannot replace a full HTTP routing framework. The dep is retained. |
+| `hono`  | `^4.12.23`    | Hono is the page-router runtime — it is the entire point of this package. `zfb-runtime` wraps Hono's routing primitives to provide file-system-based page routing, content snapshots, and SSR for Cloudflare Workers. A Node built-in cannot replace a full HTTP routing framework. The dep is retained. Floor raised from `^4.7.0` to clear 9 advisories patched at >=4.12.21 (#813). |
 
 ### `@takazudo/zfb-adapter-cloudflare`
 

--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -2011,59 +2011,59 @@ fn materialise_shadow(
     // Hono dispatches requests in registration order. Without explicit
     // ordering a fully-dynamic route like `/[lang]/[slug]` (→ `/:lang/:slug`)
     // registered BEFORE `/blog/[slug]` would steal `/blog/hello` by matching
-    // it as (lang=blog, slug=hello). We prevent this by sorting from most-
-    // specific to least-specific using a composite key:
+    // it as (lang=blog, slug=hello).
     //
-    //   (−static_segments, +dynamic_segments, +catchall_segments)
+    // The key is the route's per-segment rank vector, compared
+    // lexicographically left to right:
     //
-    // Interpretation:
-    //   - More static segments → lower (higher priority) primary key.
-    //   - Among same static count, fewer dynamic → lower secondary key.
-    //   - Catchall (rest) segments always sort after plain dynamic ones.
-    //   - Alphabetical order breaks remaining ties (stable and deterministic).
+    //   static = 0  <  dynamic `[p]` = 1  <  catchall `[...p]` / `[[...p]]` = 2
+    //
+    // Two overlapping patterns always agree on a common prefix and first
+    // differ at a segment where one is looser than the other, so ordering
+    // by the first differing rank registers the more-specific route first.
+    // Alphabetical order breaks remaining ties (stable and deterministic);
+    // rank-tied routes never overlap (their static segments differ).
+    //
+    // An aggregate count key (the previous design:
+    // `(−static, +dynamic, +catchall)`) is NOT sufficient here: it ranked
+    // `/docs/[...rest]` (1 static, 1 catchall) before
+    // `/docs/[version]/[page]` (1 static, 2 dynamic), letting the catchall
+    // steal `/docs/v1/intro` from the deeper dynamic route (or 404 it when
+    // the catchall's `paths()` lacks the entry). The per-segment vector
+    // compares rank 2 (catchall) against rank 1 (dynamic) at segment index
+    // 1 and orders the dynamic descendant first, matching zfb-router's
+    // per-segment sort. Probed against Hono 4.12.x: registration order is
+    // what decides between the two patterns.
+    //
+    // Required and optional catchalls share rank 2 — they can never
+    // coexist at the same prefix (scan-time conflict), so a finer
+    // ordering between them is unreachable.
     //
     // Example ordering for the routing-rendering fixture:
-    //   /              → (0, 0, 0) — static, most specific
-    //   /about         → (−1, 0, 0)
-    //   /blog          → (−1, 0, 0) — tie broken alphabetically
-    //   /blog/page/[p] → (−2, 1, 0) — 2 static segs, 1 dynamic
-    //   /blog/[slug]   → (−1, 1, 0) — 1 static seg, 1 dynamic
-    //   /docs/[...s]   → (−1, 0, 1) — 1 static seg, 1 catchall
-    //   /[lang]/[slug] → (0, 2, 0)  — 0 static segs, 2 dynamic (least specific)
-    //
-    // Using isize allows negative values for the static component, which is
-    // what we want — we want "more static" to sort EARLIER (lower).
-    fn route_sort_key(route: &str) -> (isize, isize, isize) {
-        let mut static_count = 0isize;
-        let mut dynamic_count = 0isize;
-        let mut catchall_count = 0isize;
-        for seg in route.split('/') {
-            if seg.is_empty() {
-                continue; // leading slash
-            }
-            if seg.starts_with("[[...") && seg.ends_with("]]") {
-                // Optional catchall sorts with the (required) catchall
-                // bucket — it is the loosest matcher. A required and an
-                // optional catchall can never coexist at the same prefix
-                // (scan-time conflict), so no finer ordering is needed.
-                catchall_count += 1;
-            } else if seg.starts_with("[...") && seg.ends_with(']') {
-                catchall_count += 1;
-            } else if seg.starts_with('[') && seg.ends_with(']') {
-                dynamic_count += 1;
-            } else {
-                static_count += 1;
-            }
-        }
-        // Negate static_count so higher static count → lower (earlier) key.
-        // Add catchall_count into the dynamic bucket so catchall segments sort
-        // after plain dynamic at equal static depth (e.g. /docs/[...slug] after
-        // /docs/[id]), preserving the invariant documented at line 2022.
-        (
-            -static_count,
-            dynamic_count + catchall_count,
-            catchall_count,
-        )
+    //   /              → []     — empty vector sorts first (no overlaps)
+    //   /about         → [0]    — tie with /blog broken alphabetically
+    //   /blog          → [0]
+    //   /blog/page/[p] → [0, 0, 1]
+    //   /blog/[slug]   → [0, 1]
+    //   /docs/[id]     → [0, 1]
+    //   /docs/[...s]   → [0, 2] — after /docs/[id] (rank 2 > 1 at index 1)
+    //   /[lang]/[slug] → [1, 1] — least specific (dynamic at index 0)
+    fn route_sort_key(route: &str) -> Vec<u8> {
+        route
+            .split('/')
+            .filter(|seg| !seg.is_empty())
+            .map(|seg| {
+                if (seg.starts_with("[[...") && seg.ends_with("]]"))
+                    || (seg.starts_with("[...") && seg.ends_with(']'))
+                {
+                    2
+                } else if seg.starts_with('[') && seg.ends_with(']') {
+                    1
+                } else {
+                    0
+                }
+            })
+            .collect()
     }
     routes.sort_by(|a, b| {
         let ka = route_sort_key(&a.route);
@@ -5986,6 +5986,10 @@ mod tests {
             "pages/manual/about.tsx",
             "pages/manual/[id].tsx",
             "pages/manual/[[...slug]].tsx",
+            "pages/api/[version]/[page].tsx",
+            "pages/api/[...rest].tsx",
+            "pages/kb/[version]/[page].tsx",
+            "pages/kb/[[...rest]].tsx",
         ] {
             let abs = root.join(f);
             fs::create_dir_all(abs.parent().unwrap()).unwrap();
@@ -6037,6 +6041,20 @@ mod tests {
         assert!(
             idx("/manual/[id]") < idx("/manual/[[...slug]]"),
             "/manual/[id] should be registered before /manual/[[...slug]]"
+        );
+
+        // A catchall must register AFTER a deeper dynamic descendant at the
+        // same prefix — Hono dispatches in registration order, so the old
+        // aggregate-count key let `/api/[...rest]` steal `/api/v1/intro`
+        // from `/api/[version]/[page]` (probed on Hono 4.12.x). Pin both
+        // the required and the optional form.
+        assert!(
+            idx("/api/[version]/[page]") < idx("/api/[...rest]"),
+            "/api/[version]/[page] should be registered before /api/[...rest]"
+        );
+        assert!(
+            idx("/kb/[version]/[page]") < idx("/kb/[[...rest]]"),
+            "/kb/[version]/[page] should be registered before /kb/[[...rest]]"
         );
     }
 

--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -2041,7 +2041,13 @@ fn materialise_shadow(
             if seg.is_empty() {
                 continue; // leading slash
             }
-            if seg.starts_with("[...") && seg.ends_with(']') {
+            if seg.starts_with("[[...") && seg.ends_with("]]") {
+                // Optional catchall sorts with the (required) catchall
+                // bucket — it is the loosest matcher. A required and an
+                // optional catchall can never coexist at the same prefix
+                // (scan-time conflict), so no finer ordering is needed.
+                catchall_count += 1;
+            } else if seg.starts_with("[...") && seg.ends_with(']') {
                 catchall_count += 1;
             } else if seg.starts_with('[') && seg.ends_with(']') {
                 dynamic_count += 1;
@@ -3809,6 +3815,8 @@ pub(crate) fn render_md_page_shell(
 /// `createPageRouter` registers with the Hono app.
 ///
 /// Segment rules:
+/// - `[[...param]]` → `:param{.+}?` (optional catchall — zero or more
+///   path segments; the zero case matches the bare prefix URL)
 /// - `[...param]` → `:param{.+}` (catchall — one or more path
 ///   segments separated by `/`, matched by Hono's regex quantifier)
 /// - `[param]`    → `:param` (single-segment dynamic param)
@@ -3830,7 +3838,17 @@ pub(crate) fn bracket_to_hono(route: &str) -> String {
     let mut out = String::with_capacity(route.len() + 4);
     for segment in &segments {
         out.push('/');
-        if segment.starts_with("[...") && segment.ends_with(']') {
+        if segment.starts_with("[[...") && segment.ends_with("]]") {
+            // Optional catchall: `[[...param]]` → `:param{.+}?`. Checked
+            // before the single-bracket forms so the doubled brackets do
+            // not fall into the plain-dynamic branch. Must stay
+            // bit-identical to `Segment::OptionalCatchall::template()` so
+            // the worker's `pagesByRoute` lookup keys match.
+            let name = &segment[5..segment.len() - 2];
+            out.push(':');
+            out.push_str(name);
+            out.push_str("{.+}?");
+        } else if segment.starts_with("[...") && segment.ends_with(']') {
             // Catchall: `[...param]` → `:param{.+}`
             let name = &segment[4..segment.len() - 1];
             out.push(':');
@@ -5827,6 +5845,36 @@ mod tests {
         assert_eq!(bracket_to_hono("/docs/[...slug]"), "/docs/:slug{.+}");
         // Fully dynamic catchall.
         assert_eq!(bracket_to_hono("/[...rest]"), "/:rest{.+}");
+        // Optional catchall (zero or more segments).
+        assert_eq!(bracket_to_hono("/docs/[[...slug]]"), "/docs/:slug{.+}?");
+        // Fully dynamic optional catchall.
+        assert_eq!(bracket_to_hono("/[[...rest]]"), "/:rest{.+}?");
+    }
+
+    #[test]
+    fn optional_catchall_route_key_round_trips_with_router_template() {
+        // The worker registers `bracket_to_hono(derive_route(file))` while
+        // the render pipeline keys on `zfb_router::Route::template()`. The
+        // two strings must stay bit-identical or the `pagesByRoute` /
+        // `__paths__` lookup 404s silently. Pin the round trip for the
+        // optional catchall form.
+        let route = derive_route(Path::new("docs/[[...slug]].tsx")).expect("derive");
+        assert_eq!(route, "/docs/[[...slug]]");
+        assert_eq!(bracket_to_hono(&route), "/docs/:slug{.+}?");
+
+        let scanned = {
+            let tmp = tempfile::TempDir::new().unwrap();
+            let docs = tmp.path().join("docs");
+            fs::create_dir_all(&docs).unwrap();
+            fs::write(
+                docs.join("[[...slug]].tsx"),
+                "export default function P() { return null; }\n",
+            )
+            .unwrap();
+            zfb_router::scan_pages(tmp.path()).expect("scan")
+        };
+        assert_eq!(scanned.len(), 1);
+        assert_eq!(scanned[0].template(), bracket_to_hono(&route));
     }
 
     #[test]
@@ -5932,8 +5980,16 @@ mod tests {
             fs::create_dir_all(root.join(d)).unwrap();
         }
         let stub = "export default function P() { return null; }\n";
-        for f in ["pages/docs/[id].tsx", "pages/docs/[...slug].tsx"] {
-            fs::write(root.join(f), stub).unwrap();
+        for f in [
+            "pages/docs/[id].tsx",
+            "pages/docs/[...slug].tsx",
+            "pages/manual/about.tsx",
+            "pages/manual/[id].tsx",
+            "pages/manual/[[...slug]].tsx",
+        ] {
+            let abs = root.join(f);
+            fs::create_dir_all(abs.parent().unwrap()).unwrap();
+            fs::write(abs, stub).unwrap();
         }
         let mut routes = Vec::new();
         let shadow_pages_dest = root.join("shadow").join("pages");
@@ -5970,6 +6026,17 @@ mod tests {
         assert!(
             idx("/docs/[id]") < idx("/docs/[...slug]"),
             "/docs/[id] should be registered before /docs/[...slug]"
+        );
+
+        // The optional catchall sorts with the catchall bucket — after a
+        // static sibling and after a plain dynamic at equal static depth.
+        assert!(
+            idx("/manual/about") < idx("/manual/[[...slug]]"),
+            "/manual/about should be registered before /manual/[[...slug]]"
+        );
+        assert!(
+            idx("/manual/[id]") < idx("/manual/[[...slug]]"),
+            "/manual/[id] should be registered before /manual/[[...slug]]"
         );
     }
 

--- a/crates/zfb-build/tests/integration_e2e_routing_rendering.rs
+++ b/crates/zfb-build/tests/integration_e2e_routing_rendering.rs
@@ -10,6 +10,7 @@
 //!   - pagination dynamic (`/blog/page/[page]`)
 //!   - nested dynamic (`/[lang]/[slug]`)
 //!   - catchall (`/docs/[...slug]`)
+//!   - optional catchall (`/manual/[[...slug]]` — bare `/manual` + nested; #812)
 //!
 //! Fixture source lives at
 //! `crates/zfb-render/tests/fixtures/routing-rendering/`. The test
@@ -214,6 +215,23 @@ fn route_universe() -> Vec<RouteUniverseEntry> {
             source_path: None,
         });
     }
+
+    // --- /manual/[[...slug]] — optional catchall (#812): the bare
+    // directory URL (zero segments) plus one nested page ---
+    entries.push(RouteUniverseEntry {
+        url_path: "/manual".into(),
+        output_path: PathBuf::from("manual/index.html"),
+        route_key: "/manual/[[...slug]]".into(),
+        static_html: false,
+        source_path: None,
+    });
+    entries.push(RouteUniverseEntry {
+        url_path: "/manual/setup/quick".into(),
+        output_path: PathBuf::from("manual/setup/quick/index.html"),
+        route_key: "/manual/[[...slug]]".into(),
+        static_html: false,
+        source_path: None,
+    });
 
     entries
 }
@@ -487,4 +505,8 @@ fn check_rendered_html(pages: &[(String, Vec<u8>)]) {
     has("/docs/intro", "Intro doc");
     has("/docs/guides/install", "Install guide");
     has("/docs/guides/config/framework", "Framework config");
+
+    // Manual optional catchall (#812) — bare directory URL + nested path
+    has("/manual", "Manual home");
+    has("/manual/setup/quick", "Quick setup");
 }

--- a/crates/zfb-render/src/paths.rs
+++ b/crates/zfb-render/src/paths.rs
@@ -189,12 +189,16 @@ pub fn resolve_paths(
             expected: "an array of `{ params, props }` objects".to_string(),
         })?;
 
-    // Required param names + whether they are catch-all.
-    let required: Vec<(&str, bool)> = route_segments
+    // Required param names + their kind. Every declared param — including
+    // an optional catchall — must appear as a key in each entry's `params`
+    // object; "optional" refers to the URL segments it matches (zero is
+    // allowed via an explicit empty array), not to the key itself.
+    let required: Vec<(&str, ParamKind)> = route_segments
         .iter()
         .filter_map(|seg| match seg {
-            Segment::Dynamic(name) => Some((name.as_str(), false)),
-            Segment::Catchall(name) => Some((name.as_str(), true)),
+            Segment::Dynamic(name) => Some((name.as_str(), ParamKind::Dynamic)),
+            Segment::Catchall(name) => Some((name.as_str(), ParamKind::Catchall)),
+            Segment::OptionalCatchall(name) => Some((name.as_str(), ParamKind::OptionalCatchall)),
             Segment::Static(_) => None,
         })
         .collect();
@@ -233,7 +237,7 @@ pub fn resolve_paths(
 
         // Required-param check + value extraction.
         let mut params_map: HashMap<String, String> = HashMap::with_capacity(required.len());
-        for (name, is_catchall) in &required {
+        for (name, kind) in &required {
             let raw = params_obj
                 .get(*name)
                 .ok_or_else(|| PathsError::MissingParam {
@@ -241,10 +245,10 @@ pub fn resolve_paths(
                     route: route_template.to_string(),
                     provided: sorted_keys(params_obj.keys()),
                 })?;
-            let resolved = if *is_catchall {
-                catchall_string(raw, name, route_template)?
-            } else {
-                dynamic_string(raw, name, route_template)?
+            let resolved = match kind {
+                ParamKind::Dynamic => dynamic_string(raw, name, route_template)?,
+                ParamKind::Catchall => catchall_string(raw, name, route_template, false)?,
+                ParamKind::OptionalCatchall => catchall_string(raw, name, route_template, true)?,
             };
             params_map.insert((*name).to_string(), resolved);
         }
@@ -288,6 +292,14 @@ pub fn resolve_paths(
     Ok(result)
 }
 
+/// Kind of a declared route param, derived from its [`Segment`] variant.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ParamKind {
+    Dynamic,
+    Catchall,
+    OptionalCatchall,
+}
+
 /// Validate and extract a single-segment dynamic param value (must be a
 /// non-empty string with no `/`).
 fn dynamic_string(val: &Value, name: &str, route: &str) -> Result<String, PathsError> {
@@ -316,14 +328,30 @@ fn dynamic_string(val: &Value, name: &str, route: &str) -> Result<String, PathsE
 /// Validate and extract a catch-all param value. Accepts either a single
 /// string (`"a/b/c"`) or an array of strings (`["a", "b", "c"]`); both are
 /// normalized to a slash-joined string used as one URL segment-bag.
-fn catchall_string(val: &Value, name: &str, route: &str) -> Result<String, PathsError> {
+///
+/// `optional` is `true` for an optional catchall (`[[...name]]`): the ONLY
+/// extra shape it accepts is the explicit empty array `[]` (→ the bare
+/// directory URL, normalized to the empty string here). `""`, `"/"`, and
+/// `[""]` stay invalid for both forms — zero segments must be spelled
+/// `[]`, never an empty string.
+fn catchall_string(
+    val: &Value,
+    name: &str,
+    route: &str,
+    optional: bool,
+) -> Result<String, PathsError> {
     match val {
         Value::String(s) => {
             let trimmed = s.trim_matches('/');
             if trimmed.is_empty() {
+                let hint = if optional {
+                    " (use an empty array `[]` for the zero-segment case)"
+                } else {
+                    ""
+                };
                 return Err(PathsError::InvalidParamType {
                     name: name.to_string(),
-                    reason: "catchall param string must not be empty".to_string(),
+                    reason: format!("catchall param string must not be empty{hint}"),
                     route: route.to_string(),
                 });
             }
@@ -339,6 +367,11 @@ fn catchall_string(val: &Value, name: &str, route: &str) -> Result<String, Paths
         }
         Value::Array(arr) => {
             if arr.is_empty() {
+                if optional {
+                    // Zero segments: the optional catchall serves the bare
+                    // directory URL. Joined-string convention → empty.
+                    return Ok(String::new());
+                }
                 return Err(PathsError::InvalidParamType {
                     name: name.to_string(),
                     reason: "catchall param array must not be empty".to_string(),
@@ -395,6 +428,16 @@ fn build_url(route_segments: &[Segment], params: &HashMap<String, String>) -> St
             Segment::Dynamic(name) | Segment::Catchall(name) => {
                 if let Some(v) = params.get(name) {
                     parts.push(v.as_str());
+                }
+            }
+            Segment::OptionalCatchall(name) => {
+                // Zero segments resolve to the empty string — skip the
+                // segment entirely so `/docs` comes out bare, never
+                // `/docs/` with a dangling separator.
+                if let Some(v) = params.get(name) {
+                    if !v.is_empty() {
+                        parts.push(v.as_str());
+                    }
                 }
             }
         }
@@ -858,5 +901,152 @@ mod tests {
         let _ = resolve_paths(&mut cache, "[lang]/[slug].tsx", &segs, &a).unwrap();
         let _ = resolve_paths(&mut cache, "[lang]/[slug].tsx", &segs, &b).unwrap();
         assert_eq!(cache.hit_count(), 1);
+    }
+
+    // ---- optional catchall `[[...slug]]` (#812) -----------------------------
+
+    fn route_docs_optional_catchall() -> Vec<Segment> {
+        vec![
+            Segment::Static("docs".to_string()),
+            Segment::OptionalCatchall("slug".to_string()),
+        ]
+    }
+
+    #[test]
+    fn optional_catchall_empty_array_resolves_bare_url() {
+        let mut cache = PathsCache::new();
+        let segs = route_docs_optional_catchall();
+        let export = json!([
+            { "params": { "slug": [] }, "props": { "title": "Docs home" } }
+        ]);
+
+        let out =
+            resolve_paths(&mut cache, "docs/[[...slug]].tsx", &segs, &export).unwrap();
+
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].url, "/docs", "zero segments must map to the bare URL");
+        assert_eq!(out[0].params.get("slug").unwrap(), "");
+        assert_eq!(out[0].props, json!({ "title": "Docs home" }));
+    }
+
+    #[test]
+    fn optional_catchall_nested_paths_still_resolve() {
+        let mut cache = PathsCache::new();
+        let segs = route_docs_optional_catchall();
+        let export = json!([
+            { "params": { "slug": [] } },
+            { "params": { "slug": ["a", "b"] } },
+            { "params": { "slug": "c/d" } }
+        ]);
+
+        let out =
+            resolve_paths(&mut cache, "docs/[[...slug]].tsx", &segs, &export).unwrap();
+
+        let urls: Vec<&str> = out.iter().map(|r| r.url.as_str()).collect();
+        assert_eq!(urls, vec!["/docs", "/docs/a/b", "/docs/c/d"]);
+    }
+
+    #[test]
+    fn top_level_optional_catchall_zero_segments_is_root() {
+        let mut cache = PathsCache::new();
+        let segs = vec![Segment::OptionalCatchall("rest".to_string())];
+        let export = json!([{ "params": { "rest": [] } }]);
+
+        let out = resolve_paths(&mut cache, "[[...rest]].tsx", &segs, &export).unwrap();
+        assert_eq!(out[0].url, "/");
+    }
+
+    #[test]
+    fn optional_catchall_rejects_empty_string() {
+        // `""` stays invalid — zero segments must be spelled `[]`.
+        let mut cache = PathsCache::new();
+        let segs = route_docs_optional_catchall();
+        let export = json!([{ "params": { "slug": "" } }]);
+
+        let err =
+            resolve_paths(&mut cache, "docs/[[...slug]].tsx", &segs, &export).unwrap_err();
+        assert!(matches!(err, PathsError::InvalidParamType { .. }));
+        assert!(
+            err.to_string().contains("[]"),
+            "error should hint at the `[]` spelling: {err}",
+        );
+    }
+
+    #[test]
+    fn optional_catchall_rejects_slash_string() {
+        let mut cache = PathsCache::new();
+        let segs = route_docs_optional_catchall();
+        let export = json!([{ "params": { "slug": "/" } }]);
+
+        let err =
+            resolve_paths(&mut cache, "docs/[[...slug]].tsx", &segs, &export).unwrap_err();
+        assert!(matches!(err, PathsError::InvalidParamType { .. }));
+    }
+
+    #[test]
+    fn optional_catchall_rejects_array_with_empty_element() {
+        let mut cache = PathsCache::new();
+        let segs = route_docs_optional_catchall();
+        let export = json!([{ "params": { "slug": [""] } }]);
+
+        let err =
+            resolve_paths(&mut cache, "docs/[[...slug]].tsx", &segs, &export).unwrap_err();
+        assert!(matches!(err, PathsError::InvalidParamType { .. }));
+    }
+
+    #[test]
+    fn optional_catchall_still_requires_the_param_key() {
+        // The zero case needs an explicit `slug: []` — a missing key is
+        // still a MissingParam error, not an implicit empty.
+        let mut cache = PathsCache::new();
+        let segs = route_docs_optional_catchall();
+        let export = json!([{ "params": {} }]);
+
+        let err =
+            resolve_paths(&mut cache, "docs/[[...slug]].tsx", &segs, &export).unwrap_err();
+        assert!(matches!(err, PathsError::MissingParam { .. }));
+    }
+
+    #[test]
+    fn optional_catchall_duplicate_bare_urls_are_ambiguous() {
+        let mut cache = PathsCache::new();
+        let segs = route_docs_optional_catchall();
+        let export = json!([
+            { "params": { "slug": [] } },
+            { "params": { "slug": [] } }
+        ]);
+
+        let err =
+            resolve_paths(&mut cache, "docs/[[...slug]].tsx", &segs, &export).unwrap_err();
+        assert!(matches!(err, PathsError::AmbiguousResolution { .. }));
+    }
+
+    #[test]
+    fn required_catchall_still_rejects_empty_array() {
+        // The strict `[...slug]` form keeps its guard: `[]` is invalid.
+        let mut cache = PathsCache::new();
+        let segs = route_docs_catchall();
+        let export = json!([{ "params": { "slug": [] } }]);
+
+        let err = resolve_paths(&mut cache, "docs/[...slug].tsx", &segs, &export).unwrap_err();
+        match err {
+            PathsError::InvalidParamType { reason, .. } => {
+                assert!(
+                    reason.contains("must not be empty"),
+                    "unexpected reason: {reason}",
+                );
+            }
+            other => unreachable!("expected InvalidParamType, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn required_catchall_still_rejects_empty_string() {
+        let mut cache = PathsCache::new();
+        let segs = route_docs_catchall();
+        let export = json!([{ "params": { "slug": "" } }]);
+
+        let err = resolve_paths(&mut cache, "docs/[...slug].tsx", &segs, &export).unwrap_err();
+        assert!(matches!(err, PathsError::InvalidParamType { .. }));
     }
 }

--- a/crates/zfb-render/tests/fixtures/routing-rendering/pages/manual/[[...slug]].tsx
+++ b/crates/zfb-render/tests/fixtures/routing-rendering/pages/manual/[[...slug]].tsx
@@ -1,0 +1,30 @@
+// Optional catchall page at "/manual/[[...slug]]" (#812). Matches the
+// bare directory URL (`/manual`, slug = []) AND arbitrary-depth nested
+// paths. `paths()` includes the explicit `slug: []` entry so the harness
+// can assert the zero-segment page builds at `manual/index.html`.
+
+export const meta = {
+  title: "Manual",
+  layout: "default",
+};
+
+const stubPages: { slug: string[]; body: string }[] = [
+  { slug: [], body: "Manual home." },
+  { slug: ["setup", "quick"], body: "Quick setup." },
+];
+
+export function paths() {
+  return stubPages.map((p) => ({
+    params: { slug: p.slug },
+    props: { slug: p.slug, body: p.body },
+  }));
+}
+
+export default function ManualPage({ slug, body }: { slug: string[]; body: string }) {
+  return (
+    <section className="page page-manual">
+      <h2>{slug.length === 0 ? "Manual" : slug.join(" / ")}</h2>
+      <p>{body}</p>
+    </section>
+  );
+}

--- a/crates/zfb-render/tests/integration_routing_rendering.rs
+++ b/crates/zfb-render/tests/integration_routing_rendering.rs
@@ -61,6 +61,7 @@ fn router_discovers_all_required_routes() {
         "/blog/:slug",
         "/blog/page/:page",
         "/docs/:slug{.+}",
+        "/manual/:slug{.+}?",
         "/:lang/:slug",
     ] {
         assert!(
@@ -89,5 +90,7 @@ fn router_classifies_route_kinds_correctly() {
     assert_eq!(kind_of("/blog/:slug"), RouteKind::Dynamic);
     assert_eq!(kind_of("/blog/page/:page"), RouteKind::Dynamic);
     assert_eq!(kind_of("/docs/:slug{.+}"), RouteKind::Catchall);
+    // Optional catchall (#812) shares RouteKind::Catchall.
+    assert_eq!(kind_of("/manual/:slug{.+}?"), RouteKind::Catchall);
     assert_eq!(kind_of("/:lang/:slug"), RouteKind::Dynamic);
 }

--- a/crates/zfb-router/src/error.rs
+++ b/crates/zfb-router/src/error.rs
@@ -44,4 +44,19 @@ pub enum RouterError {
         first: PathBuf,
         second: PathBuf,
     },
+
+    /// An optional catchall route (`[[...name]]`) overlaps another route:
+    /// either both serve the same bare URL (the zero-segment case), or
+    /// another catchall occupies the same position (full overlap on every
+    /// non-empty path, regardless of param name).
+    #[error(
+        "conflicting routes {first} and {second}: {reason}",
+        first = first.display(),
+        second = second.display(),
+    )]
+    OptionalCatchallConflict {
+        first: PathBuf,
+        second: PathBuf,
+        reason: String,
+    },
 }

--- a/crates/zfb-router/src/route.rs
+++ b/crates/zfb-router/src/route.rs
@@ -120,7 +120,9 @@ impl Route {
         for seg in &self.segments {
             url_parts.push(match seg {
                 Segment::Static(s) => s.clone(),
-                Segment::Dynamic(_) | Segment::Catchall(_) => seg.template(),
+                Segment::Dynamic(_) | Segment::Catchall(_) | Segment::OptionalCatchall(_) => {
+                    seg.template()
+                }
             });
         }
 

--- a/crates/zfb-router/src/route.rs
+++ b/crates/zfb-router/src/route.rs
@@ -16,17 +16,6 @@ pub enum RouteKind {
     Catchall,
 }
 
-impl RouteKind {
-    /// Lower numbers sort first (i.e. higher priority).
-    pub(crate) fn order_key(self) -> u8 {
-        match self {
-            RouteKind::Static => 0,
-            RouteKind::Dynamic => 1,
-            RouteKind::Catchall => 2,
-        }
-    }
-}
-
 /// A single resolved route.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Route {

--- a/crates/zfb-router/src/scan.rs
+++ b/crates/zfb-router/src/scan.rs
@@ -449,9 +449,31 @@ fn detect_ambiguity(routes: &[Route]) -> Result<(), RouterError> {
     detect_optional_catchall_conflicts(routes)
 }
 
+/// Render a segment slice as a param-name-insensitive shape key: static
+/// segments keep their literal, dynamic segments collapse to `:*`, and
+/// catchall segments to `:...`. Two routes (or prefixes) with equal shape
+/// keys match exactly the same set of URLs regardless of how their params
+/// are named — `/[id]` and `/[lang]` both render as `/:*`.
+fn shape_key(segments: &[Segment]) -> String {
+    if segments.is_empty() {
+        return "/".to_string();
+    }
+    let mut out = String::new();
+    for seg in segments {
+        out.push('/');
+        match seg {
+            Segment::Static(s) => out.push_str(s),
+            Segment::Dynamic(_) => out.push_str(":*"),
+            Segment::Catchall(_) | Segment::OptionalCatchall(_) => out.push_str(":..."),
+        }
+    }
+    out
+}
+
 /// Render the template of a segment-slice prefix (`/docs` for
 /// `[Static("docs")]`, `/` for the empty slice). Mirrors
-/// [`Route::template`] but over an arbitrary prefix.
+/// [`Route::template`] but over an arbitrary prefix. Used for error
+/// messages only — conflict comparisons use [`shape_key`].
 fn prefix_template(segments: &[Segment]) -> String {
     if segments.is_empty() {
         return "/".to_string();
@@ -469,14 +491,16 @@ fn prefix_template(segments: &[Segment]) -> String {
 /// never hide a conflict — `[` sorts before `i`, so `[[...slug]].tsx` is
 /// walked before a sibling `index.tsx`.
 ///
-/// For each `[[...name]]` route with prefix `P` (the URL it serves for
-/// zero segments):
+/// For each `[[...name]]` route with prefix `P` (the URL set it serves
+/// for zero segments):
 ///
-/// 1. Any route whose full template equals `P` conflicts — both produce
-///    the bare URL (e.g. `pages/docs/index.tsx` / `pages/docs.tsx` vs
-///    `pages/docs/[[...slug]].tsx`, all serving `/docs`).
-/// 2. Any other catchall (required or optional) at the same prefix
-///    conflicts regardless of param name — they overlap on every
+/// 1. Any route whose full shape equals `P`'s shape conflicts — both
+///    produce the bare URL (e.g. `pages/docs/index.tsx` / `pages/docs.tsx`
+///    vs `pages/docs/[[...slug]].tsx`, all serving `/docs`). The shape
+///    comparison is param-name-insensitive so `pages/[id].tsx` also
+///    conflicts with `pages/[lang]/[[...slug]].tsx` — both match `/en`.
+/// 2. Any other catchall (required or optional) at a same-shaped prefix
+///    conflicts regardless of param names — they overlap on every
 ///    non-empty path.
 ///
 /// Deeper / more specific routes under the prefix (`docs/about.tsx`,
@@ -487,12 +511,14 @@ fn detect_optional_catchall_conflicts(routes: &[Route]) -> Result<(), RouterErro
         if !matches!(route.segments.last(), Some(Segment::OptionalCatchall(_))) {
             continue;
         }
-        let prefix = prefix_template(&route.segments[..route.segments.len() - 1]);
+        let prefix_segs = &route.segments[..route.segments.len() - 1];
+        let prefix_shape = shape_key(prefix_segs);
+        let prefix = prefix_template(prefix_segs);
         for (j, other) in routes.iter().enumerate() {
             if i == j {
                 continue;
             }
-            if other.template() == prefix {
+            if shape_key(&other.segments) == prefix_shape {
                 return Err(RouterError::OptionalCatchallConflict {
                     first: other.source_path.clone(),
                     second: route.source_path.clone(),
@@ -505,7 +531,7 @@ fn detect_optional_catchall_conflicts(routes: &[Route]) -> Result<(), RouterErro
             if matches!(
                 other.segments.last(),
                 Some(Segment::Catchall(_) | Segment::OptionalCatchall(_))
-            ) && prefix_template(&other.segments[..other.segments.len() - 1]) == prefix
+            ) && shape_key(&other.segments[..other.segments.len() - 1]) == prefix_shape
             {
                 return Err(RouterError::OptionalCatchallConflict {
                     first: other.source_path.clone(),
@@ -727,6 +753,37 @@ mod tests {
     fn root_optional_catchall_conflicts_with_root_index() {
         let err = scan_tree(&["[[...rest]].tsx", "index.tsx"]).unwrap_err();
         assert!(matches!(err, RouterError::OptionalCatchallConflict { .. }));
+    }
+
+    #[test]
+    fn dynamic_prefix_bare_conflict_is_param_name_insensitive() {
+        // `pages/[id].tsx` (`/:id`) and `pages/[lang]/[[...slug]].tsx`
+        // (zero-segment prefix `/:lang`) both match `/en` — the differing
+        // param names must not hide the conflict.
+        let err = scan_tree(&["[id].tsx", "[lang]/[[...slug]].tsx"]).unwrap_err();
+        assert!(
+            matches!(err, RouterError::OptionalCatchallConflict { .. }),
+            "expected OptionalCatchallConflict, got {err:?}",
+        );
+    }
+
+    #[test]
+    fn dynamic_prefix_catchall_overlap_is_param_name_insensitive() {
+        // `pages/[a]/[...x].tsx` and `pages/[b]/[[...y]].tsx` overlap on
+        // every non-empty nested path regardless of param names.
+        let err = scan_tree(&["[a]/[...x].tsx", "[b]/[[...y]].tsx"]).unwrap_err();
+        assert!(matches!(err, RouterError::OptionalCatchallConflict { .. }));
+    }
+
+    #[test]
+    fn static_prefix_dynamic_sibling_is_not_a_bare_conflict() {
+        // `pages/[id].tsx` and `pages/docs/[[...slug]].tsx`: `/docs` is
+        // matched by both at runtime, but the static-prefixed catchall is
+        // strictly more specific there — this is ordinary overlap resolved
+        // by the specificity sort, not a conflict.
+        let routes = scan_tree(&["[id].tsx", "docs/[[...slug]].tsx"])
+            .expect("static-prefix optional catchall must coexist with /[id]");
+        assert_eq!(routes.len(), 2);
     }
 
     #[test]

--- a/crates/zfb-router/src/scan.rs
+++ b/crates/zfb-router/src/scan.rs
@@ -12,6 +12,7 @@
 //! | `pages/blog/[slug].tsx`             | `/blog/:slug`      |                                |
 //! | `pages/blog/page/[page].tsx`        | `/blog/page/:page` |                                |
 //! | `pages/docs/[...slug].tsx`          | `/docs/:slug{.+}`  |                                |
+//! | `pages/docs/[[...slug]].tsx`        | `/docs/:slug{.+}?` | optional catchall: also `/docs`|
 //! | `pages/[lang]/[slug].tsx`           | `/:lang/:slug`     |                                |
 //!
 //! Files starting with `_` (e.g. `_app.tsx`, `_document.tsx`) are ignored.
@@ -242,13 +243,15 @@ fn parse_route(source: &Path, rel: &Path) -> Result<Route, RouterError> {
     let total = raw_segments.len();
     for (i, raw) in raw_segments.iter().enumerate() {
         let parsed = parse_segment(source, raw)?;
-        if let Segment::Catchall(_) = &parsed {
-            if i != total - 1 {
-                return Err(RouterError::CatchallNotLast {
-                    path: source.to_path_buf(),
-                    segment: raw.clone(),
-                });
-            }
+        if matches!(
+            &parsed,
+            Segment::Catchall(_) | Segment::OptionalCatchall(_)
+        ) && i != total - 1
+        {
+            return Err(RouterError::CatchallNotLast {
+                path: source.to_path_buf(),
+                segment: raw.clone(),
+            });
         }
         segments.push(parsed);
     }
@@ -322,6 +325,30 @@ fn parse_segment(source: &Path, raw: &str) -> Result<Segment, RouterError> {
         return Ok(Segment::Static(raw.to_string()));
     }
 
+    // Optional catchall: `[[...name]]` (Next.js-style). Matched before the
+    // single-bracket forms so the doubled brackets are not mis-parsed as a
+    // parameter literally named `[...name]`.
+    if raw.starts_with("[[") && raw.ends_with("]]") {
+        let inner = &raw[2..raw.len() - 2];
+        let Some(name) = inner.strip_prefix("...") else {
+            return Err(RouterError::InvalidSegment {
+                path: source.to_path_buf(),
+                segment: raw.to_string(),
+                message: "double brackets are only valid as an optional catchall `[[...name]]`"
+                    .into(),
+            });
+        };
+        if name.is_empty() {
+            return Err(RouterError::InvalidSegment {
+                path: source.to_path_buf(),
+                segment: raw.to_string(),
+                message: "empty optional catchall parameter name".into(),
+            });
+        }
+        validate_param_name(source, raw, name)?;
+        return Ok(Segment::OptionalCatchall(name.to_string()));
+    }
+
     // Strip outer brackets.
     let inner = &raw[1..raw.len() - 1];
     if inner.is_empty() {
@@ -371,7 +398,11 @@ fn classify(segments: &[Segment]) -> RouteKind {
     let mut has_dynamic = false;
     for seg in segments {
         match seg {
-            Segment::Catchall(_) => return RouteKind::Catchall,
+            // Optional catchalls share `RouteKind::Catchall`: the kind only
+            // drives sorting/dispatch, and a required + optional catchall
+            // can never coexist at the same prefix (scan-time conflict), so
+            // no finer ordering between them is ever needed.
+            Segment::Catchall(_) | Segment::OptionalCatchall(_) => return RouteKind::Catchall,
             Segment::Dynamic(_) => has_dynamic = true,
             Segment::Static(_) => {}
         }
@@ -389,7 +420,7 @@ fn score(segments: &[Segment], source: &Path) -> u32 {
         total = total.saturating_add(match seg {
             Segment::Static(_) => STATIC_WEIGHT,
             Segment::Dynamic(_) => DYNAMIC_WEIGHT,
-            Segment::Catchall(_) => CATCHALL_WEIGHT,
+            Segment::Catchall(_) | Segment::OptionalCatchall(_) => CATCHALL_WEIGHT,
         });
     }
     if source
@@ -413,6 +444,78 @@ fn detect_ambiguity(routes: &[Route]) -> Result<(), RouterError> {
                 first: prev.to_path_buf(),
                 second: route.source_path.clone(),
             });
+        }
+    }
+    detect_optional_catchall_conflicts(routes)
+}
+
+/// Render the template of a segment-slice prefix (`/docs` for
+/// `[Static("docs")]`, `/` for the empty slice). Mirrors
+/// [`Route::template`] but over an arbitrary prefix.
+fn prefix_template(segments: &[Segment]) -> String {
+    if segments.is_empty() {
+        return "/".to_string();
+    }
+    let mut out = String::new();
+    for seg in segments {
+        out.push('/');
+        out.push_str(&seg.template());
+    }
+    out
+}
+
+/// Detect conflicts specific to optional catchall routes. A full-set pass
+/// (not folded into the incremental template map) so file-visit order can
+/// never hide a conflict — `[` sorts before `i`, so `[[...slug]].tsx` is
+/// walked before a sibling `index.tsx`.
+///
+/// For each `[[...name]]` route with prefix `P` (the URL it serves for
+/// zero segments):
+///
+/// 1. Any route whose full template equals `P` conflicts — both produce
+///    the bare URL (e.g. `pages/docs/index.tsx` / `pages/docs.tsx` vs
+///    `pages/docs/[[...slug]].tsx`, all serving `/docs`).
+/// 2. Any other catchall (required or optional) at the same prefix
+///    conflicts regardless of param name — they overlap on every
+///    non-empty path.
+///
+/// Deeper / more specific routes under the prefix (`docs/about.tsx`,
+/// `docs/sub/[id].tsx`) are NOT conflicts — they coexist via the
+/// specificity sort exactly as they do with a required `[...slug]`.
+fn detect_optional_catchall_conflicts(routes: &[Route]) -> Result<(), RouterError> {
+    for (i, route) in routes.iter().enumerate() {
+        if !matches!(route.segments.last(), Some(Segment::OptionalCatchall(_))) {
+            continue;
+        }
+        let prefix = prefix_template(&route.segments[..route.segments.len() - 1]);
+        for (j, other) in routes.iter().enumerate() {
+            if i == j {
+                continue;
+            }
+            if other.template() == prefix {
+                return Err(RouterError::OptionalCatchallConflict {
+                    first: other.source_path.clone(),
+                    second: route.source_path.clone(),
+                    reason: format!(
+                        "both serve the bare URL `{prefix}` (an optional catchall \
+                         `[[...name]]` matches zero segments)"
+                    ),
+                });
+            }
+            if matches!(
+                other.segments.last(),
+                Some(Segment::Catchall(_) | Segment::OptionalCatchall(_))
+            ) && prefix_template(&other.segments[..other.segments.len() - 1]) == prefix
+            {
+                return Err(RouterError::OptionalCatchallConflict {
+                    first: other.source_path.clone(),
+                    second: route.source_path.clone(),
+                    reason: format!(
+                        "two catchall routes at the same prefix `{prefix}` overlap on \
+                         every non-empty path; keep exactly one of them"
+                    ),
+                });
+            }
         }
     }
     Ok(())
@@ -448,7 +551,10 @@ fn segment_rank(seg: &Segment) -> u8 {
     match seg {
         Segment::Static(_) => 0,
         Segment::Dynamic(_) => 1,
-        Segment::Catchall(_) => 2,
+        // Required and optional catchalls share a rank: they can never
+        // coexist at the same prefix (scan-time conflict), so a finer
+        // ordering between them is unreachable.
+        Segment::Catchall(_) | Segment::OptionalCatchall(_) => 2,
     }
 }
 
@@ -512,6 +618,147 @@ mod tests {
         let p = PathBuf::from("blog/[].tsx");
         let err = parse_route(&p, &p).unwrap_err();
         assert!(matches!(err, RouterError::InvalidSegment { .. }));
+    }
+
+    // ---- optional catchall `[[...name]]` (#812) -----------------------------
+
+    #[test]
+    fn parses_optional_catchall_segment() {
+        let r = route_from("docs/[[...slug]].tsx");
+        assert_eq!(r.template(), "/docs/:slug{.+}?");
+        assert_eq!(r.kind, RouteKind::Catchall);
+        assert_eq!(
+            r.segments,
+            vec![
+                Segment::Static("docs".into()),
+                Segment::OptionalCatchall("slug".into()),
+            ],
+        );
+    }
+
+    #[test]
+    fn parses_top_level_optional_catchall() {
+        let r = route_from("[[...rest]].tsx");
+        assert_eq!(r.template(), "/:rest{.+}?");
+        assert_eq!(r.kind, RouteKind::Catchall);
+        assert_eq!(r.segments, vec![Segment::OptionalCatchall("rest".into())]);
+    }
+
+    #[test]
+    fn rejects_optional_catchall_in_middle() {
+        let p = PathBuf::from("docs/[[...slug]]/edit.tsx");
+        let err = parse_route(&p, &p).unwrap_err();
+        assert!(matches!(err, RouterError::CatchallNotLast { .. }));
+    }
+
+    #[test]
+    fn rejects_double_bracket_without_catchall_dots() {
+        // `[[slug]]` is not a valid form — optional params exist only as
+        // the optional catchall `[[...slug]]`.
+        let p = PathBuf::from("docs/[[slug]].tsx");
+        let err = parse_route(&p, &p).unwrap_err();
+        assert!(matches!(err, RouterError::InvalidSegment { .. }));
+    }
+
+    #[test]
+    fn rejects_empty_optional_catchall_name() {
+        let p = PathBuf::from("docs/[[...]].tsx");
+        let err = parse_route(&p, &p).unwrap_err();
+        assert!(matches!(err, RouterError::InvalidSegment { .. }));
+    }
+
+    #[test]
+    fn rejects_invalid_optional_catchall_name() {
+        let p = PathBuf::from("docs/[[...1slug]].tsx");
+        let err = parse_route(&p, &p).unwrap_err();
+        assert!(matches!(err, RouterError::InvalidSegment { .. }));
+    }
+
+    fn scan_tree(files: &[&str]) -> Result<Vec<Route>, RouterError> {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        for rel in files {
+            let abs = tmp.path().join(rel);
+            fs::create_dir_all(abs.parent().unwrap()).unwrap();
+            fs::write(&abs, "export default function P() { return null; }\n").unwrap();
+        }
+        // TempDir must outlive the scan; routes carry owned PathBufs so
+        // returning them after drop is fine.
+        scan_pages(tmp.path())
+    }
+
+    #[test]
+    fn optional_catchall_conflicts_with_sibling_index() {
+        // Both produce the bare `/docs` URL. Note `[` sorts before `i` in
+        // the directory walk, so this also pins the full-set conflict pass
+        // (a forward-only check would visit `[[...slug]].tsx` first and
+        // miss `index.tsx`).
+        let err = scan_tree(&["docs/[[...slug]].tsx", "docs/index.tsx"]).unwrap_err();
+        assert!(
+            matches!(err, RouterError::OptionalCatchallConflict { .. }),
+            "expected OptionalCatchallConflict, got {err:?}",
+        );
+        assert!(err.to_string().contains("/docs"), "got: {err}");
+    }
+
+    #[test]
+    fn optional_catchall_conflicts_with_file_route_at_prefix() {
+        // `pages/docs.tsx` also produces `/docs`.
+        let err = scan_tree(&["docs.tsx", "docs/[[...slug]].tsx"]).unwrap_err();
+        assert!(matches!(err, RouterError::OptionalCatchallConflict { .. }));
+    }
+
+    #[test]
+    fn optional_catchall_conflicts_with_required_catchall_any_name() {
+        // Overlap on every non-empty path, regardless of param name.
+        let err = scan_tree(&["docs/[...a].tsx", "docs/[[...b]].tsx"]).unwrap_err();
+        assert!(matches!(err, RouterError::OptionalCatchallConflict { .. }));
+    }
+
+    #[test]
+    fn two_optional_catchalls_at_same_prefix_conflict() {
+        let err = scan_tree(&["docs/[[...a]].tsx", "docs/[[...b]].tsx"]).unwrap_err();
+        assert!(matches!(err, RouterError::OptionalCatchallConflict { .. }));
+    }
+
+    #[test]
+    fn root_optional_catchall_conflicts_with_root_index() {
+        let err = scan_tree(&["[[...rest]].tsx", "index.tsx"]).unwrap_err();
+        assert!(matches!(err, RouterError::OptionalCatchallConflict { .. }));
+    }
+
+    #[test]
+    fn optional_catchall_coexists_with_deeper_routes() {
+        // More-specific routes under the prefix are NOT conflicts — they
+        // coexist via the specificity sort, exactly like with a required
+        // catchall.
+        let routes = scan_tree(&[
+            "docs/[[...slug]].tsx",
+            "docs/about.tsx",
+            "docs/sub/[id].tsx",
+        ])
+        .expect("deeper routes under an optional catchall must coexist");
+        assert_eq!(routes.len(), 3);
+        // The optional catchall must sort last (loosest matcher).
+        assert_eq!(
+            routes.last().unwrap().template(),
+            "/docs/:slug{.+}?",
+            "optional catchall should sort last: {:?}",
+            routes.iter().map(Route::template).collect::<Vec<_>>(),
+        );
+    }
+
+    #[test]
+    fn required_catchall_unaffected_by_optional_support() {
+        // The strict form keeps its behaviour: a required catchall at one
+        // prefix and an optional at another coexist.
+        let routes = scan_tree(&["docs/[...slug].tsx", "manual/[[...slug]].tsx"])
+            .expect("catchalls at different prefixes must coexist");
+        let templates: Vec<String> = routes.iter().map(Route::template).collect();
+        assert!(templates.contains(&"/docs/:slug{.+}".to_string()));
+        assert!(templates.contains(&"/manual/:slug{.+}?".to_string()));
     }
 
     // ---- non-HTML page convention (Sub 49) -------------------------------

--- a/crates/zfb-router/src/scan.rs
+++ b/crates/zfb-router/src/scan.rs
@@ -548,29 +548,36 @@ fn detect_optional_catchall_conflicts(routes: &[Route]) -> Result<(), RouterErro
 }
 
 /// Sort routes by:
-/// 1. Kind (static < dynamic < catchall) — most specific first.
-/// 2. Number of segments, longer first.
-/// 3. `index.tsx` before non-index siblings (via specificity bonus).
-/// 4. Per-segment kind from left to right (static beats dynamic beats catchall).
-/// 5. Source path, lexicographically, for total ordering.
+/// 1. Per-segment rank vector, compared lexicographically left to right
+///    (static `0` < dynamic `1` < catchall / optional-catchall `2`); a
+///    shorter prefix-matching vector sorts first — most specific first.
+/// 2. `index.tsx` before non-index siblings (via specificity bonus).
+/// 3. Source path, lexicographically, for total ordering.
+///
+/// The rank-vector key is kept byte-for-byte in sync with
+/// `zfb_build::bundler::route_sort_key` (the JS/Hono runtime's
+/// registration order). Mirroring it here is load-bearing: dev SSR
+/// dispatch (`DevRenderSession::ssr_patterns` → `SsrRouteSet::find_match`,
+/// first-match) preserves this scan order, so a coarse per-route kind
+/// sort (the previous design) would let a top-level dynamic SSR route
+/// (`/[id]`, `/[lang]/[slug]`) steal `/docs` / `/docs/a` from a
+/// static-prefixed optional catchall (`/docs/[[...slug]]`) in dev while
+/// the bundled Hono runtime correctly chose the catchall — a dev/prod
+/// routing divergence for the optional-catchall route type.
 fn sort_routes(routes: &mut [Route]) {
     routes.sort_by(|a, b| {
-        a.kind
-            .order_key()
-            .cmp(&b.kind.order_key())
-            .then_with(|| b.segments.len().cmp(&a.segments.len()))
+        route_rank_vector(&a.segments)
+            .cmp(&route_rank_vector(&b.segments))
             .then_with(|| b.specificity.cmp(&a.specificity))
-            .then_with(|| {
-                for (sa, sb) in a.segments.iter().zip(b.segments.iter()) {
-                    let ord = segment_rank(sa).cmp(&segment_rank(sb));
-                    if ord != std::cmp::Ordering::Equal {
-                        return ord;
-                    }
-                }
-                std::cmp::Ordering::Equal
-            })
             .then_with(|| a.source_path.cmp(&b.source_path))
     });
+}
+
+/// Per-segment specificity rank vector for a route. Mirrors
+/// `zfb_build::bundler::route_sort_key` so dev and prod agree on which
+/// of two overlapping routes is more specific (see [`sort_routes`]).
+fn route_rank_vector(segments: &[Segment]) -> Vec<u8> {
+    segments.iter().map(segment_rank).collect()
 }
 
 fn segment_rank(seg: &Segment) -> u8 {
@@ -784,6 +791,105 @@ mod tests {
         let routes = scan_tree(&["[id].tsx", "docs/[[...slug]].tsx"])
             .expect("static-prefix optional catchall must coexist with /[id]");
         assert_eq!(routes.len(), 2);
+    }
+
+    /// Index of `template` in a scanned + sorted route list, or panic.
+    fn template_index(routes: &[Route], template: &str) -> usize {
+        routes
+            .iter()
+            .position(|r| r.template() == template)
+            .unwrap_or_else(|| {
+                panic!(
+                    "missing route {template}; got {:?}",
+                    routes.iter().map(Route::template).collect::<Vec<_>>(),
+                )
+            })
+    }
+
+    // ---- per-segment specificity sort (dev/prod parity, #814) --------------
+    //
+    // These pin the scan order that dev SSR first-match dispatch
+    // (`SsrRouteSet::find_match`) preserves, against the JS/Hono runtime's
+    // `route_sort_key` registration order in zfb-build's bundler.
+
+    #[test]
+    fn optional_catchall_sorts_before_top_level_dynamic_sibling() {
+        // Divergence case 1: URL `/docs` is matched by both
+        // `pages/docs/[[...slug]].tsx` (zero-segment optional catchall) and
+        // `pages/[id].tsx`. The static-prefixed catchall is strictly more
+        // specific at `/docs`, so it must sort FIRST — otherwise dev SSR
+        // first-match would send `/docs` to the less-specific `/[id]`.
+        let routes = scan_tree(&["[id].tsx", "docs/[[...slug]].tsx"]).expect("scan");
+        assert!(
+            template_index(&routes, "/docs/:slug{.+}?")
+                < template_index(&routes, "/:id"),
+            "optional catchall /docs/[[...slug]] must sort before /[id]: {:?}",
+            routes.iter().map(Route::template).collect::<Vec<_>>(),
+        );
+    }
+
+    #[test]
+    fn optional_catchall_sorts_before_top_level_dynamic_pair() {
+        // Divergence case 2: URL `/docs/a` is matched by both
+        // `pages/docs/[[...slug]].tsx` and `pages/[lang]/[slug].tsx`. The
+        // static-prefixed catchall (rank `[0, 2]`) is more specific than the
+        // fully-dynamic pair (rank `[1, 1]`) — first differing segment is
+        // static-vs-dynamic at index 0 — so it must sort FIRST.
+        let routes = scan_tree(&["[lang]/[slug].tsx", "docs/[[...slug]].tsx"]).expect("scan");
+        assert!(
+            template_index(&routes, "/docs/:slug{.+}?")
+                < template_index(&routes, "/:lang/:slug"),
+            "optional catchall /docs/[[...slug]] must sort before /[lang]/[slug]: {:?}",
+            routes.iter().map(Route::template).collect::<Vec<_>>(),
+        );
+    }
+
+    #[test]
+    fn required_catchall_orderings_unchanged() {
+        // Existing required-catchall / dynamic invariants stay green under
+        // the per-segment sort:
+        //   - a plain dynamic sibling sorts before the catchall at the same
+        //     static depth (`/docs/[id]` before `/docs/[...slug]`);
+        //   - a static-prefixed catchall sorts before a fully-dynamic pair
+        //     (`/docs/[...slug]` before `/[lang]/[slug]`);
+        //   - a deeper dynamic descendant sorts before the shallow catchall
+        //     (`/docs/v/[page]` before `/docs/[...slug]`).
+        let routes = scan_tree(&[
+            "docs/[id].tsx",
+            "docs/[...slug].tsx",
+            "docs/v/[page].tsx",
+            "[lang]/[slug].tsx",
+        ])
+        .expect("scan");
+        let cat = template_index(&routes, "/docs/:slug{.+}");
+        assert!(
+            template_index(&routes, "/docs/:id") < cat,
+            "/docs/:id before /docs/:slug{{.+}}: {:?}",
+            routes.iter().map(Route::template).collect::<Vec<_>>(),
+        );
+        assert!(
+            cat < template_index(&routes, "/:lang/:slug"),
+            "/docs/:slug{{.+}} before /:lang/:slug: {:?}",
+            routes.iter().map(Route::template).collect::<Vec<_>>(),
+        );
+        assert!(
+            template_index(&routes, "/docs/v/:page") < cat,
+            "/docs/v/:page before /docs/:slug{{.+}}: {:?}",
+            routes.iter().map(Route::template).collect::<Vec<_>>(),
+        );
+    }
+
+    #[test]
+    fn index_sibling_outranks_top_level_dynamic() {
+        // The index-bonus path still resolves a same-shape tie: `/foo`
+        // (from `pages/foo/index.tsx`) and `/:foo` (from `pages/[foo].tsx`)
+        // are both single-segment; the static one must sort first.
+        let routes = scan_tree(&["foo/index.tsx", "[foo].tsx"]).expect("scan");
+        assert!(
+            template_index(&routes, "/foo") < template_index(&routes, "/:foo"),
+            "static /foo must sort before dynamic /:foo: {:?}",
+            routes.iter().map(Route::template).collect::<Vec<_>>(),
+        );
     }
 
     #[test]

--- a/crates/zfb-router/tests/fixtures/pages/manual/[[...slug]].tsx
+++ b/crates/zfb-router/tests/fixtures/pages/manual/[[...slug]].tsx
@@ -1,0 +1,9 @@
+// Optional catchall fixture (#812): serves the bare `/manual` URL
+// (slug = []) and every nested path (`/manual/a/b`, slug = ["a", "b"]).
+export function paths() {
+  return [{ params: { slug: [] } }, { params: { slug: ["setup", "quick"] } }];
+}
+
+export default function ManualPage() {
+  return null;
+}

--- a/crates/zfb-router/tests/scan_routes.rs
+++ b/crates/zfb-router/tests/scan_routes.rs
@@ -161,50 +161,67 @@ fn dynamic_param_name_preserved() {
 }
 
 #[test]
-fn sort_order_static_then_dynamic_then_catchall() {
+fn sort_order_is_per_segment_rank_vector() {
+    // Routes are sorted by the per-segment rank vector (static `0` <
+    // dynamic `1` < catchall `2`), compared lexicographically — the same
+    // key `zfb_build::bundler::route_sort_key` uses for Hono registration
+    // order (#814). The whole table must be non-decreasing in that key.
+    // A coarse per-route kind sort is intentionally NOT the contract: a
+    // static-prefixed catchall (`/docs/:slug{.+}` → `[0, 2]`) sorts ahead
+    // of a fully-dynamic pair (`/:lang/:slug` → `[1, 1]`).
     let router = Router::scan(&fixture("pages")).expect("scan");
-    let kinds: Vec<RouteKind> = router.routes().iter().map(|r| r.kind).collect();
-    let mut last_rank: u8 = 0;
-    for kind in kinds {
-        let rank = kind_rank(kind);
-        assert!(last_rank <= rank, "routes not sorted by kind");
-        last_rank = rank;
+    let keys: Vec<Vec<u8>> = router.routes().iter().map(rank_vector).collect();
+    for w in keys.windows(2) {
+        assert!(
+            w[0] <= w[1],
+            "routes not sorted by per-segment rank vector: {:?} before {:?}",
+            w[0],
+            w[1],
+        );
     }
 }
 
-fn kind_rank(k: RouteKind) -> u8 {
-    match k {
-        RouteKind::Static => 0,
-        RouteKind::Dynamic => 1,
-        RouteKind::Catchall => 2,
-    }
+fn rank_vector(route: &Route) -> Vec<u8> {
+    route
+        .segments
+        .iter()
+        .map(|s| match s {
+            Segment::Static(_) => 0u8,
+            Segment::Dynamic(_) => 1,
+            Segment::Catchall(_) | Segment::OptionalCatchall(_) => 2,
+        })
+        .collect()
 }
 
 #[test]
-fn longer_paths_sort_before_shorter_within_kind() {
+fn more_specific_routes_sort_before_looser_overlapping_ones() {
     let router = Router::scan(&fixture("pages")).expect("scan");
     let templates = templates(router.routes());
+    let pos = |t: &str| {
+        templates
+            .iter()
+            .position(|x| x == t)
+            .unwrap_or_else(|| panic!("missing {t} in {templates:?}"))
+    };
 
-    // Among static routes, /about and /blog (1 segment) should appear before /
-    // (0 segments).
-    let pos_root = templates.iter().position(|t| t == "/").expect("/");
-    let pos_about = templates.iter().position(|t| t == "/about").expect("/about");
-    let pos_blog = templates.iter().position(|t| t == "/blog").expect("/blog");
-    assert!(pos_about < pos_root, "/about should sort before /");
-    assert!(pos_blog < pos_root, "/blog should sort before /");
+    // The empty (index) route carries the empty rank vector, which sorts
+    // first — matching the bundler (`/ → []` "empty vector sorts first").
+    // `/` never overlaps `/about`, so this is a deterministic tiebreak only.
+    assert!(pos("/") < pos("/about"), "/ (empty vector) sorts first");
 
-    // Catchall /docs/:slug{.+} must come last (after everything dynamic).
-    let pos_docs = templates
-        .iter()
-        .position(|t| t == "/docs/:slug{.+}")
-        .expect("/docs/:slug{.+}");
-    let pos_blog_slug = templates
-        .iter()
-        .position(|t| t == "/blog/:slug")
-        .expect("/blog/:slug");
+    // Static prefix beats a fully-dynamic pair at the same depth: a URL
+    // like `/docs/a` is matched by both `/docs/:slug{.+}` and `/:lang/:slug`
+    // and must dispatch to the static-prefixed catchall (#814).
     assert!(
-        pos_blog_slug < pos_docs,
-        "dynamic should beat catchall in sort order",
+        pos("/docs/:slug{.+}") < pos("/:lang/:slug"),
+        "static-prefixed catchall must beat the fully-dynamic pair",
+    );
+
+    // A deeper static-prefixed dynamic route still beats a fully-dynamic
+    // pair too (`/blog/:slug` before `/:lang/:slug`).
+    assert!(
+        pos("/blog/:slug") < pos("/:lang/:slug"),
+        "static-prefixed dynamic must beat the fully-dynamic pair",
     );
 }
 

--- a/crates/zfb-router/tests/scan_routes.rs
+++ b/crates/zfb-router/tests/scan_routes.rs
@@ -29,6 +29,7 @@ fn scans_canonical_pages_dir() {
         "/blog/:slug",
         "/blog/page/:page",
         "/docs/:slug{.+}",
+        "/manual/:slug{.+}?",
         "/:lang/:slug",
     ] {
         assert!(
@@ -99,6 +100,26 @@ fn classifies_static_dynamic_catchall() {
     assert_eq!(by_template["/blog/page/:page"], RouteKind::Dynamic);
     assert_eq!(by_template["/:lang/:slug"], RouteKind::Dynamic);
     assert_eq!(by_template["/docs/:slug{.+}"], RouteKind::Catchall);
+    // The optional catchall shares RouteKind::Catchall (it only drives
+    // sorting/dispatch; the segment carries the optional-ness).
+    assert_eq!(by_template["/manual/:slug{.+}?"], RouteKind::Catchall);
+}
+
+#[test]
+fn optional_catchall_param_name_preserved() {
+    let router = Router::scan(&fixture("pages")).expect("scan");
+    let manual = router
+        .routes()
+        .iter()
+        .find(|r| r.template() == "/manual/:slug{.+}?")
+        .expect("/manual/:slug{.+}?");
+    assert_eq!(
+        manual.segments,
+        vec![
+            Segment::Static("manual".into()),
+            Segment::OptionalCatchall("slug".into()),
+        ],
+    );
 }
 
 #[test]

--- a/crates/zfb-server/src/injected_routes.rs
+++ b/crates/zfb-server/src/injected_routes.rs
@@ -97,6 +97,10 @@ impl InjectedRouteSet {
 /// - `foo` matches the literal segment `foo` only.
 /// - `[name]` matches exactly one segment (cannot be empty).
 /// - `[...rest]` matches one or more segments (catch-all).
+/// - `[[...rest]]` matches zero or more segments (optional catch-all).
+///   The zero case matches the bare prefix (`/docs` for
+///   `/docs/[[...rest]]`) but NOT the trailing-slash form (`/docs/`),
+///   mirroring Hono's `:rest{.+}?` behaviour.
 ///
 /// Mirrors the subset of `pages/`-router semantics the spec
 /// explicitly calls out (`/blog/[slug]`); full feature parity with
@@ -109,6 +113,25 @@ pub fn pattern_matches(pattern: &str, url_path: &str) -> bool {
     let mut ui = 0usize;
     while pi < p_segments.len() {
         let p = p_segments[pi];
+        // Optional catch-all `[[...rest]]` — checked before the
+        // single-bracket forms so the doubled brackets are not
+        // mis-read as a param literally named `[...rest]`.
+        if p.starts_with("[[...") && p.ends_with("]]") {
+            if pi != p_segments.len() - 1 {
+                return false;
+            }
+            let remaining = &u_segments[ui..];
+            if remaining.iter().any(|s| !s.is_empty()) {
+                // One or more segments: same as the required catch-all.
+                return true;
+            }
+            // Zero segments: only the bare prefix (no trailing slash)
+            // or the root URL itself. `/docs/` leaves an empty trailing
+            // segment which Hono's `:rest{.+}?` also rejects; `/` is
+            // special-cased because the root URL always splits to one
+            // empty segment.
+            return remaining.is_empty() || url_path == "/";
+        }
         if let Some(name) = strip_brackets(p) {
             if let Some(rest) = name.strip_prefix("...") {
                 // Catch-all `[...rest]` — must be the last pattern
@@ -188,6 +211,36 @@ mod tests {
         assert!(s.find_match("/docs/a/b/c").is_some());
         assert!(s.find_match("/docs").is_none());
         assert!(s.find_match("/docs/").is_none());
+    }
+
+    #[test]
+    fn optional_catchall_matches_zero_or_more_segments() {
+        let s = InjectedRouteSet::new(vec![rec("/docs/[[...rest]]")]);
+        // Zero segments: the bare prefix matches…
+        assert!(s.find_match("/docs").is_some());
+        // …but the trailing-slash form does not (Hono `:rest{.+}?` parity).
+        assert!(s.find_match("/docs/").is_none());
+        // One or more segments: same as the required catch-all.
+        assert!(s.find_match("/docs/a").is_some());
+        assert!(s.find_match("/docs/a/b/c").is_some());
+        // Different prefix never matches.
+        assert!(s.find_match("/other").is_none());
+        assert!(s.find_match("/other/a").is_none());
+    }
+
+    #[test]
+    fn root_optional_catchall_matches_root_url() {
+        let s = InjectedRouteSet::new(vec![rec("/[[...rest]]")]);
+        assert!(s.find_match("/").is_some());
+        assert!(s.find_match("/a").is_some());
+        assert!(s.find_match("/a/b").is_some());
+    }
+
+    #[test]
+    fn optional_catchall_must_be_last_pattern_segment() {
+        let s = InjectedRouteSet::new(vec![rec("/docs/[[...rest]]/edit")]);
+        assert!(s.find_match("/docs/a/edit").is_none());
+        assert!(s.find_match("/docs/edit").is_none());
     }
 
     #[test]

--- a/crates/zfb-server/src/ssr.rs
+++ b/crates/zfb-server/src/ssr.rs
@@ -252,4 +252,54 @@ mod tests {
         assert!(s.is_empty());
         assert_eq!(s.len(), 0);
     }
+
+    // ---- scan-order dispatch parity (#814) ---------------------------------
+    //
+    // `find_match` is first-match over `records`, and the bin crate fills
+    // `records` in `zfb_router` scan order (most specific first). These pin
+    // that a static-prefixed optional catchall, ordered ahead of a sibling
+    // top-level dynamic SSR route by the per-segment sort, wins the URLs the
+    // bundled Hono runtime would also send to it — dev/prod parity.
+
+    fn set(patterns: &[&str]) -> SsrRouteSet {
+        SsrRouteSet::new(
+            patterns.iter().map(|p| rec(p)).collect(),
+            Arc::new(StubDispatcher::new(SsrResponse::default())),
+        )
+    }
+
+    #[test]
+    fn optional_catchall_wins_bare_prefix_over_top_level_dynamic() {
+        // Scan order for `pages/docs/[[...slug]].tsx` + `pages/[id].tsx`:
+        // the static-prefixed catchall sorts first. `/docs` (the
+        // zero-segment case of the optional catchall) must dispatch to it,
+        // not to `/[id]`.
+        let s = set(&["/docs/[[...slug]]", "/[id]"]);
+        assert_eq!(
+            s.find_match("/docs").map(|r| r.pattern.as_str()),
+            Some("/docs/[[...slug]]"),
+        );
+        // A non-`/docs` single segment still falls through to `/[id]`.
+        assert_eq!(
+            s.find_match("/other").map(|r| r.pattern.as_str()),
+            Some("/[id]"),
+        );
+    }
+
+    #[test]
+    fn optional_catchall_wins_nested_path_over_dynamic_pair() {
+        // Scan order for `pages/docs/[[...slug]].tsx` +
+        // `pages/[lang]/[slug].tsx`: the static-prefixed catchall sorts
+        // first. `/docs/a` must dispatch to it, not to `/[lang]/[slug]`.
+        let s = set(&["/docs/[[...slug]]", "/[lang]/[slug]"]);
+        assert_eq!(
+            s.find_match("/docs/a").map(|r| r.pattern.as_str()),
+            Some("/docs/[[...slug]]"),
+        );
+        // A two-segment URL with a different prefix falls through.
+        assert_eq!(
+            s.find_match("/en/intro").map(|r| r.pattern.as_str()),
+            Some("/[lang]/[slug]"),
+        );
+    }
 }

--- a/crates/zfb-types/src/segment.rs
+++ b/crates/zfb-types/src/segment.rs
@@ -16,6 +16,9 @@ use serde::{Deserialize, Serialize};
 /// - `Dynamic("slug")` — single-segment dynamic param from `[slug].tsx`.
 /// - `Catchall("slug")` — rest param from `[...slug].tsx`; matches one or
 ///   more trailing segments.
+/// - `OptionalCatchall("slug")` — rest param from `[[...slug]].tsx`;
+///   matches zero or more trailing segments (also serves the bare
+///   directory URL).
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Segment {
     /// Literal text that must match exactly. e.g. `about` in `/about`.
@@ -26,6 +29,11 @@ pub enum Segment {
     /// Catchall (rest) parameter from `[...name].tsx`. Matches one or more
     /// trailing segments. Only allowed as the final segment of a route.
     Catchall(String),
+    /// Optional catchall (rest) parameter from `[[...name]].tsx`. Matches
+    /// zero or more trailing segments — the zero-segment case serves the
+    /// bare directory URL (e.g. `/docs` for `pages/docs/[[...slug]].tsx`).
+    /// Only allowed as the final segment of a route.
+    OptionalCatchall(String),
 }
 
 impl Segment {
@@ -34,6 +42,7 @@ impl Segment {
     /// `/__paths__/` worker lookups, and human-readable diagnostics.
     ///
     /// Catchall segments emit Hono's regex-quantifier form `:name{.+}`
+    /// (optional catchalls add Hono's optional marker: `:name{.+}?`)
     /// rather than the Astro / Express `:name*` style. This keeps the
     /// route-key produced by `Route::template()` and the route-key
     /// registered by `bracket_to_hono` (in zfb-build) bit-identical, so
@@ -44,6 +53,10 @@ impl Segment {
             Segment::Static(s) => s.clone(),
             Segment::Dynamic(name) => format!(":{name}"),
             Segment::Catchall(name) => format!(":{name}{{.+}}"),
+            // `:name{.+}?` — probed against Hono 4.12.x: matches the bare
+            // prefix (`/docs`, params empty) and nested paths, but NOT the
+            // trailing-slash form (`/docs/`).
+            Segment::OptionalCatchall(name) => format!(":{name}{{.+}}?"),
         }
     }
 }

--- a/crates/zfb/build.rs
+++ b/crates/zfb/build.rs
@@ -73,7 +73,7 @@ const PREACT_VERSION: &str = "10.29.1";
 const PREACT_RTS_VERSION: &str = "6.6.7";
 
 /// Pinned `hono` version (transitive dep of `@takazudo/zfb-runtime`).
-const HONO_VERSION: &str = "4.12.15";
+const HONO_VERSION: &str = "4.12.23";
 
 // ---------------------------------------------------------------------------
 // SHA-256 constants — esbuild 0.25.12 (from the npm package binary)

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -2459,6 +2459,7 @@ fn refresh_live_ssr_routes(session: &DevRenderSession, handle: &SsrRoutesHandle)
 /// Grammar:
 /// - `:name`        → `[name]`        (single-segment dynamic param)
 /// - `:name{.+}`    → `[...name]`     (catchall — Hono regex quantifier)
+/// - `:name{.+}?`   → `[[...name]]`   (optional catchall — zero or more)
 /// - literal segments are preserved unchanged
 ///
 /// The root `/` is preserved as `/`.
@@ -2471,8 +2472,13 @@ fn colon_template_to_bracket(template: &str) -> String {
     for seg in &segments {
         out.push('/');
         if let Some(rest) = seg.strip_prefix(':') {
-            // Catchall (Hono `:name{.+}`) wins over single-segment.
-            if let Some(name) = rest.strip_suffix("{.+}") {
+            // Optional catchall (`:name{.+}?`) wins over required
+            // (`:name{.+}`), which wins over single-segment.
+            if let Some(name) = rest.strip_suffix("{.+}?") {
+                out.push_str("[[...");
+                out.push_str(name);
+                out.push_str("]]");
+            } else if let Some(name) = rest.strip_suffix("{.+}") {
                 out.push_str("[...");
                 out.push_str(name);
                 out.push(']');
@@ -2792,6 +2798,15 @@ mod tests {
         assert_eq!(
             colon_template_to_bracket("/docs/:rest{.+}"),
             "/docs/[...rest]",
+        );
+        // Optional catchall (`:name{.+}?`) → `[[...name]]`.
+        assert_eq!(
+            colon_template_to_bracket("/docs/:rest{.+}?"),
+            "/docs/[[...rest]]",
+        );
+        assert_eq!(
+            colon_template_to_bracket("/:rest{.+}?"),
+            "/[[...rest]]",
         );
         assert_eq!(
             colon_template_to_bracket("/a/:b/c/:d"),

--- a/crates/zfb/src/render_pipeline.rs
+++ b/crates/zfb/src/render_pipeline.rs
@@ -585,7 +585,7 @@ fn expand_resolved_urls(
     let catchall_names: std::collections::HashSet<&str> = segments
         .iter()
         .filter_map(|seg| {
-            if let Segment::Catchall(name) = seg {
+            if let Segment::Catchall(name) | Segment::OptionalCatchall(name) = seg {
                 Some(name.as_str())
             } else {
                 None
@@ -613,7 +613,14 @@ fn expand_resolved_urls(
         for (k, v) in &r.params {
             if catchall_names.contains(k.as_str()) {
                 // Catchall strings were joined from an array; split back.
-                let parts: Vec<String> = v.split('/').map(|s| s.to_string()).collect();
+                // An optional catchall's zero-segment case is the empty
+                // string — that must surface as `[]` in the manifest, not
+                // `[""]` (which `"".split('/')` would produce).
+                let parts: Vec<String> = if v.is_empty() {
+                    Vec::new()
+                } else {
+                    v.split('/').map(|s| s.to_string()).collect()
+                };
                 arrays.insert(k.clone(), parts);
             } else {
                 scalars.insert(k.clone(), v.clone());
@@ -1885,6 +1892,64 @@ mod tests {
         assert_eq!(
             out.resolved[1].output_path,
             PathBuf::from("docs/x/y/z/index.html")
+        );
+    }
+
+    #[test]
+    fn expand_dynamic_routes_handles_optional_catchall_zero_segments() {
+        // `[[...slug]]` with `slug: []` must produce the bare directory
+        // URL (`/docs`, no trailing slash — matching the existing
+        // url_path style) and `docs/index.html`, and the manifest must
+        // report `slug: []` (an empty array, not `[""]`). #812.
+        let body = r#"
+            export function paths() {
+                return [
+                    { params: { slug: [] } },
+                    { params: { slug: ["guides", "install"] } },
+                ];
+            }
+        "#;
+        let (dir, pending) = stage_dynamic_page(
+            "pages/docs/[[...slug]].tsx",
+            vec![
+                Segment::Static("docs".into()),
+                Segment::OptionalCatchall("slug".into()),
+            ],
+            "/docs/:slug{.+}?",
+            body,
+        );
+        let mut cache = PathsCache::new();
+        let out = expand_dynamic_routes(&[pending], dir.path(), &mut cache)
+            .expect("optional catchall with literal paths() should succeed");
+
+        assert_eq!(out.deferred.len(), 0, "deferred: {:?}", out.deferred);
+        assert_eq!(out.resolved.len(), 2);
+
+        // Zero-segment entry: bare URL + directory-index output.
+        assert_eq!(out.resolved[0].url_path, "/docs");
+        assert_eq!(
+            out.resolved[0].output_path,
+            PathBuf::from("docs/index.html"),
+        );
+        assert_eq!(out.resolved[0].route_key, "/docs/:slug{.+}?");
+
+        // Nested entry unchanged.
+        assert_eq!(out.resolved[1].url_path, "/docs/guides/install");
+        assert_eq!(
+            out.resolved[1].output_path,
+            PathBuf::from("docs/guides/install/index.html"),
+        );
+
+        // Manifest params: the zero case is an EMPTY array, never `[""]`.
+        assert_eq!(out.resolved_with_params.len(), 2);
+        assert_eq!(
+            out.resolved_with_params[0].params.arrays.get("slug"),
+            Some(&Vec::<String>::new()),
+            "zero-segment optional catchall must surface `slug: []`",
+        );
+        assert_eq!(
+            out.resolved_with_params[1].params.arrays.get("slug"),
+            Some(&vec!["guides".to_string(), "install".to_string()]),
         );
     }
 

--- a/docs/src/content/docs-ja/concepts/routing.mdx
+++ b/docs/src/content/docs-ja/concepts/routing.mdx
@@ -18,6 +18,7 @@ zfb は `pages/` ディレクトリ配下で **ファイルシステムルーテ
 | `pages/blog/index.tsx` | `/blog` | |
 | `pages/blog/[slug].tsx` | `/blog/:slug`（動的） | |
 | `pages/docs/[...slug].tsx` | `/docs/:slug*`（catchall） | |
+| `pages/docs/[[...slug]].tsx` | `/docs/:slug*?`（オプショナル catchall） | ベース URL の `/docs` にもマッチ |
 | `pages/[lang]/[slug].tsx` | `/:lang/:slug` | |
 
 最初に押さえておきたいルールがいくつかあります。
@@ -33,6 +34,8 @@ zfb は `pages/` ディレクトリ配下で **ファイルシステムルーテ
 ## 静的・動的・catchall ルート
 
 静的ルート（`pages/about.tsx`）は単一の具体的な URL にマッチします。動的ルートはファイル名に `[param]` の角括弧を使って単一のパスセグメントをキャプチャし、catchall ルートは `[...param]` を使って末尾の任意個数のセグメントをキャプチャします。
+
+catchall は **オプショナル** にもできます。二重角括弧の `[[...param]]` はディレクトリ直下のベース URL にもマッチします — `pages/docs/[[...slug]].tsx` は `/docs/a/b` に加えて `/docs`（`slug = []`）も配信します。必須形の `[...param]` は厳密なままで、ゼロセグメントには決してマッチしません。オプショナル catchall はルートの最後のセグメントでなければならず、同じ位置の兄弟 `index.tsx`（または同位置の `[...param]`）とは共存できません — 同じ URL を取り合うため、ルーターはスキャン時にこの組み合わせを拒否します。
 
 ```tsx
 // pages/blog/[slug].tsx

--- a/docs/src/content/docs/concepts/dynamic-routes.mdx
+++ b/docs/src/content/docs/concepts/dynamic-routes.mdx
@@ -128,6 +128,7 @@ you need to look up an entry by it.
 | `pages/about.tsx` | static | `/about` | n/a |
 | `pages/blog/[slug].tsx` | dynamic | `/blog/hello-zfb` | `{ slug: string }` |
 | `pages/docs/[...slug].tsx` | catchall | `/docs/a/b/c` | `{ slug: string[] }` |
+| `pages/docs/[[...slug]].tsx` | optional catchall | `/docs` and `/docs/a/b/c` | `{ slug: string[] }` (`[]` for the bare URL) |
 | `pages/[lang]/[slug].tsx` | dynamic × 2 | `/ja/intro` | `{ lang: string, slug: string }` |
 
 When two patterns can match the same URL, the more specific one wins:
@@ -141,6 +142,11 @@ this when it builds the route table — see
   error before any HTML is written.
 - For catchall segments, `params.slug` must be a `string[]` (even with
   one element). Passing a plain string is a type error.
+- A required catchall (`[...slug]`) rejects the empty array — it always
+  needs at least one segment. To build the bare directory URL (`/docs`),
+  rename the file to the optional form (`[[...slug]]`) and return an
+  explicit `{ params: { slug: [] } }` entry. `[""]` and `""` stay
+  invalid for both forms.
 - `paths()` is **synchronous**. The whole content snapshot is loaded
   before any page evaluates, so there's no async boundary to wait
   on. Keep it pure-data and deterministic — the router calls it

--- a/docs/src/content/docs/concepts/routing.mdx
+++ b/docs/src/content/docs/concepts/routing.mdx
@@ -18,6 +18,7 @@ zfb uses **file-system routing** under the `pages/` directory. The router scans 
 | `pages/blog/index.tsx` | `/blog` | |
 | `pages/blog/[slug].tsx` | `/blog/:slug` (dynamic) | |
 | `pages/docs/[...slug].tsx` | `/docs/:slug*` (catchall) | |
+| `pages/docs/[[...slug]].tsx` | `/docs/:slug*?` (optional catchall) | also matches the bare `/docs` |
 | `pages/[lang]/[slug].tsx` | `/:lang/:slug` | |
 
 A few rules worth knowing up front:
@@ -33,6 +34,8 @@ The scan is performed by `Router::scan` in the `zfb-router` crate. Results are s
 ## Static, dynamic, and catchall routes
 
 Static routes (`pages/about.tsx`) match a single concrete URL. Dynamic routes use `[param]` brackets in the file name to capture a single path segment, and catchall routes use `[...param]` to capture any number of trailing segments.
+
+A catchall can also be **optional**: `[[...param]]` (double brackets) matches the bare directory URL as well — `pages/docs/[[...slug]].tsx` serves `/docs` (with `slug = []`) in addition to `/docs/a/b`. The required form `[...param]` stays strict and never matches zero segments. An optional catchall must be the last segment of its route, and it cannot coexist with a sibling `index.tsx` (or a `[...param]` at the same position) — both would claim the same URLs, so the router rejects the combination at scan time.
 
 ```tsx
 // pages/blog/[slug].tsx

--- a/packages/zfb-runtime/package.json
+++ b/packages/zfb-runtime/package.json
@@ -80,7 +80,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "hono": "^4.7.0"
+    "hono": "^4.12.23"
   },
   "peerDependencies": {
     "@takazudo/zfb": "workspace:*"

--- a/packages/zfb-runtime/src/__tests__/router.test.ts
+++ b/packages/zfb-runtime/src/__tests__/router.test.ts
@@ -842,3 +842,108 @@ describe("createPageRouter — __paths__ endpoint", () => {
     expect(body).toEqual([{ params: { slug: "hello" } }, { params: { slug: "world" } }]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Issue #812 — optional catchall (`[[...slug]]` → `/docs/:slug{.+}?`)
+// ---------------------------------------------------------------------------
+
+describe("createPageRouter — optional catchall (issue #812)", () => {
+  afterEach(() => {
+    setContentSnapshot(undefined);
+  });
+
+  /**
+   * Helper: build a router with one optional-catchall page whose paths()
+   * covers the zero-segment case (`slug: []`) and a nested path. Captures
+   * the input passed to default() for shape assertions.
+   */
+  function optionalCatchallRouter(): {
+    router: ReturnType<typeof createPageRouter>;
+    received: () => unknown;
+  } {
+    let received: unknown = null;
+    const page: PageModule & { paths: () => unknown[] } = {
+      default: (input) => {
+        received = input;
+        return null;
+      },
+      paths: () => [
+        { params: { slug: [] }, props: { title: "Docs home" } },
+        { params: { slug: ["guides", "install"] }, props: { title: "Install" } },
+      ],
+    };
+    const router = createPageRouter({
+      pages: [{ route: "/docs/:slug{.+}?", module: () => Promise.resolve(page) }],
+      contentSnapshot: { collections: {} },
+      framework: { renderToString: () => "" },
+    });
+    return { router, received: () => received };
+  }
+
+  it("renders the bare URL from the explicit `slug: []` paths() entry", async () => {
+    // Hono matches `/docs` for `/docs/:slug{.+}?` with NO params captured.
+    // The router must still resolve the paths() entry whose slug is []
+    // instead of rendering with `{}` (the pre-#812 bug).
+    const { router, received } = optionalCatchallRouter();
+    const res = await router(new Request("http://test.local/docs"));
+    expect(res.status).toBe(200);
+    expect(received()).toEqual({
+      params: { slug: [] },
+      title: "Docs home",
+    });
+  });
+
+  it("renders nested paths exactly like a required catchall", async () => {
+    const { router, received } = optionalCatchallRouter();
+    const res = await router(new Request("http://test.local/docs/guides/install"));
+    expect(res.status).toBe(200);
+    expect(received()).toEqual({
+      params: { slug: ["guides", "install"] },
+      title: "Install",
+    });
+  });
+
+  it("returns 404 for a nested URL not enumerated by paths()", async () => {
+    const { router } = optionalCatchallRouter();
+    const res = await router(new Request("http://test.local/docs/missing"));
+    expect(res.status).toBe(404);
+  });
+
+  it("does not match the trailing-slash form of the bare URL", async () => {
+    // `/docs/` is NOT matched by Hono's `:slug{.+}?` (probed on 4.12.x);
+    // pin that here so a Hono behaviour change is caught by CI.
+    const { router } = optionalCatchallRouter();
+    const res = await router(new Request("http://test.local/docs/"));
+    expect(res.status).toBe(404);
+  });
+
+  it("required catchall keeps rejecting the bare URL (no zero-segment match)", async () => {
+    const page: PageModule & { paths: () => unknown[] } = {
+      default: () => null,
+      paths: () => [{ params: { slug: ["a"] } }],
+    };
+    const router = createPageRouter({
+      pages: [{ route: "/docs/:slug{.+}", module: () => Promise.resolve(page) }],
+      contentSnapshot: { collections: {} },
+      framework: { renderToString: () => "" },
+    });
+    const bare = await router(new Request("http://test.local/docs"));
+    expect(bare.status).toBe(404);
+    const nested = await router(new Request("http://test.local/docs/a"));
+    expect(nested.status).toBe(200);
+  });
+
+  it("zero-segment URL 404s when paths() has no `[]` entry", async () => {
+    const page: PageModule & { paths: () => unknown[] } = {
+      default: () => null,
+      paths: () => [{ params: { slug: ["a"] } }],
+    };
+    const router = createPageRouter({
+      pages: [{ route: "/docs/:slug{.+}?", module: () => Promise.resolve(page) }],
+      contentSnapshot: { collections: {} },
+      framework: { renderToString: () => "" },
+    });
+    const res = await router(new Request("http://test.local/docs"));
+    expect(res.status).toBe(404);
+  });
+});

--- a/packages/zfb-runtime/src/router.ts
+++ b/packages/zfb-runtime/src/router.ts
@@ -317,13 +317,26 @@ export function createPageRouter(opts: CreatePageRouterOptions): PageRouter {
       // an empty object — the component signature has no required props.
       // For dynamic routes whose URL params do not match any paths()
       // entry, we return a 404 rather than rendering with empty props.
-      const rawUrlParams = c.req.param();
-      const urlParams = (rawUrlParams ?? {}) as Record<string, string>;
-      const hasDynamicParams = Object.keys(urlParams).length > 0;
+      //
+      // Whether the route is dynamic is derived from the ROUTE PATTERN,
+      // not from the captured params: for an optional catchall
+      // (`/docs/:slug{.+}?`), Hono matches the bare `/docs` with NO
+      // params captured at all, so `Object.keys(c.req.param())` would
+      // be empty and the old gate skipped paths() entirely — rendering
+      // with `{}` instead of the entry whose `slug` is `[]`.
+      const declaredParams = routeParamSpecs(page.route);
+      const rawUrlParams = c.req.param() ?? {};
+      const urlParams: Record<string, string> = {};
+      for (const [k, v] of Object.entries(rawUrlParams)) {
+        // Unmatched optional params may surface as undefined — drop them
+        // so "param absent" is represented uniformly.
+        if (typeof v === "string") urlParams[k] = v;
+      }
+      const isDynamicRoute = declaredParams.length > 0;
 
       let componentInput: Record<string, unknown> = {};
 
-      if (hasDynamicParams && typeof mod.paths === "function") {
+      if (isDynamicRoute && typeof mod.paths === "function") {
         let pathsResult: unknown;
         try {
           pathsResult = await mod.paths();
@@ -358,15 +371,27 @@ export function createPageRouter(opts: CreatePageRouterOptions): PageRouter {
         // /docs/[...slug]), Hono returns a slash-joined string (e.g.
         // "guides/install"), so we compare against the paths() entry's
         // params.slug joined with "/".
+        //
+        // Matching iterates the params DECLARED by the route pattern so
+        // the zero-segment optional-catchall case is covered: when Hono
+        // matched `/docs` for `/docs/:slug{.+}?` no `slug` param exists
+        // in the URL, and the matching entry is the one whose param is
+        // the explicit empty array (`{ slug: [] }`).
         const match = (pathsResult as PathsEntry[]).find((entry) => {
-          return Object.entries(urlParams).every(([k, v]) => {
-            const paramVal = entry.params[k];
+          return declaredParams.every(({ name, optionalCatchall }) => {
+            const urlVal = urlParams[name];
+            const paramVal = entry.params[name];
+            if (urlVal === undefined) {
+              // Param absent from the URL: only valid for an optional
+              // catchall, and only against the explicit `[]` entry.
+              return optionalCatchall && Array.isArray(paramVal) && paramVal.length === 0;
+            }
             if (Array.isArray(paramVal)) {
               // catchall: paths() emits slug as string[] but Hono
               // provides it as a "/"-joined string
-              return paramVal.join("/") === v;
+              return paramVal.join("/") === urlVal;
             }
-            return String(paramVal) === v;
+            return String(paramVal) === urlVal;
           });
         });
 
@@ -386,7 +411,7 @@ export function createPageRouter(opts: CreatePageRouterOptions): PageRouter {
           params: match.params,
           ...(match.props ?? {}),
         };
-      } else if (!hasDynamicParams && typeof mod.getStaticProps === "function") {
+      } else if (!isDynamicRoute && typeof mod.getStaticProps === "function") {
         // Static route with `getStaticProps`: call it to fetch build-time
         // data and pass the returned props to the default component. This
         // supports the `export async function getStaticProps()` pattern
@@ -490,13 +515,48 @@ function isPathsEntry(x: unknown): x is PathsEntry {
 }
 
 /**
+ * One param declared by a Hono route pattern. `optionalCatchall` is
+ * `true` for the `:name{.+}?` form (file-system `[[...name]]`), whose
+ * zero-segment match captures no param at all.
+ */
+interface RouteParamSpec {
+  readonly name: string;
+  readonly optionalCatchall: boolean;
+}
+
+/**
+ * Parse the params declared by a Hono route pattern (the `route` string
+ * the build pipeline registers, e.g. `/blog/:slug`, `/docs/:slug{.+}`,
+ * `/docs/:slug{.+}?`). Static routes return an empty list.
+ *
+ * Only the pattern shapes emitted by `bracket_to_hono` (zfb-build) are
+ * recognised — `:name`, `:name{.+}`, `:name{.+}?` — which is the entire
+ * grammar the file router produces.
+ */
+function routeParamSpecs(route: string): RouteParamSpec[] {
+  const specs: RouteParamSpec[] = [];
+  for (const seg of route.split("/")) {
+    if (!seg.startsWith(":")) continue;
+    const optionalCatchall = seg.endsWith("?");
+    const body = optionalCatchall ? seg.slice(1, -1) : seg.slice(1);
+    const braceIdx = body.indexOf("{");
+    const name = braceIdx === -1 ? body : body.slice(0, braceIdx);
+    if (name.length > 0) {
+      specs.push({ name, optionalCatchall });
+    }
+  }
+  return specs;
+}
+
+/**
  * Heuristic check for user-authored routes that may shadow the
  * synthetic `/__paths__/<encoded-route-key>` endpoint.
  *
  * Returns true when the route literal contains `/__paths__` (an
  * obvious collision) or when its first segment is a Hono catchall
- * (`:name{.+}`) or a file-system catchall (`[...name]`) at the root —
- * those would match `/__paths__/...` once Hono dispatches to them.
+ * (`:name{.+}`, optionally `:name{.+}?`) or a file-system catchall
+ * (`[...name]` / `[[...name]]`) at the root — those would match
+ * `/__paths__/...` once Hono dispatches to them.
  */
 function routeShadowsPathsEndpoint(route: string): boolean {
   if (route.includes("/__paths__")) {
@@ -506,12 +566,15 @@ function routeShadowsPathsEndpoint(route: string): boolean {
   // anything deeper cannot match `/__paths__` because the literal
   // first segment differs.
   const firstSeg = route.replace(/^\/+/, "").split("/")[0] ?? "";
-  // Hono regex-quantifier catchall: `:name{.+}`.
-  if (/^:[A-Za-z_][\w]*\{\.[+*]\}$/.test(firstSeg)) {
+  // Hono regex-quantifier catchall: `:name{.+}` / optional `:name{.+}?`.
+  if (/^:[A-Za-z_][\w]*\{\.[+*]\}\??$/.test(firstSeg)) {
     return true;
   }
-  // File-system catchall (pre-bracket-to-hono): `[...name]`.
+  // File-system catchall (pre-bracket-to-hono): `[...name]` / `[[...name]]`.
   if (/^\[\.\.\.[A-Za-z_][\w]*\]$/.test(firstSeg)) {
+    return true;
+  }
+  if (/^\[\[\.\.\.[A-Za-z_][\w]*\]\]$/.test(firstSeg)) {
     return true;
   }
   return false;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,8 +188,8 @@ importers:
   packages/zfb-runtime:
     dependencies:
       hono:
-        specifier: ^4.7.0
-        version: 4.12.15
+        specifier: ^4.12.23
+        version: 4.12.23
     devDependencies:
       '@takazudo/zfb':
         specifier: workspace:*
@@ -2555,8 +2555,8 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
 
-  hono@4.12.15:
-    resolution: {integrity: sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==}
+  hono@4.12.23:
+    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@3.0.3:
@@ -6379,7 +6379,7 @@ snapshots:
 
   he@1.2.0: {}
 
-  hono@4.12.15: {}
+  hono@4.12.23: {}
 
   html-escaper@3.0.3: {}
 


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/814

---

## Summary

- Add Next.js-style **optional catchall** route support with `[[...slug]]` — matches the bare directory URL (`/docs` with `slug = []`) plus nested paths (`/docs/a/b`), fixing the zero-segment gap where `[...slug]` rejected `[]`, `[""]`, and the `[[...slug]]` filename. Closes #812
- **Raise the declared hono floor** in `@takazudo/zfb-runtime` from `^4.7.0` to `^4.12.23` so the range no longer admits versions carrying the 9 known advisories (all patched at >=4.12.21); lockfile refreshed and the embedded `HONO_VERSION` pin in `crates/zfb/build.rs` synced. Closes #813
- Align route precedence between dev SSR and the bundled Hono runtime by switching to **per-segment specificity ordering**, preventing dynamic routes from stealing optional-catchall matches (codex review fix).

## Changes

**Routing semantics**
- Teach the router / build pipeline / type model to recognize `[[...param]]` as an optional catchall and emit the Hono template `:param{.+}?`.
- Preserve required-catchall behavior: `[...param]` still requires at least one segment; the optional form accepts zero segments only via an explicit empty array in `paths()` (`""`, `"/"`, and `[""]` stay invalid for both forms).
- Trailing-slash behavior stays strict: `/docs` matches, `/docs/` does not.

**Ambiguity prevention & precedence**
- Scan-time conflict detection: an optional catchall cannot coexist with a sibling bare-URL producer (`index.tsx`, `docs.tsx`) or another catchall at the same prefix (param-name-insensitive).
- `[[...slug]]` must be the last segment; only one optional catchall per route.
- Replaced coarse route-kind sorting with a per-segment rank-vector ordering (`crates/zfb-router/src/scan.rs`, aligned with `bundler.rs::route_sort_key`) so dev SSR and prod registration choose the same most-specific route — also fixes a pre-existing required-catchall ordering quirk.

**Render / runtime integration**
- Path resolution + manifest generation map the zero-segment entry to the bare directory URL (`/docs` → `dist/docs/index.html`) and report `slug: []` (not `[""]`).
- Runtime `paths()` matching treats dynamic-ness as declared by the route pattern, so the zero-segment Hono match (no params captured) resolves the `slug: []` entry instead of rendering with empty props.
- Dev parity: `colon_template_to_bracket` and injected-route / SSR pattern matching understand the optional form.

**Dependencies**
- `packages/zfb-runtime/package.json`: `hono` `^4.7.0` → `^4.12.23`; `pnpm-lock.yaml` resolves 4.12.23 (churn limited to hono entries); `SECURITY-DEPS.md` updated; `crates/zfb/build.rs` `HONO_VERSION` synced (stale pin would panic clean builds / embed the advisoried version).

**Coverage & docs**
- Fixtures, unit and integration tests across zfb-router, zfb-render, zfb-build, zfb-server, zfb CLI/dev SSR, and zfb-runtime (vitest): bare-prefix matching, nested matches, conflict rejection, dev/prod ordering parity, required-catchall behavior unchanged.
- Documented `[[...param]]` syntax, zero-segment behavior, and conflict rules (EN + JA routing docs).

## Test Plan

- `cargo test --workspace` — 46 suites green locally
- `pnpm --filter @takazudo/zfb-runtime test` (115 tests) + `typecheck`
- `pnpm audit --prod` — hono advisories cleared
- `pnpm --filter docs build` — 219 pages
- Manual: a `[[...slug]]` page with `paths()` entries for `slug: []` and nested slugs renders `/docs` (zero-segment) and `/docs/a/b`; `/docs/` 404s; scan-time conflicts rejected.

Refs #814 (workflow tracking)