### PR TITLE
feat(zfb-content): configurable hierarchical heading-ID strategy for HeadingLinks

### DIFF
--- a/crates/zfb-content/src/lib.rs
+++ b/crates/zfb-content/src/lib.rs
@@ -30,8 +30,8 @@ pub use plugins::toc::TocConfig;
 // threading `markdown.features` into the feature-aware pipeline constructor,
 // without taking a direct dependency on `zfb-md-ast` / `zfb-md-extras`.
 pub use zfb_md_extras::{
-    directives_enabled, DirectiveFullSpec, DirectiveSpec, DirectiveSpecKind, FeatureToggle,
-    MarkdownFeaturesConfig, into_directive_def,
+    directives_enabled, heading_id_strategy, DirectiveFullSpec, DirectiveSpec, DirectiveSpecKind,
+    FeatureToggle, HeadingIdStrategy, HeadingIdsConfig, MarkdownFeaturesConfig, into_directive_def,
 };
 
 pub use frontmatter::{FrontmatterError, UnifiedFrontmatter};

--- a/crates/zfb-content/src/mdx_jsx_emit.rs
+++ b/crates/zfb-content/src/mdx_jsx_emit.rs
@@ -52,7 +52,7 @@ use crate::pipeline::{
     constructs_for_jsx_emit, mdast_to_hast_with, HastNode, JsxEmitStrategy, Pipeline,
     PipelineError, ResolvedGfmConstructs,
 };
-use crate::plugins::heading_links::{next_slug, slugify};
+use crate::plugins::heading_links::{slugify, HeadingIdStrategy, SlugAllocator};
 
 /// Options controlling the emitted JSX module.
 #[derive(Debug, Clone)]
