### PR TITLE
fix(docs): ts-expect-error guard for copyPublicWithBase (#946)

### DIFF
--- a/docs/zfb.config.ts
+++ b/docs/zfb.config.ts
@@ -137,6 +137,9 @@ export default defineConfig({
   // public/ to dist/ (not to dist/pj/zudo-front-builder/) is the
   // correct placement. copyPublicWithBase:false replaces the old
   // copy-public-plugin.mjs that did the same thing manually.
+  // @ts-expect-error -- copyPublicWithBase is honored by the local engine on main but
+  // missing from the pinned @takazudo/zfb 0.1.0-next.35 ZfbConfig type (#946); this
+  // directive errors (forcing its removal) once the bump to a typed version lands.
   copyPublicWithBase: false,
   collections,
   stripMdExt: true,

--- a/docs/zfb.config.ts
+++ b/docs/zfb.config.ts
@@ -140,6 +140,7 @@ export default defineConfig({
   // @ts-expect-error -- copyPublicWithBase is honored by the local engine on main but
   // missing from the pinned @takazudo/zfb 0.1.0-next.35 ZfbConfig type (#946); this
   // directive errors (forcing its removal) once the bump to a typed version lands.
+  // Remove together with the TRANSITION copy-public-plugin.mjs fallback (#932).
   copyPublicWithBase: false,
   collections,
   stripMdExt: true,


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/946

---

## Summary

Restores a green `pnpm --filter docs check` / `b4push`: the pinned `@takazudo/zfb` 0.1.0-next.35 predates the `copyPublicWithBase` type added on main (PR #934), so the untyped key failed TS2353. A scoped `@ts-expect-error` (self-removing — it errors once a typed engine version is installed) plus a note to remove it together with the TRANSITION copy-public-plugin fallback (#932).

Closes #946

## Test Plan

- `pnpm --filter docs check` — green (failed before)
- `pnpm --filter docs b4push` — green (229 pages)
- Reviewed (opus): directive suppresses exactly the one property line; self-removal enforced by TS2578

🤖 Generated with [Claude Code](https://claude.com/claude-code)