### PR TITLE
Fix 5 agent-found bugs: tailwind-disabled CSS pipeline, watcher git-restore, islands warning, tmpfile leak, CSS Modules hash reproducibility

### DIFF
--- a/crates/zfb-css/src/authored_engine.rs
+++ b/crates/zfb-css/src/authored_engine.rs
@@ -1,0 +1,65 @@
+//! Tailwind-free CSS engine: pass authored global CSS through verbatim.
+//!
+//! When a project sets `tailwind: { enabled: false }` in its config it
+//! wants to opt out of the Tailwind layers — the `@import "tailwindcss"`,
+//! the `@source` utility scan, the preflight/reset, and the subprocess —
+//! while keeping its authored global stylesheet and CSS Modules.
+//!
+//! [`AuthoredCssEngine`] is the engine half of that path. It implements
+//! [`crate::CssEngine`] by returning a fixed CSS string (the project's
+//! authored `styles/global.css`, or empty when none exists) without
+//! spawning any subprocess or synthesising any Tailwind directives. The
+//! rest of the pipeline — CSS Modules compilation, concatenation,
+//! hashing, asset emission — is engine-agnostic and runs unchanged, so
+//! the disabled path reuses [`crate::CssPipeline`] instead of
+//! hand-rolling its own combine + hash logic.
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+
+use crate::engine::CssEngine;
+
+/// A [`CssEngine`] that emits a pre-supplied authored CSS string and runs
+/// no subprocess. Used for the `tailwind.enabled = false` path so the
+/// authored global stylesheet still reaches the combined output while the
+/// Tailwind import/scan/preflight are skipped entirely.
+#[derive(Debug, Clone, Default)]
+pub struct AuthoredCssEngine {
+    css: String,
+}
+
+impl AuthoredCssEngine {
+    /// Construct an engine that returns `css` verbatim from
+    /// [`CssEngine::produce_utility_css`]. Pass the contents of the
+    /// project's authored global stylesheet, or the empty string when the
+    /// project has none.
+    pub fn new(css: impl Into<String>) -> Self {
+        Self { css: css.into() }
+    }
+}
+
+impl CssEngine for AuthoredCssEngine {
+    fn produce_utility_css(&self, _sources: &[PathBuf]) -> Result<String> {
+        Ok(self.css.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_authored_css_verbatim() {
+        let engine = AuthoredCssEngine::new("body { margin: 0; }");
+        let out = engine.produce_utility_css(&[]).unwrap();
+        assert_eq!(out, "body { margin: 0; }");
+    }
+
+    #[test]
+    fn empty_when_no_authored_css() {
+        let engine = AuthoredCssEngine::default();
+        let out = engine.produce_utility_css(&[]).unwrap();
+        assert!(out.is_empty());
+    }
+}

--- a/crates/zfb-css/src/engine.rs
+++ b/crates/zfb-css/src/engine.rs
@@ -343,6 +343,29 @@ fn strip_css_comments(text: &str) -> String {
     out
 }
 
+/// Whether a single CSS line is an `@import "tailwindcss"` directive.
+///
+/// Matches the v4 umbrella import (`@import "tailwindcss"`) and the split
+/// sub-imports (`tailwindcss/preflight`, `tailwindcss/utilities`, …) in
+/// either quote style, after trimming surrounding whitespace. This is the
+/// single predicate shared by:
+///
+/// - [`build_synthesised_entry_css`]'s `user_has_import` detection (the
+///   Tailwind-enabled path), and
+/// - the `zfb` build command's authored-CSS import stripper (the
+///   `tailwind.enabled = false` path, issue #824),
+///
+/// so both paths agree byte-for-byte on what counts as "the Tailwind
+/// import". The caller passes a raw line; trimming happens here, so callers
+/// feeding lines with or without a trailing `\n` get identical results.
+pub fn is_tailwind_import_line(line: &str) -> bool {
+    let t = line.trim();
+    t.starts_with("@import \"tailwindcss\"")
+        || t.starts_with("@import 'tailwindcss'")
+        || t.starts_with("@import \"tailwindcss/")
+        || t.starts_with("@import 'tailwindcss/")
+}
+
 /// Build the synthesised entry CSS that the engine hands to Tailwind v4.
 ///
 /// The output, in order, is:
@@ -380,13 +403,7 @@ pub fn build_synthesised_entry_css(
     let user_has_import = input_css_text
         .map(|t| {
             let stripped = strip_css_comments(t);
-            stripped.lines().any(|l| {
-                let t = l.trim();
-                t.starts_with("@import \"tailwindcss\"")
-                    || t.starts_with("@import 'tailwindcss'")
-                    || t.starts_with("@import \"tailwindcss/")
-                    || t.starts_with("@import 'tailwindcss/")
-            })
+            stripped.lines().any(is_tailwind_import_line)
         })
         .unwrap_or(false);
 

--- a/crates/zfb-css/src/engine.rs
+++ b/crates/zfb-css/src/engine.rs
@@ -491,6 +491,66 @@ impl TailwindSubprocessEngine {
     }
 }
 
+/// Filename prefix for the synthesised Tailwind entry temp file. Shared by
+/// the create site and the self-healing sweep so the two never drift.
+const ENTRY_TMP_PREFIX: &str = "zfb-tailwind-entry-";
+/// Filename suffix (extension) for the synthesised Tailwind entry temp file.
+const ENTRY_TMP_SUFFIX: &str = ".css";
+/// Minimum age before the sweep will delete a stranded entry temp file.
+///
+/// The sweep removes only files older than this so two concurrent builds in
+/// the same project dir cannot delete each other's *live* entry file: a
+/// Tailwind pass reads its entry within seconds, well under this window, so a
+/// file this old is necessarily orphaned by an earlier aborted run.
+const ENTRY_TMP_STALE_AFTER: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Delete `zfb-tailwind-entry-*.css` files left in `dir` by a previous run
+/// that died before its [`tempfile::NamedTempFile`] `Drop` could clean up
+/// (SIGKILL / crash / Ctrl-C). See zfb#821.
+///
+/// Only files older than [`ENTRY_TMP_STALE_AFTER`] are removed, so a sibling
+/// build running concurrently in the same project keeps its freshly-created
+/// live entry. Best-effort: any individual error (unreadable dir, racing
+/// unlink, permission denied) is ignored — a failed sweep must never break a
+/// build.
+fn sweep_stale_entry_files(dir: &Path) {
+    sweep_stale_entry_files_at(dir, std::time::SystemTime::now());
+}
+
+/// Core of [`sweep_stale_entry_files`], parameterised on the reference time
+/// so tests can drive staleness without manipulating file mtimes (which has
+/// no `std`-only setter). A file counts as stale when
+/// `now - mtime >= ENTRY_TMP_STALE_AFTER`.
+fn sweep_stale_entry_files_at(dir: &Path, now: std::time::SystemTime) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return,
+    };
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        if !(name.starts_with(ENTRY_TMP_PREFIX) && name.ends_with(ENTRY_TMP_SUFFIX)) {
+            continue;
+        }
+        // Skip directories and anything we can't stat.
+        let metadata = match entry.metadata() {
+            Ok(m) if m.is_file() => m,
+            _ => continue,
+        };
+        // Age out via mtime: only sweep files that have been sitting long
+        // enough to be certainly orphaned, never a sibling's live entry.
+        let old_enough = metadata
+            .modified()
+            .ok()
+            .and_then(|mtime| now.duration_since(mtime).ok())
+            .map(|age| age >= ENTRY_TMP_STALE_AFTER)
+            .unwrap_or(false);
+        if old_enough {
+            let _ = std::fs::remove_file(entry.path());
+        }
+    }
+}
+
 impl CssEngine for TailwindSubprocessEngine {
     fn produce_utility_css(&self, sources: &[PathBuf]) -> Result<String> {
         // Build the synthesised entry CSS. Read user input_css if set —
@@ -526,13 +586,24 @@ impl CssEngine for TailwindSubprocessEngine {
             ));
         }
 
+        // Self-heal: delete entry temp files stranded by a past abnormal
+        // termination (SIGKILL / crash / Ctrl-C skips the RAII `Drop` that
+        // normally removes them). Done before we create the new file so the
+        // project root is clean even if `git add -A` ran since the leak.
+        // See zfb#821.
+        sweep_stale_entry_files(&self.config.working_dir);
+
         // Materialise the synthesised entry CSS into a temp file so
-        // Tailwind's `@source` resolution uses our wrapper (and the user
-        // file's relative imports still resolve, since the temp file is
-        // adjacent to the working_dir, not to the user file).
+        // Tailwind's `@source` resolution uses our wrapper. The file lives
+        // in `working_dir` (not a subdir like `.zfb/`) on purpose: the
+        // user's `input_css` is inlined into this entry, so any relative
+        // `@import "./x.css";` in it resolves against the entry file's
+        // directory — which must be `working_dir` for those imports to find
+        // the user's siblings. `@source` paths are already absolute, so they
+        // are unaffected by the location.
         let mut entry_tmp = tempfile::Builder::new()
-            .prefix("zfb-tailwind-entry-")
-            .suffix(".css")
+            .prefix(ENTRY_TMP_PREFIX)
+            .suffix(ENTRY_TMP_SUFFIX)
             .tempfile_in(&self.config.working_dir)
             .context("failed to allocate temp file for tailwind entry CSS")?;
         {
@@ -862,5 +933,91 @@ mod tests {
             stripped.contains("@import \"tailwindcss\";"),
             "active import after block comment must survive stripping; got:\n{stripped}"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // zfb#821 — self-healing sweep of stranded entry temp files
+    // -----------------------------------------------------------------------
+
+    use std::time::{Duration, SystemTime};
+
+    /// A reference "now" far enough in the future that any just-written file
+    /// reads as stale to the sweep — exercises the stale branch without an
+    /// mtime setter (which `std` lacks).
+    fn future_now() -> SystemTime {
+        SystemTime::now() + ENTRY_TMP_STALE_AFTER + Duration::from_secs(3600)
+    }
+
+    /// A stale `zfb-tailwind-entry-*.css` left in `working_dir` by an aborted
+    /// run (SIGKILL skipped its RAII `Drop`) must be removed by the sweep so a
+    /// later `git add -A` cannot sweep it into the user's repo.
+    #[test]
+    fn sweep_removes_stale_entry_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let stranded = dir.path().join("zfb-tailwind-entry-UErIaE.css");
+        std::fs::write(&stranded, b"/* leaked */").unwrap();
+
+        // `now` in the future → the just-written file is past the stale window.
+        sweep_stale_entry_files_at(dir.path(), future_now());
+
+        assert!(
+            !stranded.exists(),
+            "stale entry temp file should have been swept; still present at {}",
+            stranded.display()
+        );
+    }
+
+    /// The sweep must NOT delete a freshly-created entry file — that would be
+    /// a *live* sibling's file in a concurrent build in the same project dir.
+    #[test]
+    fn sweep_keeps_fresh_entry_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let live = dir.path().join("zfb-tailwind-entry-rN8CIp.css");
+        std::fs::write(&live, b"/* live */").unwrap();
+
+        // Real `now`: the file's mtime is within the stale window, so it stays.
+        sweep_stale_entry_files_at(dir.path(), SystemTime::now());
+
+        assert!(
+            live.exists(),
+            "a fresh entry temp file (live concurrent build) must be kept"
+        );
+    }
+
+    /// The sweep must touch ONLY `zfb-tailwind-entry-*.css` files. Unrelated
+    /// files in the project root — even ones old enough to be eligible by age
+    /// — must survive.
+    #[test]
+    fn sweep_leaves_unrelated_files_alone() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let user_file = dir.path().join("global.css");
+        let other_tmp = dir.path().join("zfb-tailwind-out-abc.css"); // output temp, different prefix
+        let no_ext = dir.path().join("zfb-tailwind-entry-noext"); // right prefix, wrong suffix
+        std::fs::write(&user_file, b"body{}").unwrap();
+        std::fs::write(&other_tmp, b"/* out */").unwrap();
+        std::fs::write(&no_ext, b"x").unwrap();
+
+        // Future `now` makes every file age-eligible; only the name filter
+        // protects the unrelated ones.
+        sweep_stale_entry_files_at(dir.path(), future_now());
+
+        assert!(user_file.exists(), "user CSS must never be swept");
+        assert!(
+            other_tmp.exists(),
+            "output temp (different prefix) must not be swept by the entry sweep"
+        );
+        assert!(
+            no_ext.exists(),
+            "file with the entry prefix but wrong suffix must not be swept"
+        );
+    }
+
+    /// The sweep on a non-existent directory must be a silent no-op (best
+    /// effort) — it must never panic or surface an error into the build.
+    #[test]
+    fn sweep_on_missing_dir_is_noop() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing = dir.path().join("does-not-exist");
+        sweep_stale_entry_files_at(&missing, future_now()); // must not panic
     }
 }

--- a/crates/zfb-css/src/engine.rs
+++ b/crates/zfb-css/src/engine.rs
@@ -500,8 +500,20 @@ const ENTRY_TMP_SUFFIX: &str = ".css";
 ///
 /// The sweep removes only files older than this so two concurrent builds in
 /// the same project dir cannot delete each other's *live* entry file: a
