### PR TITLE
ci(release): cap binary-*/archive-* artifact retention at 1 day

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -402,6 +402,9 @@ jobs:
           name: binary-${{ matrix.settings.target }}
           path: packages/zfb-${{ matrix.settings.platform }}/${{ matrix.settings.binary }}
           if-no-files-found: error
+          # Consumed within this run by the npm-publish job; the real binaries
+          # ship as GitHub Release assets, so cap Actions storage at the 1-day floor.
+          retention-days: 1
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -410,6 +413,9 @@ jobs:
             zfb-*-${{ matrix.settings.target }}.${{ matrix.settings.archive_ext }}
             zfb-*-${{ matrix.settings.target }}.${{ matrix.settings.archive_ext }}.sha256
           if-no-files-found: error
+          # Consumed within this run by the release-assets job; the archives are
+          # promoted to GitHub Release assets, so cap Actions storage at the 1-day floor.
+          retention-days: 1
 
   release-assets:
     # Attaches all 5 archives + 5 sha256 files to the GitHub Release.


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/888

---

## Summary

Adds `retention-days: 1` to the two `upload-artifact` steps in `release.yml` (`binary-*` and `archive-*`) — the only upload steps in the repo still missing a retention cap. These per-platform release intermediates accumulated ~22 GB of Actions storage; they are redundant once promoted to GitHub Releases and only need to survive within the run. Refs #888.

## Background

On 2026-06-08 the account hit ~90% of its included Actions storage; a scan found this repo holding ~22.5 GB of active artifacts, dominated by `binary-*` / `archive-*` from `release.yml`. The 22 GB was already purged manually — this PR prevents recurrence. Every other `upload-artifact` step (`preview-deploy.yml`, `main-deploy.yml`, `node-free-smoke.yml` ×2, `pr-checks.yml`) already set `retention-days: 1`; `release.yml` was the remaining gap.

## Changes

- `release.yml`: `retention-days: 1` on the `binary-*` upload step (consumed in-run by the npm-publish job).
- `release.yml`: `retention-days: 1` on the `archive-*` upload step (consumed in-run by the release-assets job; archives ship as GitHub Release assets).

## Test Plan

- `actionlint` CI job validates the workflow YAML on this PR.
- Both artifacts are downloaded by later jobs within the **same run** (`binary-*` → publish job at release.yml:514; `archive-*` → release-assets job at release.yml:442), so the 1-day floor cannot break the release flow.

## Out of scope — tracked in #888, require human action

- Repo-level **Artifact and log retention** (90 → ~7 days): UI-only setting, no REST API (`/repos/.../settings/actions` → 404). A human must change it in **Settings → Actions → General**.
- Confirming the next release run does not re-accumulate multi-GB artifacts (post-merge observation).