@@ -238,16 +238,24 @@ fn mdx_to_jsx_module_inner(
     // Heading metadata is collected from the post-mdast-visitor tree
     // either way — hast plugins like `HeadingLinksPlugin` mutate the
     // hast (slug → `id` attribute, anchor child) but the slug
-    // computation in `collect_headings` shares the same `next_slug`
-    // helper so the emitted `headings` array stays in lockstep with
+    // computation in `collect_headings` shares the same `SlugAllocator`
+    // so the emitted `headings` array stays in lockstep with
     // the rendered `<hN id="…">`. Custom hast visitors that rewrite
     // heading text or remove headings would diverge — none ship with
     // `Pipeline::with_defaults()` today; if a future plugin needs to
     // rewrite headings, this collection should move post-hast.
+    //
+    // The heading-ID strategy comes from the pipeline (set by
+    // `with_defaults_and_full_config` from `features.headingIds`,
+    // zfb#871). No pipeline → flat, matching the legacy constructors.
+    let strategy = pipeline_mut
+        .as_deref()
+        .map(|p| p.heading_id_strategy())
+        .unwrap_or_default();
     let CollectedHeadings {
         entries: headings,
         nested_slugs,
-    } = collect_headings(&children);
+    } = collect_headings(&children, strategy);
 
     let (body, html_tags, component_names, hoisted_esm) = if take_hast_detour {
         // Wrap children back into a Root so `mdast_to_hast_with` can
@@ -418,15 +426,18 @@ struct CollectedHeadings {
 /// Walk the parsed mdast and collect every heading in document order.
 ///
 /// Slugs match what [`crate::plugins::heading_links`] would emit for
-/// the same document: same `slugify`, same `-1`, `-2`, … numbering for
-/// repeats. Per heading_links semantics, only `<h2>`–`<h6>` participate
-/// in the dedup counter; `<h1>` slugs are emitted raw.
+/// the same document and strategy: the walk shares the plugin's
+/// [`SlugAllocator`], so flat mode gets the same `slugify` + `-1`, `-2`,
+/// … numbering, and hierarchical mode (zfb#871) gets the same
+/// ancestor-prefixed candidates. Per heading_links semantics, only
+/// `<h2>`–`<h6>` participate in the allocator; `<h1>` slugs are emitted
+/// raw.
 ///
 /// ## Dedup ordering across the two render passes
 ///
 /// On the production hast-detour path, top-level headings stay real
 /// hast `<hN>` elements and get their `id` from `HeadingLinksPlugin`
-/// (its own `seen` map). Headings nested inside an MDX JSX body are
+/// (its own `SlugAllocator`). Headings nested inside an MDX JSX body are
 /// rendered to an opaque JsxRaw string before hast visitors run, so
 /// `HeadingLinksPlugin` never sees them — `jsx_render_child` must stamp
 /// their `id` instead. This walk is the single source of truth that
@@ -443,23 +454,30 @@ struct CollectedHeadings {
 /// this walk through the pipeline/bridge — invasive and not required by
 /// the issue (its acceptance case is top-level-first). The common case
 /// (top-level heading before any same-text nested heading) is exact.
-fn collect_headings(children: &[MdastNode]) -> CollectedHeadings {
+///
+/// The hierarchical strategy has the analogous asymmetry: a JSX-nested
+/// heading joins this walk's ancestor stack but not the plugin's, so a
+/// *top-level* heading that is deeper than a preceding JSX-nested one
+/// gets a different prefix in the two passes. Same root cause, same
+/// accepted scope — plain-markdown outlines (the zfb#871 consumer's
+/// case) never hit it.
+fn collect_headings(children: &[MdastNode], strategy: HeadingIdStrategy) -> CollectedHeadings {
     let mut out = CollectedHeadings {
         entries: Vec::new(),
         nested_slugs: Vec::new(),
     };
-    let mut seen: HashMap<String, usize> = HashMap::new();
+    let mut slugs = SlugAllocator::new(strategy);
     // `in_jsx == false` at the top level; flips to true once we descend
     // into an MDX JSX element body so we can route those headings' slugs
     // into `nested_slugs` for the emitter to replay.
-    walk_collect_headings(children, &mut out, &mut seen, false);
+    walk_collect_headings(children, &mut out, &mut slugs, false);
     out
 }
 
 fn walk_collect_headings(
     nodes: &[MdastNode],
     out: &mut CollectedHeadings,
-    seen: &mut HashMap<String, usize>,
+    slugs: &mut SlugAllocator,
     in_jsx: bool,
 ) {
     for node in nodes {
@@ -468,14 +486,14 @@ fn walk_collect_headings(
                 let depth = h.depth.clamp(1, 6);
                 let text = mdast_inline_text(&h.children);
                 let base = slugify(&text);
-                // For h2-h6 we must mirror heading_links' next_slug()
+                // For h2-h6 we must mirror heading_links' SlugAllocator
                 // exactly so `headings[i].slug` matches the rendered
-                // `<hN id="…">`. h1 is left out of the dedup pool
+                // `<hN id="…">`. h1 is left out of the allocator
                 // because heading_links never sees it.
                 let slug = if depth == 1 {
                     base
                 } else {
-                    next_slug(seen, &base)
+                    slugs.allocate(depth, &base)
                 };
                 // A heading inside an MDX JSX body is emitted by
                 // `jsx_render_child`, not by HeadingLinksPlugin — record
@@ -492,10 +510,10 @@ fn walk_collect_headings(
             // so descend into block-level containers. We deliberately do
             // NOT descend into Paragraph/Heading children themselves —
             // headings cannot appear there.
-            MdastNode::Root(r) => walk_collect_headings(&r.children, out, seen, in_jsx),
-            MdastNode::Blockquote(b) => walk_collect_headings(&b.children, out, seen, in_jsx),
-            MdastNode::List(l) => walk_collect_headings(&l.children, out, seen, in_jsx),
-            MdastNode::ListItem(li) => walk_collect_headings(&li.children, out, seen, in_jsx),
+            MdastNode::Root(r) => walk_collect_headings(&r.children, out, slugs, in_jsx),
+            MdastNode::Blockquote(b) => walk_collect_headings(&b.children, out, slugs, in_jsx),
+            MdastNode::List(l) => walk_collect_headings(&l.children, out, slugs, in_jsx),
+            MdastNode::ListItem(li) => walk_collect_headings(&li.children, out, slugs, in_jsx),
             // Descend into MDX JSX element bodies (e.g. `<Outro>## …`).
             // Everything below here is rendered by `jsx_render_child`, so
             // flip `in_jsx` on so the slugs land in `nested_slugs`. The
@@ -504,10 +522,10 @@ fn walk_collect_headings(
             // pop order will drift from this walk (debug_assert in
             // `mdx_to_jsx_module*` guards against that).
             MdastNode::MdxJsxFlowElement(j) => {
-                walk_collect_headings(&j.children, out, seen, true);
+                walk_collect_headings(&j.children, out, slugs, true);
             }
             MdastNode::MdxJsxTextElement(j) => {
-                walk_collect_headings(&j.children, out, seen, true);
+                walk_collect_headings(&j.children, out, slugs, true);
             }
             _ => {}
         }

--- a/crates/zfb-content/src/pipeline.rs
+++ b/crates/zfb-content/src/pipeline.rs
@@ -292,6 +292,21 @@ impl Pipeline {
         self.heading_id_strategy
     }
 
+    /// Declare the heading-ID strategy of a manually wired
+    /// [`HeadingLinksPlugin`] so the JSX-emit path (`collect_headings`)
+    /// mirrors the rendered `<hN id="…">`.
+    ///
+    /// Only needed for custom pipelines that call
+    /// [`add_hast_visitor`](Pipeline::add_hast_visitor) with
+    /// `HeadingLinksPlugin::with_strategy(…)` themselves — without this,
+    /// the `headings` export stays on the flat default while the rendered
+    /// ids are hierarchical. [`Pipeline::with_defaults_and_full_config`]
+    /// sets it automatically from `features.headingIds`.
+    pub fn set_heading_id_strategy(&mut self, strategy: HeadingIdStrategy) -> &mut Self {
+        self.heading_id_strategy = strategy;
+        self
+    }
+
     /// Set the `add_trailing_slash` option. Affects subsequent
     /// `add_strip_md_ext()` calls. Defaults to `true`.
     pub fn set_add_trailing_slash(&mut self, value: bool) -> &mut Self {
@@ -746,7 +761,7 @@ impl Pipeline {
         // the resolved strategy is also stored on the pipeline so the
         // JSX-emit path (`collect_headings`) mirrors the same scheme.
         let strategy = zfb_md_extras::heading_id_strategy(&features.heading_ids);
-        p.heading_id_strategy = strategy;
+        p.set_heading_id_strategy(strategy);
         p.add_hast_visitor(Box::new(HeadingLinksPlugin::with_strategy(strategy)));
         p.add_hast_visitor(Box::new(CodeTitlePlugin::new()));
         // Single call-path from zfb-content into zfb-md-extras: adds the opt-in

--- a/crates/zfb-content/src/pipeline.rs
+++ b/crates/zfb-content/src/pipeline.rs
@@ -23,6 +23,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use markdown::mdast::{AttributeContent, AttributeValue, Node as MdastNode};
+use zfb_md_ast::HeadingIdStrategy;
 
 use crate::plugins::{
     BrokenLinkDiagnostic, CjkFriendlyPlugin, CodeTitlePlugin, ExternalLinksConfig,
@@ -190,6 +191,11 @@ pub struct Pipeline {
     /// after the directives step) so link rewriting sees finalized
     /// mdast link nodes.
     resolve_links: Option<ResolveLinksPlugin>,
+    /// Heading-ID strategy the wired `HeadingLinksPlugin` uses
+    /// (`markdown.features.headingIds`, zfb#871). Read back by the
+    /// JSX-emit path so `collect_headings` mirrors the same scheme.
+    /// Default: [`HeadingIdStrategy::Flat`].
+    heading_id_strategy: HeadingIdStrategy,
 }
 
 impl Default for Pipeline {
@@ -257,6 +263,7 @@ impl Pipeline {
             gfm_constructs: resolved,
             add_trailing_slash: true,
             resolve_links: None,
+            heading_id_strategy: HeadingIdStrategy::default(),
         }
     }
 
@@ -270,6 +277,19 @@ impl Pipeline {
     #[must_use]
     pub fn gfm_constructs(&self) -> ResolvedGfmConstructs {
         self.gfm_constructs
+    }
+
+    /// The heading-ID strategy this pipeline's `HeadingLinksPlugin` was
+    /// wired with (`markdown.features.headingIds`, zfb#871).
+    ///
+    /// The JSX-emit detour reads this so `collect_headings` computes the
+    /// same slugs the rendered `<hN id="…">` carries. Defaults to
+    /// [`HeadingIdStrategy::Flat`] on every constructor except
+    /// [`Pipeline::with_defaults_and_full_config`], which resolves it from
+    /// `markdown.features`.
+    #[must_use]
+    pub fn heading_id_strategy(&self) -> HeadingIdStrategy {
+        self.heading_id_strategy
     }
 
     /// Set the `add_trailing_slash` option. Affects subsequent
@@ -722,7 +742,12 @@ impl Pipeline {
             p.add_mdast_visitor(Box::new(HardBreaksPlugin::new()));
         }
         // hast phase — HeadingLinksPlugin and CodeTitlePlugin are always on.
-        p.add_hast_visitor(Box::new(HeadingLinksPlugin::new()));
+        // HeadingLinksPlugin honours `features.headingIds.strategy` (zfb#871);
+        // the resolved strategy is also stored on the pipeline so the
+        // JSX-emit path (`collect_headings`) mirrors the same scheme.
+        let strategy = zfb_md_extras::heading_id_strategy(&features.heading_ids);
+        p.heading_id_strategy = strategy;
+        p.add_hast_visitor(Box::new(HeadingLinksPlugin::with_strategy(strategy)));
         p.add_hast_visitor(Box::new(CodeTitlePlugin::new()));
         // Single call-path from zfb-content into zfb-md-extras: adds the opt-in
         // visitors in the correct phase/position (before SyntectPlugin for

--- a/crates/zfb-content/src/plugins/heading_links.rs
+++ b/crates/zfb-content/src/plugins/heading_links.rs
@@ -480,6 +480,202 @@ mod tests {
         assert_eq!(slugify("Café au lait"), "café-au-lait");
     }
 
+    fn all_ids(tree: &HastNode) -> Vec<Option<String>> {
+        let HastNode::Root { children } = tree else {
+            unreachable!("expected HastNode::Root")
+        };
+        children
+            .iter()
+            .map(|c| first_attr(c, "id").map(str::to_string))
+            .collect()
+    }
+
+    /// The issue's headline example (zfb#871): `## Foo / ### Moo / #### Mew`
+    /// → `foo`, `foo-moo`, `foo-moo-mew`.
+    #[test]
+    fn hierarchical_chain_prefixes_ancestors() {
+        let mut tree = root(vec![h(2, "Foo"), h(3, "Moo"), h(4, "Mew")]);
+        HeadingLinksPlugin::with_strategy(HeadingIdStrategy::Hierarchical).visit(&mut tree);
+        assert_eq!(
+            all_ids(&tree),
+            vec![
+                Some("foo".into()),
+                Some("foo-moo".into()),
+                Some("foo-moo-mew".into()),
+            ]
+        );
+    }
+
+    /// The hash-link anchor href must carry the hierarchical id, not the
+    /// base slug.
+    #[test]
+    fn hierarchical_anchor_href_matches_id() {
+        let mut tree = root(vec![h(2, "Foo"), h(3, "Moo")]);
+        HeadingLinksPlugin::with_strategy(HeadingIdStrategy::Hierarchical).visit(&mut tree);
+        let HastNode::Root { children } = tree else {
+            unreachable!("expected HastNode::Root")
+        };
+        let HastNode::Element { children: hc, .. } = &children[1] else {
+            unreachable!("expected HastNode::Element")
+        };
+        let HastNode::Element { attrs, .. } = &hc[1] else {
+            unreachable!("expected anchor element")
+        };
+        assert!(attrs.contains(&("href".to_string(), "#foo-moo".to_string())));
+    }
+
+    /// A sibling at the same depth pops its predecessor off the stack;
+    /// a new h2 resets the chain entirely.
+    #[test]
+    fn hierarchical_siblings_pop_stack() {
+        let mut tree = root(vec![h(2, "A"), h(3, "B"), h(3, "C"), h(2, "D"), h(3, "E")]);
+        HeadingLinksPlugin::with_strategy(HeadingIdStrategy::Hierarchical).visit(&mut tree);
+        assert_eq!(
+            all_ids(&tree),
+            vec![
+                Some("a".into()),
+                Some("a-b".into()),
+                Some("a-c".into()),
+                Some("d".into()),
+                Some("d-e".into()),
+            ]
+        );
+    }
+
+    /// Depth jumps (h2 → h4 with no h3) prefix with the nearest real
+    /// ancestor.
+    #[test]
+    fn hierarchical_depth_jump_uses_nearest_ancestor() {
+        let mut tree = root(vec![h(2, "A"), h(4, "B"), h(3, "C")]);
+        HeadingLinksPlugin::with_strategy(HeadingIdStrategy::Hierarchical).visit(&mut tree);
+        // h4 "B" nests under "A"; the following h3 "C" pops the h4 and
+        // also nests under "A".
+        assert_eq!(
+            all_ids(&tree),
+            vec![Some("a".into()), Some("a-b".into()), Some("a-c".into())]
+        );
+    }
+
+    /// Duplicate siblings under the same parent are deduped on the full
+    /// path, mirroring github-slugger numbering.
+    #[test]
+    fn hierarchical_duplicates_under_same_parent_numbered() {
+        let mut tree = root(vec![h(2, "A"), h(3, "B"), h(3, "B")]);
+        HeadingLinksPlugin::with_strategy(HeadingIdStrategy::Hierarchical).visit(&mut tree);
+        assert_eq!(
+            all_ids(&tree),
+            vec![Some("a".into()), Some("a-b".into()), Some("a-b-1".into())]
+        );
+    }
+
+    /// A deduped parent contributes its FINAL id to children: the second
+    /// `## Foo` becomes `foo-1`, so its `### Bar` becomes `foo-1-bar` —
+    /// the child anchor always extends the section it actually lives in.
+    #[test]
+    fn hierarchical_deduped_parent_prefixes_final_id() {
+        let mut tree = root(vec![h(2, "Foo"), h(2, "Foo"), h(3, "Bar")]);
+        HeadingLinksPlugin::with_strategy(HeadingIdStrategy::Hierarchical).visit(&mut tree);
+        assert_eq!(
+            all_ids(&tree),
+            vec![
+                Some("foo".into()),
+                Some("foo-1".into()),
+                Some("foo-1-bar".into()),
+            ]
+        );
+    }
+
+    /// Empty-text headings are skipped entirely (no id, not on the
+    /// ancestor stack) — a deeper heading after one nests under the
+    /// nearest REAL ancestor.
+    #[test]
+    fn hierarchical_empty_heading_skipped_entirely() {
+        let mut tree = root(vec![h(2, "A"), h(3, ""), h(4, "C")]);
+        HeadingLinksPlugin::with_strategy(HeadingIdStrategy::Hierarchical).visit(&mut tree);
+        assert_eq!(
+            all_ids(&tree),
+            vec![Some("a".into()), None, Some("a-c".into())]
+        );
+    }
+
+    /// h1 is untouched in hierarchical mode too — it never joins the
+    /// ancestor stack, so a following h2 starts an unprefixed chain.
+    #[test]
+    fn hierarchical_h1_left_alone() {
+        let mut tree = root(vec![h(1, "Title"), h(2, "A"), h(3, "B")]);
+        HeadingLinksPlugin::with_strategy(HeadingIdStrategy::Hierarchical).visit(&mut tree);
+        assert_eq!(
+            all_ids(&tree),
+            vec![None, Some("a".into()), Some("a-b".into())]
+        );
+    }
+
+    /// `reset()` clears the ancestor stack as well as the dedup counter —
+    /// reusing the plugin across documents must not leak a stale prefix
+    /// (zfb#187 analogue for the hierarchical stack).
+    #[test]
+    fn hierarchical_reset_clears_stack_between_documents() {
+        let mut plugin = HeadingLinksPlugin::with_strategy(HeadingIdStrategy::Hierarchical);
+        let mut doc_a = root(vec![h(2, "A"), h(3, "B")]);
+        plugin.visit(&mut doc_a);
+        assert_eq!(all_ids(&doc_a), vec![Some("a".into()), Some("a-b".into())]);
+        plugin.reset();
+        // Without reset, this h3 would have inherited the stale `a`
+        // ancestor (and `b` would dedup to `b`-with-prefix anyway).
+        let mut doc_b = root(vec![h(3, "B")]);
+        plugin.visit(&mut doc_b);
+        assert_eq!(all_ids(&doc_b), vec![Some("b".into())]);
+    }
+
+    /// The heading-ID registry (link validation, wave 6) records the
+    /// hierarchical ids, so `[x](#foo-moo)` validates and `[x](#moo)`
+    /// correctly fails once the strategy is on.
+    #[test]
+    fn hierarchical_ids_reach_heading_registry() {
+        use crate::heading_registry::HeadingRegistry;
+
+        let mut registry = HeadingRegistry::new();
+        let mut ctx = BuildContext::for_paths("/docs/a.md", "/docs", "/docs/public");
+        ctx.heading_registry = Some(&mut registry);
+
+        let mut tree = root(vec![h(2, "Foo"), h(3, "Moo")]);
+        HeadingLinksPlugin::with_strategy(HeadingIdStrategy::Hierarchical)
+            .visit_with_context(&mut tree, &mut ctx);
+
+        let entries = registry
+            .get(std::path::Path::new("/docs/a.md"))
+            .expect("registry entries recorded");
+        let ids: Vec<&str> = entries.iter().map(|e| e.id.as_str()).collect();
+        assert_eq!(ids, vec!["foo", "foo-moo"]);
+    }
+
+    /// Flat golden regression (byte-stability guardrail): duplicates,
+    /// h1, an empty heading, and cross-level repeats keep the exact
+    /// pre-#871 flat ids when no strategy is opted into.
+    #[test]
+    fn flat_golden_ids_unchanged() {
+        let mut tree = root(vec![
+            h(1, "Title"),
+            h(2, "Intro"),
+            h(3, "Intro"),
+            h(3, ""),
+            h(2, "Usage"),
+            h(4, "Intro"),
+        ]);
+        HeadingLinksPlugin::new().visit(&mut tree);
+        assert_eq!(
+            all_ids(&tree),
+            vec![
+                None,                   // h1 untouched
+                Some("intro".into()),   // first occurrence
+                Some("intro-1".into()), // cross-level dedup
+                None,                   // empty heading skipped
+                Some("usage".into()),
+                Some("intro-2".into()), // shared counter across levels
+            ]
+        );
+    }
+
     #[test]
     fn slugify_preserves_accented_latin_decomposed() {
         // Decomposed: e (U+0065) + combining acute accent (U+0301).

--- a/crates/zfb-content/src/plugins/heading_links.rs
+++ b/crates/zfb-content/src/plugins/heading_links.rs
@@ -22,26 +22,98 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
+pub use zfb_md_ast::HeadingIdStrategy;
+
 use crate::heading_registry::HeadingEntry;
 use crate::pipeline::{BuildContext, HastNode, HastVisitor};
 use crate::plugins::util::hast_text::extract_text;
 
 /// Visitor that adds permalink anchors to headings.
 pub struct HeadingLinksPlugin {
-    seen: HashMap<String, usize>,
+    slugs: SlugAllocator,
 }
 
 impl HeadingLinksPlugin {
-    /// New plugin with an empty per-document slug counter.
+    /// New plugin with the default flat strategy and an empty per-document
+    /// slug counter.
     #[must_use]
     pub fn new() -> Self {
+        Self::with_strategy(HeadingIdStrategy::Flat)
+    }
+
+    /// New plugin with an explicit heading-ID strategy
+    /// (`markdown.features.headingIds.strategy`, zfb#871).
+    #[must_use]
+    pub fn with_strategy(strategy: HeadingIdStrategy) -> Self {
         Self {
+            slugs: SlugAllocator::new(strategy),
+        }
+    }
+}
+
+/// Strategy-aware slug allocator shared by [`HeadingLinksPlugin`] and
+/// `mdx_jsx_emit::collect_headings` so the rendered `<hN id="…">` and the
+/// emitted `headings[i].slug` can never drift (zfb#871).
+///
+/// - [`HeadingIdStrategy::Flat`] delegates to [`next_slug`] untouched —
+///   byte-identical to the pre-#871 scheme.
+/// - [`HeadingIdStrategy::Hierarchical`] prefixes each slug with its
+///   ancestor chain: the candidate is `{parent_final_id}-{base}` (just
+///   `base` for a top-of-outline heading), deduped on the full candidate
+///   through the same [`next_slug`] counter. The ancestor stack records the
+///   parent's *final* (post-dedup) id, so a child anchor always extends the
+///   anchor of the section it actually lives in.
+///
+/// Empty `base` short-circuits to the empty string in BOTH strategies and
+/// leaves all state untouched — empty-text headings get no id and do not
+/// participate in the outline.
+pub struct SlugAllocator {
+    strategy: HeadingIdStrategy,
+    seen: HashMap<String, usize>,
+    /// Hierarchical ancestor stack of `(depth, final id)`. Unused in flat
+    /// mode.
+    stack: Vec<(u8, String)>,
+}
+
+impl SlugAllocator {
+    /// New allocator with empty per-document state.
+    #[must_use]
+    pub fn new(strategy: HeadingIdStrategy) -> Self {
+        Self {
+            strategy,
             seen: HashMap::new(),
+            stack: Vec::new(),
         }
     }
 
-    fn next_slug(&mut self, base: &str) -> String {
-        next_slug(&mut self.seen, base)
+    /// Allocate the slug for a heading of `depth` (2–6) whose slugified
+    /// text is `base`. Returns the empty string for an empty `base`.
+    pub fn allocate(&mut self, depth: u8, base: &str) -> String {
+        match self.strategy {
+            HeadingIdStrategy::Flat => next_slug(&mut self.seen, base),
+            HeadingIdStrategy::Hierarchical => {
+                if base.is_empty() {
+                    return String::new();
+                }
+                while self.stack.last().is_some_and(|(d, _)| *d >= depth) {
+                    self.stack.pop();
+                }
+                let candidate = match self.stack.last() {
+                    Some((_, parent)) => format!("{parent}-{base}"),
+                    None => base.to_string(),
+                };
+                let slug = next_slug(&mut self.seen, &candidate);
+                self.stack.push((depth, slug.clone()));
+                slug
+            }
+        }
+    }
+
+    /// Clear all per-document state (dedup counters AND the hierarchical
+    /// ancestor stack) — called between documents (zfb#187).
+    pub fn reset(&mut self) {
+        self.seen.clear();
+        self.stack.clear();
     }
 }
 
@@ -77,14 +149,15 @@ impl Default for HeadingLinksPlugin {
 }
 
 impl HastVisitor for HeadingLinksPlugin {
-    /// Reset the per-document slug counter.
+    /// Reset the per-document slug state (dedup counter + hierarchical
+    /// ancestor stack).
     ///
     /// Called by [`Pipeline::reset_per_entry`] between documents so the
     /// same `## Basic Usage` heading always produces `basic-usage` in each
     /// file rather than `basic-usage-7` when the pipeline is reused across
     /// multiple entries (zfb#187).
     fn reset(&mut self) {
-        self.seen.clear();
+        self.slugs.reset();
     }
 
     fn visit(&mut self, node: &mut HastNode) {
@@ -120,7 +193,7 @@ impl HeadingLinksPlugin {
                 let text = extract_text(node);
                 let base = slugify(&text);
                 if !base.is_empty() {
-                    slug_and_text = Some((self.next_slug(&base), text, depth));
+                    slug_and_text = Some((self.slugs.allocate(depth, &base), text, depth));
                 }
             }
         }

--- a/crates/zfb-content/tests/mdx_jsx_emit_hast.rs
+++ b/crates/zfb-content/tests/mdx_jsx_emit_hast.rs
@@ -897,3 +897,30 @@ fn default_features_keep_flat_heading_ids() {
         "hierarchical ids must NOT appear without opting in:\n{out}",
     );
 }
+
+/// Codex-review follow-up (zfb#871): a CUSTOM pipeline that hand-wires
+/// `HeadingLinksPlugin::with_strategy(Hierarchical)` must call
+/// `set_heading_id_strategy` so the `headings` export mirrors the
+/// rendered ids — this test pins the setter keeping the two in sync.
+#[test]
+fn manual_wiring_with_setter_keeps_headings_export_in_sync() {
+    use zfb_content::plugins::heading_links::{HeadingIdStrategy, HeadingLinksPlugin};
+
+    let mut p = Pipeline::with_mdx();
+    p.set_heading_id_strategy(HeadingIdStrategy::Hierarchical);
+    p.add_hast_visitor(Box::new(HeadingLinksPlugin::with_strategy(
+        HeadingIdStrategy::Hierarchical,
+    )));
+    let out =
+        mdx_to_jsx_module_with_pipeline("## Foo\n\n### Moo\n", MdxJsxOptions::default(), &mut p)
+            .expect("pipeline emit ok");
+
+    assert!(
+        out.contains("id=\"foo-moo\""),
+        "manually wired plugin must render hierarchical ids:\n{out}",
+    );
+    assert!(
+        out.contains("slug: \"foo-moo\""),
+        "headings export must follow the declared strategy:\n{out}",
+    );
+}

--- a/crates/zfb-content/tests/mdx_jsx_emit_hast.rs
+++ b/crates/zfb-content/tests/mdx_jsx_emit_hast.rs
@@ -785,3 +785,115 @@ fn toc_export_plugin_emits_at_column_0_on_jsx_path() {
             panic!("SWC rejected toc-export output (#599 regression): {e}\n--- src ---\n{out}")
         });
 }
+
+/// zfb#871 headline acceptance: `features.headingIds.strategy =
+/// "hierarchical"` must produce ancestor-prefixed ids in BOTH render
+/// paths — the rendered `<hN id="…">` + hash-link anchors (stamped by
+/// `HeadingLinksPlugin` on the hast detour) AND the `headings` export
+/// (computed by `collect_headings` via the shared `SlugAllocator`).
+#[test]
+fn hierarchical_strategy_ids_match_in_both_paths() {
+    use zfb_md_extras::{HeadingIdStrategy, HeadingIdsConfig, MarkdownFeaturesConfig};
+
+    let features = MarkdownFeaturesConfig {
+        heading_ids: Some(HeadingIdsConfig {
+            strategy: HeadingIdStrategy::Hierarchical,
+        }),
+        ..Default::default()
+    };
+    let mut p = Pipeline::with_defaults_and_features(&features);
+    let out = mdx_to_jsx_module_with_pipeline(
+        "## Foo\n\n### Moo\n\n#### Mew\n",
+        MdxJsxOptions::default(),
+        &mut p,
+    )
+    .expect("pipeline emit ok");
+
+    // Rendered hast path: ids + matching anchor hrefs.
+    for (id, href) in [
+        ("foo", "#foo"),
+        ("foo-moo", "#foo-moo"),
+        ("foo-moo-mew", "#foo-moo-mew"),
+    ] {
+        assert!(
+            out.contains(&format!("id=\"{id}\"")),
+            "rendered heading must carry hierarchical id {id:?}:\n{out}",
+        );
+        assert!(
+            out.contains(&format!("href=\"{href}\"")),
+            "hash-link must carry hierarchical href {href:?}:\n{out}",
+        );
+    }
+
+    // headings export path: same slugs, in document order.
+    for slug in ["\"foo\"", "\"foo-moo\"", "\"foo-moo-mew\""] {
+        assert!(
+            out.contains(&format!("slug: {slug}")),
+            "headings export must carry hierarchical slug {slug}:\n{out}",
+        );
+    }
+    // The flat slugs must NOT leak through for the nested levels.
+    assert!(
+        !out.contains("slug: \"moo\"") && !out.contains("id=\"moo\""),
+        "flat slug `moo` must not appear in hierarchical mode:\n{out}",
+    );
+}
+
+/// zfb#871: a JSX-nested heading gets its hierarchical id stamped by
+/// `jsx_render_child` (HeadingLinksPlugin never sees it), prefixed by
+/// the preceding top-level ancestor.
+#[test]
+fn hierarchical_strategy_jsx_nested_heading_prefixed() {
+    use zfb_md_extras::{HeadingIdStrategy, HeadingIdsConfig, MarkdownFeaturesConfig};
+
+    let features = MarkdownFeaturesConfig {
+        heading_ids: Some(HeadingIdsConfig {
+            strategy: HeadingIdStrategy::Hierarchical,
+        }),
+        ..Default::default()
+    };
+    let mut p = Pipeline::with_defaults_and_features(&features);
+    let out = mdx_to_jsx_module_with_pipeline(
+        "## Foo\n\n<Note>\n\n### Moo\n\n</Note>\n",
+        MdxJsxOptions::default(),
+        &mut p,
+    )
+    .expect("pipeline emit ok");
+
+    assert!(
+        out.contains("id=\"foo-moo\""),
+        "JSX-nested heading must get hierarchical id `foo-moo`:\n{out}",
+    );
+    assert!(
+        out.contains("slug: \"foo-moo\""),
+        "headings export must record the nested hierarchical slug:\n{out}",
+    );
+}
+
+/// zfb#871 byte-stability guardrail: an absent (or default) `headingIds`
+/// keeps the flat scheme — nested headings keep their unprefixed slugs
+/// and the cross-level dedup counter still applies.
+#[test]
+fn default_features_keep_flat_heading_ids() {
+    use zfb_md_extras::MarkdownFeaturesConfig;
+
+    let features = MarkdownFeaturesConfig::default();
+    let mut p = Pipeline::with_defaults_and_features(&features);
+    let out = mdx_to_jsx_module_with_pipeline(
+        "## Foo\n\n### Moo\n\n### Foo\n",
+        MdxJsxOptions::default(),
+        &mut p,
+    )
+    .expect("pipeline emit ok");
+
+    for id in ["id=\"foo\"", "id=\"moo\"", "id=\"foo-1\""] {
+        assert!(
+            out.contains(id),
+            "flat default must keep unprefixed + deduped ids ({id}):\n{out}",
+        );
+    }
+    assert!(
+        !out.contains("id=\"foo-moo\""),
+        "hierarchical ids must NOT appear without opting in:\n{out}",
+    );
+}

--- a/crates/zfb-md-ast/src/features_config.rs
+++ b/crates/zfb-md-ast/src/features_config.rs
@@ -353,6 +353,50 @@ pub fn reading_time_enabled(toggle: &Option<ReadingTimeFeature>) -> bool {
     toggle.as_ref().is_some_and(ReadingTimeFeature::is_enabled)
 }
 
+/// Heading-ID strategy applied by the always-on `HeadingLinks` plugin.
+///
+/// Selected via `markdown.features.headingIds.strategy` in `zfb.config.ts`.
+/// `Flat` is the long-standing default (github-slugger slugs with a
+/// per-document `-1`, `-2`, … dedup counter shared across h2–h6).
+/// `Hierarchical` prefixes each heading's slug with its ancestor chain
+/// (`## Foo` / `### Moo` / `#### Mew` → `foo`, `foo-moo`, `foo-moo-mew`),
+/// which makes anchors reconstructible from the heading outline and far
+/// less collision-prone (requested by zudolab/zudo-doc#1938 via zfb#871).
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum HeadingIdStrategy {
+    /// Flat github-slugger slugs + global per-document dedup (default).
+    #[default]
+    Flat,
+    /// Ancestor-prefixed slugs (`foo-moo-mew`), deduped on the full path.
+    Hierarchical,
+}
+
+/// Options for the `headingIds` entry in `markdown.features`.
+///
+/// Configures the always-on `HeadingLinks` plugin rather than toggling an
+/// opt-in feature — absent means [`HeadingIdStrategy::Flat`], preserving the
+/// pre-#871 anchor scheme byte-for-byte.
+///
+/// `deny_unknown_fields` ensures `headingIds: { bogus: true }` is rejected
+/// rather than silently treated as defaults.
+///
+/// Mirrors `HeadingIdsConfig` in `packages/zfb/src/config.ts`.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, Default)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct HeadingIdsConfig {
+    /// Heading-ID strategy. Default: [`HeadingIdStrategy::Flat`].
+    #[serde(default)]
+    pub strategy: HeadingIdStrategy,
+}
+
+/// Resolve the `headingIds` config to a concrete [`HeadingIdStrategy`].
+/// Absent → [`HeadingIdStrategy::Flat`] (pre-#871 behaviour unchanged).
+#[must_use]
+pub fn heading_id_strategy(cfg: &Option<HeadingIdsConfig>) -> HeadingIdStrategy {
+    cfg.as_ref().map(|c| c.strategy).unwrap_or_default()
+}
+
 /// Directive kind for user-defined directives.
 ///
 /// Maps to [`crate::directives::DirectiveKind`]. A separate serde DTO is
@@ -532,6 +576,12 @@ pub struct MarkdownFeaturesConfig {
     /// [`TocConfig`] options object — see [`HeadingMarkerTocFeature`].
     #[serde(default)]
     pub heading_marker_toc: Option<HeadingMarkerTocFeature>,
+
+    /// Heading-ID strategy for the always-on `HeadingLinks` plugin.
+    /// Absent → flat (pre-#871 behaviour). `{ strategy: "hierarchical" }`
+    /// opts into ancestor-prefixed anchor IDs — see [`HeadingIdsConfig`].
+    #[serde(default)]
+    pub heading_ids: Option<HeadingIdsConfig>,
 }
 
 #[cfg(test)]
@@ -589,6 +639,59 @@ mod tests {
         let cfg: MarkdownFeaturesConfig =
             serde_json::from_value(json).expect("empty directives deserialises");
         assert!(directives_enabled(&cfg.directives));
+    }
+
+    // `headingIds: { strategy: "hierarchical" }` parses to the enum variant.
+    #[test]
+    fn heading_ids_hierarchical_parses() {
+        let json = serde_json::json!({ "headingIds": { "strategy": "hierarchical" } });
+        let cfg: MarkdownFeaturesConfig =
+            serde_json::from_value(json).expect("headingIds hierarchical deserialises");
+        assert_eq!(
+            heading_id_strategy(&cfg.heading_ids),
+            HeadingIdStrategy::Hierarchical
+        );
+    }
+
+    // `headingIds: { strategy: "flat" }` is the explicit form of the default.
+    #[test]
+    fn heading_ids_flat_parses() {
+        let json = serde_json::json!({ "headingIds": { "strategy": "flat" } });
+        let cfg: MarkdownFeaturesConfig =
+            serde_json::from_value(json).expect("headingIds flat deserialises");
+        assert_eq!(heading_id_strategy(&cfg.heading_ids), HeadingIdStrategy::Flat);
+    }
+
+    // `headingIds: {}` and an absent key both resolve to Flat.
+    #[test]
+    fn heading_ids_defaults_to_flat() {
+        let json = serde_json::json!({ "headingIds": {} });
+        let cfg: MarkdownFeaturesConfig =
+            serde_json::from_value(json).expect("empty headingIds deserialises");
+        assert_eq!(heading_id_strategy(&cfg.heading_ids), HeadingIdStrategy::Flat);
+        assert_eq!(heading_id_strategy(&None), HeadingIdStrategy::Flat);
+    }
+
+    // Unknown fields inside `headingIds` are rejected (deny_unknown_fields).
+    #[test]
+    fn heading_ids_unknown_field_rejected() {
+        let json = serde_json::json!({ "headingIds": { "bogus": true } });
+        let result: Result<MarkdownFeaturesConfig, _> = serde_json::from_value(json);
+        assert!(
+            result.is_err(),
+            "headingIds.bogus must be rejected; got: {result:?}"
+        );
+    }
+
+    // An invalid strategy value is rejected rather than falling back to flat.
+    #[test]
+    fn heading_ids_invalid_strategy_rejected() {
+        let json = serde_json::json!({ "headingIds": { "strategy": "nested" } });
+        let result: Result<MarkdownFeaturesConfig, _> = serde_json::from_value(json);
+        assert!(
+            result.is_err(),
+            "headingIds.strategy must reject unknown variants; got: {result:?}"
+        );
     }
 
     // `admonitionsPreset` is a removed key. `deny_unknown_fields` on

--- a/crates/zfb-md-ast/src/lib.rs
+++ b/crates/zfb-md-ast/src/lib.rs
@@ -29,11 +29,12 @@ pub use directives::{
     ValidatedAttrValue,
 };
 pub use features_config::{
-    directives_enabled, feature_enabled, heading_marker_toc_enabled, reading_time_enabled,
-    CodeEnrichmentConfig, DirectiveFullSpec, DirectiveSpec, DirectiveSpecKind, FeatureOptions,
-    FeatureToggle, GithubAutolinksConfig, HeadingMarkerTocFeature, ImageDimensionsConfig,
-    LinkValidationConfig, MarkdownFeaturesConfig, ReadingTimeFeature, ReadingTimeOptions, TocConfig,
-    TocExportConfig, TranscludeConfig, into_directive_def,
+    directives_enabled, feature_enabled, heading_id_strategy, heading_marker_toc_enabled,
+    reading_time_enabled, CodeEnrichmentConfig, DirectiveFullSpec, DirectiveSpec,
+    DirectiveSpecKind, FeatureOptions, FeatureToggle, GithubAutolinksConfig, HeadingIdStrategy,
+    HeadingIdsConfig, HeadingMarkerTocFeature, ImageDimensionsConfig, LinkValidationConfig,
+    MarkdownFeaturesConfig, ReadingTimeFeature, ReadingTimeOptions, TocConfig, TocExportConfig,
+    TranscludeConfig, into_directive_def,
 };
 pub use hast_text::extract_text;
 

--- a/crates/zfb-md-extras/src/lib.rs
+++ b/crates/zfb-md-extras/src/lib.rs
@@ -19,10 +19,11 @@
 // in the natural location (this is the "features" crate, after all) without
 // reaching past it for the type.
 pub use zfb_md_ast::{
-    directives_enabled, feature_enabled, heading_marker_toc_enabled, into_directive_def,
-    CodeEnrichmentConfig, DirectiveFullSpec, DirectiveSpec, DirectiveSpecKind, FeatureOptions,
-    FeatureToggle, GithubAutolinksConfig, HeadingMarkerTocFeature, ImageDimensionsConfig,
-    LinkValidationConfig, MarkdownFeaturesConfig, TocConfig, TocExportConfig, TranscludeConfig,
+    directives_enabled, feature_enabled, heading_id_strategy, heading_marker_toc_enabled,
+    into_directive_def, CodeEnrichmentConfig, DirectiveFullSpec, DirectiveSpec, DirectiveSpecKind,
+    FeatureOptions, FeatureToggle, GithubAutolinksConfig, HeadingIdStrategy, HeadingIdsConfig,
+    HeadingMarkerTocFeature, ImageDimensionsConfig, LinkValidationConfig, MarkdownFeaturesConfig,
+    TocConfig, TocExportConfig, TranscludeConfig,
 };
 
 /// Test harness module — `run_fixture` and helpers for fixture-based

--- a/crates/zfb/src/config.rs
+++ b/crates/zfb/src/config.rs
@@ -942,11 +942,11 @@ pub struct MarkdownConfig {
 // like `zfb::config::{MarkdownFeaturesConfig, FeatureToggle, ...}` and
 // `zfb::config::TocConfig` continue to resolve.
 pub use zfb_md_ast::{
-    directives_enabled, into_directive_def, reading_time_enabled, CodeEnrichmentConfig,
-    DirectiveFullSpec, DirectiveSpec, DirectiveSpecKind, FeatureOptions, FeatureToggle,
-    GithubAutolinksConfig, HeadingMarkerTocFeature, ImageDimensionsConfig, LinkValidationConfig,
-    MarkdownFeaturesConfig, ReadingTimeFeature, ReadingTimeOptions, TocConfig, TocExportConfig,
-    TranscludeConfig,
+    directives_enabled, heading_id_strategy, into_directive_def, reading_time_enabled,
+    CodeEnrichmentConfig, DirectiveFullSpec, DirectiveSpec, DirectiveSpecKind, FeatureOptions,
+    FeatureToggle, GithubAutolinksConfig, HeadingIdStrategy, HeadingIdsConfig,
+    HeadingMarkerTocFeature, ImageDimensionsConfig, LinkValidationConfig, MarkdownFeaturesConfig,
+    ReadingTimeFeature, ReadingTimeOptions, TocConfig, TocExportConfig, TranscludeConfig,
 };
 
 /// Options for the `rehype-external-links` port.

--- a/docs/src/content/docs/markdown-features/heading-links.mdx
+++ b/docs/src/content/docs/markdown-features/heading-links.mdx
@@ -39,8 +39,57 @@ Produces:
 
 ## Config
 
-Always on, no config key. The slug algorithm is fixed (GitHub-slugger
-rules) and cannot be customised from `zfb.config.ts`.
+The plugin itself is always on. The **ID strategy** is configurable via
+`markdown.features.headingIds`:
+
+```ts
+// zfb.config.ts
+export default {
+  markdown: {
+    features: {
+      headingIds: { strategy: "hierarchical" },
+    },
+  },
+};
+```
+
+### `strategy: "flat"` (default)
+
+The behaviour described above: GitHub-slugger slugs with one dedup counter
+shared across `h2`–`h6`. Omitting `headingIds` entirely keeps this scheme.
+
+### `strategy: "hierarchical"`
+
+Each heading's ID is prefixed with its ancestor chain, joined by `-`:
+
+```md
+## Foo
+
+### Moo
+
+#### Mew
+```
+
+Produces `id="foo"`, `id="foo-moo"`, `id="foo-moo-mew"` (instead of the
+flat `foo`, `moo`, `mew`). The in-heading hash-link anchors, the
+`headings` export, [TOC export](/markdown-features/toc-export), and
+[link validation](/markdown-features/link-validation) all follow the
+same IDs.
+
+Details:
+
+- A duplicated full path still gets the dedup counter (`a-b`, `a-b-1`).
+- A deduplicated parent contributes its **final** ID to children: the
+  second `## Foo` is `foo-1`, so its `### Bar` becomes `foo-1-bar`.
+- Hierarchical anchors are reconstructible from the heading outline and
+  collide far less often than flat slugs, at the cost of longer URLs.
+
+<Warning>
+
+Switching strategies is **anchor-breaking**: existing deep links to
+nested headings (`#moo`) stop resolving once IDs become `#foo-moo`.
+
+</Warning>
 
 ## Ordering note
 

--- a/packages/zfb/src/config.ts
+++ b/packages/zfb/src/config.ts
@@ -754,6 +754,35 @@ export type MarkdownFeaturesConfig = {
    * `HeadingMarkerTocFeature` enum.
    */
   headingMarkerToc?: HeadingMarkerTocFeature;
+
+  /**
+   * Heading-ID strategy for the always-on `HeadingLinks` plugin.
+   * Absent → `"flat"` (the long-standing github-slugger scheme).
+   * `{ strategy: "hierarchical" }` opts into ancestor-prefixed anchor
+   * IDs (`## Foo` / `### Moo` / `#### Mew` → `foo`, `foo-moo`,
+   * `foo-moo-mew`) — see {@link HeadingIdsConfig}.
+   */
+  headingIds?: HeadingIdsConfig;
+};
+
+/**
+ * Options for the `headingIds` entry in `markdown.features`.
+ *
+ * Configures the always-on `HeadingLinks` plugin rather than toggling an
+ * opt-in feature. Note: switching to `"hierarchical"` is anchor-breaking
+ * for existing deep links to nested headings.
+ *
+ * Mirrors `HeadingIdsConfig` in crates/zfb-md-ast/src/features_config.rs.
+ */
+export type HeadingIdsConfig = {
+  /**
+   * `"flat"` (default): github-slugger slugs with a per-document dedup
+   * counter shared across h2–h6 (`overview`, `overview-1`, …).
+   * `"hierarchical"`: each heading's slug is prefixed with its ancestor
+   * chain and deduped on the full path — anchors become reconstructible
+   * from the heading outline.
+   */
+  strategy?: "flat" | "hierarchical";
 };
 
 /**


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/871

---

## Summary

- Adds an opt-in **hierarchical / ancestor-prefixed** heading-ID strategy to the always-on `HeadingLinks` plugin, requested by zudolab/zudo-doc#1938 via #871.
- New config knob: `markdown.features.headingIds: { strategy: "hierarchical" | "flat" }` — absent/`"flat"` keeps the long-standing github-slugger + dedup scheme **byte-for-byte**.
- One shared `SlugAllocator` drives both the rendered `<hN id="…">` (hast path) and the `headings` export / JSX-nested heading ids (JSX-emit path), so the two can't drift.

```md
## Foo
### Moo
#### Mew
```

- flat (default): `#foo`, `#moo`, `#mew`
- hierarchical: `#foo`, `#foo-moo`, `#foo-moo-mew`

## Changes

### Config surface
- `zfb-md-ast`: `HeadingIdStrategy` enum (`flat` default | `hierarchical`), `HeadingIdsConfig { strategy }` (`deny_unknown_fields`), new `headingIds` field on `MarkdownFeaturesConfig`, `heading_id_strategy()` resolver. Re-exported through `zfb-md-extras`, `zfb-content`, and `zfb::config`.
- TS mirror: `HeadingIdsConfig` + `headingIds` in `packages/zfb/src/config.ts`.

### Core implementation (`zfb-content`)
- `SlugAllocator` in `heading_links.rs`: flat arm delegates to the existing `next_slug` untouched; hierarchical arm pops an ancestor stack to the nearest shallower heading, builds `{parent_final_id}-{base}`, dedups on the full path, and pushes `(depth, final_id)`. Empty-text headings are skipped entirely; h1 never participates; `reset()` clears counter + stack between documents (zfb#187-safe).
- `HeadingLinksPlugin::with_strategy(…)` (`new()` stays flat). Registry entries (link validation) carry the hierarchical ids automatically; `tocExport` / `headingMarkerToc` read the rendered `id` attribute so they follow for free.
- `Pipeline` carries the resolved strategy (`heading_id_strategy()` getter + `set_heading_id_strategy()` setter for manually wired pipelines — codex-review follow-up). `with_defaults_and_full_config` resolves it from `features.headingIds`; legacy constructors stay flat.
- `mdx_jsx_emit::collect_headings` allocates through the same `SlugAllocator` (strategy read back from the pipeline; no pipeline → flat), covering both the `headings` export and JSX-nested heading ids stamped by `jsx_render_child`. The pre-existing #477 JSX-nested dedup asymmetry has a documented hierarchical analog (same root cause, same accepted scope).

### Docs
- `markdown-features/heading-links.mdx`: documents the new strategy knob, hierarchical rules (full-path dedup, final-id parent prefixes), and the anchor-breaking caveat.

## Test Plan

- 12 new unit tests in `heading_links.rs`: the issue's `foo`/`foo-moo`/`foo-moo-mew` chain, sibling pops, depth jumps (h2→h4), dedup under the same parent, deduped-parent final-id prefixes (`foo`/`foo-1`/`foo-1-bar`), empty-heading skip, h1 exclusion, reset clearing the stack between documents, heading-registry coverage, and a **flat golden regression** pinning the pre-#871 ids.
- 4 new integration tests in `mdx_jsx_emit_hast.rs`: hierarchical ids identical across the rendered hast path and the `headings` export, JSX-nested heading prefixes, flat default unchanged without opt-in, and manual-wiring sync via the setter.
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo test --workspace` green (78 suites); `pnpm --filter docs build` OK; `tsc --noEmit` OK for `packages/zfb`.