-/// Tailwind pass reads its entry within seconds, well under this window, so a
-/// file this old is necessarily orphaned by an earlier aborted run.
+/// Tailwind pass opens its `-i` entry at spawn (milliseconds), ~1000x under
+/// this window, so a file this old is necessarily orphaned by an earlier
+/// aborted run.
+///
+/// Out of scope (deliberately): the residual cross-process race where two
+/// `zfb` builds run in the *same* `working_dir` and one build's Tailwind has
+/// not opened its entry within this window (e.g. a multi-minute-latency
+/// wrapper via `ZFB_TAILWIND_BIN`). std offers no portable file-liveness
+/// check, a lockfile would add a dependency for a non-supported workflow, and
+/// the worst case is a single build failing loudly with "file not found" —
+/// never corruption or a silent bad artifact. On Unix, unlinking a file the
+/// reader has already opened is harmless (the inode survives until fd close),
+/// so only the create→open gap is at risk; on Windows the open file cannot be
+/// unlinked at all.
 const ENTRY_TMP_STALE_AFTER: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// Delete `zfb-tailwind-entry-*.css` files left in `dir` by a previous run

--- a/crates/zfb-css/src/lib.rs
+++ b/crates/zfb-css/src/lib.rs
@@ -76,6 +76,7 @@
 //! that prefers to inline the maps can do so without touching the disk
 //! artefacts.
 
+pub mod authored_engine;
 pub mod emitter;
 pub mod engine;
 pub mod modules;
@@ -83,6 +84,7 @@ pub mod native_engine;
 pub mod pipeline;
 pub mod scanner;
 
