### PR TITLE
review-fixes-r2: round 2 review fixes — cache bounds, dedup, drift guard

### DIFF
--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -1645,6 +1645,59 @@ struct MaterialiseCtx<'a> {
     project_root: &'a Path,
 }
 
+impl MaterialiseCtx<'_> {
+    /// Construct the single feature-aware [`zfb_content::pipeline::Pipeline`]
+    /// shared by both walkers.
+    ///
+    /// Hoisted here so `materialise_shadow` and `materialise_collection` both
+    /// call the same construction path — this structurally guarantees that both
+    /// walks produce byte-identical MDX-cache fingerprints (see zfb#910).
+    ///
+    /// The caller receives a ready-to-use pipeline with all opt-in plugins
+    /// already wired (toc, strip-md-ext, resolve-links, external-links).
+    /// `source_dir` for `ResolveLinksPlugin` is still updated per-file inside
+    /// the walk loop; that per-file state lives on the borrowed `&mut Pipeline`,
+    /// not in the construction phase.
+    fn build_pipeline(&self) -> Result<zfb_content::pipeline::Pipeline> {
+        // Single feature-aware entry point — MUST match the snapshot walker's
+        // dispatch (`SnapshotPipelineConfig::build_pipeline`) so the JSX
+        // `content_hash` stays byte-identical. `markdown_features = None` is an
+        // empty feature set: the former-Core framework features are off
+        // (the post-epic opt-in default).
+        let mut pipeline = zfb_content::pipeline::Pipeline::with_defaults_and_full_config(
+            self.code_highlight_theme,
+            self.gfm_constructs,
+            self.code_highlight_themes_dir,
+            self.cjk_friendly,
+            self.hard_breaks,
+            self.markdown_features,
+        )
+        .with_context(|| {
+            // `Err` only occurs when `themes_dir` is `Some` (theme-file load),
+            // so the `unwrap_or_default()` empty-string branch is unreachable.
+            format!(
+                "codeHighlight.themesDir: failed to load themes from {}",
+                self.code_highlight_themes_dir
+                    .map(|d| d.display().to_string())
+                    .unwrap_or_default()
+            )
+        })?;
+        if let Some(toc_cfg) = self.toc.clone() {
+            pipeline.add_toc(toc_cfg);
+        }
+        if self.strip_md_ext {
+            pipeline.add_strip_md_ext();
+        }
+        if let Some(map) = self.resolve_source_map {
+            pipeline.add_resolve_links(map.clone());
+        }
+        if let Some((cfg, site)) = self.external_links {
+            pipeline.add_external_links(cfg.clone(), site.as_deref());
+        }
+        Ok(pipeline)
+    }
+}
+
 /// Recursively copy `src` into `dest`, transforming `.mdx` files via
 /// [`compile_mdx_to_jsx_module_cached`] so esbuild can parse them as
 /// JSX (the `.mdx` extension is preserved; the bundler uses
