### PR TITLE
docs(zfb-router): add .mdx to scan.rs module doc-comment extension list

### DIFF
--- a/crates/zfb-router/src/scan.rs
+++ b/crates/zfb-router/src/scan.rs
@@ -16,7 +16,7 @@
 //! | `pages/[lang]/[slug].tsx`           | `/:lang/:slug`     |                                |
 //!
 //! Files starting with `_` (e.g. `_app.tsx`, `_document.tsx`) are ignored.
-//! Accepted page extensions: `.tsx`, `.md`, `.html`. Files with any other
+//! Accepted page extensions: `.tsx`, `.mdx`, `.md`, `.html`. Files with any other
 //! extension are skipped with a `tracing::warn!` so authors notice accidental
 //! mis-placements.
 //!


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/852

---

## Summary
One-line doc-comment fix from the Docs Refresh epic's auto-fix pass: the scan.rs module docs said three accepted page extensions; the `ACCEPTED_PAGE_EXTENSIONS` constant (scan.rs:59) has four (`tsx`, `mdx`, `md`, `html`).

Closes #852

🤖 Generated with [Claude Code](https://claude.com/claude-code)