+pub use authored_engine::AuthoredCssEngine;
 pub use emitter::{css_relative_path, CssEmitterOutput, CssProductionEmitter};
 pub use engine::{
     build_synthesised_entry_css, CssEngine, TailwindSubprocessConfig, TailwindSubprocessEngine,

--- a/crates/zfb-css/src/lib.rs
+++ b/crates/zfb-css/src/lib.rs
@@ -87,7 +87,8 @@ pub mod scanner;
 pub use authored_engine::AuthoredCssEngine;
 pub use emitter::{css_relative_path, CssEmitterOutput, CssProductionEmitter};
 pub use engine::{
-    build_synthesised_entry_css, CssEngine, TailwindSubprocessConfig, TailwindSubprocessEngine,
+    build_synthesised_entry_css, is_tailwind_import_line, CssEngine, TailwindSubprocessConfig,
+    TailwindSubprocessEngine,
 };
 pub use modules::{CssModulesOutput, CssModulesProcessor};
 pub use native_engine::NativeRustEngine;

--- a/crates/zfb-css/src/modules.rs
+++ b/crates/zfb-css/src/modules.rs
@@ -35,6 +35,28 @@ pub struct CssModulesConfig {
     /// Class-name pattern. Defaults to lightningcss's `[hash]_[local]`
     /// equivalent (its own default).
     pub pattern: Option<String>,
+
+    /// Project root used to derive the *project-relative* filename that
+    /// lightningcss hashes into the scoped class prefix (`[hash]`).
+    ///
+    /// The default `[hash]_[local]` pattern derives `[hash]` from the
+    /// filename we hand to lightningcss. Passing the absolute module path
+    /// there makes byte-identical sources produce different scoped class
+    /// names — and a different `styles-<hash>.css` filename — across
+    /// machines/checkout paths (see issue #825). Passing the path
+    /// relative to this root (with `/` separators) keeps `[hash]` stable
+    /// across checkouts while staying unique across same-basename modules
+    /// in different directories.
+    ///
+    /// When `None`, or when a module path is not under this root, we fall
+    /// back to the absolute path — the non-reproducible-but-correct
+    /// behaviour from before #825.
+    ///
+    /// Note: this only affects the *string fed to lightningcss for
+    /// hashing*. The returned [`CssModulesOutput::class_maps`] stays keyed
+    /// by the original absolute path so downstream bundler lookups are
+    /// unaffected.
+    pub project_root: Option<PathBuf>,
 }
 
 /// Output of [`CssModulesProcessor::process`].
@@ -122,7 +144,7 @@ impl CssModulesProcessor {
             .map_err(|e| anyhow::anyhow!("invalid CSS Modules pattern {pattern:?}: {e}"))?;
 
         let parser_opts = ParserOptions {
-            filename: path.to_string_lossy().into_owned(),
+            filename: hash_filename(path, self.config.project_root.as_deref()),
             css_modules: Some(LcssConfig {
                 pattern: pattern_parsed,
                 dashed_idents: false,
@@ -155,5 +177,141 @@ impl CssModulesProcessor {
         }
 
         Ok((printed.code, names))
+    }
+}
+
+/// Derive the filename string fed to a *user-visible hash* for a CSS
+/// Modules file.
+///
+/// When `project_root` is `Some` and `path` is under it, returns the
+/// project-relative path with `/` separators (so the hash is stable
+/// across machines/checkout paths — see issue #825, and matches across
+/// OSes by normalising Windows `\` to `/`). Otherwise falls back to the
+/// absolute (lossy) path: stable within a build, just not across
+/// relocations.
+///
+/// Used for the lightningcss `[hash]` prefix in [`CssModulesProcessor`]
+/// and for the class-map JSON filename hash in `pipeline.rs`, so both
+/// user-visible hashes derive from the same normalised string.
+pub(crate) fn hash_filename(path: &Path, project_root: Option<&Path>) -> String {
+    let rel = project_root.and_then(|root| path.strip_prefix(root).ok());
+    let chosen = rel.unwrap_or(path);
+    let lossy = chosen.to_string_lossy();
+    // Normalise Windows separators so the hash matches across OSes.
+    if lossy.contains('\\') {
+        lossy.replace('\\', "/")
+    } else {
+        lossy.into_owned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SOURCE: &str = ".section { color: red; }";
+
+    fn processor_with_root(root: &str) -> CssModulesProcessor {
+        CssModulesProcessor::new(CssModulesConfig {
+            project_root: Some(PathBuf::from(root)),
+            ..CssModulesConfig::default()
+        })
+    }
+
+    /// Synthetic absolute paths only — no tempdirs. A disk-backed
+    /// tempdir on macOS resolves `/var` → `/private/var`, which would
+    /// make `strip_prefix(project_root)` flaky; the production inputs
+    /// are lexical (see `scanner::resolve_specifier`), so synthetic
+    /// paths model them faithfully.
+    fn scoped_name(processor: &CssModulesProcessor, path: &str) -> String {
+        let (_, names) = processor
+            .process_source(Path::new(path), SOURCE)
+            .expect("process_source");
+        names
+            .get("section")
+            .cloned()
+            .expect("scoped name for `section`")
+    }
+
+    /// #825: byte-identical sources at the *same project-relative path*
+    /// under two different absolute roots must produce identical scoped
+    /// class names, so builds are reproducible across machines/checkout
+    /// paths.
+    #[test]
+    fn scoped_names_are_stable_across_project_roots() {
+        let a = scoped_name(
+            &processor_with_root("/home/runner/work/proj"),
+            "/home/runner/work/proj/src/card.module.css",
+        );
+        let b = scoped_name(
+            &processor_with_root("/Users/dev/repos/proj"),
+            "/Users/dev/repos/proj/src/card.module.css",
+        );
+        assert_eq!(
+            a, b,
+            "same relative path under different roots must hash identically"
+        );
+    }
+
+    /// Uniqueness is preserved: two same-basename modules in different
+    /// subdirectories of the *same* root must still get different scoped
+    /// names (the relative path, not just the basename, feeds the hash).
+    #[test]
+    fn scoped_names_differ_for_same_basename_in_different_dirs() {
+        let processor = processor_with_root("/proj");
+        let a = scoped_name(&processor, "/proj/src/a/card.module.css");
+        let b = scoped_name(&processor, "/proj/src/b/card.module.css");
+        assert_ne!(
+            a, b,
+            "same basename in different dirs must keep distinct scoped names"
+        );
+    }
+
+    /// Without a `project_root`, the absolute path feeds the hash (the
+    /// pre-#825 behaviour): two different absolute paths yield different
+    /// names — correct within a build, just not reproducible across
+    /// relocations.
+    #[test]
+    fn scoped_names_fall_back_to_absolute_path_without_root() {
+        let processor = CssModulesProcessor::with_default_config();
+        let a = scoped_name(&processor, "/root-a/src/card.module.css");
+        let b = scoped_name(&processor, "/root-b/src/card.module.css");
+        assert_ne!(
+            a, b,
+            "absolute-path fallback keeps per-build uniqueness when no root is set"
+        );
+    }
+
+    #[test]
+    fn hash_filename_relativises_under_root() {
+        assert_eq!(
+            hash_filename(
+                Path::new("/proj/src/card.module.css"),
+                Some(Path::new("/proj"))
+            ),
+            "src/card.module.css"
+        );
+    }
+
+    #[test]
+    fn hash_filename_falls_back_to_absolute_outside_root() {
+        // Path not under the root → lossy absolute fallback.
+        assert_eq!(
+            hash_filename(
+                Path::new("/elsewhere/card.module.css"),
+                Some(Path::new("/proj"))
+            ),
+            "/elsewhere/card.module.css"
+        );
+    }
+
+    #[test]
+    fn hash_filename_normalises_backslashes() {
+        // Even on a non-Windows host, a backslash in the relative tail
+        // must normalise so the hash matches a Unix checkout.
+        assert_eq!(
+            hash_filename(Path::new(r"sub\card.module.css"), None),
+            "sub/card.module.css"
+        );
     }
 }

--- a/crates/zfb-css/src/modules.rs
+++ b/crates/zfb-css/src/modules.rs
@@ -73,6 +73,24 @@ pub struct CssModulesOutput {
     pub class_maps: HashMap<PathBuf, HashMap<String, String>>,
 }
 
+impl CssModulesConfig {
+    /// Production config that hashes scoped class names off the
+    /// *project-relative* module path (issue #825).
+    ///
+    /// This is the single source of truth for the reproducible-hash config
+    /// used by the build's CSS pipeline: the emitted `styles-<hash>.css` and
+    /// the build-time JSX class-map rewrite MUST construct their
+    /// `CssModulesProcessor` with the same `project_root` so the scoped names
+    /// (and therefore the asset hash) agree. Using this constructor at every
+    /// such site makes the invariant structural instead of comment-enforced.
+    pub fn for_project_root(root: &Path) -> Self {
+        Self {
+            project_root: Some(root.to_path_buf()),
+            ..Self::default()
+        }
+    }
+}
+
 /// Compiles `*.module.css` files into scoped CSS plus a class-name map.
 #[derive(Debug, Clone)]
 pub struct CssModulesProcessor {

--- a/crates/zfb-css/src/pipeline.rs
+++ b/crates/zfb-css/src/pipeline.rs
@@ -173,7 +173,11 @@ impl<E: CssEngine> CssPipeline<E> {
 
         // Emit JSON class-name maps if requested.
         let class_map_files = if let Some(dir) = &self.config.class_map_dir {
-            write_class_map_files(dir, &modules.class_maps)?
+            write_class_map_files(
+                dir,
+                &modules.class_maps,
+                self.config.modules_config.project_root.as_deref(),
+            )?
         } else {
             HashMap::new()
         };
@@ -225,7 +229,11 @@ impl<E: CssEngine> CssPipeline<E> {
         // break the bytes-only path for any project that uses CSS
         // Modules.
         if let Some(dir) = &self.config.class_map_dir {
-            write_class_map_files(dir, &modules.class_maps)?;
+            write_class_map_files(
+                dir,
+                &modules.class_maps,
+                self.config.modules_config.project_root.as_deref(),
+            )?;
         }
 
         Ok(CssEmitterOutput {
@@ -278,16 +286,23 @@ impl<E: CssEngine> CssPipeline<E> {
 /// guarantees uniqueness across the whole module set even when two
 /// modules share a basename, while keeping the basename visible for
 /// debugging.
+///
+/// `project_root` is used to relativize the path before hashing so the
+/// JSON filename prefix is stable across machines/checkout paths — the
+/// same normalisation lightningcss uses for the scoped `[hash]` prefix
+/// (see issue #825 and [`crate::modules::hash_filename`]). The
+/// `class_maps` keys stay absolute; only the hash *input* is normalised.
 fn write_class_map_files(
     dir: &Path,
     class_maps: &HashMap<PathBuf, HashMap<String, String>>,
+    project_root: Option<&Path>,
 ) -> Result<HashMap<PathBuf, PathBuf>> {
     std::fs::create_dir_all(dir)
         .with_context(|| format!("failed to create class-map dir {}", dir.display()))?;
     let mut out: HashMap<PathBuf, PathBuf> = HashMap::new();
     for (module_path, names) in class_maps {
         let mut hasher = Sha256::new();
-        hasher.update(module_path.to_string_lossy().as_bytes());
+        hasher.update(crate::modules::hash_filename(module_path, project_root).as_bytes());
         let h = hex::encode(hasher.finalize());
         let prefix: &str = &h[..8];
         let basename = module_path

--- a/crates/zfb-islands/src/scanner.rs
+++ b/crates/zfb-islands/src/scanner.rs
@@ -142,6 +142,32 @@ pub struct ScanMeta {
     /// only cost is a few KB; treating the import as the signal keeps the
     /// scanner cheap.
     pub uses_client_router: bool,
+
+    /// Count of scanned modules that *look like* they intended to be a
+    /// `"use client"` island but did not register one — i.e. the source
+    /// text contains the literal substring `use client`, yet the module
+    /// contributed zero islands (issue #822).
+    ///
+    /// This is a cheap "near-miss" heuristic, not a precise diagnostic.
+    /// It flags the two authoring mistakes the empty-islands warning is
+    /// actually written for:
+    ///
+    /// - a misplaced directive — `"use client"` appears, but not as the
+    ///   first statement of the module prologue, so
+    ///   [`has_use_client_directive`] rejects it; and
+    /// - a misspelled / mis-cased directive (e.g. `"use  client"`,
+    ///   `'use client '`) that still contains the `use client` substring.
+    ///
+    /// It deliberately does *not* try to detect islands that are simply
+    /// unreachable from `pages/` (the scanner never reads those files, so
+    /// it has nothing to inspect) — that case is left to documentation.
+    ///
+    /// The caller uses this to decide *how* to report an empty island
+    /// set: when `> 0` there is a plausible authoring mistake, so the
+    /// loud warning + verify-hint is justified; when `0` the project is
+    /// island-free on purpose, so a quiet info note suffices and the
+    /// verify-hint would be pure noise.
+    pub near_miss_candidates: usize,
 }
 
 /// Abstraction over module resolution + source reading.
@@ -1279,6 +1305,10 @@ pub fn scan_islands_with_meta<R: Resolver>(
     // verdict (following `export *` re-export edges) is computed from
     // these once the walk completes.
     let mut client_router_facts: HashMap<PathBuf, ClientRouterFacts> = HashMap::new();
+    // Issue #822: count modules that contain a `"use client"`-like
+    // substring but contributed no island — likely a misplaced /
+    // misspelled directive the empty-islands warning should point at.
+    let mut near_miss_candidates: usize = 0;
 
     while let Some(current) = stack.pop() {
         if !visited.insert(current.clone()) {
@@ -1320,13 +1350,29 @@ pub fn scan_islands_with_meta<R: Resolver>(
             collect_client_router_facts(&module, |spec| resolver.resolve(&importer_dir, spec));
 
         if has_use_client_directive(&module) {
-            for record in exported_island_records(&module) {
+            let records = exported_island_records(&module);
+            if records.is_empty() {
+                // Issue #822: a valid `"use client"` module that exports
+                // nothing is still a near-miss — the author flagged it as
+                // an island but gave the bundler nothing to ship. Keep the
+                // verify-hint pointing at it.
+                near_miss_candidates += 1;
+            }
+            for record in records {
                 let key = (current.clone(), record.component_name.clone());
                 let path = current.clone();
                 found.entry(key).or_insert_with(|| {
                     Island::with_marker_name(record.component_name, path, record.marker_name)
                 });
             }
+        } else if source.contains("use client") {
+            // Issue #822: the module didn't register a valid directive
+            // (so `has_use_client_directive` is false) yet its source
+            // still mentions `use client` — a misplaced or misspelled
+            // directive is the most likely cause. Count it so the caller
+            // can keep the loud verify-hint for this genuine near-miss
+            // instead of nagging an intentionally island-free project.
+            near_miss_candidates += 1;
         }
 
         // Walk imports → push resolved paths onto the stack.
@@ -1354,6 +1400,7 @@ pub fn scan_islands_with_meta<R: Resolver>(
         found.into_values().collect(),
         ScanMeta {
             uses_client_router: resolve_client_router_usage(&client_router_facts),
+            near_miss_candidates,
         },
     ))
 }
@@ -5451,6 +5498,157 @@ mod tests {
         assert!(
             !islands.iter().any(|i| i.component_name == "Foo"),
             "Foo is a per-specifier type-only export and must NOT be emitted as an island; got {islands:?}"
+        );
+    }
+
+    // --- near-miss candidate detection (issue #822) ---------------------
+
+    #[test]
+    fn island_free_project_reports_zero_near_miss_candidates() {
+        // A page that imports a server-only component — no `"use client"`
+        // anywhere. The scanner must report zero near-miss candidates so
+        // the caller can demote the empty-islands warning to a quiet note.
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import { ServerOnly } from "../components/server-only";
+                export default function Home() { return <ServerOnly/>; }
+                "#,
+            )
+            .with_file(
+                root().join("components/server-only.tsx"),
+                r#"export function ServerOnly() { return <div/>; }
+                "#,
+            );
+
+        let (islands, meta) =
+            scan_islands_with_meta(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert!(islands.is_empty(), "no islands expected: {islands:?}");
+        assert_eq!(
+            meta.near_miss_candidates, 0,
+            "island-free project must report zero near-miss candidates"
+        );
+    }
+
+    #[test]
+    fn misplaced_use_client_directive_counts_as_near_miss() {
+        // The directive is present but not first in the prologue (an
+        // import precedes it), so `has_use_client_directive` rejects it
+        // and no island is registered — but the author clearly intended
+        // one. This is the case the verify-hint is written for.
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import { Counter } from "../components/counter";
+                export default function Home() { return <Counter/>; }
+                "#,
+            )
+            .with_file(
+                root().join("components/counter.tsx"),
+                r#"import { useState } from "preact/hooks";
+                "use client";
+                export function Counter() {}
+                "#,
+            );
+
+        let (islands, meta) =
+            scan_islands_with_meta(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert!(
+            islands.is_empty(),
+            "misplaced directive must not register an island: {islands:?}"
+        );
+        assert_eq!(
+            meta.near_miss_candidates, 1,
+            "a module with a misplaced `use client` directive is a near-miss"
+        );
+    }
+
+    #[test]
+    fn malformed_use_client_directive_counts_as_near_miss() {
+        // A directive with a trailing space: `has_use_client_directive`
+        // requires the exact `use client` literal value, so `"use client "`
+        // is rejected — but the source still contains the `use client`
+        // substring, so it is correctly flagged as a near-miss.
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import { Counter } from "../components/counter";
+                export default function Home() { return <Counter/>; }
+                "#,
+            )
+            .with_file(
+                root().join("components/counter.tsx"),
+                r#""use client ";
+                export function Counter() {}
+                "#,
+            );
+
+        let (islands, meta) =
+            scan_islands_with_meta(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert!(
+            islands.is_empty(),
+            "misspelled directive must not register an island: {islands:?}"
+        );
+        assert_eq!(
+            meta.near_miss_candidates, 1,
+            "a module with a malformed `use client` directive is a near-miss"
+        );
+    }
+
+    #[test]
+    fn valid_directive_with_no_exports_counts_as_near_miss() {
+        // A valid `"use client"` module that exports nothing: flagged as
+        // an island by the author but giving the bundler nothing to ship.
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import { Counter } from "../components/counter";
+                export default function Home() { return <Counter/>; }
+                "#,
+            )
+            .with_file(
+                root().join("components/counter.tsx"),
+                r#""use client";
+                function Counter() {}
+                "#,
+            );
+
+        let (islands, meta) =
+            scan_islands_with_meta(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert!(
+            islands.is_empty(),
+            "no exported island expected: {islands:?}"
+        );
+        assert_eq!(
+            meta.near_miss_candidates, 1,
+            "a valid directive with no exported component is a near-miss"
+        );
+    }
+
+    #[test]
+    fn valid_island_reports_zero_near_miss_candidates() {
+        // The happy path: a correctly-authored island. It registers as an
+        // island, so it must NOT be double-counted as a near-miss.
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import { Counter } from "../components/counter";
+                export default function Home() { return <Counter/>; }
+                "#,
+            )
+            .with_file(
+                root().join("components/counter.tsx"),
+                r#""use client";
+                export function Counter() {}
+                "#,
+            );
+
+        let (islands, meta) =
+            scan_islands_with_meta(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert_eq!(islands.len(), 1, "expected one island: {islands:?}");
+        assert_eq!(
+            meta.near_miss_candidates, 0,
+            "a correctly-authored island must not be counted as a near-miss"
         );
     }
 }

--- a/crates/zfb-islands/src/scanner.rs
+++ b/crates/zfb-islands/src/scanner.rs
@@ -1365,13 +1365,15 @@ pub fn scan_islands_with_meta<R: Resolver>(
                     Island::with_marker_name(record.component_name, path, record.marker_name)
                 });
             }
-        } else if source.contains("use client") {
+        } else if has_near_miss_use_client_directive(&module) {
             // Issue #822: the module didn't register a valid directive
-            // (so `has_use_client_directive` is false) yet its source
-            // still mentions `use client` — a misplaced or misspelled
-            // directive is the most likely cause. Count it so the caller
-            // can keep the loud verify-hint for this genuine near-miss
-            // instead of nagging an intentionally island-free project.
+            // (so `has_use_client_directive` is false) yet a top-level
+            // string-literal statement normalizes to `use client` — a
+            // misplaced, mis-cased, or whitespace-malformed directive is
+            // the most likely cause. Count it so the caller can keep the
+            // loud verify-hint for this genuine near-miss instead of
+            // nagging an intentionally island-free project. AST-based, so
+            // a `// use client` comment never trips it.
             near_miss_candidates += 1;
         }
 
@@ -1761,6 +1763,61 @@ fn has_use_client_directive(module: &Module) -> bool {
         // the prologue.
     }
     false
+}
+
+/// Issue #822: return true iff the module looks like a *near-miss*
+/// `"use client"` island — a directive the author clearly intended but
+/// that [`has_use_client_directive`] rejected.
+///
+/// This is the signal the empty-islands report uses to keep its loud
+/// warning + verify-hint instead of demoting to a quiet "island-free on
+/// purpose" note. Callers should only consult it once
+/// [`has_use_client_directive`] has already returned false.
+///
+/// We scan *every* top-level expression-statement string literal in the
+/// module body — not just the leading prologue — and compare a normalized
+/// value (lowercased, trimmed, internal whitespace collapsed to a single
+/// space) against `use client`. That catches the realistic authoring
+/// mistakes:
+///
+/// - a misplaced directive — `"use client"` after an `import`, so it is
+///   no longer in the prologue (`has_use_client_directive` stops at the
+///   first non-string statement);
+/// - a mis-cased directive — `"Use client"`, `"USE CLIENT"`;
+/// - a whitespace-malformed directive — `"use  client"`, `"use client "`.
+///
+/// Crucially, it works on the parsed AST, not the raw file text, so a
+/// `// use client` comment or a `"...use client..."` substring inside an
+/// ordinary expression is *not* a false positive — neither is a top-level
+/// `ExprStmt(Str)`. False positives matter more than false negatives here:
+/// a false positive resurrects exactly the warning #822 is silencing on
+/// an intentionally island-free site.
+fn has_near_miss_use_client_directive(module: &Module) -> bool {
+    for item in &module.body {
+        let ModuleItem::Stmt(Stmt::Expr(expr_stmt)) = item else {
+            continue;
+        };
+        let Expr::Lit(Lit::Str(s)) = &*expr_stmt.expr else {
+            continue;
+        };
+        if normalize_directive(&s.value) == "use client" {
+            return true;
+        }
+    }
+    false
+}
+
+/// Lowercase, trim, and collapse internal whitespace runs to a single
+/// space — the normalization used to match malformed `"use client"`
+/// directives (issue #822). Returns an owned [`String`]; only ever called
+/// on the short directive literals in a module prologue, so the
+/// allocation is negligible.
+fn normalize_directive(value: &Wtf8Atom) -> String {
+    atom_to_string(value)
+        .to_lowercase()
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// Convert a [`Wtf8Atom`] (the SWC AST string type) to a plain [`String`].
@@ -5564,11 +5621,42 @@ mod tests {
     }
 
     #[test]
-    fn malformed_use_client_directive_counts_as_near_miss() {
-        // A directive with a trailing space: `has_use_client_directive`
-        // requires the exact `use client` literal value, so `"use client "`
-        // is rejected — but the source still contains the `use client`
-        // substring, so it is correctly flagged as a near-miss.
+    fn whitespace_malformed_use_client_directive_counts_as_near_miss() {
+        // Double-spaced and trailing-space directives: `has_use_client_directive`
+        // requires the exact `use client` literal value, so both are
+        // rejected — but the normalized near-miss check collapses the
+        // whitespace and flags them.
+        for directive in [r#""use  client";"#, r#""use client ";"#] {
+            let resolver = InMemoryResolver::new()
+                .with_file(
+                    root().join("pages/home.tsx"),
+                    r#"import { Counter } from "../components/counter";
+                    export default function Home() { return <Counter/>; }
+                    "#,
+                )
+                .with_file(
+                    root().join("components/counter.tsx"),
+                    format!("{directive}\nexport function Counter() {{}}\n"),
+                );
+
+            let (islands, meta) =
+                scan_islands_with_meta(&[root().join("pages/home.tsx")], &resolver).unwrap();
+            assert!(
+                islands.is_empty(),
+                "malformed directive {directive:?} must not register an island: {islands:?}"
+            );
+            assert_eq!(
+                meta.near_miss_candidates, 1,
+                "module with whitespace-malformed directive {directive:?} is a near-miss"
+            );
+        }
+    }
+
+    #[test]
+    fn miscased_use_client_directive_counts_as_near_miss() {
+        // A mis-cased directive (`"Use client"`): `has_use_client_directive`
+        // requires the exact lowercase literal, so it is rejected — the
+        // normalized near-miss check lowercases and flags it.
         let resolver = InMemoryResolver::new()
             .with_file(
                 root().join("pages/home.tsx"),
@@ -5578,7 +5666,7 @@ mod tests {
             )
             .with_file(
                 root().join("components/counter.tsx"),
-                r#""use client ";
+                r#""Use client";
                 export function Counter() {}
                 "#,
             );
@@ -5587,11 +5675,41 @@ mod tests {
             scan_islands_with_meta(&[root().join("pages/home.tsx")], &resolver).unwrap();
         assert!(
             islands.is_empty(),
-            "misspelled directive must not register an island: {islands:?}"
+            "mis-cased directive must not register an island: {islands:?}"
         );
         assert_eq!(
             meta.near_miss_candidates, 1,
-            "a module with a malformed `use client` directive is a near-miss"
+            "a module with a mis-cased `use client` directive is a near-miss"
+        );
+    }
+
+    #[test]
+    fn use_client_in_comment_or_expression_is_not_a_near_miss() {
+        // Issue #822 false-positive guard: the near-miss check is
+        // AST-based, so a `use client` mention in a comment or inside an
+        // ordinary expression string must NOT resurrect the warning on an
+        // intentionally island-free site.
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import { ServerOnly } from "../components/server-only";
+                export default function Home() { return <ServerOnly/>; }
+                "#,
+            )
+            .with_file(
+                root().join("components/server-only.tsx"),
+                r#"// use client — note: this island was removed on purpose
+                const label = "switch to use client mode";
+                export function ServerOnly() { return <div>{label}</div>; }
+                "#,
+            );
+
+        let (islands, meta) =
+            scan_islands_with_meta(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert!(islands.is_empty(), "no islands expected: {islands:?}");
+        assert_eq!(
+            meta.near_miss_candidates, 0,
+            "a `use client` mention in a comment or expression must not be a near-miss"
         );
     }
 

--- a/crates/zfb-watcher/src/lib.rs
+++ b/crates/zfb-watcher/src/lib.rs
@@ -350,6 +350,10 @@ fn merge_kind(existing: Option<ChangeKind>, incoming: ChangeKind) -> ChangeKind 
 fn resolve_emit_kind(path: &Path, kind: ChangeKind) -> ChangeKind {
     let exists = path.try_exists().unwrap_or(false);
     match (kind, exists) {
+        // Accepted trade-off: a bare-Remove from a git-restore of a
+        // brand-new route upgrades to Modified (never Created), so the
+        // orchestrator's watch-ADD discovery hook does not fire for that
+        // restored route on this tick.
         (ChangeKind::Removed, true) => ChangeKind::Modified,
         (ChangeKind::Removed, false) => ChangeKind::Removed,
         (_, true) => kind,

--- a/crates/zfb-watcher/src/lib.rs
+++ b/crates/zfb-watcher/src/lib.rs
@@ -325,21 +325,35 @@ fn merge_kind(existing: Option<ChangeKind>, incoming: ChangeKind) -> ChangeKind 
     }
 }
 
-/// Resolve the kind to actually emit for a path at flush time.
+/// Resolve the kind to actually emit for a path at flush time, reconciling
+/// the coalesced kind against the path's actual on-disk state.
 ///
-/// Defense-in-depth on top of `merge_kind` for issue #823: some platforms
-/// (e.g. macOS FSEvents under load) can deliver a bare `Remove` for a git
-/// restore without a paired `Create` ever arriving — so the coalescer never
-/// gets a Create/Modify to override the pending `Removed`. If the pending
-/// kind is `Removed` but the path is in fact still present on disk, the file
-/// was restored, not deleted: emit `Modified` so the rebuild loop re-renders
-/// it instead of pruning it. Any I/O error falls through to the original kind
-/// (treat as genuinely removed — the conservative choice).
+/// On-disk existence is authoritative for the **Removed boundary** (it never
+/// touches the Created vs Modified distinction — that is `merge_kind`'s job,
+/// where the #660 discovery-hook fix lives):
+///
+/// - Pending `Removed` but the path is present → the file was restored, not
+///   deleted: emit `Modified`. Covers platforms (e.g. macOS FSEvents under
+///   load) that deliver a bare `Remove` for a git restore with no paired
+///   `Create`, so the coalescer never got a Create/Modify to override it
+///   (issue #823).
+/// - Pending `Created`/`Modified` but the path is absent → it really is gone:
+///   emit `Removed`. A backend can deliver `Remove` then a trailing
+///   `Modify`-like event (name/metadata flags) for an already-deleted path,
+///   which `merge_kind` coalesces to `Modified`; without this branch the
+///   deletion would be lost and `tick_with_kinds` would skip its prune path.
+/// - Otherwise pass the kind through unchanged.
+///
+/// `try_exists().unwrap_or(false)` is the conservative default in both
+/// directions: an I/O error is treated as "absent", which biases toward
+/// emitting `Removed` — the change we can least afford to drop.
 fn resolve_emit_kind(path: &Path, kind: ChangeKind) -> ChangeKind {
-    if kind == ChangeKind::Removed && path.try_exists().unwrap_or(false) {
-        ChangeKind::Modified
-    } else {
-        kind
+    let exists = path.try_exists().unwrap_or(false);
+    match (kind, exists) {
+        (ChangeKind::Removed, true) => ChangeKind::Modified,
+        (ChangeKind::Removed, false) => ChangeKind::Removed,
+        (_, true) => kind,
+        (_, false) => ChangeKind::Removed,
     }
 }
 
@@ -593,12 +607,32 @@ mod tests {
     }
 
     #[test]
-    fn resolve_emit_kind_non_removed_is_passthrough() {
+    fn resolve_emit_kind_present_non_removed_is_passthrough() {
         let tmp = tempfile::tempdir().expect("tempdir");
         let file = tmp.path().join("any.txt");
         std::fs::write(&file, b"x").expect("write");
         assert_eq!(resolve_emit_kind(&file, ChangeKind::Created), ChangeKind::Created);
         assert_eq!(resolve_emit_kind(&file, ChangeKind::Modified), ChangeKind::Modified);
+    }
+
+    #[test]
+    fn resolve_emit_kind_absent_non_removed_becomes_removed() {
+        // A real deletion can land as Remove→Modify (trailing name/metadata
+        // event) for an already-gone path; merge_kind coalesces that to
+        // Modified, so flush-time existence must downgrade it back to Removed
+        // or the orchestrator skips its prune path.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let file = tmp.path().join("gone.txt");
+        assert_eq!(
+            resolve_emit_kind(&file, ChangeKind::Modified),
+            ChangeKind::Removed,
+            "Modified for a missing path is a genuine deletion",
+        );
+        assert_eq!(
+            resolve_emit_kind(&file, ChangeKind::Created),
+            ChangeKind::Removed,
+            "Created for a missing path is a genuine deletion",
+        );
     }
 
     /// Regression test for the `Watcher::shutdown()` circular-wait deadlock

--- a/crates/zfb-watcher/src/lib.rs
+++ b/crates/zfb-watcher/src/lib.rs
@@ -290,6 +290,59 @@ struct Pending {
     last_seen: Instant,
 }
 
+/// Merge an incoming [`ChangeKind`] with whatever kind is already pending
+/// for the same path within the debounce window.
+///
+/// Truth table (rows = pending, cols = incoming):
+///
+/// | pending \ incoming | Created | Modified | Removed |
+/// |--------------------|---------|----------|---------|
+/// | None               | Created | Modified | Removed |
+/// | Created            | Created | Created  | Removed |
+/// | Modified           | Created | Modified | Removed |
+/// | Removed            | Created | Modified | Removed |
+///
+/// Rules:
+///   - An incoming `Removed` always wins: the file is gone, so any preceding
+///     Create/Modify is moot.
+///   - `Created` followed by `Modified` stays `Created`: on macOS FSEvents
+///     (and some Linux inotify setups) `fs::write` to a brand-new path fires
+///     Create then one or more Modify events within the window. Collapsing to
+///     `Modified` would drop the `Created` signal the watch-ADD discovery hook
+///     relies on (`tick_with_kinds` only calls the hook for `Created`).
+///   - A pending `Removed` followed by `Created`/`Modified` takes the incoming
+///     kind: git's restore path (`git checkout --`, `git pull`, `git stash
+///     pop`) unlinks then recreates a tracked file, so a Remove immediately
+///     followed by a Create/Modify on the same path must surface as a real
+///     change — NOT a stale `Removed` that `tick_with_kinds` would treat as a
+///     deletion and skip from rebuild planning (issue #823). `Removed` is no
+///     longer sticky.
+///   - Otherwise take the incoming kind.
+fn merge_kind(existing: Option<ChangeKind>, incoming: ChangeKind) -> ChangeKind {
+    match existing {
+        Some(ChangeKind::Created) if incoming == ChangeKind::Modified => ChangeKind::Created,
+        _ => incoming,
+    }
+}
+
+/// Resolve the kind to actually emit for a path at flush time.
+///
+/// Defense-in-depth on top of `merge_kind` for issue #823: some platforms
+/// (e.g. macOS FSEvents under load) can deliver a bare `Remove` for a git
+/// restore without a paired `Create` ever arriving — so the coalescer never
+/// gets a Create/Modify to override the pending `Removed`. If the pending
+/// kind is `Removed` but the path is in fact still present on disk, the file
+/// was restored, not deleted: emit `Modified` so the rebuild loop re-renders
+/// it instead of pruning it. Any I/O error falls through to the original kind
+/// (treat as genuinely removed — the conservative choice).
+fn resolve_emit_kind(path: &Path, kind: ChangeKind) -> ChangeKind {
+    if kind == ChangeKind::Removed && path.try_exists().unwrap_or(false) {
+        ChangeKind::Modified
+    } else {
+        kind
+    }
+}
+
 /// The debouncer loop. Runs on a tokio task.
 ///
 /// Strategy: bridge the sync `notify` channel onto a tokio channel via
@@ -354,41 +407,10 @@ async fn debouncer_task(
                         let kind = classify(&evt.kind);
                         let now = Instant::now();
                         for path in evt.paths {
-                            // Merge the incoming kind with any already-pending
-                            // kind for this path, preserving the highest-priority
-                            // kind across the burst window.
-                            //
-                            // Priority (highest → lowest): Removed > Created > Modified.
-                            //
-                            // Rationale:
-                            //   - `Removed` always wins: the file is gone — any
-                            //     preceding Create/Modify is moot.
-                            //   - `Created` wins over `Modified`: on macOS FSEvents
-                            //     (and some Linux inotify setups), `fs::write` to a
-                            //     brand-new path fires both a Create event and then
-                            //     one or more Modify events within the debounce
-                            //     window. The old "keep latest" rule collapsed the
-                            //     burst to `Modified`, silently dropping the `Created`
-                            //     signal that the watch-ADD discovery hook relies on
-                            //     (`tick_with_kinds` only calls the hook for
-                            //     `ChangeKind::Created`). Preserving `Created` when
-                            //     it was ever seen during the burst closes that hole.
-                            //   - `Modified` is a no-op upgrade when `Created` is
-                            //     already pending: the consumer re-reads the file
-                            //     either way, so demoting `Created` to `Modified`
-                            //     would only hurt (breaks discovery), never help.
-                            let merged_kind = match pending.get(&path).map(|p| p.kind) {
-                                Some(ChangeKind::Removed) => ChangeKind::Removed, // Removed is sticky
-                                Some(ChangeKind::Created) => {
-                                    // Created already seen; only Removed can upgrade it.
-                                    if kind == ChangeKind::Removed {
-                                        ChangeKind::Removed
-                                    } else {
-                                        ChangeKind::Created
-                                    }
-                                }
-                                _ => kind, // Modified or nothing: take the incoming kind
-                            };
+                            // Coalesce the incoming kind with any already-pending
+                            // kind for this path across the burst window. See
+                            // `merge_kind` for the full truth table and rationale.
+                            let merged_kind = merge_kind(pending.get(&path).map(|p| p.kind), kind);
                             pending.insert(path, Pending { kind: merged_kind, last_seen: now });
                         }
                     }
@@ -410,6 +432,7 @@ async fn debouncer_task(
                     pending.remove(path);
                 }
                 for (path, kind) in ready {
+                    let kind = resolve_emit_kind(&path, kind);
                     if out_tx.send(Change { path, kind }).await.is_err() {
                         // Receiver dropped; bail out of the loop.
                         bridge.abort();
@@ -426,7 +449,8 @@ async fn debouncer_task(
 
 async fn flush_all(pending: &mut HashMap<PathBuf, Pending>, out_tx: &mpsc::Sender<Change>) {
     for (path, p) in pending.drain() {
-        if out_tx.send(Change { path, kind: p.kind }).await.is_err() {
+        let kind = resolve_emit_kind(&path, p.kind);
+        if out_tx.send(Change { path, kind }).await.is_err() {
             return;
         }
     }
@@ -456,39 +480,26 @@ mod tests {
     }
 
     // ---------------------------------------------------------------------------
-    // Burst-coalescing merge tests (the "sticky Created" fix — issue #660).
+    // Burst-coalescing merge tests for `merge_kind` (the production helper).
     //
-    // On macOS FSEvents (and some Linux inotify setups), `fs::write` to a
-    // brand-new path fires both a `Create` event and then one or more
-    // `Modify` events within the debounce window. The "keep latest kind" rule
-    // that existed before this fix collapsed such a burst to `Modified`,
-    // silently dropping the `Created` signal that the watch-ADD discovery hook
-    // relies on. The merged-kind logic below guarantees `Created` is preserved
-    // when it was ever seen for a path during the burst window.
+    // Two coalescing rules are exercised here:
+    //   - The "sticky Created" fix (issue #660): `fs::write` to a brand-new
+    //     path fires Create then one or more Modify events within the debounce
+    //     window. Collapsing the burst to `Modified` would drop the `Created`
+    //     signal the watch-ADD discovery hook relies on, so `(Created,
+    //     Modified) → Created`.
+    //   - The git-restore fix (issue #823): git's restore path unlinks then
+    //     recreates a tracked file. A pending `Removed` must NOT be sticky —
+    //     a subsequent Create/Modify on the same path overrides it, so the
+    //     restored file surfaces as a real change rather than a stale deletion.
     // ---------------------------------------------------------------------------
-
-    /// Simulate the merge logic inline so we can property-test it without
-    /// reaching into the private debouncer internals.
-    fn merge(existing: Option<ChangeKind>, incoming: ChangeKind) -> ChangeKind {
-        match existing {
-            Some(ChangeKind::Removed) => ChangeKind::Removed,
-            Some(ChangeKind::Created) => {
-                if incoming == ChangeKind::Removed {
-                    ChangeKind::Removed
-                } else {
-                    ChangeKind::Created
-                }
-            }
-            _ => incoming,
-        }
-    }
 
     #[test]
     fn created_then_modified_stays_created() {
-        // The primary fix: a new file write on macOS fires Create→Modify.
-        // Downstream discovery hook requires Created.
+        // A new file write on macOS fires Create→Modify; the downstream
+        // discovery hook requires Created.
         assert_eq!(
-            merge(Some(ChangeKind::Created), ChangeKind::Modified),
+            merge_kind(Some(ChangeKind::Created), ChangeKind::Modified),
             ChangeKind::Created,
             "Created must survive a subsequent Modified in the same burst",
         );
@@ -498,7 +509,7 @@ mod tests {
     fn created_then_removed_becomes_removed() {
         // Created then immediately Removed: file is gone; Removed wins.
         assert_eq!(
-            merge(Some(ChangeKind::Created), ChangeKind::Removed),
+            merge_kind(Some(ChangeKind::Created), ChangeKind::Removed),
             ChangeKind::Removed,
         );
     }
@@ -506,24 +517,39 @@ mod tests {
     #[test]
     fn modified_then_removed_becomes_removed() {
         assert_eq!(
-            merge(Some(ChangeKind::Modified), ChangeKind::Removed),
+            merge_kind(Some(ChangeKind::Modified), ChangeKind::Removed),
             ChangeKind::Removed,
         );
     }
 
     #[test]
-    fn removed_is_sticky_against_anything() {
-        // Once Removed is the pending kind, nothing demotes it.
-        assert_eq!(merge(Some(ChangeKind::Removed), ChangeKind::Created), ChangeKind::Removed);
-        assert_eq!(merge(Some(ChangeKind::Removed), ChangeKind::Modified), ChangeKind::Removed);
-        assert_eq!(merge(Some(ChangeKind::Removed), ChangeKind::Removed), ChangeKind::Removed);
+    fn removed_then_recreate_overrides() {
+        // Issue #823: a git restore (unlink + recreate) lands as Remove→Create
+        // (or Remove→Modify) on the same path within the debounce window. The
+        // recreate MUST override the pending Removed so the page rebuilds
+        // instead of being treated as a deletion. A repeated Removed stays
+        // Removed (a genuine delete).
+        assert_eq!(
+            merge_kind(Some(ChangeKind::Removed), ChangeKind::Created),
+            ChangeKind::Created,
+            "a Create after a pending Removed must override it (git restore)",
+        );
+        assert_eq!(
+            merge_kind(Some(ChangeKind::Removed), ChangeKind::Modified),
+            ChangeKind::Modified,
+            "a Modify after a pending Removed must override it (git restore)",
+        );
+        assert_eq!(
+            merge_kind(Some(ChangeKind::Removed), ChangeKind::Removed),
+            ChangeKind::Removed,
+        );
     }
 
     #[test]
     fn no_prior_takes_incoming_kind() {
-        assert_eq!(merge(None, ChangeKind::Created), ChangeKind::Created);
-        assert_eq!(merge(None, ChangeKind::Modified), ChangeKind::Modified);
-        assert_eq!(merge(None, ChangeKind::Removed), ChangeKind::Removed);
+        assert_eq!(merge_kind(None, ChangeKind::Created), ChangeKind::Created);
+        assert_eq!(merge_kind(None, ChangeKind::Modified), ChangeKind::Modified);
+        assert_eq!(merge_kind(None, ChangeKind::Removed), ChangeKind::Removed);
     }
 
     #[test]
@@ -531,9 +557,48 @@ mod tests {
         // Unusual but possible: Modify event arrives before Create (OS ordering).
         // The incoming Created must win over the prior Modified.
         assert_eq!(
-            merge(Some(ChangeKind::Modified), ChangeKind::Created),
+            merge_kind(Some(ChangeKind::Modified), ChangeKind::Created),
             ChangeKind::Created,
         );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Flush-time existence reconciliation (`resolve_emit_kind`) — issue #823
+    // defense-in-depth. If a path's pending kind is Removed but the file is
+    // present on disk at flush time, it was restored (e.g. git checkout that
+    // emitted only a bare Remove on this platform): emit Modified, not Removed.
+    // ---------------------------------------------------------------------------
+
+    #[test]
+    fn resolve_emit_kind_removed_but_present_becomes_modified() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let file = tmp.path().join("restored.txt");
+        std::fs::write(&file, b"hello").expect("write");
+        assert_eq!(
+            resolve_emit_kind(&file, ChangeKind::Removed),
+            ChangeKind::Modified,
+            "Removed for an existing path means it was restored",
+        );
+    }
+
+    #[test]
+    fn resolve_emit_kind_removed_and_absent_stays_removed() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let file = tmp.path().join("gone.txt");
+        assert_eq!(
+            resolve_emit_kind(&file, ChangeKind::Removed),
+            ChangeKind::Removed,
+            "Removed for a missing path is a genuine deletion",
+        );
+    }
+
+    #[test]
+    fn resolve_emit_kind_non_removed_is_passthrough() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let file = tmp.path().join("any.txt");
+        std::fs::write(&file, b"x").expect("write");
+        assert_eq!(resolve_emit_kind(&file, ChangeKind::Created), ChangeKind::Created);
+        assert_eq!(resolve_emit_kind(&file, ChangeKind::Modified), ChangeKind::Modified);
     }
 
     /// Regression test for the `Watcher::shutdown()` circular-wait deadlock
@@ -553,5 +618,103 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(3), watcher.shutdown())
             .await
             .expect("Watcher::shutdown() must complete (circular-wait deadlock regression)");
+    }
+
+    // ---------------------------------------------------------------------------
+    // Real-watcher integration tests for issue #823 (git-restore not picked up).
+    //
+    // These drive a live `notify` watcher in a tempdir and assert that a
+    // git-restore-shaped mutation — `remove_file(target)` then re-creating the
+    // same path — surfaces as a NON-`Removed` change. We assert "not Removed"
+    // (rather than an exact kind) because FSEvents/inotify may coalesce the
+    // remove+recreate into a single Create, deliver Remove→Create, or (under
+    // load) emit only a bare Remove that the `resolve_emit_kind` existence
+    // check then upgrades to Modified. All three paths must reach the rebuild
+    // loop, so the only wrong outcome is a surviving `Removed`.
+    //
+    // Timing is deliberately generous (200ms debounce, multi-second drain
+    // deadlines) so the tests stay reliable on a busy CI runner.
+    // ---------------------------------------------------------------------------
+
+    /// Collect changes touching `target` until `deadline`, returning the last
+    /// kind seen for that path (or `None` if no event arrived in time).
+    async fn last_kind_for(
+        rx: &mut mpsc::Receiver<Change>,
+        target: &Path,
+        deadline: Duration,
+    ) -> Option<ChangeKind> {
+        let mut seen = None;
+        let _ = tokio::time::timeout(deadline, async {
+            while let Some(change) = rx.recv().await {
+                if change.path == target {
+                    seen = Some(change.kind);
+                }
+            }
+        })
+        .await;
+        seen
+    }
+
+    /// `git checkout -- <file>` unlinks then recreates the tracked file. The
+    /// watcher must report a non-`Removed` change so the dev server re-renders
+    /// instead of serving the pre-restore page forever (issue #823).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn git_restore_remove_then_write_is_reported() {
+        // FSEvents reports canonical paths (/var/folders → /private/...), so
+        // canonicalize the root before watching to match received paths.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().canonicalize().expect("canonicalize tempdir");
+        let target = root.join("hello.txt");
+        std::fs::write(&target, b"original\n").expect("seed file");
+
+        let debounce = Duration::from_millis(200);
+        let (watcher, mut rx) =
+            Watcher::start_with_debounce(&root, std::iter::once("."), debounce)
+                .expect("watcher start");
+
+        // Let the OS watch settle and drain the seed/create noise.
+        let _ = last_kind_for(&mut rx, &target, Duration::from_millis(500)).await;
+
+        // Simulate git's write_entry: unlink, then recreate with new bytes.
+        std::fs::remove_file(&target).expect("remove");
+        std::fs::write(&target, b"restored\n").expect("recreate");
+
+        let kind = last_kind_for(&mut rx, &target, Duration::from_secs(3)).await;
+        assert!(
+            matches!(kind, Some(ChangeKind::Created) | Some(ChangeKind::Modified)),
+            "git restore (remove+write) must surface a non-Removed change, got {kind:?}",
+        );
+
+        watcher.shutdown().await;
+    }
+
+    /// The other git-restore shape: unlink the target, then rename a temp file
+    /// over it (atomic replace, new inode). Must also report non-`Removed`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn git_restore_remove_then_rename_over_is_reported() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().canonicalize().expect("canonicalize tempdir");
+        let target = root.join("hello.txt");
+        std::fs::write(&target, b"original\n").expect("seed file");
+
+        let debounce = Duration::from_millis(200);
+        let (watcher, mut rx) =
+            Watcher::start_with_debounce(&root, std::iter::once("."), debounce)
+                .expect("watcher start");
+
+        let _ = last_kind_for(&mut rx, &target, Duration::from_millis(500)).await;
+
+        std::fs::remove_file(&target).expect("remove");
+        let staged = root.join("hello.txt.tmp");
+        std::fs::write(&staged, b"restored\n").expect("stage");
+        std::fs::rename(&staged, &target).expect("rename over");
+
+        let kind = last_kind_for(&mut rx, &target, Duration::from_secs(3)).await;
+        assert!(
+            matches!(kind, Some(ChangeKind::Created) | Some(ChangeKind::Modified)),
+            "git restore (remove+rename-over) must surface a non-Removed change, got {kind:?}",
+        );
+
+        watcher.shutdown().await;
     }
 }

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -61,7 +61,7 @@ use zfb_build::pipeline::{
 };
 use zfb_build::renderer::{render_all, Backend, RendererInput, RendererOutput};
 use zfb_css::{
-    css_relative_path, CssPipeline, CssPipelineConfig, TailwindSubprocessConfig,
+    css_relative_path, AuthoredCssEngine, CssPipeline, CssPipelineConfig, TailwindSubprocessConfig,
     TailwindSubprocessEngine,
 };
 use zfb_islands::{
@@ -660,15 +660,20 @@ impl BuildRunner for DefaultRunner {
 /// Run the real `CssPipeline::build_emitter` for a project and return
 /// its bytes packaged for [`ProductionAssetPipeline`].
 ///
+/// When the user disabled Tailwind via `zfb.config.{ts,json}`
+/// (`tailwind: { enabled: false }`), this skips the Tailwind layers
+/// (import / `@source` scan / preflight / subprocess) but still
+/// processes the authored global stylesheet and CSS Modules — see
+/// [`build_authored_only_css_payload`]. `enabled: false` means "no
+/// Tailwind", not "no CSS" (issue #824).
+///
 /// Returns `Ok(None)` when:
 ///
-/// - the user explicitly disabled Tailwind via
-///   `zfb.config.{ts,json}` (`tailwind: { enabled: false }`), OR
 /// - no scannable source files were found under the conventional
-///   project roots (`pages/`, `components/`, `layouts/`, `content/`).
-///   In that case the project carries no utility-class authoring
-///   surface and emitting an empty stylesheet would just leave a
-///   broken `<link>` tag in HTML.
+///   project roots (`pages/`, `components/`, `layouts/`, `content/`)
+///   AND no authored global stylesheet exists. In that case the
+///   project carries no CSS authoring surface and emitting an empty
+///   stylesheet would just leave a broken `<link>` tag in HTML.
 ///
 /// On `Ok(Some(_))` the orchestrator hashes the bytes and writes
 /// `dist/assets/styles-<hash>.css`. The `relative_path` /
@@ -681,12 +686,14 @@ pub(crate) fn build_default_css_payload(
     outdir: &Path,
     config: &Config,
 ) -> Result<Option<AssetEmitterPayload>> {
-    // Honour the user's opt-out switch before doing any source
-    // discovery work — keeps the default runner free of subprocess
-    // cost when the project explicitly does not want Tailwind.
+    // `tailwind: { enabled: false }` disables only the Tailwind layers,
+    // not the authored-CSS pipeline. Route to the Tailwind-free path so
+    // global CSS + CSS Modules still ship (issue #824). Falling back to
+    // the Tailwind subprocess path here would re-add the preflight the
+    // user opted out of and incur subprocess cost.
     let tailwind_enabled = config.tailwind.as_ref().map(|t| t.enabled).unwrap_or(true);
     if !tailwind_enabled {
-        return Ok(None);
+        return build_authored_only_css_payload(project_root, outdir);
     }
 
     let sources = discover_css_source_files(project_root);
@@ -769,6 +776,67 @@ pub(crate) fn build_default_css_payload(
 
     let pipeline = CssPipeline::new(engine, pipe_cfg);
     let emitter_out = pipeline.build_emitter()?;
+
+    Ok(Some(AssetEmitterPayload {
+        bytes: emitter_out.bytes,
+        relative_path: css_relative_path(),
+        stable_url: emitter_out.stable_url,
+        companions: Vec::new(),
+    }))
+}
+
+/// CSS payload for the `tailwind: { enabled: false }` path: authored
+/// global stylesheet + CSS Modules, with the Tailwind layers
+/// (import / `@source` scan / preflight / subprocess) skipped entirely.
+///
+/// `enabled: false` opts out of Tailwind, not out of CSS (issue #824).
+/// The authored global stylesheet currently rides *inside* the Tailwind
+/// engine via its `input_css` slot, so simply skipping the engine would
+/// drop the user's globals too. Instead we read the authored global CSS
+/// independently (same probe order as the Tailwind path,
+/// [`resolve_input_global_css`]) and feed it through an
+/// [`AuthoredCssEngine`] — a no-subprocess engine that returns the
+/// authored bytes verbatim as the "engine half" of the combined
+/// stylesheet. CSS Modules processing, concatenation, hashing, and
+/// asset emission are engine-agnostic and run unchanged via
+/// [`CssPipeline::build_emitter`].
+///
+/// Returns `Ok(None)` when the project has neither an authored global
+/// stylesheet nor any CSS Modules — the combined output would be
+/// whitespace only, and emitting it would leave a broken `<link>` tag
+/// in HTML. This mirrors the empty-stylesheet guard on the Tailwind
+/// path.
+fn build_authored_only_css_payload(
+    project_root: &Path,
+    outdir: &Path,
+) -> Result<Option<AssetEmitterPayload>> {
+    let authored_css = match resolve_input_global_css(project_root) {
+        Some(path) => std::fs::read_to_string(&path)
+            .with_context(|| format!("failed to read global CSS at {}", path.display()))?,
+        None => String::new(),
+    };
+
+    let sources = discover_css_source_files(project_root);
+    let engine = AuthoredCssEngine::new(authored_css);
+
+    let pipe_cfg = CssPipelineConfig {
+        sources,
+        class_map_dir: None,
+        output_root: outdir.to_path_buf(),
+        ..CssPipelineConfig::default()
+    };
+
+    let pipeline = CssPipeline::new(engine, pipe_cfg);
+    let emitter_out = pipeline.build_emitter()?;
+
+    // Skip the link when there is nothing to ship. With Tailwind off and
+    // no authored globals + no modules, `combine` yields only its `"\n"`
+    // separator; emitting that would inject a `<link>` to an effectively
+    // empty stylesheet. The Tailwind path never hits this because its
+    // preflight bytes are always non-empty.
+    if emitter_out.bytes.iter().all(u8::is_ascii_whitespace) {
+        return Ok(None);
+    }
 
     Ok(Some(AssetEmitterPayload {
         bytes: emitter_out.bytes,
@@ -869,24 +937,21 @@ fn discover_css_source_files(project_root: &Path) -> Vec<std::path::PathBuf> {
 /// config `CssPipeline` uses inside `build_emitter`), so the scoped
 /// names agree without a shared channel.
 ///
-/// Returns an empty map when Tailwind/CSS is disabled or no
-/// `.module.css` files are reachable — the build then behaves exactly
-/// as before.
+/// Returns an empty map when no `.module.css` files are reachable — the
+/// build then behaves exactly as before.
+///
+/// CSS Modules are processed regardless of `tailwind.enabled`: the
+/// authored-CSS pipeline (and hence the emitted `styles-<hash>.css`)
+/// ships the scoped module CSS even when Tailwind is off (issue #824),
+/// so the class-map rewrite must run in lockstep or the HTML `class`
+/// attributes would reference classes that never appear in the
+/// stylesheet. The `_config` parameter is retained for call-site
+/// symmetry with [`build_default_css_payload`].
 pub(crate) fn compute_css_module_class_maps(
     project_root: &Path,
-    config: &Config,
+    _config: &Config,
 ) -> Result<std::collections::HashMap<PathBuf, std::collections::HashMap<String, String>>> {
     use std::collections::HashMap;
-
-    // CSS Modules processing is independent of Tailwind, but the CSS
-    // emitter is gated on `tailwind.enabled`. When CSS is disabled
-    // entirely there is no stylesheet to carry the scoped CSS, so a
-    // class-map rewrite would point at classes that never ship. Keep
-    // the two sides consistent: skip the rewrite when CSS is off.
-    let css_enabled = config.tailwind.as_ref().map(|t| t.enabled).unwrap_or(true);
-    if !css_enabled {
-        return Ok(HashMap::new());
-    }
 
     let sources = discover_css_source_files(project_root);
     if sources.is_empty() {
@@ -3943,28 +4008,107 @@ mod tests {
         assert_eq!(resolve_input_global_css(project_root), None);
     }
 
-    /// Tailwind disabled in config => CSS emitter slot is `None`.
-    /// This is the cheap, no-subprocess coverage point for
-    /// `DefaultRunner::emit_prod_assets`'s CSS branch.
+    /// Regression (issue #824): `tailwind.enabled = false` disables only
+    /// the Tailwind layers, NOT the authored-CSS pipeline. With an
+    /// authored global stylesheet and a CSS Module present, the emitter
+    /// must still ship a stylesheet containing both — and crucially WITHOUT
+    /// the Tailwind preflight (no `@import "tailwindcss"`, no subprocess).
+    /// This path runs `AuthoredCssEngine`, so the test is hermetic (no
+    /// tailwind binary required).
     #[test]
-    fn default_runner_returns_none_css_when_tailwind_disabled_in_config() {
+    fn css_payload_ships_authored_css_when_tailwind_disabled() {
         let tmp = tempdir().unwrap();
         let project_root = tmp.path();
-        // Stage some sources so the empty-sources branch wouldn't
-        // be the reason for None — only `tailwind.enabled = false`
-        // should drive the result.
+
+        // Authored global stylesheet at the conventional location.
+        std::fs::create_dir_all(project_root.join("styles")).unwrap();
+        std::fs::write(
+            project_root.join("styles/global.css"),
+            ".authored-global { color: rebeccapurple; }\n",
+        )
+        .unwrap();
+
+        // A page importing a CSS Module so auto-discovery picks it up.
+        std::fs::create_dir_all(project_root.join("pages")).unwrap();
+        std::fs::write(
+            project_root.join("pages/index.tsx"),
+            "import styles from \"./index.module.css\";\nexport default function() { return null }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            project_root.join("pages/index.module.css"),
+            ".box { display: grid; }\n",
+        )
+        .unwrap();
+
+        let cfg = Config {
+            tailwind: Some(crate::config::TailwindConfig { enabled: false }),
+            ..Config::default()
+        };
+        let payload = build_default_css_payload(project_root, &project_root.join("dist"), &cfg)
+            .expect("should not error")
+            .expect("expected Some payload: authored CSS + module must ship even with tailwind off");
+
+        let css = String::from_utf8(payload.bytes).unwrap();
+        assert!(
+            css.contains(".authored-global"),
+            "authored global CSS must survive tailwind.enabled=false; got:\n{css}",
+        );
+        assert!(
+            css.contains("display: grid") || css.contains("display:grid"),
+            "CSS Module rule must be emitted; got:\n{css}",
+        );
+        // The Tailwind layers must be skipped entirely — no preflight, no
+        // synthesised import.
+        assert!(
+            !css.contains("@import \"tailwindcss\""),
+            "tailwind import must NOT be synthesised when disabled; got:\n{css}",
+        );
+        assert!(
+            !css.contains("tailwindcss v4"),
+            "tailwind preflight banner must NOT appear when disabled; got:\n{css}",
+        );
+
+        // And the class-map producer must run in lockstep so the HTML
+        // `class` attributes reference classes that actually ship.
+        let maps = compute_css_module_class_maps(project_root, &cfg).expect("class maps");
+        assert!(
+            !maps.is_empty(),
+            "CSS Modules class maps must be non-empty when tailwind is disabled",
+        );
+        let scoped = maps
+            .values()
+            .flat_map(|m| m.values())
+            .any(|scoped| scoped.ends_with("_box") || scoped.contains("box"));
+        assert!(
+            scoped,
+            "scoped class for `.box` must appear in the class map; got: {maps:?}",
+        );
+    }
+
+    /// `tailwind.enabled = false` AND no authored CSS AND no CSS Modules
+    /// => no stylesheet to ship, so the emitter slot stays `None` (avoids
+    /// a `<link>` to an empty stylesheet).
+    #[test]
+    fn css_payload_none_when_tailwind_disabled_and_no_css() {
+        let tmp = tempdir().unwrap();
+        let project_root = tmp.path();
+        // A page with no module import and no global stylesheet.
         std::fs::create_dir_all(project_root.join("pages")).unwrap();
         std::fs::write(
             project_root.join("pages/index.tsx"),
             "export default function() { return null }\n",
         )
         .unwrap();
-        let cfg = Config { tailwind: Some(crate::config::TailwindConfig { enabled: false }), ..Config::default() };
+        let cfg = Config {
+            tailwind: Some(crate::config::TailwindConfig { enabled: false }),
+            ..Config::default()
+        };
         let payload = build_default_css_payload(project_root, &project_root.join("dist"), &cfg)
             .expect("should not error");
         assert!(
             payload.is_none(),
-            "expected None when tailwind.enabled=false; got {payload:?}",
+            "expected None when tailwind disabled and no authored CSS/modules; got {payload:?}",
         );
     }
 

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -982,20 +982,34 @@ pub(crate) fn build_default_islands_payload(
     // import ships — so the empty-islands short-circuit below only fires
     // when client-router is NOT in play.
     if islands_set.is_empty() && !scan_meta.uses_client_router {
-        // Issue #122 / #117: this branch used to be silent, which made
-        // pnpm-workspace consumers with `"use client"` islands inside a
-        // workspace package look "fine" while shipping no client
-        // runtime. Surface it loudly so authoring problems (a missing
-        // `"use client"` directive, an island reachable only through a
-        // path the scanner can't follow) become discoverable.
-        output::warn(format!(
-            "scanned {} page entr{} but found no \"use client\" islands; \
-             dist/assets/islands.js will not be emitted. \
-             Verify each island module starts with the literal directive \
-             \"use client\" and is reachable from a page in pages/.",
-            entries.len(),
-            if entries.len() == 1 { "y" } else { "ies" }
-        ));
+        // Issue #822: only the loud warning + verify-hint when the scan
+        // saw a *near-miss* — a module that looks like it meant to be a
+        // `"use client"` island but didn't register one (a misplaced or
+        // misspelled directive, or a valid directive with no exported
+        // component). For a project that is island-free on purpose
+        // (`near_miss_candidates == 0`), the verify-hint is permanent
+        // noise, so we demote to a quiet info note with no hint.
+        if scan_meta.near_miss_candidates == 0 {
+            output::info(
+                "no \"use client\" islands found; skipping islands bundle \
+                 (dist/assets/islands.js will not be emitted)",
+            );
+        } else {
+            // Issue #122 / #117: this branch used to be silent, which made
+            // pnpm-workspace consumers with `"use client"` islands inside a
+            // workspace package look "fine" while shipping no client
+            // runtime. Surface it loudly so authoring problems (a missing
+            // `"use client"` directive, an island reachable only through a
+            // path the scanner can't follow) become discoverable.
+            output::warn(format!(
+                "scanned {} page entr{} but found no \"use client\" islands; \
+                 dist/assets/islands.js will not be emitted. \
+                 Verify each island module starts with the literal directive \
+                 \"use client\" and is reachable from a page in pages/.",
+                entries.len(),
+                if entries.len() == 1 { "y" } else { "ies" }
+            ));
+        }
         return Ok(None);
     }
 
@@ -4014,6 +4028,47 @@ mod tests {
         assert!(
             payload.is_none(),
             "expected None when no use-client components; got {payload:?}",
+        );
+    }
+
+    /// Issue #822: a page that imports a module with a *misplaced*
+    /// `"use client"` directive still emits no islands bundle (the
+    /// directive is rejected), so the payload is `None`. This exercises
+    /// the near-miss branch of the empty-islands report — the one that
+    /// keeps the loud warning + verify-hint. We can't assert on the
+    /// stderr text here, but the `None` return confirms the short-circuit
+    /// fires on the same path the near-miss accounting flows through.
+    #[test]
+    fn default_runner_returns_none_islands_for_near_miss_directive() {
+        let tmp = tempdir().unwrap();
+        let project_root = tmp.path();
+        std::fs::create_dir_all(project_root.join("pages")).unwrap();
+        std::fs::create_dir_all(project_root.join("components")).unwrap();
+        std::fs::write(
+            project_root.join("pages/index.tsx"),
+            "import { Counter } from \"../components/counter\";\n\
+             export default function Index() { return <Counter/>; }\n",
+        )
+        .unwrap();
+        // Directive is not first in the prologue (an import precedes it),
+        // so it is rejected and no island is registered.
+        std::fs::write(
+            project_root.join("components/counter.tsx"),
+            "import { useState } from \"preact/hooks\";\n\
+             \"use client\";\n\
+             export function Counter() { return null; }\n",
+        )
+        .unwrap();
+        let payload = build_default_islands_payload(
+            project_root,
+            &project_root.join("dist"),
+            crate::config::Framework::Preact,
+            &IslandsPluginConfig::default(),
+        )
+        .expect("should not error");
+        assert!(
+            payload.is_none(),
+            "expected None for a misplaced use-client directive; got {payload:?}",
         );
     }
 

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -811,8 +811,17 @@ fn build_authored_only_css_payload(
     outdir: &Path,
 ) -> Result<Option<AssetEmitterPayload>> {
     let authored_css = match resolve_input_global_css(project_root) {
-        Some(path) => std::fs::read_to_string(&path)
-            .with_context(|| format!("failed to read global CSS at {}", path.display()))?,
+        Some(path) => {
+            let raw = std::fs::read_to_string(&path)
+                .with_context(|| format!("failed to read global CSS at {}", path.display()))?;
+            // Skip the Tailwind import layer: the default zfb template's
+            // `styles/global.css` ships `@import "tailwindcss";` (or the
+            // split `tailwindcss/preflight` / `utilities` forms). With no
+            // Tailwind subprocess to resolve them, emitting those lines
+            // verbatim would make the browser request a non-existent
+            // stylesheet, so we drop them here (issue #824).
+            strip_tailwind_imports(&raw)
+        }
         None => String::new(),
     };
 
@@ -844,6 +853,42 @@ fn build_authored_only_css_payload(
         stable_url: emitter_out.stable_url,
         companions: Vec::new(),
     }))
+}
+
+/// Drop `@import "tailwindcss"` directives from authored global CSS for
+/// the Tailwind-disabled path.
+///
+/// Removes whole lines whose trimmed form starts with the Tailwind
+/// import, covering both the umbrella import and the v4 split sub-imports
+/// (`tailwindcss/preflight`, `tailwindcss/utilities`, …), in either quote
+/// style. The matched patterns mirror `user_has_import` in
+/// `zfb_css::engine::build_synthesised_entry_css` so the enabled and
+/// disabled paths agree on what counts as "the Tailwind import".
+///
+/// Scope: this strips the `@import` layer only. Other Tailwind-v4-only
+/// at-rules (`@theme`, `@apply`, `@source`, `@utility`) are left as-is —
+/// a zero-Tailwind project (the `enabled: false` scenario, issue #824)
+/// does not author them, and sanitising the full Tailwind syntax is out
+/// of scope. A commented-out import (`/* @import "tailwindcss"; */`) is
+/// inert and intentionally left untouched: its trimmed line starts with
+/// `/*`, not `@import`, so it never matches.
+fn strip_tailwind_imports(css: &str) -> String {
+    fn is_tailwind_import(line: &str) -> bool {
+        let t = line.trim();
+        t.starts_with("@import \"tailwindcss\"")
+            || t.starts_with("@import 'tailwindcss'")
+            || t.starts_with("@import \"tailwindcss/")
+            || t.starts_with("@import 'tailwindcss/")
+    }
+
+    let mut out = String::with_capacity(css.len());
+    for line in css.split_inclusive('\n') {
+        if is_tailwind_import(line) {
+            continue;
+        }
+        out.push_str(line);
+    }
+    out
 }
 
 /// Locate the project's authored global Tailwind input CSS file.
@@ -4110,6 +4155,63 @@ mod tests {
             payload.is_none(),
             "expected None when tailwind disabled and no authored CSS/modules; got {payload:?}",
         );
+    }
+
+    /// Regression (issue #824): with Tailwind disabled, a `@import
+    /// "tailwindcss"` in the authored global stylesheet must be stripped
+    /// (no subprocess resolves it, so emitting it would 404 in the
+    /// browser) while the rest of the authored CSS survives.
+    #[test]
+    fn css_payload_strips_tailwind_import_when_disabled() {
+        let tmp = tempdir().unwrap();
+        let project_root = tmp.path();
+        std::fs::create_dir_all(project_root.join("styles")).unwrap();
+        std::fs::write(
+            project_root.join("styles/global.css"),
+            "@import \"tailwindcss\";\n.real-rule { color: red; }\n",
+        )
+        .unwrap();
+        let cfg = Config {
+            tailwind: Some(crate::config::TailwindConfig { enabled: false }),
+            ..Config::default()
+        };
+        let payload = build_default_css_payload(project_root, &project_root.join("dist"), &cfg)
+            .expect("should not error")
+            .expect("authored CSS must still ship");
+        let css = String::from_utf8(payload.bytes).unwrap();
+        assert!(
+            !css.contains("@import \"tailwindcss\""),
+            "tailwind import must be stripped from authored CSS when disabled; got:\n{css}",
+        );
+        assert!(
+            css.contains(".real-rule"),
+            "non-import authored rules must survive the strip; got:\n{css}",
+        );
+    }
+
+    #[test]
+    fn strip_tailwind_imports_drops_only_tailwind_imports() {
+        let input = concat!(
+            "@import \"tailwindcss\";\n",
+            "@import 'tailwindcss/preflight';\n",
+            "@import \"tailwindcss/utilities\";\n",
+            "@import \"./vendor.css\";\n",
+            ".keep { color: blue; }\n",
+        );
+        let out = strip_tailwind_imports(input);
+        assert!(!out.contains("tailwindcss"), "all tailwind imports gone; got:\n{out}");
+        assert!(out.contains("@import \"./vendor.css\""), "vendor import kept");
+        assert!(out.contains(".keep"), "authored rule kept");
+    }
+
+    #[test]
+    fn strip_tailwind_imports_keeps_commented_import() {
+        let input = "/* @import \"tailwindcss\"; */\n.keep { color: green; }\n";
+        let out = strip_tailwind_imports(input);
+        // A commented-out import is inert; leaving it is harmless and the
+        // trimmed line starts with `/*`, not `@import`.
+        assert!(out.contains("/* @import \"tailwindcss\"; */"), "commented import kept");
+        assert!(out.contains(".keep"), "authored rule kept");
     }
 
     /// No `pages/` directory => islands emitter slot is `None`.

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -764,6 +764,16 @@ pub(crate) fn build_default_css_payload(
         // class-map writer when `class_map_dir` is `Some`. Pin it to
         // the configured outdir for forward-compat.
         output_root: outdir.to_path_buf(),
+        // Hash CSS Modules scoped names off the *project-relative* path
+        // so byte-identical sources yield identical scoped names (and a
+        // stable `styles-<hash>.css`) across machines/checkout paths
+        // (issue #825). Must match `compute_css_module_class_maps` below
+        // — both feed the same absolute module paths and the same root,
+        // so the build-time JSX rewrite and the emitted CSS agree.
+        modules_config: zfb_css::modules::CssModulesConfig {
+            project_root: Some(project_root.to_path_buf()),
+            ..zfb_css::modules::CssModulesConfig::default()
+        },
         ..CssPipelineConfig::default()
     };
 
@@ -909,8 +919,16 @@ pub(crate) fn compute_css_module_class_maps(
         return Ok(HashMap::new());
     }
 
-    let processor =
-        zfb_css::CssModulesProcessor::new(zfb_css::modules::CssModulesConfig::default());
+    // Hash scoped names off the project-relative path (issue #825). This
+    // MUST use the same `project_root` as `build_default_css_payload`'s
+    // pipeline above so the scoped names baked into the JSX rewrite match
+    // the ones in the emitted `styles-<hash>.css`. Both sides derive
+    // module paths from `discover_css_source_files(project_root)`, so the
+    // absolute inputs — and therefore the relative hash strings — agree.
+    let processor = zfb_css::CssModulesProcessor::new(zfb_css::modules::CssModulesConfig {
+        project_root: Some(project_root.to_path_buf()),
+        ..zfb_css::modules::CssModulesConfig::default()
+    });
     let out = processor
         .process(&module_files)
         .context("CSS Modules compilation failed")?;

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -61,8 +61,8 @@ use zfb_build::pipeline::{
 };
 use zfb_build::renderer::{render_all, Backend, RendererInput, RendererOutput};
 use zfb_css::{
-    css_relative_path, AuthoredCssEngine, CssPipeline, CssPipelineConfig, TailwindSubprocessConfig,
-    TailwindSubprocessEngine,
+    css_relative_path, is_tailwind_import_line, AuthoredCssEngine, CssEngine, CssPipeline,
+    CssPipelineConfig, TailwindSubprocessConfig, TailwindSubprocessEngine,
 };
 use zfb_islands::{
     build_production_islands_asset, scan_islands_with_meta, BundleConfig, EsbuildSubprocessBundler,
@@ -756,43 +756,60 @@ pub(crate) fn build_default_css_payload(
 
     let engine = TailwindSubprocessEngine::new(tw_cfg);
 
+    // Tailwind path always ships a payload — its preflight bytes are never
+    // empty, so there is no whitespace-only guard here (unlike the
+    // authored-only path).
+    let payload = run_css_emitter(engine, project_root, outdir, sources)?;
+    Ok(Some(payload))
+}
+
+/// Shared tail of the two CSS-emitter paths
+/// ([`build_default_css_payload`] and [`build_authored_only_css_payload`]).
+///
+/// Given an already-configured [`CssEngine`] (Tailwind subprocess or
+/// authored-verbatim), builds the [`CssPipelineConfig`], runs
+/// [`CssPipeline::build_emitter`], and packages the result as an
+/// [`AssetEmitterPayload`]. Both call sites feed the same `project_root`
+/// and `outdir`, so the CSS Modules hash root is identical across them and
+/// matches [`compute_css_module_class_maps`] (issue #825). The per-call-site
+/// differences (the authored path's whitespace-only `None` guard vs the
+/// Tailwind path's always-emit) stay at the call sites, not in this helper.
+fn run_css_emitter<E: CssEngine>(
+    engine: E,
+    project_root: &Path,
+    outdir: &Path,
+    sources: Vec<PathBuf>,
+) -> Result<AssetEmitterPayload> {
     let pipe_cfg = CssPipelineConfig {
         sources,
         // The on-disk class-map JSON writer is not used: the build-time
         // CSS Modules rewrite consumes the maps in-memory instead.
         // `compute_css_module_class_maps` runs `CssModulesProcessor`
-        // directly (same default config this emitter uses, so scoped
-        // names agree) and feeds `BundlerInput::css_module_class_maps`,
-        // which the bundler applies in the shadow tree. No JSON channel
-        // is needed, so `class_map_dir` stays `None`.
+        // directly (same config this emitter uses, so scoped names agree)
+        // and feeds `BundlerInput::css_module_class_maps`, which the
+        // bundler applies in the shadow tree. No JSON channel is needed,
+        // so `class_map_dir` stays `None`.
         class_map_dir: None,
         // `output_root` is unused by `build_emitter` (it does not
         // write the hashed asset itself) but is read by the
         // class-map writer when `class_map_dir` is `Some`. Pin it to
         // the configured outdir for forward-compat.
         output_root: outdir.to_path_buf(),
-        // Hash CSS Modules scoped names off the *project-relative* path
-        // so byte-identical sources yield identical scoped names (and a
-        // stable `styles-<hash>.css`) across machines/checkout paths
-        // (issue #825). Must match `compute_css_module_class_maps` below
-        // — both feed the same absolute module paths and the same root,
-        // so the build-time JSX rewrite and the emitted CSS agree.
-        modules_config: zfb_css::modules::CssModulesConfig {
-            project_root: Some(project_root.to_path_buf()),
-            ..zfb_css::modules::CssModulesConfig::default()
-        },
+        // Hash root shared with `compute_css_module_class_maps` via
+        // `CssModulesConfig::for_project_root` (issue #825).
+        modules_config: zfb_css::modules::CssModulesConfig::for_project_root(project_root),
         ..CssPipelineConfig::default()
     };
 
     let pipeline = CssPipeline::new(engine, pipe_cfg);
     let emitter_out = pipeline.build_emitter()?;
 
-    Ok(Some(AssetEmitterPayload {
+    Ok(AssetEmitterPayload {
         bytes: emitter_out.bytes,
         relative_path: css_relative_path(),
         stable_url: emitter_out.stable_url,
         companions: Vec::new(),
-    }))
+    })
 }
 
 /// CSS payload for the `tailwind: { enabled: false }` path: authored
@@ -838,71 +855,56 @@ fn build_authored_only_css_payload(
     let sources = discover_css_source_files(project_root);
     let engine = AuthoredCssEngine::new(authored_css);
 
-    let pipe_cfg = CssPipelineConfig {
-        sources,
-        class_map_dir: None,
-        output_root: outdir.to_path_buf(),
-        // Same project-relative hash root as `build_default_css_payload`
-        // and `compute_css_module_class_maps` (issue #825) — without it,
-        // the emitted stylesheet would hash absolute paths while the
-        // build-time JSX class rewrite hashes relative ones, and the
-        // scoped names would not match on the Tailwind-disabled path.
-        modules_config: zfb_css::modules::CssModulesConfig {
-            project_root: Some(project_root.to_path_buf()),
-            ..zfb_css::modules::CssModulesConfig::default()
-        },
-        ..CssPipelineConfig::default()
-    };
-
-    let pipeline = CssPipeline::new(engine, pipe_cfg);
-    let emitter_out = pipeline.build_emitter()?;
+    let payload = run_css_emitter(engine, project_root, outdir, sources)?;
 
     // Skip the link when there is nothing to ship. With Tailwind off and
     // no authored globals + no modules, `combine` yields only its `"\n"`
     // separator; emitting that would inject a `<link>` to an effectively
     // empty stylesheet. The Tailwind path never hits this because its
     // preflight bytes are always non-empty.
-    if emitter_out.bytes.iter().all(u8::is_ascii_whitespace) {
+    if payload.bytes.iter().all(u8::is_ascii_whitespace) {
         return Ok(None);
     }
 
-    Ok(Some(AssetEmitterPayload {
-        bytes: emitter_out.bytes,
-        relative_path: css_relative_path(),
-        stable_url: emitter_out.stable_url,
-        companions: Vec::new(),
-    }))
+    Ok(Some(payload))
 }
 
 /// Drop `@import "tailwindcss"` directives from authored global CSS for
 /// the Tailwind-disabled path.
 ///
-/// Removes whole lines whose trimmed form starts with the Tailwind
-/// import, covering both the umbrella import and the v4 split sub-imports
-/// (`tailwindcss/preflight`, `tailwindcss/utilities`, …), in either quote
-/// style. The matched patterns mirror `user_has_import` in
-/// `zfb_css::engine::build_synthesised_entry_css` so the enabled and
-/// disabled paths agree on what counts as "the Tailwind import".
+/// Removes whole physical lines whose trimmed form starts with the
+/// Tailwind import, covering both the umbrella import and the v4 split
+/// sub-imports (`tailwindcss/preflight`, `tailwindcss/utilities`, …), in
+/// either quote style. The per-line test is the shared
+/// [`zfb_css::is_tailwind_import_line`] predicate — the same one
+/// `build_synthesised_entry_css`'s `user_has_import` detection uses — so
+/// the enabled and disabled paths agree byte-for-byte on what counts as
+/// "the Tailwind import".
 ///
 /// Scope: this strips the `@import` layer only. Other Tailwind-v4-only
 /// at-rules (`@theme`, `@apply`, `@source`, `@utility`) are left as-is —
 /// a zero-Tailwind project (the `enabled: false` scenario, issue #824)
 /// does not author them, and sanitising the full Tailwind syntax is out
-/// of scope. A commented-out import (`/* @import "tailwindcss"; */`) is
-/// inert and intentionally left untouched: its trimmed line starts with
-/// `/*`, not `@import`, so it never matches.
+/// of scope.
+///
+/// Known limitations (intentional — this is a line filter, not a CSS
+/// parser, and unlike the Tailwind path it does **not** strip comments
+/// before scanning):
+///
+/// - An `@import "tailwindcss";` line *inside* a multi-line
+///   `/* … */` block comment is dropped even though it is already inert.
+///   Harmless: the surrounding comment delimiters stay, the output is
+///   still valid CSS, and the browser requests nothing. (A single-line
+///   `/* @import "tailwindcss"; */` is untouched — its trimmed line starts
+///   with `/*`, not `@import`.)
+/// - A same-line trailing rule (`@import "tailwindcss"; .real{…}`) is lost
+///   along with the import, because whole physical lines are dropped. The
+///   default zfb template puts the import on its own line, so this does not
+///   bite real projects.
 fn strip_tailwind_imports(css: &str) -> String {
-    fn is_tailwind_import(line: &str) -> bool {
-        let t = line.trim();
-        t.starts_with("@import \"tailwindcss\"")
-            || t.starts_with("@import 'tailwindcss'")
-            || t.starts_with("@import \"tailwindcss/")
-            || t.starts_with("@import 'tailwindcss/")
-    }
-
     let mut out = String::with_capacity(css.len());
     for line in css.split_inclusive('\n') {
-        if is_tailwind_import(line) {
+        if is_tailwind_import_line(line) {
             continue;
         }
         out.push_str(line);
@@ -1009,11 +1011,9 @@ fn discover_css_source_files(project_root: &Path) -> Vec<std::path::PathBuf> {
 /// ships the scoped module CSS even when Tailwind is off (issue #824),
 /// so the class-map rewrite must run in lockstep or the HTML `class`
 /// attributes would reference classes that never appear in the
-/// stylesheet. The `_config` parameter is retained for call-site
-/// symmetry with [`build_default_css_payload`].
+/// stylesheet.
 pub(crate) fn compute_css_module_class_maps(
     project_root: &Path,
-    _config: &Config,
 ) -> Result<std::collections::HashMap<PathBuf, std::collections::HashMap<String, String>>> {
     use std::collections::HashMap;
 
@@ -1038,16 +1038,13 @@ pub(crate) fn compute_css_module_class_maps(
         return Ok(HashMap::new());
     }
 
-    // Hash scoped names off the project-relative path (issue #825). This
-    // MUST use the same `project_root` as `build_default_css_payload`'s
-    // pipeline above so the scoped names baked into the JSX rewrite match
-    // the ones in the emitted `styles-<hash>.css`. Both sides derive
-    // module paths from `discover_css_source_files(project_root)`, so the
-    // absolute inputs — and therefore the relative hash strings — agree.
-    let processor = zfb_css::CssModulesProcessor::new(zfb_css::modules::CssModulesConfig {
-        project_root: Some(project_root.to_path_buf()),
-        ..zfb_css::modules::CssModulesConfig::default()
-    });
+    // Hash scoped names off the project-relative path via the shared
+    // `for_project_root` constructor (issue #825) — the same config
+    // `run_css_emitter` feeds its pipeline, so the scoped names baked into
+    // the JSX rewrite match the ones in the emitted `styles-<hash>.css`.
+    let processor = zfb_css::CssModulesProcessor::new(
+        zfb_css::modules::CssModulesConfig::for_project_root(project_root),
+    );
     let out = processor
         .process(&module_files)
         .context("CSS Modules compilation failed")?;
@@ -1743,7 +1740,7 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
     // `CssModulesProcessor` with the default config so the scoped
     // names match. Empty for projects with no `.module.css` files.
     bundler_input.css_module_class_maps =
-        compute_css_module_class_maps(project_root, config)
+        compute_css_module_class_maps(project_root)
             .context("CSS Modules class-map computation failed")?;
 
     // Snapshot the bundler input before consuming it so the runtime-only
@@ -4157,7 +4154,7 @@ mod tests {
 
         // And the class-map producer must run in lockstep so the HTML
         // `class` attributes reference classes that actually ship.
-        let maps = compute_css_module_class_maps(project_root, &cfg).expect("class maps");
+        let maps = compute_css_module_class_maps(project_root).expect("class maps");
         assert!(
             !maps.is_empty(),
             "CSS Modules class maps must be non-empty when tailwind is disabled",

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -842,6 +842,15 @@ fn build_authored_only_css_payload(
         sources,
         class_map_dir: None,
         output_root: outdir.to_path_buf(),
+        // Same project-relative hash root as `build_default_css_payload`
+        // and `compute_css_module_class_maps` (issue #825) — without it,
+        // the emitted stylesheet would hash absolute paths while the
+        // build-time JSX class rewrite hashes relative ones, and the
+        // scoped names would not match on the Tailwind-disabled path.
+        modules_config: zfb_css::modules::CssModulesConfig {
+            project_root: Some(project_root.to_path_buf()),
+            ..zfb_css::modules::CssModulesConfig::default()
+        },
         ..CssPipelineConfig::default()
     };
 

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -1775,7 +1775,7 @@ fn assemble_and_bundle_dev(
     // non-fatal: log it and continue with empty maps (`.module.css`
     // imports then degrade to `{}` rather than aborting the dev boot).
     bundler_input.css_module_class_maps =
-        match crate::commands::build::compute_css_module_class_maps(project_root, cfg) {
+        match crate::commands::build::compute_css_module_class_maps(project_root) {
             Ok(maps) => maps,
             Err(e) => {
                 crate::output::warn(format!(

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -704,7 +704,10 @@ pub async fn run(args: &DevArgs) -> Result<()> {
             }
         }
         Ok(None) => {
-            // Tailwind disabled or no sources. Leave the handle at None.
+            // No CSS to ship (no authored globals, no CSS Modules, and —
+            // when Tailwind is enabled — no scannable sources). Leave the
+            // handle at None. Tailwind being disabled no longer implies
+            // None on its own: authored CSS still ships (issue #824).
         }
         Err(err) => {
             output::warn(format!(

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -1766,7 +1766,8 @@ fn assemble_and_bundle_dev(
     // CSS Modules — mirror the production-build wiring so dev preview
     // resolves `import styles from "./x.module.css"` to the same scoped
     // class names `zfb build` produces. The scoped names are
-    // deterministic (both sides use `CssModulesConfig::default()`), so
+    // deterministic (both sides go through `compute_css_module_class_maps`,
+    // which hashes the project-relative module path — issue #825), so
     // the dev stylesheet and dev-rendered HTML agree. A failure here is
     // non-fatal: log it and continue with empty maps (`.module.css`
     // imports then degrade to `{}` rather than aborting the dev boot).


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/826

---

## Summary

Batch-fix of the 5 recent `agent-found` issues, developed as 5 parallel worktree topics merged into `base/agent-found-fixes`, plus a manager-applied cross-topic composition fix and a deep-review DRY pass.

Closes #821
Closes #822
Closes #823
Closes #824
Closes #825
Closes #826

### Fixes

- **#824 — `tailwind: { enabled: false }` silently dropped all authored CSS.** Two gates in `crates/zfb/src/commands/build.rs` killed the whole CSS emitter and the CSS-Modules class maps when Tailwind was off. New `AuthoredCssEngine` (`crates/zfb-css/src/authored_engine.rs`) + `build_authored_only_css_payload` keep authored global CSS and CSS Modules compiling/emitting while skipping only the Tailwind layers; `@import "tailwindcss"` lines are stripped on that path (they would 404 with no subprocess). Both `zfb build` and `zfb dev` covered.
- **#823 — dev server missed git-restored files (checkout/pull/stash).** The `zfb-watcher` debouncer made `Removed` sticky during event coalescing, so git's unlink+recreate lost its Create. Coalescer semantics fixed (Create/Modify after pending Removed now override) plus a flush-time defense where on-disk existence is authoritative for the Removed boundary in both directions. Unit + real-watcher integration tests added.
- **#822 — misleading "no use-client islands" warning on island-free sites.** `ScanMeta` now tracks near-miss candidates via AST-based detection (misplaced/mis-cased/malformed directives, islands exporting no component); with zero candidates the message demotes to an info note without the verify-hint. `"use client"` inside comments/strings does not resurrect the warning.
- **#821 — `zfb-tailwind-entry-*.css` stranded in project root on abnormal termination.** Self-healing sweep deletes stale entry files (60s age gate protects concurrent live builds) at each `produce_utility_css` call. Relocation under `.zfb/` was evaluated and rejected: the synthesized entry inlines user CSS, so relative `@import` specifiers must resolve against `working_dir`.
- **#825 — CSS Modules scoped names hashed the absolute module path (non-reproducible builds).** LightningCSS now hashes a project-relative, forward-slash-normalized path via `CssModulesConfig::for_project_root`; class-map lookup keys stay absolute. Byte-identical sources now produce identical scoped names and `styles-<hash>.css` across machines/checkout paths.

### Cross-topic + review hardening

- `b140dfd` threads `project_root` into the authored-only pipeline so the Tailwind-disabled path hashes scoped names identically to the class-map rewrite (#824 × #825 interaction caught at merge).
- `b81f46f` deep-review pass: shared `run_css_emitter` helper, structural `CssModulesConfig::for_project_root` constructor, single exported `is_tailwind_import_line` predicate (was duplicated across crates), dead param removal, doc corrections.

## Verification

- Full workspace `cargo test` green on the merged base.
- Real-CLI pass (scaffolded `basic-blog`): tailwind-off build keeps styles + matching scoped classes; live `zfb dev` picks up `git checkout --` restores ≤5s; island-free build prints info (no warning); pre-seeded stale entry file swept; two checkout paths produce byte-identical asset names.

## Topic branches (merged locally, deleted)

`tailwind-disabled-css` #824 · `watch-git-restore` #823 · `islands-warning` #822 · `tailwind-tmpfile` #821 · `css-modules-hash` #825 · `review-fixes` (deep-review pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)