@@ -1712,41 +1765,7 @@ fn materialise_shadow(
     // also wired into the mdast phase after the directives step so
     // author-written `[label](./other.mdx)` links rewrite to the
     // rendered route URL. The `source_dir` is updated per-file below.
-    // Single feature-aware entry point — MUST match the snapshot walker's
-    // dispatch (`SnapshotPipelineConfig::build_pipeline`) so the JSX
-    // `content_hash` stays byte-identical. `markdown_features = None` is an
-    // empty feature set: the former-Core framework features are off
-    // (the post-epic opt-in default).
-    let mut pipeline = zfb_content::pipeline::Pipeline::with_defaults_and_full_config(
-        ctx.code_highlight_theme,
-        ctx.gfm_constructs,
-        ctx.code_highlight_themes_dir,
-        ctx.cjk_friendly,
-        ctx.hard_breaks,
-        ctx.markdown_features,
-    )
-    .with_context(|| {
-        // `Err` only occurs when `themes_dir` is `Some` (theme-file load),
-        // so the `unwrap_or_default()` empty-string branch is unreachable.
-        format!(
-            "codeHighlight.themesDir: failed to load themes from {}",
-            ctx.code_highlight_themes_dir
-                .map(|d| d.display().to_string())
-                .unwrap_or_default()
-        )
-    })?;
-    if let Some(toc_cfg) = ctx.toc.clone() {
-        pipeline.add_toc(toc_cfg);
-    }
-    if ctx.strip_md_ext {
-        pipeline.add_strip_md_ext();
-    }
-    if let Some(map) = ctx.resolve_source_map {
-        pipeline.add_resolve_links(map.clone());
-    }
-    if let Some((cfg, site)) = ctx.external_links {
-        pipeline.add_external_links(cfg.clone(), site.as_deref());
-    }
+    let mut pipeline = ctx.build_pipeline()?;
 
     // sort_by_file_name() gives lexicographic order within each directory
     // level, matching walk_collection's explicit files.sort() contract so
@@ -2311,41 +2330,7 @@ fn materialise_collection(
     // When `resolve_source_map` is `Some`, the `ResolveLinksPlugin` is
     // also wired after the directives step in the mdast phase. The
     // `source_dir` is updated per-file inside the walk loop.
-    // Single feature-aware entry point — MUST match the snapshot walker's
-    // dispatch (`SnapshotPipelineConfig::build_pipeline`) so the JSX
-    // `content_hash` stays byte-identical. `markdown_features = None` is an
-    // empty feature set: the three former-Core framework features are off
-    // (the post-epic opt-in default).
-    let mut pipeline = zfb_content::pipeline::Pipeline::with_defaults_and_full_config(
-        ctx.code_highlight_theme,
-        ctx.gfm_constructs,
-        ctx.code_highlight_themes_dir,
-        ctx.cjk_friendly,
-        ctx.hard_breaks,
-        ctx.markdown_features,
-    )
-    .with_context(|| {
-        // `Err` only occurs when `themes_dir` is `Some` (theme-file load),
-        // so the `unwrap_or_default()` empty-string branch is unreachable.
-        format!(
-            "codeHighlight.themesDir: failed to load themes from {}",
-            ctx.code_highlight_themes_dir
-                .map(|d| d.display().to_string())
-                .unwrap_or_default()
-        )
-    })?;
-    if let Some(toc_cfg) = ctx.toc.clone() {
-        pipeline.add_toc(toc_cfg);
-    }
-    if ctx.strip_md_ext {
-        pipeline.add_strip_md_ext();
-    }
-    if let Some(map) = ctx.resolve_source_map {
-        pipeline.add_resolve_links(map.clone());
-    }
-    if let Some((cfg, site)) = ctx.external_links {
-        pipeline.add_external_links(cfg.clone(), site.as_deref());
-    }
+    let mut pipeline = ctx.build_pipeline()?;
 
     // sort_by_file_name() gives lexicographic order within each directory
     // level, matching walk_collection's explicit files.sort() contract so

--- a/crates/zfb-content/src/mdx_jsx_emit.rs
+++ b/crates/zfb-content/src/mdx_jsx_emit.rs
@@ -1937,6 +1937,24 @@ fn collection_and_slug(file_path: &Path) -> (String, String) {
     (collection, slug)
 }
 
+/// Maximum number of entries the [`MdxModuleCache`] retains before
+/// evicting the entire map.
+///
+/// **Policy: clear-all on overflow.** When an insertion would push the
+/// entry count past this threshold the whole map is cleared first, then
+/// the new entry is inserted.  This is the mechanically-safest bounded
+/// policy: it is O(1) to decide, requires no ordering structure, and is
+/// trivially correct — after a clear the invariant `len ≤ CAP` holds
+/// again.  The trade-off is a one-time cold-compile burst when the cap
+/// is hit, which is preferable to unbounded memory growth in a long
+/// `zfb dev` session.
+///
+/// 4 096 entries: a compiled `CompiledMdx` is roughly 2–8 KiB of JSX
+/// source.  At the generous end that is ~32 MiB for the whole map —
+/// well within a normal dev-server budget — while still bounding
+/// worst-case accumulation from edit churn across a large content tree.
+const MDX_MODULE_CACHE_CAP: usize = 4_096;
+
 /// In-memory cache of compiled MDX modules, keyed by the SHA-256 of the
 /// raw input source plus the supplied pipeline's config fingerprint.
 ///
@@ -1977,10 +1995,11 @@ impl MdxModuleCache {
     /// walker all reuse this one instance, so a dev process that runs
     /// snapshot + bundle every tick compiles each unchanged
     /// `(input, pipeline-config)` pair exactly once and serves every
-    /// later tick from memory. Entries are never evicted — memory grows
-    /// with the number of distinct (body, config) pairs seen by the
-    /// process, which is bounded by edit churn in practice and resets
-    /// on process restart.
+    /// later tick from memory. The map is bounded at
+    /// [`MDX_MODULE_CACHE_CAP`] entries: when an insertion would exceed
+    /// the cap the entire map is cleared first (clear-on-overflow
+    /// policy), so memory is always bounded even across a long edit
+    /// session with high churn.
     ///
     /// Safe to share between configs because every entry is keyed by
     /// the pipeline config fingerprint (see the type-level docs);
@@ -2131,7 +2150,15 @@ pub fn compile_mdx_to_jsx_module_cached(
     };
 
     if let (Some(c), Some(key)) = (cache_for_lookup, cache_key) {
-        c.lock().insert(key, compiled.clone());
+        let mut guard = c.lock();
+        // Clear-on-overflow: if inserting this entry would push the map
+        // past the cap, evict everything first.  Simple and correct —
+        // the next hit on any previously-cached key will re-compile once,
+        // then re-populate.
+        if guard.len() >= MDX_MODULE_CACHE_CAP {
+            guard.clear();
+        }
+        guard.insert(key, compiled.clone());
     }
 
     Ok(compiled)
@@ -2700,6 +2727,41 @@ mod tests {
         assert!(
             out.starts_with("<span dangerouslySetInnerHTML"),
             "HTML comment raw node must use <span> wrapper, got: {out}"
+        );
+    }
+
+    // zfb#911: inserting more than MDX_MODULE_CACHE_CAP entries must
+    // trigger the clear-on-overflow policy so the map stays bounded.
+    //
+    // Uses a fresh `MdxModuleCache::new()` (not the process-global) so
+    // this test is hermetic and not affected by other tests' entries.
+    // Keys are distinct bodies — one per iteration — so no hits occur
+    // and each `compile_mdx_to_jsx_module_cached` call adds one entry.
+    #[test]
+    fn cache_clears_on_overflow_past_cap() {
+        let cache = MdxModuleCache::new();
+        let path = Path::new("/virtual/blog/overflow.mdx");
+
+        // Fill exactly up to the cap with distinct single-word bodies.
+        // We rely only on the returned len(), not on map iteration order.
+        for i in 0..MDX_MODULE_CACHE_CAP {
+            let src = format!("word{i}\n");
+            compile_mdx_to_jsx_module_cached(&src, path, Some(&cache), None)
+                .expect("compile fill");
+        }
+        assert_eq!(
+            cache.len(),
+            MDX_MODULE_CACHE_CAP,
+            "filling exactly to the cap must not trigger a clear"
+        );
+
+        // One more entry: this should trigger a clear then re-insert → len 1.
+        compile_mdx_to_jsx_module_cached("overflow_trigger\n", path, Some(&cache), None)
+            .expect("compile overflow");
+        assert_eq!(
+            cache.len(),
+            1,
+            "overflow past CAP must clear the map; only the triggering entry remains"
         );
     }
 }

--- a/crates/zfb-content/src/pipeline.rs
+++ b/crates/zfb-content/src/pipeline.rs
@@ -150,13 +150,20 @@ const FINGERPRINT_VERSION: &str = "zfb-pipeline-fp-v1";
 
 /// Canonical descriptor segment for a [`ResolvedGfmConstructs`] set.
 fn gfm_fingerprint_segment(resolved: ResolvedGfmConstructs) -> String {
+    // Drift guard (zfb#913): exhaustive destructure — NO `..` rest pattern.
+    // Adding a construct flag to `ResolvedGfmConstructs` stops compiling
+    // here until the new flag joins the descriptor below, instead of
+    // silently aliasing compile-cache entries across configs that differ
+    // only in that flag.
+    let ResolvedGfmConstructs {
+        strikethrough,
+        table,
+        autolink_literal,
+        task_list_item,
+        footnote_definition,
+    } = resolved;
     format!(
-        "gfm=strikethrough:{},table:{},autolink_literal:{},task_list_item:{},footnote_definition:{}",
-        resolved.strikethrough,
-        resolved.table,
-        resolved.autolink_literal,
-        resolved.task_list_item,
-        resolved.footnote_definition,
+        "gfm=strikethrough:{strikethrough},table:{table},autolink_literal:{autolink_literal},task_list_item:{task_list_item},footnote_definition:{footnote_definition}"
     )
 }
 
@@ -215,9 +222,127 @@ fn themes_dir_fingerprint_segment(themes_dir: Option<&Path>) -> Option<String> {
 fn features_fingerprint_segment(
     features: &zfb_md_extras::MarkdownFeaturesConfig,
 ) -> Option<String> {
+    assert_features_fingerprint_covers_every_field(features);
     let mut v = serde_json::to_value(features).ok()?;
     sort_value_keys(&mut v);
     Some(format!("features={v}"))
+}
+
+/// Drift guard for the `markdown.features` part of the fingerprint
+/// (zfb#913): exhaustively destructures [`MarkdownFeaturesConfig`] AND
+/// every nested per-feature option struct/enum — **no `..` rest pattern
+/// anywhere** — so adding a field to any of them is a compile error in
+/// this function until the author decides how the fingerprint covers the
+/// new knob:
+///
+/// - plain data fields are covered automatically by the canonical
+///   features JSON ([`features_fingerprint_segment`] serializes the WHOLE
+///   struct via serde) — bind the new field below and you are done. Do
+///   NOT add `#[serde(skip)]` / `#[serde(skip_serializing_if)]` to these
+///   structs: a skipped field silently vanishes from the descriptor (the
+///   `canonical_features_json_covers_every_field` test in
+///   `tests/pipeline_fingerprint.rs` pins the serialized key set as a
+///   second line of defense);
+/// - a feature whose plugin reads OTHER files at compile time must ALSO
+///   join the `filesystem_dependent_feature` gate in
+///   [`Pipeline::with_defaults_and_full_config`] so the pipeline becomes
+///   uncacheable — a cached entry cannot see the referenced files change.
+///
+/// All bindings are deliberately discarded; the function exists purely to
+/// break the build on config drift (the optimizer removes it entirely).
+///
+/// [`MarkdownFeaturesConfig`]: zfb_md_extras::MarkdownFeaturesConfig
+fn assert_features_fingerprint_covers_every_field(
+    features: &zfb_md_extras::MarkdownFeaturesConfig,
+) {
+    use zfb_md_ast::{ReadingTimeFeature, ReadingTimeOptions};
+    use zfb_md_extras::{
+        CodeEnrichmentConfig, DirectiveFullSpec, DirectiveSpec, FeatureOptions, FeatureToggle,
+        GithubAutolinksConfig, HeadingIdsConfig, HeadingMarkerTocFeature, ImageDimensionsConfig,
+        LinkValidationConfig, MarkdownFeaturesConfig, TocExportConfig, TranscludeConfig,
+    };
+
+    let MarkdownFeaturesConfig {
+        github_alerts,
+        reading_time,
+        github_autolinks,
+        code_enrichment,
+        code_tabs,
+        ruby,
+        toc_export,
+        image_dimensions,
+        link_validation,
+        transclude,
+        directives,
+        mermaid,
+        heading_marker_toc,
+        heading_ids,
+    } = features;
+
+    // Bool-or-empty-options toggles share the FeatureToggle shape.
+    for toggle in [github_alerts, code_tabs, ruby, mermaid] {
+        match toggle {
+            Some(FeatureToggle::Options(FeatureOptions {}) | FeatureToggle::Bool(_)) | None => {}
+        }
+    }
+    match reading_time {
+        Some(
+            ReadingTimeFeature::Options(ReadingTimeOptions { wpm: _ })
+            | ReadingTimeFeature::Bool(_),
+        )
+        | None => {}
+    }
+    match github_autolinks {
+        Some(GithubAutolinksConfig { repo: _ }) | None => {}
+    }
+    match code_enrichment {
+        Some(CodeEnrichmentConfig {
+            diff_markers: _,
+            line_highlight: _,
+        })
+        | None => {}
+    }
+    match toc_export {
+        Some(TocExportConfig { max_depth: _ }) | None => {}
+    }
+    match image_dimensions {
+        Some(ImageDimensionsConfig { skip_remote: _ }) | None => {}
+    }
+    match link_validation {
+        Some(LinkValidationConfig {
+            fail_on_broken: _,
+            allow_external: _,
+        })
+        | None => {}
+    }
+    match transclude {
+        Some(TranscludeConfig { max_depth: _ }) | None => {}
+    }
+    if let Some(map) = directives {
+        for spec in map.values() {
+            match spec {
+                DirectiveSpec::Full(DirectiveFullSpec {
+                    component: _,
+                    kind: _,
+                    title_from_label: _,
+                }) => {}
+                DirectiveSpec::Short(_) => {}
+            }
+        }
+    }
+    match heading_marker_toc {
+        Some(
+            HeadingMarkerTocFeature::Config(TocConfig {
+                heading: _,
+                max_depth: _,
+            })
+            | HeadingMarkerTocFeature::Bool(_),
+        )
+        | None => {}
+    }
+    match heading_ids {
+        Some(HeadingIdsConfig { strategy: _ }) | None => {}
+    }
 }
 
 /// Recursively sort all object keys in `value` so its serialization is
@@ -469,6 +594,43 @@ impl Pipeline {
         }
     }
 
+    /// Internal, non-invalidating visitor push.
+    ///
+    /// **Invalidation rule (zfb#913): internal pushes that derive purely
+    /// from already-fingerprinted config MUST NOT invalidate the
+    /// fingerprint; manual external pushes MUST.**
+    ///
+    /// Internal wiring — the constructors, the named config mutators
+    /// ([`Pipeline::add_toc`], [`Pipeline::add_strip_md_ext`],
+    /// [`Pipeline::add_external_links`]), and the `register_features*`
+    /// internals — builds the visitor chain from config the fingerprint
+    /// already (or finally) describes, so it pushes through these private
+    /// helpers. Two obligations come with the shortcut:
+    ///
+    /// - a **constructor** that wires visitors this way MUST finish with
+    ///   [`Pipeline::set_config_fingerprint_base`], passing a descriptor
+    ///   covering every knob it consumed (or `None` for uncacheable
+    ///   shapes) — leaving the interim bare-constructor descriptor in
+    ///   place would alias the bare pipeline's compile-cache entries;
+    /// - a **post-construction named mutator** MUST call
+    ///   [`Pipeline::extend_config_fingerprint`] with a segment capturing
+    ///   its full config.
+    ///
+    /// Everything reachable by consumers — [`Pipeline::add_mdast_visitor`],
+    /// [`Pipeline::add_hast_visitor`], [`register_features`],
+    /// [`register_post_syntect_features`] — MUST invalidate instead: an
+    /// arbitrary external mutation cannot be derived from config, so the
+    /// compile cache must never key it.
+    fn push_config_derived_mdast_visitor(&mut self, v: Box<dyn MdastVisitor>) {
+        self.mdast_visitors.push(v);
+    }
+
+    /// Hast twin of [`Pipeline::push_config_derived_mdast_visitor`] —
+    /// same invalidation rule.
+    fn push_config_derived_hast_visitor(&mut self, v: Box<dyn HastVisitor>) {
+        self.hast_visitors.push(v);
+    }
+
     /// Borrow the resolved GFM construct set this pipeline was built
     /// with.
     ///
@@ -526,16 +688,15 @@ impl Pipeline {
     /// current `add_trailing_slash` setting (defaults to `true`).
     ///
     /// Config-driven and deterministic per input, so this **extends**
-    /// the config fingerprint instead of invalidating it (the visitor
-    /// is pushed directly, not via the fingerprint-invalidating
-    /// [`Pipeline::add_hast_visitor`]).
+    /// the config fingerprint instead of invalidating it (invalidation
+    /// rule — see [`Pipeline::push_config_derived_hast_visitor`]).
     pub fn add_strip_md_ext(&mut self) -> &mut Self {
         let plugin = if self.add_trailing_slash {
             StripMdExtensionPlugin::with_trailing_slash()
         } else {
             StripMdExtensionPlugin::new()
         };
-        self.hast_visitors.push(Box::new(plugin));
+        self.push_config_derived_hast_visitor(Box::new(plugin));
         self.extend_config_fingerprint(format!(
             "strip_md_ext;trailing_slash={}",
             self.add_trailing_slash
@@ -554,7 +715,8 @@ impl Pipeline {
     /// visitor not registered, output identical to today.
     ///
     /// Config-driven and deterministic per input, so this **extends**
-    /// the config fingerprint instead of invalidating it.
+    /// the config fingerprint instead of invalidating it (invalidation
+    /// rule — see [`Pipeline::push_config_derived_hast_visitor`]).
     pub fn add_external_links(
         &mut self,
         config: ExternalLinksConfig,
@@ -564,8 +726,7 @@ impl Pipeline {
             "external_links;rel={:?};target={:?};site={:?}",
             config.rel, config.target, site
         );
-        self.hast_visitors
-            .push(Box::new(ExternalLinksPlugin::new(config, site)));
+        self.push_config_derived_hast_visitor(Box::new(ExternalLinksPlugin::new(config, site)));
         self.extend_config_fingerprint(segment);
         self
     }
@@ -625,11 +786,15 @@ impl Pipeline {
     /// identical.
     pub fn add_toc(&mut self, cfg: TocConfig) -> &mut Self {
         // Config-driven and deterministic per input → extends the config
-        // fingerprint (see `config_fingerprint`) rather than invalidating.
+        // fingerprint (see `config_fingerprint`) rather than invalidating
+        // (invalidation rule — see `push_config_derived_hast_visitor`).
         let segment = format!("toc;heading={:?};max_depth={}", cfg.heading, cfg.max_depth);
         // Insert at position 1 in the hast visitors list so TOC runs
         // immediately after HeadingLinksPlugin (index 0) and before all
         // subsequent hast visitors. This guarantees ids are already set.
+        // Inserted at a fixed position rather than pushed, so this site
+        // manipulates `hast_visitors` directly instead of going through
+        // the push helper — same non-invalidating contract.
         //
         // If the list is empty (e.g. in a bare pipeline built without
         // with_defaults), append normally so the visitor still runs.
@@ -838,27 +1003,31 @@ impl Pipeline {
         }
         let highlighter = Arc::new(highlighter);
         let mut p = Self::with_resolved_gfm_constructs(resolved);
-        // mdast phase.
+        // mdast phase. Config-derived wiring — pushed through the
+        // non-invalidating helpers (invalidation rule — see
+        // `push_config_derived_mdast_visitor`).
         if cjk_friendly {
-            p.add_mdast_visitor(Box::new(CjkFriendlyPlugin::new()));
+            p.push_config_derived_mdast_visitor(Box::new(CjkFriendlyPlugin::new()));
         }
         // No directive registry here: core seeds zero directive names. Callers
         // that want `:::name` → `<Component>` go through
         // `with_defaults_and_full_config` with a `features.directives` map.
         // hast phase — ordering rationale lives in the doc comment above.
-        p.add_hast_visitor(Box::new(HeadingLinksPlugin::new()));
-        p.add_hast_visitor(Box::new(CodeTitlePlugin::new()));
-        p.add_hast_visitor(Box::new(MermaidPlugin::new()));
+        p.push_config_derived_hast_visitor(Box::new(HeadingLinksPlugin::new()));
+        p.push_config_derived_hast_visitor(Box::new(CodeTitlePlugin::new()));
+        p.push_config_derived_hast_visitor(Box::new(MermaidPlugin::new()));
         let syntect = if let Some(t) = theme {
             SyntectPlugin::new(highlighter).with_theme(t)
         } else {
             SyntectPlugin::new(highlighter)
         };
-        p.add_hast_visitor(Box::new(syntect));
-        // Fingerprint the construction config LAST: the add_*_visitor
-        // calls above invalidated the bare-constructor fingerprint, and
-        // this final assignment replaces it with the legacy-defaults
-        // descriptor. `defaults` vs `full` prefix keeps this chain (which
+        p.push_config_derived_hast_visitor(Box::new(syntect));
+        // Fingerprint the construction config LAST: the interim descriptor
+        // from `with_resolved_gfm_constructs` only covers the bare
+        // constructor; this final assignment replaces it with the
+        // legacy-defaults descriptor covering every knob this chain
+        // consumed (constructor obligation of the invalidation rule).
+        // `defaults` vs `full` prefix keeps this chain (which
         // always wires the core MermaidPlugin) distinct from the
         // feature-aware `with_defaults_and_full_config` chain even when
         // the shared knobs coincide.
@@ -999,14 +1168,17 @@ impl Pipeline {
         let highlighter = Arc::new(highlighter);
         let mut p = Self::with_resolved_gfm_constructs(resolved);
         // mdast phase — CjkFriendlyPlugin honours the cjk_friendly toggle.
+        // Config-derived wiring throughout this constructor is pushed via
+        // the non-invalidating helpers (invalidation rule — see
+        // `push_config_derived_mdast_visitor`).
         if cjk_friendly {
-            p.add_mdast_visitor(Box::new(CjkFriendlyPlugin::new()));
+            p.push_config_derived_mdast_visitor(Box::new(CjkFriendlyPlugin::new()));
         }
         // HardBreaksPlugin runs AFTER CjkFriendlyPlugin so CJK emphasis
         // re-tokenisation sees intact Text nodes first (emphasis markers are
         // resolved before soft line breaks are split). Default is false.
         if hard_breaks {
-            p.add_mdast_visitor(Box::new(HardBreaksPlugin::new()));
+            p.push_config_derived_mdast_visitor(Box::new(HardBreaksPlugin::new()));
         }
         // hast phase — HeadingLinksPlugin and CodeTitlePlugin are always on.
         // HeadingLinksPlugin honours `features.headingIds.strategy` (zfb#871);
@@ -1014,12 +1186,14 @@ impl Pipeline {
         // JSX-emit path (`collect_headings`) mirrors the same scheme.
         let strategy = zfb_md_extras::heading_id_strategy(&features.heading_ids);
         p.set_heading_id_strategy(strategy);
-        p.add_hast_visitor(Box::new(HeadingLinksPlugin::with_strategy(strategy)));
-        p.add_hast_visitor(Box::new(CodeTitlePlugin::new()));
+        p.push_config_derived_hast_visitor(Box::new(HeadingLinksPlugin::with_strategy(strategy)));
+        p.push_config_derived_hast_visitor(Box::new(CodeTitlePlugin::new()));
         // Single call-path from zfb-content into zfb-md-extras: adds the opt-in
         // visitors in the correct phase/position (before SyntectPlugin for
-        // mermaid; after for post-syntect).
-        register_features(&mut p, features);
+        // mermaid; after for post-syntect). The `_config_derived` variant
+        // does not invalidate — the final base descriptor below covers the
+        // whole `features` value.
+        register_features_config_derived(&mut p, features);
         // SyntectPlugin MUST be added AFTER register_features so pre-syntect
         // extras visitors (mermaid, …) run first.
         let syntect = if let Some(t) = theme {
@@ -1027,14 +1201,16 @@ impl Pipeline {
         } else {
             SyntectPlugin::new(highlighter)
         };
-        p.add_hast_visitor(Box::new(syntect));
+        p.push_config_derived_hast_visitor(Box::new(syntect));
         // Post-syntect extras visitors operate on the per-line
         // <span class="line"> structure SyntectPlugin emits.
-        register_post_syntect_features(&mut p, features);
-        // Fingerprint the construction config LAST — the wiring above
-        // went through the fingerprint-invalidating add_*_visitor
-        // methods; this final assignment replaces the interim `None`
-        // with the real descriptor (see `config_fingerprint`).
+        register_post_syntect_features_config_derived(&mut p, features);
+        // Fingerprint the construction config LAST — the interim
+        // descriptor from `with_resolved_gfm_constructs` only covers the
+        // bare constructor; this final assignment replaces it with the
+        // full-config descriptor covering every knob this chain consumed
+        // (constructor obligation of the invalidation rule — see
+        // `push_config_derived_mdast_visitor`).
         //
         // Plugins that read OTHER files at compile time make the JSX
         // output depend on filesystem state the cache key cannot see
@@ -1070,9 +1246,14 @@ impl Pipeline {
     /// **uncacheable** ([`Pipeline::config_fingerprint`] → `None`): a
     /// `Box<dyn MdastVisitor>` cannot be fingerprinted from outside, so
     /// the MDX compile cache could not tell two manually-wired
-    /// pipelines apart. Constructors that wire visitors internally set
-    /// the fingerprint *after* wiring, so config-built pipelines stay
-    /// cacheable.
+    /// pipelines apart.
+    ///
+    /// Invalidation rule (zfb#913): manual external pushes — this method,
+    /// [`Pipeline::add_hast_visitor`], and the public [`register_features`]
+    /// / [`register_post_syntect_features`] helpers — MUST invalidate;
+    /// internal pushes that derive purely from already-fingerprinted
+    /// config MUST NOT (they go through the private
+    /// `push_config_derived_*` helpers — see there for the full rule).
     pub fn add_mdast_visitor(&mut self, v: Box<dyn MdastVisitor>) -> &mut Self {
         self.mdast_visitors.push(v);
         self.invalidate_config_fingerprint();
@@ -1081,8 +1262,8 @@ impl Pipeline {
 
     /// Append a hast visitor; visitors run in insertion order.
     ///
-    /// Same cacheability contract as [`Pipeline::add_mdast_visitor`]:
-    /// the pipeline becomes uncacheable.
+    /// Same cacheability contract and invalidation rule as
+    /// [`Pipeline::add_mdast_visitor`]: the pipeline becomes uncacheable.
     pub fn add_hast_visitor(&mut self, v: Box<dyn HastVisitor>) -> &mut Self {
         self.hast_visitors.push(v);
         self.invalidate_config_fingerprint();
@@ -1275,7 +1456,30 @@ impl Pipeline {
 /// visitor must be inserted before `SyntectPlugin`, use
 /// `Pipeline::add_mdast_visitor` / `Pipeline::add_hast_visitor` with explicit
 /// ordering (document it in the feature module's sub-issue).
+///
+/// # Cacheability
+///
+/// Calling this helper manually after construction makes the pipeline
+/// **uncacheable** ([`Pipeline::config_fingerprint`] → `None`), even with an
+/// empty feature set: a post-construction registration wires visitors the
+/// construction-time descriptor knows nothing about (invalidation rule —
+/// manual external pushes MUST invalidate; see
+/// [`Pipeline::add_mdast_visitor`]). The feature-aware constructor routes
+/// through the non-invalidating internal variant instead and covers the
+/// whole `features` value in its final base descriptor.
 pub fn register_features(
+    p: &mut Pipeline,
+    features: &zfb_md_extras::MarkdownFeaturesConfig,
+) {
+    register_features_config_derived(p, features);
+    p.invalidate_config_fingerprint();
+}
+
+/// Internal, non-invalidating implementation of [`register_features`] —
+/// called from [`Pipeline::with_defaults_and_full_config`], whose final base
+/// descriptor covers the whole `features` value (invalidation rule — see
+/// `Pipeline::push_config_derived_mdast_visitor`).
+fn register_features_config_derived(
     p: &mut Pipeline,
     features: &zfb_md_extras::MarkdownFeaturesConfig,
 ) {
@@ -1305,7 +1509,7 @@ pub fn register_features(
     // (source_path + project_root) to resolve file paths. When the pipeline
     // is driven via `run_with_context`, the context is automatically threaded.
     if let Some(cfg) = &features.transclude {
-        p.add_mdast_visitor(Box::new(
+        p.push_config_derived_mdast_visitor(Box::new(
             zfb_md_extras::transclude::TranscludePlugin::new(cfg.clone()),
         ));
     }
@@ -1316,7 +1520,7 @@ pub fn register_features(
     // the literal `:::code-group` opener and the closing `:::` separator so
     // it must see raw paragraph nodes, not already-rewritten JSX elements.
     if feature_enabled(&features.code_tabs) {
-        p.add_mdast_visitor(Box::new(
+        p.push_config_derived_mdast_visitor(Box::new(
             zfb_md_extras::code_tabs::CodeTabsPlugin::new(),
         ));
     }
@@ -1325,7 +1529,7 @@ pub fn register_features(
     // coexist: alert blockquotes are rewritten to MdxJsxFlowElement first,
     // then the directives pass handles `:::directive` syntax separately.
     if feature_enabled(&features.github_alerts) {
-        p.add_mdast_visitor(Box::new(
+        p.push_config_derived_mdast_visitor(Box::new(
             zfb_md_extras::github_alerts::GithubAlertsPlugin::new(),
         ));
     }
@@ -1336,7 +1540,7 @@ pub fn register_features(
             .as_ref()
             .and_then(zfb_md_ast::ReadingTimeFeature::wpm)
             .unwrap_or(200);
-        p.add_mdast_visitor(Box::new(
+        p.push_config_derived_mdast_visitor(Box::new(
             zfb_md_extras::reading_time::ReadingTimePlugin::with_wpm(wpm),
         ));
     }
@@ -1345,7 +1549,7 @@ pub fn register_features(
     // Order-independent relative to github_alerts and the directives step
     // (those operate on blockquote/directive shapes; ruby operates on Text).
     if feature_enabled(&features.ruby) {
-        p.add_mdast_visitor(Box::new(zfb_md_extras::ruby::RubyPlugin::new()));
+        p.push_config_derived_mdast_visitor(Box::new(zfb_md_extras::ruby::RubyPlugin::new()));
     }
 
     // Build a DirectiveRegistry from the `directives` map only. Core seeds NO
@@ -1362,7 +1566,7 @@ pub fn register_features(
                 registry.register(into_directive_def(name, spec));
             }
         }
-        p.add_mdast_visitor(registry.into_visitor());
+        p.push_config_derived_mdast_visitor(registry.into_visitor());
     }
 
     // ── hast phase (all before SyntectPlugin) ──────────────────────────────
@@ -1376,12 +1580,12 @@ pub fn register_features(
             .as_ref()
             .map(zfb_md_ast::HeadingMarkerTocFeature::to_config)
             .unwrap_or_default();
-        p.add_hast_visitor(Box::new(
+        p.push_config_derived_hast_visitor(Box::new(
             zfb_md_extras::heading_marker_toc::TocPlugin::new(cfg),
         ));
     }
     if feature_enabled(&features.mermaid) {
-        p.add_hast_visitor(Box::new(
+        p.push_config_derived_hast_visitor(Box::new(
             zfb_md_extras::mermaid::MermaidPlugin::new(),
         ));
     }
@@ -1390,7 +1594,7 @@ pub fn register_features(
     // is_some() + required `repo` field extraction.
     if let Some(cfg) = features.github_autolinks.as_ref() {
         if let Some(repo) = cfg.repo.as_ref() {
-            p.add_hast_visitor(Box::new(
+            p.push_config_derived_hast_visitor(Box::new(
                 zfb_md_extras::github_autolinks::GithubAutolinksPlugin::new(repo.clone()),
             ));
         }
@@ -1403,7 +1607,7 @@ pub fn register_features(
     // export node lands at the front of the document root before code blocks
     // are transformed.
     if let Some(cfg) = &features.toc_export {
-        p.add_hast_visitor(Box::new(
+        p.push_config_derived_hast_visitor(Box::new(
             zfb_md_extras::toc_export::TocExportPlugin::new(cfg.clone()),
         ));
     }
@@ -1411,7 +1615,7 @@ pub fn register_features(
     // Gated on `is_some()` (Option<ImageDimensionsConfig>; no outer FeatureToggle).
     // Uses visit_with_context — pipeline must call run_with_context for this to fire.
     if let Some(cfg) = features.image_dimensions.clone() {
-        p.add_hast_visitor(Box::new(
+        p.push_config_derived_hast_visitor(Box::new(
             zfb_md_extras::image_dimensions::ImageDimensionsPlugin::new(cfg),
         ));
     }
@@ -1422,7 +1626,7 @@ pub fn register_features(
     // current file are already populated by HeadingLinksPlugin. Gated on
     // `is_some()` (uses a rich options struct, not a FeatureToggle).
     if let Some(cfg) = &features.link_validation {
-        p.add_hast_visitor(Box::new(
+        p.push_config_derived_hast_visitor(Box::new(
             zfb_md_extras::link_validation::LinkValidationPlugin::new(cfg.clone()),
         ));
     }
@@ -1446,13 +1650,31 @@ pub fn register_features(
 /// All visitors registered here run AFTER SyntectPlugin.
 /// They MUST NOT rewrite the `<pre><code>` structure itself — only mutate
 /// existing `<span class="line">` children.
+///
+/// # Cacheability
+///
+/// Same contract as [`register_features`]: a manual post-construction call
+/// makes the pipeline uncacheable, even with an empty feature set.
 pub fn register_post_syntect_features(
+    p: &mut Pipeline,
+    features: &zfb_md_extras::MarkdownFeaturesConfig,
+) {
+    register_post_syntect_features_config_derived(p, features);
+    p.invalidate_config_fingerprint();
+}
+
+/// Internal, non-invalidating implementation of
+/// [`register_post_syntect_features`] — called from
+/// [`Pipeline::with_defaults_and_full_config`], whose final base descriptor
+/// covers the whole `features` value (invalidation rule — see
+/// `Pipeline::push_config_derived_mdast_visitor`).
+fn register_post_syntect_features_config_derived(
     p: &mut Pipeline,
     features: &zfb_md_extras::MarkdownFeaturesConfig,
 ) {
     // Wave 5 (#575): code_enrichment — diff markers + line highlighting.
     if let Some(cfg) = &features.code_enrichment {
-        p.add_hast_visitor(Box::new(
+        p.push_config_derived_hast_visitor(Box::new(
             zfb_md_extras::code_enrichment::CodeEnrichmentPlugin::new(cfg.clone()),
         ));
     }

--- a/crates/zfb-content/tests/pipeline_fingerprint.rs
+++ b/crates/zfb-content/tests/pipeline_fingerprint.rs
@@ -256,6 +256,93 @@ fn manual_visitor_mutation_invalidates_the_fingerprint() {
 }
 
 #[test]
+fn config_derived_mutators_do_not_invalidate_the_fingerprint() {
+    // Invalidation rule (zfb#913): internal pushes that derive purely from
+    // already-fingerprinted config MUST NOT invalidate — the named config
+    // mutators extend the fingerprint with a segment instead, keeping the
+    // pipeline cacheable.
+    let mut p = baseline();
+    p.add_toc(TocConfig::default());
+    p.add_strip_md_ext();
+    p.add_external_links(ExternalLinksConfig::default(), None);
+    p.set_heading_id_strategy(HeadingIdStrategy::Hierarchical);
+    assert!(
+        p.config_fingerprint().is_some(),
+        "named config-driven mutators must keep the pipeline cacheable"
+    );
+}
+
+#[test]
+fn manual_feature_registration_invalidates_the_fingerprint() {
+    // Invalidation rule (zfb#913): manual external pushes MUST invalidate.
+    // The public registration helpers are external surface — a
+    // post-construction call wires visitors the construction-time
+    // descriptor knows nothing about, so even an empty feature set drops
+    // cacheability.
+    let empty = MarkdownFeaturesConfig::default();
+
+    let mut p = baseline();
+    assert!(p.config_fingerprint().is_some());
+    zfb_content::pipeline::register_features(&mut p, &empty);
+    assert!(
+        p.config_fingerprint().is_none(),
+        "manual register_features must invalidate, even with an empty feature set"
+    );
+
+    let mut p = baseline();
+    zfb_content::pipeline::register_post_syntect_features(&mut p, &empty);
+    assert!(
+        p.config_fingerprint().is_none(),
+        "manual register_post_syntect_features must invalidate, even with an empty feature set"
+    );
+}
+
+#[test]
+fn canonical_features_json_covers_every_field() {
+    // Companion to the compile-time drift guard
+    // (`assert_features_fingerprint_covers_every_field` in pipeline.rs).
+    // The guard forces a new `MarkdownFeaturesConfig` field to be bound at
+    // the fingerprint site; THIS test pins that every field actually
+    // reaches the canonical features JSON — a `#[serde(skip)]` /
+    // `skip_serializing_if` attribute would drop the field from the
+    // descriptor and silently alias configs that differ only in it.
+    let v = serde_json::to_value(MarkdownFeaturesConfig::default())
+        .expect("features config serializes");
+    let keys: std::collections::BTreeSet<String> = v
+        .as_object()
+        .expect("features config serializes to a JSON object")
+        .keys()
+        .cloned()
+        .collect();
+    let expected: std::collections::BTreeSet<String> = [
+        "codeEnrichment",
+        "codeTabs",
+        "directives",
+        "githubAlerts",
+        "githubAutolinks",
+        "headingIds",
+        "headingMarkerToc",
+        "imageDimensions",
+        "linkValidation",
+        "mermaid",
+        "readingTime",
+        "ruby",
+        "tocExport",
+        "transclude",
+    ]
+    .into_iter()
+    .map(String::from)
+    .collect();
+    assert_eq!(
+        keys, expected,
+        "every MarkdownFeaturesConfig field must appear in the canonical \
+         features JSON (and in this list) — update the drift-guard \
+         destructure in pipeline.rs AND this list when adding a field; \
+         never serde-skip a field on these structs"
+    );
+}
+
+#[test]
 fn resolve_links_invalidates_the_fingerprint() {
     // ResolveLinksPlugin output depends on the per-file source_dir (set
     // between compiles) and drains broken-link diagnostics — both

--- a/packages/zfb-runtime/src/client-router/prefetch.ts
+++ b/packages/zfb-runtime/src/client-router/prefetch.ts
@@ -179,82 +179,71 @@ export function prefetch(url: string, opts: PrefetchOptions = {}): void {
 }
 
 // ---------------------------------------------------------------------------
+// Shared enter/leave handler factory
+// ---------------------------------------------------------------------------
+
+type CancelHandleMap = Map<Element, ReturnType<typeof setTimeout> | number>;
+
+/**
+ * Returns a pair of [enterHandler, leaveHandler] that queue and cancel an idle
+ * prefetch callback, keyed on the supplied per-trigger cancel-handle map.
+ *
+ * Both the pointer (hover) and focus triggers use identical queue/cancel logic;
+ * the only difference between them is which map tracks their pending handles.
+ * Parameterising by the map eliminates that duplication.
+ */
+function makeEnterLeaveHandlers(
+  cancelHandles: CancelHandleMap,
+): [enterHandler: (e: Event) => void, leaveHandler: (e: Event) => void] {
+  function enterHandler(e: Event): void {
+    const link = (e.target as Element).closest("a[href]") as HTMLAnchorElement | null;
+    if (!link) return;
+    if (!shouldPrefetchLink(link, "hover")) return;
+
+    // Use requestIdleCallback if available, else a small timeout.
+    const fire = () => {
+      cancelHandles.delete(link);
+      prefetch(link.href);
+    };
+
+    if (typeof requestIdleCallback !== "undefined") {
+      const handle = requestIdleCallback(fire);
+      cancelHandles.set(link, handle);
+    } else {
+      const handle = setTimeout(fire, 100);
+      cancelHandles.set(link, handle);
+    }
+  }
+
+  function leaveHandler(e: Event): void {
+    const link = (e.target as Element).closest("a[href]") as HTMLAnchorElement | null;
+    if (!link) return;
+
+    const handle = cancelHandles.get(link);
+    if (handle === undefined) return;
+
+    if (typeof cancelIdleCallback !== "undefined") {
+      cancelIdleCallback(handle as number);
+    } else {
+      clearTimeout(handle as ReturnType<typeof setTimeout>);
+    }
+    cancelHandles.delete(link);
+  }
+
+  return [enterHandler, leaveHandler];
+}
+
+// ---------------------------------------------------------------------------
 // Trigger: hover (pointerenter / pointerleave)
 // ---------------------------------------------------------------------------
 
-function onPointerEnter(e: Event): void {
-  const link = (e.target as Element).closest("a[href]") as HTMLAnchorElement | null;
-  if (!link) return;
-  if (!shouldPrefetchLink(link, "hover")) return;
-
-  // Use requestIdleCallback if available, else a small timeout.
-  const fire = () => {
-    hoverCancelHandles.delete(link);
-    prefetch(link.href);
-  };
-
-  if (typeof requestIdleCallback !== "undefined") {
-    const handle = requestIdleCallback(fire);
-    hoverCancelHandles.set(link, handle);
-  } else {
-    const handle = setTimeout(fire, 100);
-    hoverCancelHandles.set(link, handle);
-  }
-}
-
-function onPointerLeave(e: Event): void {
-  const link = (e.target as Element).closest("a[href]") as HTMLAnchorElement | null;
-  if (!link) return;
-
-  const handle = hoverCancelHandles.get(link);
-  if (handle === undefined) return;
-
-  if (typeof cancelIdleCallback !== "undefined") {
-    cancelIdleCallback(handle as number);
-  } else {
-    clearTimeout(handle as ReturnType<typeof setTimeout>);
-  }
-  hoverCancelHandles.delete(link);
-}
+const [onPointerEnter, onPointerLeave] = makeEnterLeaveHandlers(hoverCancelHandles);
 
 // ---------------------------------------------------------------------------
 // Trigger: focus (focusin / focusout with cancel on focusout)
 // ---------------------------------------------------------------------------
 
-function onFocusIn(e: Event): void {
-  const link = (e.target as Element).closest("a[href]") as HTMLAnchorElement | null;
-  if (!link) return;
-  if (!shouldPrefetchLink(link, "hover")) return;
-
-  // Use requestIdleCallback if available, else a small timeout.
-  const fire = () => {
-    focusCancelHandles.delete(link);
-    prefetch(link.href);
-  };
-
-  if (typeof requestIdleCallback !== "undefined") {
-    const handle = requestIdleCallback(fire);
-    focusCancelHandles.set(link, handle);
-  } else {
-    const handle = setTimeout(fire, 100);
-    focusCancelHandles.set(link, handle);
-  }
-}
-
-function onFocusOut(e: Event): void {
-  const link = (e.target as Element).closest("a[href]") as HTMLAnchorElement | null;
-  if (!link) return;
-
-  const handle = focusCancelHandles.get(link);
-  if (handle === undefined) return;
-
-  if (typeof cancelIdleCallback !== "undefined") {
-    cancelIdleCallback(handle as number);
-  } else {
-    clearTimeout(handle as ReturnType<typeof setTimeout>);
-  }
-  focusCancelHandles.delete(link);
-}
+const [onFocusIn, onFocusOut] = makeEnterLeaveHandlers(focusCancelHandles);
 
 // ---------------------------------------------------------------------------
 // Trigger: tap (touchstart / mousedown)


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/909
- parent PR
    - https://github.com/Takazudo/zudo-front-builder/pull/893

---

## Summary

Implements all 4 sub-issues of epic #909 (review-loop round 2 big findings):

- **#910** `MaterialiseCtx::build_pipeline` — the ~35-line Pipeline-construction block duplicated between materialise_shadow/materialise_collection now exists once (and structurally guarantees identical cache fingerprints across walks). −15 lines.
- **#911** Bounded MDX cache — `MDX_MODULE_CACHE_CAP = 4096` with clear-on-overflow (documented ~32 MiB worst-case budget); stale "never evicted" doc fixed; deterministic bound test added.
- **#912** Prefetch trigger dedup — `makeEnterLeaveHandlers(cancelHandles)` factory replaces the duplicated pointer/focus handler pairs. −11 lines, no behavior change.
- **#913** Config-fingerprint drift guard — exhaustive no-`..` destructuring of `ResolvedGfmConstructs`, `MarkdownFeaturesConfig`, and every nested per-feature struct (compile error E0027 on any new uncovered field, demonstrated with dummy fields then removed); serialized-key-set pin test catches serde-skip drift; non-invalidating push convention unified via `push_config_derived_*` helpers with the rule documented; 4 new tests.

## Verification

- Per-topic and merged-base: `cargo test -p zfb-build -p zfb-content` green, `cargo clippy --workspace --all-targets -- -D warnings` clean, zfb-runtime vitest 120/120 + typecheck
- Step 9 QA: codex review of the merged diff — no regressions
- CI: 12/12 checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)