### PR TITLE
fix(zfb-content): leave bare #fragment / ?query links untouched in resolve_links

### DIFF
--- a/crates/zfb-content/src/plugins/resolve_links.rs
+++ b/crates/zfb-content/src/plugins/resolve_links.rs
@@ -109,6 +109,15 @@ impl ResolveLinksPlugin {
         // the path part and stitch them back on.
         let (path_part, suffix) = split_suffix(url);
 
+        // Bare same-page references (`#fragment`, `?query`) have an empty
+        // path component — nothing to resolve. Without this guard the empty
+        // path falls through to extensionless probing, where the `/index.mdx`
+        // candidate joins to `{source_dir}/index.mdx` and rewrites `#anchor`
+        // to `/<parent-dir>/#anchor` (zudolab/zudo-doc#1948).
+        if path_part.is_empty() {
+            return Ok(None);
+        }
+
         if ends_with_md(path_part) {
             // Explicit .md/.mdx path: try direct and source_dir-relative lookups.
             return match self.lookup_path(path_part, suffix) {
@@ -464,6 +473,46 @@ mod tests {
         let mut root = root_with_link("./guide#section");
         plugin.visit(&mut root);
         assert_eq!(link_url(&root), "/docs/guide/#section");
+    }
+
+    #[test]
+    fn bare_fragment_left_alone() {
+        // Regression test for zudolab/zudo-doc#1948: a same-page `#anchor`
+        // link must not resolve against the page directory even when the
+        // parent category index is present in the source map.
+        let dir = PathBuf::from("/site/docs/guides");
+        let mut map = HashMap::new();
+        map.insert(
+            PathBuf::from("/site/docs/guides/index.mdx"),
+            "/docs/guides/".to_string(),
+        );
+        let mut plugin = ResolveLinksPlugin::new(ResolveMarkdownLinksOptions {
+            source_map: map,
+            source_dir: Some(dir),
+        });
+        let mut root = root_with_link("#per-page-visibility");
+        plugin.visit(&mut root);
+        assert_eq!(link_url(&root), "#per-page-visibility");
+        assert!(plugin.take_broken_links().is_empty());
+    }
+
+    #[test]
+    fn bare_query_left_alone() {
+        // Query-only links also have an empty path component — same guard.
+        let dir = PathBuf::from("/site/docs/guides");
+        let mut map = HashMap::new();
+        map.insert(
+            PathBuf::from("/site/docs/guides/index.mdx"),
+            "/docs/guides/".to_string(),
+        );
+        let mut plugin = ResolveLinksPlugin::new(ResolveMarkdownLinksOptions {
+            source_map: map,
+            source_dir: Some(dir),
+        });
+        let mut root = root_with_link("?x=1");
+        plugin.visit(&mut root);
+        assert_eq!(link_url(&root), "?x=1");
+        assert!(plugin.take_broken_links().is_empty());
     }
 
     #[test]


### PR DESCRIPTION
- downstream issue
    - https://github.com/zudolab/zudo-doc/issues/1948

---

## Summary

- Fixes the `resolveMarkdownLinks` bug reported by downstream consumer zudo-doc (zudolab/zudo-doc#1948): bare same-page fragment links authored as `[text](#anchor)` were rewritten to `/<parent-dir>/#anchor`, pointing at the parent category index instead of the same page
- Root cause: `split_suffix` yields an empty path part for `#anchor` / `?query` URLs; the empty path fell through to extensionless candidate probing, where the `/index.mdx` candidate joins to `{source_dir}/index.mdx` — the parent directory's category index, present in the source map — so the link resolved to that page's URL
- Fix: `resolve()` now early-returns (leaves the link untouched) when the URL's path component is empty — bare `#fragment` and `?query` links are same-page references, never resolvable targets

## Changes

- `crates/zfb-content/src/plugins/resolve_links.rs`
  - Added an empty-path guard in `ResolveLinksPlugin::resolve()` right after `split_suffix`, before the `.md`/`.mdx` and extensionless-probing branches
  - Added regression tests: `bare_fragment_left_alone` (asserts no rewrite and no broken-link diagnostic even when `{source_dir}/index.mdx` is in the source map — the exact zudo-doc scenario) and `bare_query_left_alone`

## Out of scope

Relative-with-fragment links like `./#anchor` / `../#anchor` have a non-empty path part and still resolve through the `/index.mdx` candidate — that is existing (and arguably intended, directory-reference) behavior, untouched here. This PR fixes exactly the empty-path case reported downstream.

## Test Plan

- `cargo test -p zfb-content` — 352/352 pass (15 in `resolve_links`, incl. the 2 new regression tests; pre-existing fragment tests `preserves_query_and_fragment` / `extensionless_preserves_query_and_fragment` stay green)
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test --workspace` — green (one unrelated macOS-local FSEvents watcher flake in `zfb-server` passed on isolated retry)
- Downstream verification: after the next zfb release, zudo-doc bumps its pinned version and confirms `[text](#anchor)` renders as `href="#anchor"` (tracked in zudolab/zudo-doc#1948 — intentionally not auto-closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)