### PR TITLE
fix(zfb): forward signals from bin wrapper to native binary

### DIFF
--- a/packages/zfb/bin/zfb.mjs
+++ b/packages/zfb/bin/zfb.mjs
@@ -1,9 +1,14 @@
 #!/usr/bin/env node
 // Followed biome's pattern: pure os/cpu lookup → resolve platform package → spawn binary.
 // See: https://github.com/biomejs/biome (packages/js/biome/bin/biome.mjs reference)
+// Divergence from biome: async spawn + signal forwarding instead of spawnSync.
+// biome is a short-lived CLI, but `zfb dev` is a long-running server — without
+// forwarding, SIGTERM to the wrapper orphans the native binary (PPID 1) and
+// leaves the dev-server port bound (issue #873).
 import { existsSync } from "node:fs";
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import { createRequire } from "node:module";
+import { constants as osConstants } from "node:os";
 import { join } from "node:path";
 
 const require = createRequire(import.meta.url);
@@ -57,26 +62,61 @@ if (!existsSync(binPath)) {
   process.exit(1);
 }
 
-const result = spawnSync(binPath, process.argv.slice(2), { stdio: "inherit" });
+const child = spawn(binPath, process.argv.slice(2), { stdio: "inherit" });
 
-// Surface spawn errors that spawnSync stores in result.error rather than
-// propagating to stderr. Without this, a 0644 binary (EACCES) is silently
-// swallowed and the process exits with code 1 and no message — making it
-// impossible for the user to diagnose a corrupted/incomplete npm install.
-// (Issue #447 / #441 — pnpm publish strips the executable bit.)
-if (result.error) {
-  if (result.error.code === "EACCES") {
+// Forward termination signals to the child. Supervisors (concurrently
+// --kill-others, Playwright webServer teardown, timeout(1), CI runners)
+// signal only the wrapper; without forwarding, the native server survives
+// with PPID 1 and keeps its port bound. Terminal Ctrl+C already signals the
+// whole foreground group, so the child may receive SIGINT twice — the native
+// binary treats repeated signals as the same shutdown request.
+// SIGHUP is POSIX-only: on Windows child.kill("SIGHUP") throws (libuv only
+// emulates SIGINT/SIGTERM/SIGKILL/SIGQUIT), and the OS tears down console
+// processes on window close anyway.
+const forwardedSignals =
+  process.platform === "win32" ? ["SIGINT", "SIGTERM"] : ["SIGINT", "SIGTERM", "SIGHUP"];
+const signalForwarders = new Map();
+for (const sig of forwardedSignals) {
+  const forward = () => child.kill(sig);
+  signalForwarders.set(sig, forward);
+  process.on(sig, forward);
+}
+
+// Surface spawn failures clearly. Without this, a 0644 binary (EACCES) is
+// silently swallowed and the process exits with code 1 and no message —
+// making it impossible for the user to diagnose a corrupted/incomplete npm
+// install. (Issue #447 / #441 — pnpm publish strips the executable bit.)
+child.on("error", (error) => {
+  if (error.code === "EACCES") {
     process.stderr.write(
       `[zfb] binary is not executable; was the install corrupt?\n` +
         `      ${binPath}\n` +
         `      Try reinstalling: npm install --include=optional\n`,
     );
   } else {
-    process.stderr.write(
-      `[zfb] failed to spawn binary: ${result.error.message}\n` + `      ${binPath}\n`,
-    );
+    process.stderr.write(`[zfb] failed to spawn binary: ${error.message}\n` + `      ${binPath}\n`);
   }
   process.exit(1);
-}
+});
 
-process.exit(result.status ?? 1);
+child.on("exit", (code, signal) => {
+  if (signal) {
+    // Re-raise the child's termination signal on ourselves so the caller
+    // sees the real cause of death (e.g. WIFSIGNALED), not a plain exit code.
+    // Remove our forwarding listener first or it would swallow the re-raise.
+    const forward = signalForwarders.get(signal);
+    if (forward) {
+      process.off(signal, forward);
+    }
+    try {
+      process.kill(process.pid, signal);
+    } catch {
+      // Signal cannot be re-raised on this platform (Windows emulation).
+    }
+    // Reached only if the re-raised signal did not terminate us — fall back
+    // to the shell's 128+n convention for death-by-signal.
+    const signum = osConstants.signals[signal];
+    process.exit(signum ? 128 + signum : 1);
+  }
+  process.exit(code ?? 1);
+});

--- a/packages/zfb/src/__tests__/launcher.test.ts
+++ b/packages/zfb/src/__tests__/launcher.test.ts
@@ -8,8 +8,17 @@
 // against a non-executable (0644) binary. This avoids NODE_PATH tricks that
 // don't work with createRequire(import.meta.url).
 
-import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync, chmodSync, copyFileSync } from "node:fs";
+import { spawn, spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+  chmodSync,
+  copyFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -113,4 +122,133 @@ describe("launcher EACCES surfacing (issue #447)", () => {
     // Must include the binary path so the user knows exactly which file to fix.
     expect(stderr).toContain(fakeBinPath);
   });
+});
+
+// Regression tests for issue #873:
+// spawnSync forwards no signals, so SIGTERM to the wrapper orphaned the
+// native binary (PPID 1) and left the dev-server port bound. The launcher
+// now uses async spawn + signal forwarding + exit/signal propagation.
+//
+// These tests replace the fake 0644 binary from the shared beforeEach with
+// an executable shell script, so they are POSIX-only (skipped on win32 —
+// shell scripts cannot be spawned there and signal semantics are emulated).
+describe("launcher signal forwarding and exit propagation (issue #873)", () => {
+  let tmpDir: string;
+  let fakeBinPath: string;
+  let launcherCopyPath: string;
+
+  const isPosix = process.platform !== "win32" && !!platformPkg;
+
+  beforeEach(() => {
+    if (!isPosix) {
+      return;
+    }
+
+    tmpDir = mkdtempSync(join(tmpdir(), "zfb-launcher-test-"));
+
+    const launcherDir = join(tmpDir, "node_modules", "@takazudo", "zfb", "bin");
+    mkdirSync(launcherDir, { recursive: true });
+    launcherCopyPath = join(launcherDir, "zfb.mjs");
+    copyFileSync(launcherPath, launcherCopyPath);
+
+    const pkgDir = join(tmpDir, "node_modules", platformPkg);
+    mkdirSync(pkgDir, { recursive: true });
+    fakeBinPath = join(pkgDir, "zfb");
+    writeFileSync(
+      join(pkgDir, "package.json"),
+      JSON.stringify({ name: platformPkg, version: "0.0.0" }),
+    );
+  });
+
+  afterEach(() => {
+    if (tmpDir) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  /**
+   * Write an executable fake platform binary that runs the given JS source
+   * under the current Node (absolute-path shebang — no /usr/bin/env or shell
+   * dependency, and no intermediate sh process between wrapper and "binary").
+   */
+  function writeFakeBin(jsSource: string): void {
+    writeFileSync(fakeBinPath, `#!${process.execPath}\n${jsSource}`);
+    chmodSync(fakeBinPath, 0o755);
+  }
+
+  /** Poll until `check` returns true or `timeoutMs` elapses. */
+  async function waitFor(check: () => boolean, timeoutMs: number): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (check()) return true;
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    return check();
+  }
+
+  function isProcessAlive(pid: number): boolean {
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  it("propagates the child's exit code", () => {
+    if (!isPosix) {
+      console.warn(`[skip] POSIX-only test on platform: ${platformKey}`);
+      return;
+    }
+
+    writeFakeBin("process.exit(7);\n");
+
+    const result = spawnSync(process.execPath, [launcherCopyPath], { encoding: "utf8" });
+
+    expect(result.status).toBe(7);
+  });
+
+  it("forwards SIGTERM to the native child and dies by the same signal", async () => {
+    if (!isPosix) {
+      console.warn(`[skip] POSIX-only test on platform: ${platformKey}`);
+      return;
+    }
+
+    // The fake binary records its PID, then idles — mimicking the
+    // long-running `zfb dev` server.
+    const pidFile = join(tmpDir, "child.pid");
+    writeFakeBin(
+      `require("node:fs").writeFileSync(${JSON.stringify(pidFile)}, String(process.pid));\n` +
+        `setInterval(() => {}, 1000);\n`,
+    );
+
+    const wrapper = spawn(process.execPath, [launcherCopyPath], { stdio: "ignore" });
+    const wrapperExit = new Promise<{ code: number | null; signal: string | null }>((res) => {
+      wrapper.on("exit", (code, signal) => res({ code, signal }));
+    });
+
+    try {
+      // Wait for the native child to be up and registered.
+      expect(await waitFor(() => existsSync(pidFile), 5000)).toBe(true);
+      const childPid = Number(readFileSync(pidFile, "utf8").trim());
+      expect(Number.isInteger(childPid) && childPid > 0).toBe(true);
+      expect(isProcessAlive(childPid)).toBe(true);
+
+      // Signal ONLY the wrapper — the supervisor scenario from issue #873.
+      wrapper.kill("SIGTERM");
+
+      // The native child must be terminated too, not orphaned to PPID 1.
+      expect(await waitFor(() => !isProcessAlive(childPid), 5000)).toBe(true);
+
+      // The wrapper must die by the re-raised signal so callers see the
+      // real termination cause, not a plain exit code.
+      const { signal } = await wrapperExit;
+      expect(signal).toBe("SIGTERM");
+    } finally {
+      // Safety net: never leak the wrapper if an assertion above failed.
+      if (wrapper.exitCode === null && wrapper.signalCode === null) {
+        wrapper.kill("SIGKILL");
+      }
+    }
+  }, 15000);
 });


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/873

---

## Summary
- Switch `packages/zfb/bin/zfb.mjs` from `spawnSync` to async `spawn` so the wrapper can manage the native child process.
- Forward `SIGINT`/`SIGTERM` (and `SIGHUP` on POSIX) from the wrapper to the native binary — supervisors that signal only the wrapper (`concurrently --kill-others`, Playwright `webServer` teardown, `timeout(1)`, CI runners) no longer orphan the dev server to PPID 1 with its port still bound.
- Re-raise the child's terminating signal on the wrapper so callers observe the real termination outcome (with a `128+n` exit-code fallback if the re-raise doesn't terminate).
- Preserve the EACCES / spawn-failure diagnostics from #447/#441 via the `error` event.

Closes #873

## Changes
- **Launcher behavior** (`packages/zfb/bin/zfb.mjs`)
  - Replace `spawnSync` with `spawn(binPath, args, { stdio: "inherit" })`.
  - Forward `SIGINT`/`SIGTERM`/`SIGHUP` with per-signal handlers tracked in a map; the forwarding handler is removed via `process.off` before the re-raise so it can't swallow it.
  - `SIGHUP` forwarding is POSIX-only — libuv cannot emulate it on Windows (`child.kill("SIGHUP")` throws there), and Windows tears down console processes on window close anyway.
  - Clean child exit propagates the child's actual exit code; death-by-signal re-raises that signal on the wrapper.
  - Header comment documents the divergence from biome's `spawnSync` pattern (biome is a short-lived CLI; `zfb dev` is a long-running server).

- **Test coverage** (`packages/zfb/src/__tests__/launcher.test.ts`)
  - New: exit-code propagation — fake binary exits 7 → wrapper exits 7.
  - New: SIGTERM forwarding — signal only the wrapper → the native child must die (no PPID-1 orphan) and the wrapper must die by `SIGTERM`.
  - Fake binaries are Node scripts with an absolute `process.execPath` shebang (no `/bin/sh` / `sleep` dependency); POSIX-only, skipped on win32.
  - Existing EACCES regression test (#447) unchanged and green.

## Test Plan
- `pnpm test` in `packages/zfb` — 165/165 pass (3 launcher tests incl. the two new regressions); `pnpm typecheck` clean.
- Live repro against the real `darwin-arm64` binary (zfb-example-blog install): patched wrapper + `kill -TERM <wrapper>` → native server exits, port freed; unpatched wrapper (control) → native survives at PPID 1 with port bound, reproducing #873 exactly.