### PR TITLE
arm-and-narrow: arm BuildContext in production pipelines + narrow the dev render fan-out

### DIFF
--- a/crates/zfb-build/src/adapter.rs
+++ b/crates/zfb-build/src/adapter.rs
@@ -142,9 +142,7 @@ pub fn ensure_no_ssr_without_adapter(
     if ssr_routes.is_empty() {
         return Ok(());
     }
-    let first = ssr_routes
-        .first()
-        .expect("checked non-empty above");
+    let first = ssr_routes.first().expect("checked non-empty above");
     let extra = if ssr_routes.len() > 1 {
         format!(" (and {} more)", ssr_routes.len() - 1)
     } else {
@@ -213,22 +211,14 @@ pub fn run_adapter_bundle(
 /// Indirection seam over `pnpm exec` so unit tests can verify the
 /// dispatch shape without spawning a real subprocess.
 pub trait AdapterRunner {
-    fn run(
-        &self,
-        package: &str,
-        input: &AdapterBundleInput,
-    ) -> Result<AdapterBundleOutput>;
+    fn run(&self, package: &str, input: &AdapterBundleInput) -> Result<AdapterBundleOutput>;
 }
 
 /// Production runner — shells out to `pnpm exec <bin>`.
 pub struct DefaultAdapterRunner;
 
 impl AdapterRunner for DefaultAdapterRunner {
-    fn run(
-        &self,
-        package: &str,
-        input: &AdapterBundleInput,
-    ) -> Result<AdapterBundleOutput> {
+    fn run(&self, package: &str, input: &AdapterBundleInput) -> Result<AdapterBundleOutput> {
         // The bin name follows the convention `<package>` for a non-
         // scoped name and `<short-name>` for a scoped one (the npm
         // standard: `@scope/zfb-adapter-cloudflare` ships
@@ -252,9 +242,7 @@ impl AdapterRunner for DefaultAdapterRunner {
         cmd.arg(&input.outdir);
 
         let output = run_capturing(&mut cmd).with_context(|| {
-            format!(
-                "spawning `pnpm exec {bin_name} bundle ...` for adapter {package}"
-            )
+            format!("spawning `pnpm exec {bin_name} bundle ...` for adapter {package}")
         })?;
 
         let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
@@ -296,10 +284,14 @@ pub(crate) fn run_capturing(cmd: &mut Command) -> Result<Output> {
 
     cmd.stdin(Stdio::null());
     cmd.stdout(Stdio::from(
-        stdout_file.try_clone().context("cloning stdout temp file")?,
+        stdout_file
+            .try_clone()
+            .context("cloning stdout temp file")?,
     ));
     cmd.stderr(Stdio::from(
-        stderr_file.try_clone().context("cloning stderr temp file")?,
+        stderr_file
+            .try_clone()
+            .context("cloning stderr temp file")?,
     ));
 
     let mut child = cmd.spawn().context("spawning subprocess")?;
@@ -503,10 +495,8 @@ mod tests {
             route_key: "/api/foo",
             url_path: "/api/foo",
         };
-        let res = ensure_no_ssr_without_adapter(
-            &AdapterChoice::Package("anything".into()),
-            &[route],
-        );
+        let res =
+            ensure_no_ssr_without_adapter(&AdapterChoice::Package("anything".into()), &[route]);
         assert!(res.is_ok());
     }
 
@@ -608,11 +598,7 @@ mod tests {
         }
     }
     impl AdapterRunner for FakeRunner {
-        fn run(
-            &self,
-            package: &str,
-            input: &AdapterBundleInput,
-        ) -> Result<AdapterBundleOutput> {
+        fn run(&self, package: &str, input: &AdapterBundleInput) -> Result<AdapterBundleOutput> {
             self.calls
                 .borrow_mut()
                 .push((package.to_string(), input.clone()));
@@ -671,12 +657,9 @@ mod tests {
             outdir: tmp.path().join("dist"),
         };
         let runner = FakeRunner::new();
-        let err = run_adapter_bundle_with(
-            &AdapterChoice::Package("anything".into()),
-            input,
-            &runner,
-        )
-        .unwrap_err();
+        let err =
+            run_adapter_bundle_with(&AdapterChoice::Package("anything".into()), input, &runner)
+                .unwrap_err();
         assert!(format!("{err}").contains("does not exist"));
     }
 
@@ -713,6 +696,10 @@ mod tests {
             .expect("run_capturing did not return within 5 s — pipe-EOF hang regression");
 
         let output = result.expect("run_capturing returned an error");
-        assert!(output.status.success(), "sh exited non-zero: {}", output.status);
+        assert!(
+            output.status.success(),
+            "sh exited non-zero: {}",
+            output.status
+        );
     }
 }

--- a/crates/zfb-build/src/atomic.rs
+++ b/crates/zfb-build/src/atomic.rs
@@ -32,7 +32,7 @@ use std::io::Write;
 use std::path::{Component, Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 
 static SEQ: AtomicU64 = AtomicU64::new(0);
 
@@ -271,12 +271,8 @@ mod tests {
     #[test]
     fn validate_output_path_rejects_traversal() {
         let root = Path::new("/dist");
-        assert!(
-            validate_output_path(root, Path::new("../etc/passwd")).is_err()
-        );
-        assert!(
-            validate_output_path(root, Path::new("blog/../../etc/passwd")).is_err()
-        );
+        assert!(validate_output_path(root, Path::new("../etc/passwd")).is_err());
+        assert!(validate_output_path(root, Path::new("blog/../../etc/passwd")).is_err());
     }
 
     #[test]
@@ -369,11 +365,8 @@ mod tests {
         // would otherwise materialise outside dist_root.
         symlink(&outside_root, dist_root.join("escape")).unwrap();
 
-        let err = validate_output_path(
-            &dist_root,
-            Path::new("escape/newdir/file.html"),
-        )
-        .expect_err("symlink with partial parent must be rejected");
+        let err = validate_output_path(&dist_root, Path::new("escape/newdir/file.html"))
+            .expect_err("symlink with partial parent must be rejected");
         let msg = format!("{err:#}");
         assert!(
             msg.contains("outside dist_root"),

--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -1128,50 +1128,16 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
         }
     }
 
-    // 2c. Handle broken links collected across all materialise calls.
-    //
-    // All calls ran to completion first so the full set of broken links is
-    // reported in one pass (consistent with the `onBrokenLinks: 'error'`
-    // contract in the issue spec). Warnings are emitted to stderr so they
-    // are visible to both the CLI user and CI log scanners.
-    if !all_broken_links.is_empty() {
-        let on_broken = input
-            .resolve_markdown_links
-            .as_ref()
-            .map(|s| s.on_broken_links)
-            .unwrap_or(OnBrokenLinks::Warn);
-        match on_broken {
-            OnBrokenLinks::Ignore => {}
-            OnBrokenLinks::Warn => {
-                for (file, url) in &all_broken_links {
-                    eprintln!(
-                        "zfb warn: broken markdown link in {file}: \
-                         {url} could not be resolved to a known doc URL"
-                    );
-                }
-            }
-            OnBrokenLinks::Error => {
-                let mut msg = format!(
-                    "bundler: {} broken markdown link(s) found:\n",
-                    all_broken_links.len()
-                );
-                for (file, url) in &all_broken_links {
-                    msg.push_str(&format!("  {file}: {url}\n"));
-                }
-                msg.push_str(
-                    "Fix the links or set onBrokenLinks: 'warn' / 'ignore' \
-                     in resolveMarkdownLinks config to suppress this error.",
-                );
-                bail!("{}", msg);
-            }
-        }
-    }
-
-    // 2c-md. Handle markdown diagnostics (transclude errors, imageDimensions
+    // 2c. Handle markdown diagnostics (transclude errors, imageDimensions
     // warnings, linkValidation findings) collected across all materialise calls.
     //
     // All walks ran to completion first so the full set is reported in one
-    // pass — same contract as the broken-links gate above.
+    // pass — same contract as the broken-links gate below.
+    //
+    // Ordering note: this block intentionally runs BEFORE the broken-links
+    // gate (2d) so that markdown-diagnostic errors (e.g. transclude failures)
+    // are always surfaced even when `onBrokenLinks: error` would bail first.
+    // Both gates collect after all walks, so neither skips any findings.
     //
     // Severity routing:
     //   Info / Warning  → stderr warn lines with path(:line) prefix; build succeeds.
@@ -1254,7 +1220,50 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
         }
     }
 
-    // 2d. CSS Modules — rewrite every `.module.css` file in the shadow
+    // 2d. Handle broken links collected across all materialise calls.
+    //
+    // All calls ran to completion first so the full set of broken links is
+    // reported in one pass (consistent with the `onBrokenLinks: 'error'`
+    // contract in the issue spec). Warnings are emitted to stderr so they
+    // are visible to both the CLI user and CI log scanners.
+    //
+    // Ordering note: placed AFTER the markdown-diagnostics gate (2c) so that
+    // transclude/imageDimensions errors are surfaced even when this gate would
+    // bail first (both gates run after all walks, so no findings are missed).
+    if !all_broken_links.is_empty() {
+        let on_broken = input
+            .resolve_markdown_links
+            .as_ref()
+            .map(|s| s.on_broken_links)
+            .unwrap_or(OnBrokenLinks::Warn);
+        match on_broken {
+            OnBrokenLinks::Ignore => {}
+            OnBrokenLinks::Warn => {
+                for (file, url) in &all_broken_links {
+                    eprintln!(
+                        "zfb warn: broken markdown link in {file}: \
+                         {url} could not be resolved to a known doc URL"
+                    );
+                }
+            }
+            OnBrokenLinks::Error => {
+                let mut msg = format!(
+                    "bundler: {} broken markdown link(s) found:\n",
+                    all_broken_links.len()
+                );
+                for (file, url) in &all_broken_links {
+                    msg.push_str(&format!("  {file}: {url}\n"));
+                }
+                msg.push_str(
+                    "Fix the links or set onBrokenLinks: 'warn' / 'ignore' \
+                     in resolveMarkdownLinks config to suppress this error.",
+                );
+                bail!("{}", msg);
+            }
+        }
+    }
+
+    // 2e. CSS Modules — rewrite every `.module.css` file in the shadow
     //     tree to a JS module that re-exports its scoped class-name
     //     map as the default export. Paired with the
     //     `--loader:.module.css=js` esbuild flag, this makes a user's
@@ -1264,7 +1273,7 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
     rewrite_css_modules_in_shadow(shadow, &input.project_root, &input.css_module_class_maps)
         .context("bundler: failed rewriting CSS Modules in shadow tree")?;
 
-    // 2e. Project-root `mdx-components.tsx` global override map (#616).
+    // 2f. Project-root `mdx-components.tsx` global override map (#616).
     //     A root-level FILE is not materialised by any pass above, so copy
     //     it into the shadow root here. The returned spec is threaded into
     //     `write_entry_module`, which emits the `import` + the

--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -116,10 +116,10 @@ use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use walkdir::WalkDir;
 use zfb_content::frontmatter as zfb_frontmatter;
-use zfb_content::{compile_mdx_to_jsx_module_cached, MdxModuleCache};
 use zfb_content::plugins::util::source_map::{
     build_docs_source_map, CollectionRoute, DocsSourceMapOptions,
 };
+use zfb_content::{compile_mdx_to_jsx_module_cached, MdxModuleCache};
 use zfb_render::adapters::{make_adapter, Framework};
 use zfb_types::{json_string as json_str, path_to_posix_string};
 
@@ -1062,19 +1062,13 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
             let name = src_dir.file_name().unwrap_or_default().to_os_string();
             let dst_dir = shadow.join(&name);
             let mut broken = Vec::new();
-            materialise_shadow(
-                &src_dir,
-                &dst_dir,
-                &mut Vec::new(),
-                &mat_ctx,
-                &mut broken,
-            )
-            .with_context(|| {
-                format!(
-                    "bundler: failed materialising extra dir {} into shadow",
-                    src_dir.display()
-                )
-            })?;
+            materialise_shadow(&src_dir, &dst_dir, &mut Vec::new(), &mat_ctx, &mut broken)
+                .with_context(|| {
+                    format!(
+                        "bundler: failed materialising extra dir {} into shadow",
+                        src_dir.display()
+                    )
+                })?;
             all_broken_links.extend(broken);
         }
     }
@@ -1588,18 +1582,20 @@ fn materialise_shadow(
     // walk loop so the always-on Core plugins (CJK-friendly
     // emphasis, heading-links, code-title, syntect) plus the opt-in
     // feature visitors (mermaid, directives, …) all fire on every MDX file
-    // the walker visits. The dev loader at `crates/zfb-render/src/loader.rs`
-    // reuses one pipeline for the same reason — constructing a `Highlighter`
-    // and the boxed visitors per file would be wasteful. Borrow is linear (`&mut`), so
+    // the walker visits.  Constructing a `Highlighter` and the boxed
+    // visitors per file would be wasteful. Borrow is linear (`&mut`), so
     // a single hoisted pipeline serves every MDX file sequentially.
     // See zfb#127 / #128.
+    //
+    // Note: `zfb dev` is the bundler in Development mode — it also goes
+    // through this path.  The `zfb-render ModuleLoader` is a separate
+    // library/embedder path not used by the `zfb` CLI at all.
     //
     // The opt-in `StripMdExtensionPlugin` is appended here when the
     // user enabled `stripMdExt` in `zfb.config.ts` (zfb#127 / #129).
     // The plugin is intentionally NOT in `with_defaults()` because it
     // only makes sense for sites whose authors hand-write
-    // `[label](other.md)` style references. The dev loader honours the
-    // same flag so dev preview matches built dist.
+    // `[label](other.md)` style references.
     //
     // When `resolve_source_map` is `Some`, the `ResolveLinksPlugin` is
     // also wired into the mdast phase after the directives step so
@@ -2582,8 +2578,10 @@ fn parse_import_meta_glob_call(
     // Second arg MUST be `{ eager: true }`. Vite's DEFAULT (no options) is
     // LAZY, so a missing options object is also unsupported here.
     let Some(opts_arg) = call.args.get(1) else {
-        return unsupported("missing `{ eager: true }` options object (the \
-                            default lazy form is not supported)");
+        return unsupported(
+            "missing `{ eager: true }` options object (the \
+                            default lazy form is not supported)",
+        );
     };
     if opts_arg.spread.is_some() {
         return unsupported("spread in options argument");
@@ -2686,9 +2684,7 @@ fn materialise_source_file(
             if source.contains("import.meta.glob") {
                 let file_dir = from.parent().unwrap_or_else(|| Path::new("."));
                 let expanded = expand_import_meta_glob(&source, file_dir, is_excluded)
-                    .with_context(|| {
-                        format!("expand import.meta.glob in {}", from.display())
-                    })?;
+                    .with_context(|| format!("expand import.meta.glob in {}", from.display()))?;
                 // Remove any pre-existing entry (e.g. a stale symlink from a
                 // prior persistent-shadow pass) before writing the real file.
                 let _ = fs::remove_file(to);
@@ -2761,10 +2757,7 @@ fn expand_import_meta_glob(
     }
 
     let cm: Lrc<SourceMap> = Default::default();
-    let fm = cm.new_source_file(
-        FileName::Anon.into(),
-        source.to_string(),
-    );
+    let fm = cm.new_source_file(FileName::Anon.into(), source.to_string());
     // Base offset for converting global `BytePos` → 0-based string index.
     let base = fm.start_pos.0;
 
@@ -2907,9 +2900,7 @@ fn glob_match_relative(
     let glob = globset::GlobBuilder::new(pattern)
         .literal_separator(true)
         .build()
-        .map_err(|e| {
-            anyhow!("zfb bundler: invalid import.meta.glob pattern {pattern:?}: {e}")
-        })?
+        .map_err(|e| anyhow!("zfb bundler: invalid import.meta.glob pattern {pattern:?}: {e}"))?
         .compile_matcher();
 
     let mut out: Vec<String> = Vec::new();
@@ -3948,8 +3939,8 @@ fn run_esbuild(input: &BundlerInput, shadow: &Path, bundle_path: &Path) -> Resul
 
     cmd.arg(OsString::from(entry));
 
-    let output = run_capturing(&mut cmd)
-        .with_context(|| format!("failed to spawn {}", bin.display()))?;
+    let output =
+        run_capturing(&mut cmd).with_context(|| format!("failed to spawn {}", bin.display()))?;
     // Drop `resolver_inputs` now — the subprocess has finished and
     // esbuild no longer needs the virtual-module `.mjs` temp files.
     // Explicit drop makes the lifetime intent visible; the
@@ -4077,7 +4068,10 @@ mod tests {
         // subdir alias
         paths.insert("@lib/*".to_string(), vec!["/proj/src/lib/*".to_string()]);
         // single-file bare-specifier remap (no `/*` suffix)
-        paths.insert("msw".to_string(), vec!["/proj/src/mocks/msw.ts".to_string()]);
+        paths.insert(
+            "msw".to_string(),
+            vec!["/proj/src/mocks/msw.ts".to_string()],
+        );
         // external target (not under project_root) — must pass through unchanged
         paths.insert("@ext/*".to_string(), vec!["/other/pkg/*".to_string()]);
 
@@ -5569,7 +5563,8 @@ mod tests {
 
         // The bundle must succeed: both `import "./mdx-components.tsx"` and
         // its transitive `import "./components/MyH2"` resolved in-shadow.
-        let out = bundle(input).expect("real esbuild bundle with mdx-components.tsx should succeed");
+        let out =
+            bundle(input).expect("real esbuild bundle with mdx-components.tsx should succeed");
         let body = fs::read_to_string(&out.bundle_path).unwrap();
         // The installer must be present in the final bundle.
         assert!(
@@ -6195,14 +6190,7 @@ mod tests {
         let mut routes = Vec::new();
         let exclude = no_bundle_exclude();
         let ctx = default_mat_ctx(tmp.path(), &exclude);
-        materialise_shadow(
-            &src,
-            &dest,
-            &mut routes,
-            &ctx,
-            &mut Vec::new(),
-        )
-        .unwrap();
+        materialise_shadow(&src, &dest, &mut routes, &ctx, &mut Vec::new()).unwrap();
 
         // Route is detected for /about.
         assert_eq!(routes.len(), 1, "expected one route; got {routes:?}");
@@ -6265,14 +6253,7 @@ mod tests {
         let mut routes = Vec::new();
         let exclude = no_bundle_exclude();
         let ctx = default_mat_ctx(tmp.path(), &exclude);
-        materialise_shadow(
-            &src,
-            &dest,
-            &mut routes,
-            &ctx,
-            &mut Vec::new(),
-        )
-        .unwrap();
+        materialise_shadow(&src, &dest, &mut routes, &ctx, &mut Vec::new()).unwrap();
 
         assert_eq!(routes.len(), 1);
         assert_eq!(routes[0].route, "/");
@@ -6298,14 +6279,7 @@ mod tests {
         let mut routes = Vec::new();
         let exclude = no_bundle_exclude();
         let ctx = default_mat_ctx(tmp.path(), &exclude);
-        materialise_shadow(
-            &src,
-            &dest,
-            &mut routes,
-            &ctx,
-            &mut Vec::new(),
-        )
-        .unwrap();
+        materialise_shadow(&src, &dest, &mut routes, &ctx, &mut Vec::new()).unwrap();
 
         // In non-pages dir: post.md copied verbatim (not compiled into shell).
         let shadow_file = dest.join("post.md");
@@ -6347,14 +6321,7 @@ mod tests {
         let mut routes = Vec::new();
         let exclude = no_bundle_exclude();
         let ctx = default_mat_ctx(tmp.path(), &exclude);
-        materialise_shadow(
-            &src,
-            &dest,
-            &mut routes,
-            &ctx,
-            &mut Vec::new(),
-        )
-        .unwrap();
+        materialise_shadow(&src, &dest, &mut routes, &ctx, &mut Vec::new()).unwrap();
 
         let body = fs::read_to_string(dest.join("_zfb_md_body_about.jsx")).unwrap();
 
@@ -6421,14 +6388,7 @@ mod tests {
             let dest_shadow = tmp.path().join("shadow");
             let exclude = no_bundle_exclude();
             let ctx = default_mat_ctx(tmp.path(), &exclude);
-            materialise_shadow(
-                &src,
-                &dest_shadow,
-                &mut Vec::new(),
-                &ctx,
-                &mut Vec::new(),
-            )
-            .unwrap();
+            materialise_shadow(&src, &dest_shadow, &mut Vec::new(), &ctx, &mut Vec::new()).unwrap();
 
             let shadow_files = collect_dest_files(&dest_shadow);
             assert!(
@@ -6488,14 +6448,7 @@ mod tests {
         let dest = tmp.path().join("shadow");
         let exclude = no_bundle_exclude();
         let ctx = default_mat_ctx(tmp.path(), &exclude);
-        materialise_shadow(
-            &src,
-            &dest,
-            &mut Vec::new(),
-            &ctx,
-            &mut Vec::new(),
-        )
-        .unwrap();
+        materialise_shadow(&src, &dest, &mut Vec::new(), &ctx, &mut Vec::new()).unwrap();
 
         let files = collect_dest_files(&dest);
         assert!(
@@ -6522,14 +6475,7 @@ mod tests {
         let dest = tmp.path().join("shadow");
         let exclude = no_bundle_exclude();
         let ctx = default_mat_ctx(tmp.path(), &exclude);
-        materialise_shadow(
-            &src,
-            &dest,
-            &mut Vec::new(),
-            &ctx,
-            &mut Vec::new(),
-        )
-        .unwrap();
+        materialise_shadow(&src, &dest, &mut Vec::new(), &ctx, &mut Vec::new()).unwrap();
 
         let files = collect_dest_files(&dest);
         assert!(
@@ -6771,14 +6717,7 @@ mod tests {
         let dest = dest_tmp.path().join("shadow");
         let exclude = no_bundle_exclude();
         let ctx = default_mat_ctx(src_tmp.path(), &exclude);
-        materialise_shadow(
-            &src,
-            &dest,
-            &mut Vec::new(),
-            &ctx,
-            &mut Vec::new(),
-        )
-        .unwrap();
+        materialise_shadow(&src, &dest, &mut Vec::new(), &ctx, &mut Vec::new()).unwrap();
 
         for filename in &["style.css", "image.png"] {
             let dest_file = dest.join(filename);
@@ -6964,7 +6903,10 @@ mod tests {
             !out.contains("import.meta.glob("),
             "macro must be removed even with zero matches:\n{out}"
         );
-        assert!(out.contains("{}"), "zero matches must expand to `{{}}`:\n{out}");
+        assert!(
+            out.contains("{}"),
+            "zero matches must expand to `{{}}`:\n{out}"
+        );
         // No `import * as` declarations when there are no matches.
         assert!(
             !out.contains("import * as __glob_"),
@@ -7043,17 +6985,9 @@ mod tests {
         fs::write(src.join("Drop.stories.tsx"), "export const drop = 1;").unwrap();
 
         let dest = root.path().join("shadow").join("components");
-        let matcher =
-            BundleExcludeMatcher::new(&["components/*.stories.tsx".to_string()]).unwrap();
+        let matcher = BundleExcludeMatcher::new(&["components/*.stories.tsx".to_string()]).unwrap();
         let ctx = default_mat_ctx(root.path(), &matcher);
-        materialise_shadow(
-            &src,
-            &dest,
-            &mut Vec::new(),
-            &ctx,
-            &mut Vec::new(),
-        )
-        .unwrap();
+        materialise_shadow(&src, &dest, &mut Vec::new(), &ctx, &mut Vec::new()).unwrap();
 
         assert!(dest.join("Keep.tsx").exists(), "non-matching file kept");
         assert!(
@@ -7075,16 +7009,12 @@ mod tests {
         let dest = root.path().join("shadow").join("components");
         let exclude = no_bundle_exclude();
         let ctx = default_mat_ctx(root.path(), &exclude);
-        materialise_shadow(
-            &src,
-            &dest,
-            &mut Vec::new(),
-            &ctx,
-            &mut Vec::new(),
-        )
-        .unwrap();
+        materialise_shadow(&src, &dest, &mut Vec::new(), &ctx, &mut Vec::new()).unwrap();
 
-        assert!(dest.join("Keep.tsx").exists(), "Keep present with empty exclude");
+        assert!(
+            dest.join("Keep.tsx").exists(),
+            "Keep present with empty exclude"
+        );
         assert!(
             dest.join("Story.stories.tsx").exists(),
             "with empty bundle.exclude nothing is skipped (byte-identical to today)"
@@ -7107,7 +7037,10 @@ mod tests {
         let b = out.find("./widgets/b.tsx").expect("b present");
         let c = out.find("./widgets/c.tsx").expect("c present");
         assert!(a < b && b < c, "keys must be sorted a<b<c:\n{out}");
-        assert!(!out.contains("readme.md"), ".md must not match *.tsx:\n{out}");
+        assert!(
+            !out.contains("readme.md"),
+            ".md must not match *.tsx:\n{out}"
+        );
         // Three distinct namespace identifiers, dense from 0.
         assert!(out.contains("__glob_0"));
         assert!(out.contains("__glob_1"));
@@ -7217,9 +7150,18 @@ mod tests {
             "the real call must be expanded:\n{out}"
         );
         // The decoys are NOT among the expanded files (only the real glob ran).
-        assert!(!out.contains("./x.tsx\": __glob"), "decoy x not expanded:\n{out}");
-        assert!(!out.contains("./y.tsx\": __glob"), "decoy y not expanded:\n{out}");
-        assert!(!out.contains("./z.tsx\": __glob"), "decoy z not expanded:\n{out}");
+        assert!(
+            !out.contains("./x.tsx\": __glob"),
+            "decoy x not expanded:\n{out}"
+        );
+        assert!(
+            !out.contains("./y.tsx\": __glob"),
+            "decoy y not expanded:\n{out}"
+        );
+        assert!(
+            !out.contains("./z.tsx\": __glob"),
+            "decoy z not expanded:\n{out}"
+        );
     }
 
     #[test]
@@ -7232,9 +7174,7 @@ mod tests {
             ("widgets/b.tsx", "export const b = 1;"),
         ]);
         let src = r#"export const m = import.meta.glob('./widgets/*.tsx', { eager: true });"#;
-        let exclude = |p: &Path| {
-            p.file_name().and_then(|s| s.to_str()) == Some("b.tsx")
-        };
+        let exclude = |p: &Path| p.file_name().and_then(|s| s.to_str()) == Some("b.tsx");
         let out = expand_import_meta_glob(src, dir.path(), &exclude).unwrap();
         assert!(out.contains("./widgets/a.tsx"), "a kept:\n{out}");
         assert!(
@@ -7268,7 +7208,10 @@ mod tests {
         "#;
         let out = expand_import_meta_glob(src, dir.path(), &no_exclude).unwrap();
 
-        assert!(!out.contains("import.meta.glob("), "both calls removed:\n{out}");
+        assert!(
+            !out.contains("import.meta.glob("),
+            "both calls removed:\n{out}"
+        );
         // First call → __glob_0 (./x/one.tsx).
         assert!(
             out.contains(r#"import * as __glob_0 from "./x/one.tsx";"#),
@@ -7285,9 +7228,18 @@ mod tests {
             "second call's second match is __glob_2:\n{out}"
         );
         // Both object literals keep their own keys (splice didn't cross-wire).
-        assert!(out.contains(r#""./x/one.tsx": __glob_0"#), "obj a key:\n{out}");
-        assert!(out.contains(r#""./y/three.tsx": __glob_1"#), "obj b key 1:\n{out}");
-        assert!(out.contains(r#""./y/two.tsx": __glob_2"#), "obj b key 2:\n{out}");
+        assert!(
+            out.contains(r#""./x/one.tsx": __glob_0"#),
+            "obj a key:\n{out}"
+        );
+        assert!(
+            out.contains(r#""./y/three.tsx": __glob_1"#),
+            "obj b key 1:\n{out}"
+        );
+        assert!(
+            out.contains(r#""./y/two.tsx": __glob_2"#),
+            "obj b key 2:\n{out}"
+        );
         // x file must NOT appear in the y object and vice-versa: the `a`
         // assignment's object must contain only the x key.
         let a_obj_start = out.find("export const a =").expect("a decl");
@@ -7326,6 +7278,9 @@ mod tests {
         let err = expand_import_meta_glob(src, dir.path(), &no_exclude)
             .expect_err("../ pattern must error");
         let msg = format!("{err:#}");
-        assert!(msg.contains("parent-directory") || msg.contains(".."), "names the limit: {msg}");
+        assert!(
+            msg.contains("parent-directory") || msg.contains(".."),
+            "names the limit: {msg}"
+        );
     }
 }

--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -115,6 +115,7 @@ use std::process::Command;
 use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
 use walkdir::WalkDir;
+use zfb_content::diagnostics::{DiagnosticSeverity, MarkdownDiagnostic};
 use zfb_content::frontmatter as zfb_frontmatter;
 use zfb_content::plugins::util::source_map::{
     build_docs_source_map, CollectionRoute, DocsSourceMapOptions,
@@ -873,6 +874,12 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
     // After the walk completes, handled according to `on_broken_links`.
     let mut all_broken_links: Vec<(String, String)> = Vec::new(); // (file_path, url)
 
+    // Accumulated markdown diagnostics (transclude errors, imageDimensions
+    // warnings, linkValidation findings) across all materialise calls.
+    // Drained adjacent to `take_broken_links`; policy applied after ALL walks
+    // complete — mirroring the broken-links gate above (zfb#953).
+    let mut all_markdown_diagnostics: Vec<MarkdownDiagnostic> = Vec::new();
+
     // Compile `bundle.exclude` once and share it across every
     // `materialise_shadow` call (pages / content / components / layouts /
     // extra top-level dirs). Empty patterns → a matcher that never matches,
@@ -916,12 +923,14 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
     let mut routes: Vec<RouteEntry> = Vec::new();
     {
         let mut broken = Vec::new();
+        let mut md_diags = Vec::new();
         materialise_shadow(
             &pages_dir,
             &shadow_pages,
             &mut routes,
             &mat_ctx,
             &mut broken,
+            &mut md_diags,
         )
         .with_context(|| {
             format!(
@@ -930,6 +939,7 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
             )
         })?;
         all_broken_links.extend(broken);
+        all_markdown_diagnostics.extend(md_diags);
     }
 
     // Per-collection content materialisation (#506).
@@ -950,6 +960,7 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
             let col_root = resolver.resolve(&col.root);
             let dest = shadow_content.join(&col.name);
             let mut broken = Vec::new();
+            let mut md_diags = Vec::new();
             materialise_collection(
                 &col_root,
                 &dest,
@@ -960,6 +971,7 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
                 col.exclude.as_deref(),
                 col.id_strip_suffix.as_deref(),
                 &mut broken,
+                &mut md_diags,
             )
             .with_context(|| {
                 format!(
@@ -969,6 +981,7 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
                 )
             })?;
             all_broken_links.extend(broken);
+            all_markdown_diagnostics.extend(md_diags);
         }
         // Deterministic ordering — keys are `(collection, rel_path)`
         // so the emitted import indices match the underlying file
@@ -976,12 +989,14 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
         content_imports.sort_by(|a, b| a.shadow_rel_path.cmp(&b.shadow_rel_path));
     } else {
         let mut broken = Vec::new();
+        let mut md_diags = Vec::new();
         materialise_shadow(
             &content_dir,
             &shadow_content,
             &mut Vec::new(),
             &mat_ctx,
             &mut broken,
+            &mut md_diags,
         )
         .with_context(|| {
             format!(
@@ -990,16 +1005,19 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
             )
         })?;
         all_broken_links.extend(broken);
+        all_markdown_diagnostics.extend(md_diags);
     }
 
     {
         let mut broken = Vec::new();
+        let mut md_diags = Vec::new();
         materialise_shadow(
             &components_dir,
             &shadow_components,
             &mut Vec::new(),
             &mat_ctx,
             &mut broken,
+            &mut md_diags,
         )
         .with_context(|| {
             format!(
@@ -1008,15 +1026,18 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
             )
         })?;
         all_broken_links.extend(broken);
+        all_markdown_diagnostics.extend(md_diags);
     }
     {
         let mut broken = Vec::new();
+        let mut md_diags = Vec::new();
         materialise_shadow(
             &layouts_dir,
             &shadow_layouts,
             &mut Vec::new(),
             &mat_ctx,
             &mut broken,
+            &mut md_diags,
         )
         .with_context(|| {
             format!(
@@ -1025,6 +1046,7 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
             )
         })?;
         all_broken_links.extend(broken);
+        all_markdown_diagnostics.extend(md_diags);
     }
 
     // 2a-extra. Materialise any *other* directories at the project root
@@ -1062,14 +1084,23 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
             let name = src_dir.file_name().unwrap_or_default().to_os_string();
             let dst_dir = shadow.join(&name);
             let mut broken = Vec::new();
-            materialise_shadow(&src_dir, &dst_dir, &mut Vec::new(), &mat_ctx, &mut broken)
-                .with_context(|| {
-                    format!(
-                        "bundler: failed materialising extra dir {} into shadow",
-                        src_dir.display()
-                    )
-                })?;
+            let mut md_diags = Vec::new();
+            materialise_shadow(
+                &src_dir,
+                &dst_dir,
+                &mut Vec::new(),
+                &mat_ctx,
+                &mut broken,
+                &mut md_diags,
+            )
+            .with_context(|| {
+                format!(
+                    "bundler: failed materialising extra dir {} into shadow",
+                    src_dir.display()
+                )
+            })?;
             all_broken_links.extend(broken);
+            all_markdown_diagnostics.extend(md_diags);
         }
     }
 
@@ -1133,6 +1164,93 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
                 );
                 bail!("{}", msg);
             }
+        }
+    }
+
+    // 2c-md. Handle markdown diagnostics (transclude errors, imageDimensions
+    // warnings, linkValidation findings) collected across all materialise calls.
+    //
+    // All walks ran to completion first so the full set is reported in one
+    // pass — same contract as the broken-links gate above.
+    //
+    // Severity routing:
+    //   Info / Warning  → stderr warn lines with path(:line) prefix; build succeeds.
+    //   Error           → bail! listing all findings; build fails.
+    //
+    // Intentional divergence from #948's original wording:
+    //   #948 said "warnings for imageDimensions/transclude", but transclude
+    //   failures are Error severity by plugin design (the include node is
+    //   dropped when the file cannot be read — the output is broken), so
+    //   they FAIL the build.  imageDimensions failures are Warning severity
+    //   (the <img> is left unchanged) and only warn.  linkValidation severity
+    //   is governed by the `failOnBroken` config flag (Warning by default,
+    //   Error when set).  This divergence is intentional and permanent; do
+    //   not "fix" it to match the original wording (zfb#953).
+    if !all_markdown_diagnostics.is_empty() {
+        // Format a location prefix: "path" or "path:line" when available.
+        let fmt_location = |d: &MarkdownDiagnostic| -> String {
+            let loc = match d {
+                MarkdownDiagnostic::BrokenLink { location, .. } => location.as_ref(),
+                MarkdownDiagnostic::Generic { location, .. } => location.as_ref(),
+            };
+            match loc {
+                Some(l) => {
+                    let path_str = l
+                        .path
+                        .as_ref()
+                        .map(|p| p.display().to_string())
+                        .unwrap_or_default();
+                    match l.line {
+                        Some(line) => format!("{path_str}:{line}"),
+                        None => path_str,
+                    }
+                }
+                None => String::new(),
+            }
+        };
+        let fmt_message = |d: &MarkdownDiagnostic| -> String {
+            match d {
+                MarkdownDiagnostic::BrokenLink { url, .. } => {
+                    format!("broken link: {url}")
+                }
+                MarkdownDiagnostic::Generic { message, .. } => message.clone(),
+            }
+        };
+
+        let errors: Vec<&MarkdownDiagnostic> = all_markdown_diagnostics
+            .iter()
+            .filter(|d| d.severity() == DiagnosticSeverity::Error)
+            .collect();
+
+        // Emit Info / Warning diagnostics regardless of whether there are
+        // errors — the user should see all findings before the build aborts.
+        for d in &all_markdown_diagnostics {
+            if d.severity() < DiagnosticSeverity::Error {
+                let loc = fmt_location(d);
+                let msg = fmt_message(d);
+                if loc.is_empty() {
+                    eprintln!("zfb warn: {msg}");
+                } else {
+                    eprintln!("zfb warn: {loc}: {msg}");
+                }
+            }
+        }
+
+        if !errors.is_empty() {
+            let mut msg = format!(
+                "bundler: {} markdown diagnostic error(s) found:\n",
+                errors.len()
+            );
+            for d in &errors {
+                let loc = fmt_location(d);
+                let text = fmt_message(d);
+                if loc.is_empty() {
+                    msg.push_str(&format!("  error: {text}\n"));
+                } else {
+                    msg.push_str(&format!("  {loc}: {text}\n"));
+                }
+            }
+            bail!("{}", msg.trim_end());
         }
     }
 
@@ -1548,6 +1666,7 @@ fn materialise_shadow(
     routes: &mut Vec<RouteEntry>,
     ctx: &MaterialiseCtx<'_>,
     broken_links_out: &mut Vec<(String, String)>,
+    markdown_diagnostics_out: &mut Vec<MarkdownDiagnostic>,
 ) -> Result<()> {
     if !src.exists() {
         // A missing source dir is non-fatal — not every project has e.g.
@@ -1738,6 +1857,11 @@ fn materialise_shadow(
             for diag in pipeline.take_broken_links() {
                 broken_links_out.push((from.display().to_string(), diag.url));
             }
+            // Drain generic markdown diagnostics (transclude errors,
+            // imageDimensions warnings, linkValidation findings) — adjacent
+            // to the broken-links drain so all pipeline output is collected
+            // before the shadow write (zfb#953).
+            markdown_diagnostics_out.extend(pipeline.take_markdown_diagnostics());
             fs::write(&to, compiled.jsx_source.as_bytes())
                 .with_context(|| format!("write compiled mdx to {}", to.display()))?;
         } else if is_md && is_pages_dir {
@@ -1788,6 +1912,9 @@ fn materialise_shadow(
             for diag in pipeline.take_broken_links() {
                 broken_links_out.push((from.display().to_string(), diag.url));
             }
+            // Drain generic markdown diagnostics adjacent to broken-links
+            // drain (zfb#953).
+            markdown_diagnostics_out.extend(pipeline.take_markdown_diagnostics());
             // Derive slug from the relative path so the title fallback matches
             // the URL: `about.md` → "about", `index.md` → "index",
             // `blog/post.md` → "post".
@@ -2128,6 +2255,7 @@ fn materialise_collection(
     exclude: Option<&[String]>,
     id_strip_suffix: Option<&str>,
     broken_links_out: &mut Vec<(String, String)>,
+    markdown_diagnostics_out: &mut Vec<MarkdownDiagnostic>,
 ) -> Result<()> {
     if !src.exists() {
         return Ok(());
@@ -2304,6 +2432,9 @@ fn materialise_collection(
             for diag in pipeline.take_broken_links() {
                 broken_links_out.push((from.display().to_string(), diag.url));
             }
+            // Drain generic markdown diagnostics adjacent to broken-links
+            // drain (zfb#953).
+            markdown_diagnostics_out.extend(pipeline.take_markdown_diagnostics());
             fs::write(&to, compiled.jsx_source.as_bytes())
                 .with_context(|| format!("write compiled mdx to {}", to.display()))?;
 
@@ -4869,6 +5000,7 @@ mod tests {
             None,
             None,
             &mut Vec::new(),
+            &mut Vec::new(),
         )
         .unwrap();
 
@@ -4955,6 +5087,7 @@ mod tests {
             None,
             None,
             None,
+            &mut Vec::new(),
             &mut Vec::new(),
         )
         .unwrap();
@@ -5121,6 +5254,7 @@ mod tests {
             None,
             None,
             None,
+            &mut Vec::new(),
             &mut Vec::new(),
         )
         .unwrap();
@@ -5705,6 +5839,7 @@ mod tests {
             &mut routes,
             &ctx,
             &mut Vec::new(),
+            &mut Vec::new(),
         )
         .unwrap();
 
@@ -5779,6 +5914,7 @@ mod tests {
             &shadow_pages_dest,
             &mut routes,
             &ctx,
+            &mut Vec::new(),
             &mut Vec::new(),
         )
         .unwrap();
@@ -5996,6 +6132,7 @@ mod tests {
             &mut routes,
             &ctx,
             &mut Vec::new(),
+            &mut Vec::new(),
         )
         .expect_err("expected a route collision error");
         err.to_string()
@@ -6190,7 +6327,15 @@ mod tests {
         let mut routes = Vec::new();
         let exclude = no_bundle_exclude();
         let ctx = default_mat_ctx(tmp.path(), &exclude);
-        materialise_shadow(&src, &dest, &mut routes, &ctx, &mut Vec::new()).unwrap();
+        materialise_shadow(
+            &src,
+            &dest,
+            &mut routes,
+            &ctx,
+            &mut Vec::new(),
+            &mut Vec::new(),
+        )
+        .unwrap();
 
         // Route is detected for /about.
         assert_eq!(routes.len(), 1, "expected one route; got {routes:?}");
@@ -6253,7 +6398,15 @@ mod tests {
         let mut routes = Vec::new();
         let exclude = no_bundle_exclude();
         let ctx = default_mat_ctx(tmp.path(), &exclude);
-        materialise_shadow(&src, &dest, &mut routes, &ctx, &mut Vec::new()).unwrap();
+        materialise_shadow(
+            &src,
+            &dest,
+            &mut routes,
+            &ctx,
+            &mut Vec::new(),
+            &mut Vec::new(),
+        )
+        .unwrap();
 
         assert_eq!(routes.len(), 1);
         assert_eq!(routes[0].route, "/");
@@ -6279,7 +6432,15 @@ mod tests {
         let mut routes = Vec::new();
         let exclude = no_bundle_exclude();
         let ctx = default_mat_ctx(tmp.path(), &exclude);
-        materialise_shadow(&src, &dest, &mut routes, &ctx, &mut Vec::new()).unwrap();
+        materialise_shadow(
+            &src,
+            &dest,
+            &mut routes,
+            &ctx,
+            &mut Vec::new(),
+            &mut Vec::new(),
+        )
+        .unwrap();
 
         // In non-pages dir: post.md copied verbatim (not compiled into shell).
         let shadow_file = dest.join("post.md");
@@ -6321,7 +6482,15 @@ mod tests {
         let mut routes = Vec::new();
         let exclude = no_bundle_exclude();
         let ctx = default_mat_ctx(tmp.path(), &exclude);
-        materialise_shadow(&src, &dest, &mut routes, &ctx, &mut Vec::new()).unwrap();
+        materialise_shadow(
+            &src,
+            &dest,
+            &mut routes,
+            &ctx,
+            &mut Vec::new(),
+            &mut Vec::new(),
+        )
+        .unwrap();
 
         let body = fs::read_to_string(dest.join("_zfb_md_body_about.jsx")).unwrap();
 
@@ -6388,7 +6557,15 @@ mod tests {
             let dest_shadow = tmp.path().join("shadow");
             let exclude = no_bundle_exclude();
             let ctx = default_mat_ctx(tmp.path(), &exclude);
-            materialise_shadow(&src, &dest_shadow, &mut Vec::new(), &ctx, &mut Vec::new()).unwrap();
+            materialise_shadow(
+                &src,
+                &dest_shadow,
+                &mut Vec::new(),
+                &ctx,
+                &mut Vec::new(),
+                &mut Vec::new(),
+            )
+            .unwrap();
 
             let shadow_files = collect_dest_files(&dest_shadow);
             assert!(
@@ -6413,6 +6590,7 @@ mod tests {
                 None,
                 None,
                 None,
+                &mut Vec::new(),
                 &mut Vec::new(),
             )
             .unwrap();
@@ -6448,7 +6626,15 @@ mod tests {
         let dest = tmp.path().join("shadow");
         let exclude = no_bundle_exclude();
         let ctx = default_mat_ctx(tmp.path(), &exclude);
-        materialise_shadow(&src, &dest, &mut Vec::new(), &ctx, &mut Vec::new()).unwrap();
+        materialise_shadow(
+            &src,
+            &dest,
+            &mut Vec::new(),
+            &ctx,
+            &mut Vec::new(),
+            &mut Vec::new(),
+        )
+        .unwrap();
 
         let files = collect_dest_files(&dest);
         assert!(
@@ -6475,7 +6661,15 @@ mod tests {
         let dest = tmp.path().join("shadow");
         let exclude = no_bundle_exclude();
         let ctx = default_mat_ctx(tmp.path(), &exclude);
-        materialise_shadow(&src, &dest, &mut Vec::new(), &ctx, &mut Vec::new()).unwrap();
+        materialise_shadow(
+            &src,
+            &dest,
+            &mut Vec::new(),
+            &ctx,
+            &mut Vec::new(),
+            &mut Vec::new(),
+        )
+        .unwrap();
 
         let files = collect_dest_files(&dest);
         assert!(
@@ -6717,7 +6911,15 @@ mod tests {
         let dest = dest_tmp.path().join("shadow");
         let exclude = no_bundle_exclude();
         let ctx = default_mat_ctx(src_tmp.path(), &exclude);
-        materialise_shadow(&src, &dest, &mut Vec::new(), &ctx, &mut Vec::new()).unwrap();
+        materialise_shadow(
+            &src,
+            &dest,
+            &mut Vec::new(),
+            &ctx,
+            &mut Vec::new(),
+            &mut Vec::new(),
+        )
+        .unwrap();
 
         for filename in &["style.css", "image.png"] {
             let dest_file = dest.join(filename);
@@ -6773,6 +6975,7 @@ mod tests {
             None,
             None,
             &mut Vec::new(),
+            &mut Vec::new(),
         )
         .unwrap();
 
@@ -6827,6 +7030,7 @@ mod tests {
                 dest_tmp.path(),
                 &mut Vec::new(),
                 &ctx,
+                &mut Vec::new(),
                 &mut Vec::new(),
             )
             .unwrap();
@@ -6987,7 +7191,15 @@ mod tests {
         let dest = root.path().join("shadow").join("components");
         let matcher = BundleExcludeMatcher::new(&["components/*.stories.tsx".to_string()]).unwrap();
         let ctx = default_mat_ctx(root.path(), &matcher);
-        materialise_shadow(&src, &dest, &mut Vec::new(), &ctx, &mut Vec::new()).unwrap();
+        materialise_shadow(
+            &src,
+            &dest,
+            &mut Vec::new(),
+            &ctx,
+            &mut Vec::new(),
+            &mut Vec::new(),
+        )
+        .unwrap();
 
         assert!(dest.join("Keep.tsx").exists(), "non-matching file kept");
         assert!(
@@ -7009,7 +7221,15 @@ mod tests {
         let dest = root.path().join("shadow").join("components");
         let exclude = no_bundle_exclude();
         let ctx = default_mat_ctx(root.path(), &exclude);
-        materialise_shadow(&src, &dest, &mut Vec::new(), &ctx, &mut Vec::new()).unwrap();
+        materialise_shadow(
+            &src,
+            &dest,
+            &mut Vec::new(),
+            &ctx,
+            &mut Vec::new(),
+            &mut Vec::new(),
+        )
+        .unwrap();
 
         assert!(
             dest.join("Keep.tsx").exists(),

--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -1152,6 +1152,13 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
     //   is governed by the `failOnBroken` config flag (Warning by default,
     //   Error when set).  This divergence is intentional and permanent; do
     //   not "fix" it to match the original wording (zfb#953).
+    //
+    // Fatal findings from this gate and the broken-links gate (2d) are
+    // accumulated here and bailed on ONCE after both gates have reported,
+    // so a build with both failure classes surfaces the full set in one
+    // pass instead of revealing the second class only after the first is
+    // fixed.
+    let mut fatal_findings: Vec<String> = Vec::new();
     if !all_markdown_diagnostics.is_empty() {
         // Format a location prefix: "path" or "path:line" when available.
         let fmt_location = |d: &MarkdownDiagnostic| -> String {
@@ -1216,7 +1223,7 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
                     msg.push_str(&format!("  {loc}: {text}\n"));
                 }
             }
-            bail!("{}", msg.trim_end());
+            fatal_findings.push(msg.trim_end().to_string());
         }
     }
 
@@ -1227,9 +1234,9 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
     // contract in the issue spec). Warnings are emitted to stderr so they
     // are visible to both the CLI user and CI log scanners.
     //
-    // Ordering note: placed AFTER the markdown-diagnostics gate (2c) so that
-    // transclude/imageDimensions errors are surfaced even when this gate would
-    // bail first (both gates run after all walks, so no findings are missed).
+    // Error-mode findings join `fatal_findings` (declared above 2c) rather
+    // than bailing here, so both this gate and the markdown-diagnostics
+    // gate report before the single combined bail below.
     if !all_broken_links.is_empty() {
         let on_broken = input
             .resolve_markdown_links
@@ -1258,9 +1265,15 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
                     "Fix the links or set onBrokenLinks: 'warn' / 'ignore' \
                      in resolveMarkdownLinks config to suppress this error.",
                 );
-                bail!("{}", msg);
+                fatal_findings.push(msg);
             }
         }
+    }
+
+    // Single combined bail for 2c + 2d: every fatal finding from both gates
+    // is in the error, so one failed build shows the complete picture.
+    if !fatal_findings.is_empty() {
+        bail!("{}", fatal_findings.join("\n"));
     }
 
     // 2e. CSS Modules — rewrite every `.module.css` file in the shadow

--- a/crates/zfb-build/src/head_inject.rs
+++ b/crates/zfb-build/src/head_inject.rs
@@ -309,10 +309,7 @@ mod tests {
         let html = "<html><head></head><body/></html>";
         let assets = ProdHeadAssets {
             css_url: Some("/assets/styles.css".into()),
-            island_module_urls: vec![
-                "/assets/islands.js".into(),
-                "/assets/extra.js".into(),
-            ],
+            island_module_urls: vec!["/assets/islands.js".into(), "/assets/extra.js".into()],
         };
         let out = inject_prod_head_assets(html, &assets);
         let out = out.as_ref();
@@ -417,7 +414,9 @@ mod tests {
     #[test]
     fn needs_doctype_for_bare_html_document() {
         // The preact-render-to-string shell: starts with `<html …>`, no doctype.
-        assert!(needs_html5_doctype("<html lang=\"en\"><head></head><body></body></html>"));
+        assert!(needs_html5_doctype(
+            "<html lang=\"en\"><head></head><body></body></html>"
+        ));
         assert!(needs_html5_doctype("<html><body>x</body></html>"));
     }
 
@@ -426,7 +425,9 @@ mod tests {
         // Case-insensitive; never doubles an existing doctype.
         assert!(!needs_html5_doctype("<!doctype html><html></html>"));
         assert!(!needs_html5_doctype("<!DOCTYPE HTML><html></html>"));
-        assert!(!needs_html5_doctype("<!Doctype html>\n<html lang=\"en\"></html>"));
+        assert!(!needs_html5_doctype(
+            "<!Doctype html>\n<html lang=\"en\"></html>"
+        ));
     }
 
     #[test]

--- a/crates/zfb-build/src/lib.rs
+++ b/crates/zfb-build/src/lib.rs
@@ -92,7 +92,7 @@ pub use pipeline::{
     ProdAssetEmitterInputs, ProdBuildContext, ProdRenderedFile, ProductionAssetPipeline,
     ProductionEmitters, RefreshOutcome, RelDistPath, RenderedPage, RendererReloader,
 };
-pub use plan::{PageSelection, RebuildPlan};
+pub use plan::{ContentNarrowing, PageSelection, RebuildPlan};
 pub use policy::{classify_change, classify_change_with_content_roots, GranularityPolicy, PathClass};
 pub use renderer::{
     render_all, render_one, reload, shutdown, start, Backend, EmbeddedV8Host,

--- a/crates/zfb-build/src/lib.rs
+++ b/crates/zfb-build/src/lib.rs
@@ -68,14 +68,22 @@ pub use adapter::{
 pub use atomic::{atomic_write, atomic_write_string, validate_output_path};
 pub use bundler::{
     bundle, resolve_esbuild_binary_with_env, BundleManifest, BundleMode, BundlerInput,
-    BundlerOutput, ContentCollectionSpec, DEFAULT_ESBUILD_SLOT, OnBrokenLinks,
-    ResolveMarkdownLinksRoute, ResolveMarkdownLinksSpec, RouteEntry,
+    BundlerOutput, ContentCollectionSpec, OnBrokenLinks, ResolveMarkdownLinksRoute,
+    ResolveMarkdownLinksSpec, RouteEntry, DEFAULT_ESBUILD_SLOT,
 };
 pub use head_inject::{
     css_link_tag, inject_prod_head_assets, island_module_script_tag, needs_html5_doctype,
     ProdHeadAssets, HTML5_DOCTYPE_PREFIX,
 };
 pub use orchestrator::{BuildOrchestrator, DiscoveryHook, DiscoveryOutcome, OrchestratorConfig};
+pub use pipeline::{
+    apply_prod_asset_pipeline, synthesize_page_id_from_output, AssetEmitter, AssetEmitterPayload,
+    AssetKind, AssetPipeline, BuildContext, BuildMode, BuildOutcome, CssRunner, DevAssetPipeline,
+    DevBuildContext, EmittedAsset, IslandsBundleInfo, IslandsRunner, PageRenderer,
+    ProdAssetEmitterInputs, ProdBuildContext, ProdRenderedFile, ProductionAssetPipeline,
+    ProductionEmitters, RelDistPath, RenderedPage, RendererReloader,
+};
+pub use plan::{PageSelection, RebuildPlan};
 pub use plugin_registries::{
     AliasEntry, AliasMap, InjectedRoute, InjectedRouteList, SetupCommand, SetupRegistries,
     SetupRegistryError, VirtualLoaderId, VirtualModuleEntry, VirtualModuleRegistry,
@@ -85,17 +93,11 @@ pub use plugin_runner::{
     DevRegisterContext, DevRegistration, DevRequest, DevResponse, PluginError, PluginHost,
     PluginSpec, PostBuildParamValue, PostBuildRouteEntry, PostBuildRouteManifest, SetupHookContext,
 };
-pub use pipeline::{
-    apply_prod_asset_pipeline, synthesize_page_id_from_output, AssetEmitter, AssetEmitterPayload,
-    AssetKind, AssetPipeline, BuildContext, BuildMode, BuildOutcome, CssRunner, DevAssetPipeline,
-    DevBuildContext, EmittedAsset, IslandsBundleInfo, IslandsRunner, PageRenderer,
-    ProdAssetEmitterInputs, ProdBuildContext, ProdRenderedFile, ProductionAssetPipeline,
-    ProductionEmitters, RelDistPath, RenderedPage, RendererReloader,
+pub use policy::{
+    classify_change, classify_change_with_content_roots, GranularityPolicy, PathClass,
 };
-pub use plan::{PageSelection, RebuildPlan};
-pub use policy::{classify_change, classify_change_with_content_roots, GranularityPolicy, PathClass};
 pub use renderer::{
-    render_all, render_one, reload, shutdown, start, Backend, EmbeddedV8Host,
+    reload, render_all, render_one, shutdown, start, Backend, EmbeddedV8Host,
     EmbeddedV8HostFactory, HttpResponseLike, RendererError, RendererInput, RendererOutput,
     RendererStartInput, RendererState, RouteUniverseEntry, SsrManifest, SsrRouteEntry,
 };

--- a/crates/zfb-build/src/lib.rs
+++ b/crates/zfb-build/src/lib.rs
@@ -90,7 +90,7 @@ pub use pipeline::{
     AssetKind, AssetPipeline, BuildContext, BuildMode, BuildOutcome, CssRunner, DevAssetPipeline,
     DevBuildContext, EmittedAsset, IslandsBundleInfo, IslandsRunner, PageRenderer,
     ProdAssetEmitterInputs, ProdBuildContext, ProdRenderedFile, ProductionAssetPipeline,
-    ProductionEmitters, RelDistPath, RenderedPage, RendererReloader,
+    ProductionEmitters, RefreshOutcome, RelDistPath, RenderedPage, RendererReloader,
 };
 pub use plan::{PageSelection, RebuildPlan};
 pub use policy::{classify_change, classify_change_with_content_roots, GranularityPolicy, PathClass};

--- a/crates/zfb-build/src/link_base_rewrite.rs
+++ b/crates/zfb-build/src/link_base_rewrite.rs
@@ -70,9 +70,7 @@ pub fn rewrite_links_in_html(
     add_trailing_slash: bool,
 ) -> Result<String, lol_html::errors::RewritingError> {
     let a_selector: Selector = "a[href]".parse().expect("static selector is valid");
-    let form_selector: Selector = "form[action]"
-        .parse()
-        .expect("static selector is valid");
+    let form_selector: Selector = "form[action]".parse().expect("static selector is valid");
 
     // Each handler is `FnMut + Send + Sync`; capture an owned `String`
     // clone of the prefix so the closures don't borrow from the outer
@@ -86,37 +84,42 @@ pub fn rewrite_links_in_html(
             element_content_handlers: vec![
                 (
                     Cow::Owned(a_selector),
-                    ElementContentHandlers::default().element(move |el: &mut Element<'_, '_, _>| {
-                        if has_no_base_optout(el) {
-                            return Ok(());
-                        }
-                        if let Some(href) = el.get_attribute("href") {
-                            if let Some(rewritten) = compute_prefixed_with_trailing_slash(
-                                &href,
-                                &prefix_for_a,
-                                add_trailing_slash,
-                            ) {
-                                el.set_attribute("href", &rewritten)?;
+                    ElementContentHandlers::default().element(
+                        move |el: &mut Element<'_, '_, _>| {
+                            if has_no_base_optout(el) {
+                                return Ok(());
                             }
-                        }
-                        Ok(())
-                    }),
+                            if let Some(href) = el.get_attribute("href") {
+                                if let Some(rewritten) = compute_prefixed_with_trailing_slash(
+                                    &href,
+                                    &prefix_for_a,
+                                    add_trailing_slash,
+                                ) {
+                                    el.set_attribute("href", &rewritten)?;
+                                }
+                            }
+                            Ok(())
+                        },
+                    ),
                 ),
                 (
                     Cow::Owned(form_selector),
-                    ElementContentHandlers::default().element(move |el: &mut Element<'_, '_, _>| {
-                        if has_no_base_optout(el) {
-                            return Ok(());
-                        }
-                        if let Some(action) = el.get_attribute("action") {
-                            // Form actions are POST/GET targets, not
-                            // page URLs — never append trailing slash.
-                            if let Some(rewritten) = compute_prefixed(&action, &prefix_for_form) {
-                                el.set_attribute("action", &rewritten)?;
+                    ElementContentHandlers::default().element(
+                        move |el: &mut Element<'_, '_, _>| {
+                            if has_no_base_optout(el) {
+                                return Ok(());
                             }
-                        }
-                        Ok(())
-                    }),
+                            if let Some(action) = el.get_attribute("action") {
+                                // Form actions are POST/GET targets, not
+                                // page URLs — never append trailing slash.
+                                if let Some(rewritten) = compute_prefixed(&action, &prefix_for_form)
+                                {
+                                    el.set_attribute("action", &rewritten)?;
+                                }
+                            }
+                            Ok(())
+                        },
+                    ),
                 ),
             ],
             ..RewriteStrSettings::new()
@@ -252,10 +255,7 @@ fn is_under_prefix(value: &str, prefix: &str) -> bool {
         return false;
     }
     let rest = &value[prefix.len()..];
-    rest.is_empty()
-        || rest.starts_with('/')
-        || rest.starts_with('?')
-        || rest.starts_with('#')
+    rest.is_empty() || rest.starts_with('/') || rest.starts_with('?') || rest.starts_with('#')
 }
 
 /// Insert `/` between the path part and the `?query`/`#fragment`
@@ -270,9 +270,7 @@ fn maybe_insert_trailing_slash(value: &str) -> String {
         return value.to_string();
     }
     // Split off the suffix (?... or #...) so we only touch the path.
-    let suffix_idx = value
-        .find(['?', '#'])
-        .unwrap_or(value.len());
+    let suffix_idx = value.find(['?', '#']).unwrap_or(value.len());
     let (path, suffix) = value.split_at(suffix_idx);
     if path.is_empty() {
         return value.to_string();
@@ -395,22 +393,14 @@ mod tests {
             "http://example.com/x",
             "https://example.com/x",
         ] {
-            assert_eq!(
-                compute_prefixed(v, "/foo"),
-                None,
-                "expected skip for {v}"
-            );
+            assert_eq!(compute_prefixed(v, "/foo"), None, "expected skip for {v}");
         }
     }
 
     #[test]
     fn skips_relative_paths() {
         for v in ["foo.html", "./foo", "../foo", "page", "page/sub.html"] {
-            assert_eq!(
-                compute_prefixed(v, "/foo"),
-                None,
-                "expected skip for {v}"
-            );
+            assert_eq!(compute_prefixed(v, "/foo"), None, "expected skip for {v}");
         }
     }
 
@@ -612,8 +602,7 @@ mod tests {
             Some("/foo/sitemap.xml")
         );
         assert_eq!(
-            compute_prefixed_with_trailing_slash("/files/report.pdf?dl=1", "/foo", true)
-                .as_deref(),
+            compute_prefixed_with_trailing_slash("/files/report.pdf?dl=1", "/foo", true).as_deref(),
             Some("/foo/files/report.pdf?dl=1")
         );
     }

--- a/crates/zfb-build/src/orchestrator.rs
+++ b/crates/zfb-build/src/orchestrator.rs
@@ -928,8 +928,8 @@ mod tests {
     /// every assertion below.
     #[test]
     fn initial_build_renders_all_seeded_pages_with_no_file_events() {
-        use crate::pipeline::{BuildContext, RelDistPath, RenderedPage};
         use crate::pipeline::dev::DevAssetPipeline;
+        use crate::pipeline::{BuildContext, RelDistPath, RenderedPage};
         use std::sync::atomic::{AtomicUsize, Ordering};
         use tempfile::tempdir;
 

--- a/crates/zfb-build/src/orchestrator.rs
+++ b/crates/zfb-build/src/orchestrator.rs
@@ -566,6 +566,44 @@ impl<P: AssetPipeline> BuildOrchestrator<P> {
             plan.add_prune_paths(discovered.vanished_output_paths);
         }
 
+        // Content-narrowing hint (issue #958). Produced iff this tick
+        // consists EXCLUSIVELY of in-place edits (`ChangeKind::Modified`)
+        // to content-collection files (`PathClass::Content`) and the
+        // assembled plan selects at least one page. Everything else —
+        // mixed ticks, Created (discovery regime), Removed (prune
+        // regime), Global, External, Data — never narrows (fallback G1).
+        // The classifier runs with the same config `plan_for_changes`
+        // uses, so the hint can never disagree with the plan fold.
+        // Purely advisory: the dev pipeline narrows each dynamic source's
+        // render fan-out to the changed entries' routes, with mandatory
+        // full-fan-out fallbacks downstream.
+        let modified_only_content = !changes.is_empty()
+            && changes
+                .iter()
+                .all(|(_, kind)| *kind == ChangeKind::Modified)
+            && {
+                let graph = self.graph.lock().unwrap_or_else(|p| {
+                    warn!(
+                        site = "tick_with_kinds::content_narrowing",
+                        "graph mutex poisoned, recovering"
+                    );
+                    p.into_inner()
+                });
+                changes.iter().all(|(path, _)| {
+                    classify_change_with_content_roots(
+                        path,
+                        &self.config.project_root,
+                        &self.config.policy.content_roots,
+                        |p| graph.is_global(p),
+                    ) == PathClass::Content
+                })
+            };
+        if modified_only_content && !plan.pages.is_empty() {
+            plan.content_narrowing = Some(crate::plan::ContentNarrowing {
+                changed_content: changes.iter().map(|(p, _)| p.clone()).collect(),
+            });
+        }
+
         if plan.is_noop() {
             return Ok(None);
         }
@@ -907,6 +945,117 @@ mod tests {
         assert!(plan.pages.is_all());
     }
 
+    // ── Content-narrowing hint production (issue #958, §3) ──────────────
+
+    /// Build a no-op `BuildContext` for driving `tick_with_kinds` against
+    /// the recording [`CountingPipeline`].
+    fn noop_ctx(dist: &std::path::Path) -> BuildContext {
+        BuildContext {
+            dist_root: dist.to_path_buf(),
+            render_pages: Arc::new(|_, _| Ok(vec![])),
+            run_css: None,
+            run_islands: None,
+            reload_renderer: None,
+        }
+    }
+
+    /// A tick made exclusively of Modified content files produces the
+    /// narrowing hint, carrying the changed paths verbatim.
+    #[test]
+    fn modified_only_content_tick_produces_hint() {
+        use zfb_watcher::ChangeKind;
+        let pipeline = CountingPipeline::default();
+        let applies = pipeline.applies.clone();
+        let orch = make_orch(pipeline);
+        let dist = tempfile::tempdir().unwrap();
+
+        let changed = PathBuf::from("/proj/content/post.md");
+        orch.tick_with_kinds(
+            vec![(changed.clone(), ChangeKind::Modified)],
+            &noop_ctx(dist.path()),
+            None,
+        )
+        .unwrap();
+
+        let plans = applies.lock().unwrap();
+        assert_eq!(plans.len(), 1);
+        assert_eq!(
+            plans[0].content_narrowing,
+            Some(crate::plan::ContentNarrowing {
+                changed_content: vec![changed],
+            }),
+            "a Modified-only Content tick must carry the narrowing hint"
+        );
+    }
+
+    /// §3: a tick mixing a content edit with a module edit must NOT
+    /// produce the hint — module changes can affect every page's output.
+    #[test]
+    fn mixed_tick_with_module_trigger_produces_no_hint() {
+        use zfb_watcher::ChangeKind;
+        let pipeline = CountingPipeline::default();
+        let applies = pipeline.applies.clone();
+        let orch = make_orch(pipeline);
+        let dist = tempfile::tempdir().unwrap();
+
+        orch.tick_with_kinds(
+            vec![
+                (PathBuf::from("/proj/content/post.md"), ChangeKind::Modified),
+                (
+                    PathBuf::from("/proj/components/Header.tsx"),
+                    ChangeKind::Modified,
+                ),
+            ],
+            &noop_ctx(dist.path()),
+            None,
+        )
+        .unwrap();
+
+        let plans = applies.lock().unwrap();
+        assert_eq!(plans.len(), 1);
+        assert_eq!(
+            plans[0].content_narrowing, None,
+            "a mixed content+module tick must not narrow (G1)"
+        );
+    }
+
+    /// §3: Created and Removed ticks never produce the hint — they run
+    /// the discovery / prune regimes, not the in-place-edit fast path.
+    #[test]
+    fn created_or_removed_tick_produces_no_hint() {
+        use zfb_watcher::ChangeKind;
+
+        for kind in [ChangeKind::Created, ChangeKind::Removed] {
+            let pipeline = CountingPipeline::default();
+            let applies = pipeline.applies.clone();
+            let orch = make_orch(pipeline);
+            let dist = tempfile::tempdir().unwrap();
+
+            orch.tick_with_kinds(
+                vec![
+                    (PathBuf::from("/proj/content/post.md"), kind),
+                    // A Modified sibling keeps the tick non-noop even for
+                    // the Removed case (post.md's consumer is re-planned),
+                    // and proves one non-Modified change poisons the hint.
+                    (
+                        PathBuf::from("/proj/content/other.md"),
+                        ChangeKind::Modified,
+                    ),
+                ],
+                &noop_ctx(dist.path()),
+                None,
+            )
+            .unwrap();
+
+            let plans = applies.lock().unwrap();
+            assert_eq!(plans.len(), 1, "tick must apply for kind {kind:?}");
+            assert_eq!(
+                plans[0].content_narrowing, None,
+                "a tick containing a {kind:?} change must not narrow (G1)"
+            );
+        }
+    }
+
     /// Regression for zfb#642 / #644 — `zfb dev` 404'd every route on a
     /// fresh boot because nothing rendered pages into the dev cache until
     /// the user edited a file: `run()` is watcher-driven and there was no
@@ -962,7 +1111,7 @@ mod tests {
         let render_calls_cb = render_calls.clone();
         let ctx = BuildContext {
             dist_root: dist.path().to_path_buf(),
-            render_pages: Arc::new(move |pages: &[PageId]| {
+            render_pages: Arc::new(move |pages: &[PageId], _narrowing| {
                 render_calls_cb.fetch_add(pages.len(), Ordering::SeqCst);
                 Ok(pages
                     .iter()
@@ -1032,7 +1181,7 @@ mod tests {
         );
         let ctx = BuildContext {
             dist_root: dist.path().to_path_buf(),
-            render_pages: Arc::new(|_| Ok(vec![])),
+            render_pages: Arc::new(|_, _| Ok(vec![])),
             run_css: None,
             run_islands: None,
             reload_renderer: None,

--- a/crates/zfb-build/src/pipeline/dev.rs
+++ b/crates/zfb-build/src/pipeline/dev.rs
@@ -25,7 +25,7 @@ use anyhow::{Context, Result};
 use zfb_graph::PageId;
 
 use crate::atomic::{atomic_write, validate_output_path};
-use crate::pipeline::{AssetPipeline, BuildContext, BuildOutcome};
+use crate::pipeline::{AssetPipeline, BuildContext, BuildOutcome, RefreshOutcome};
 use crate::plan::{PageSelection, RebuildPlan};
 
 /// The default `zfb dev`-mode asset pipeline.
@@ -117,7 +117,13 @@ impl AssetPipeline for DevAssetPipeline {
                 // Vanished paths from an SSR-only reload are appended to
                 // prune_paths below; the pages loop's prune infrastructure
                 // is bypassed here so we handle them in the plan-prune block.
-                let vanished = reload()?;
+                // A `Skipped` outcome (issue #956) means the live host and
+                // route tables were left untouched — nothing vanished,
+                // nothing to prune.
+                let vanished = match reload()? {
+                    RefreshOutcome::Skipped => Vec::new(),
+                    RefreshOutcome::Refreshed { vanished } => vanished,
+                };
                 if !vanished.is_empty() {
                     outcome.pages_pruned.extend(vanished.iter().cloned());
                     for prev in &vanished {
@@ -148,6 +154,21 @@ impl AssetPipeline for DevAssetPipeline {
             }
         }
 
+        // Vanished route output paths consumed by the deferred-prune loop
+        // inside the render block: plan-carried paths (issue #804 P2) plus
+        // whatever the reloader reports. Hoisted out of the render block so
+        // the Skipped path (issue #956) leaves them to the plan-prune block
+        // (1b) below instead.
+        let mut route_vanished: Vec<PathBuf> = plan.prune_paths.clone();
+
+        // True when the reloader reported [`RefreshOutcome::Skipped`]
+        // (issue #956): byte-identical bundle + unchanged route universe.
+        // The render fan-out is bypassed for the tick — re-rendering
+        // against an identical bundle would re-emit identical HTML, the
+        // same determinism assumption the `last_bytes` byte-dedup cache
+        // already makes. CSS, islands, and plan prune paths still run.
+        let mut renderer_refresh_skipped = false;
+
         if !pages.is_empty() {
             // Reload the SSR renderer (embedded V8 host) before rendering
             // pages whenever the dirty set is non-empty — UNLESS the
@@ -166,13 +187,24 @@ impl AssetPipeline for DevAssetPipeline {
             // the discovery hook), reload_renderer is skipped — but the
             // plan may still carry vanished paths from that same discovery
             // refresh via RebuildPlan::prune_paths (issue #804 P2).
-            let mut route_vanished: Vec<PathBuf> = plan.prune_paths.clone();
             if !plan.renderer_fresh {
                 if let Some(reload) = &ctx.reload_renderer {
-                    route_vanished.extend(reload()?);
+                    match reload()? {
+                        RefreshOutcome::Skipped => renderer_refresh_skipped = true,
+                        RefreshOutcome::Refreshed { vanished } => {
+                            route_vanished.extend(vanished);
+                        }
+                    }
                 }
             }
+        }
 
+        // Prune safety on a skipped tick (issue #956 gate (c) / #727): when
+        // the refresh was skipped, the route table did not move, so nothing
+        // vanished this tick. By bypassing this whole block neither the
+        // stale-output candidates nor the live-dests bookkeeping run — an
+        // unrendered URL can never be mistaken for a vanished one.
+        if !pages.is_empty() && !renderer_refresh_skipped {
             let rendered = (ctx.render_pages)(&pages)?;
             outcome.pages_rendered = rendered.len();
 
@@ -325,9 +357,13 @@ impl AssetPipeline for DevAssetPipeline {
         // supplied by the orchestrator from a discovery refresh that already
         // set renderer_fresh (so reload_renderer was skipped and these paths
         // could not be returned through the normal vanished-routes channel).
-        // Only runs when pages was empty — if pages ran, prune_paths were
-        // already included in route_vanished and processed in the loop above.
-        if pages.is_empty() && !plan.prune_paths.is_empty() {
+        // Only runs when the render loop above did not — pages empty, or the
+        // renderer refresh was skipped (issue #956; defensive: a discovery
+        // refresh sets renderer_fresh, so a Skipped reload never coincides
+        // with plan prune paths in practice). If the render loop ran,
+        // prune_paths were already included in route_vanished and processed
+        // there.
+        if (pages.is_empty() || renderer_refresh_skipped) && !plan.prune_paths.is_empty() {
             for prev in &plan.prune_paths {
                 let _ = std::fs::remove_file(prev);
                 self.last_bytes
@@ -788,5 +824,223 @@ mod tests {
             "dev pipeline must leave hashed_asset_urls empty; got {:?}",
             outcome.hashed_asset_urls,
         );
+    }
+
+    // ── RefreshOutcome::Skipped — render-fan-out bypass (issue #956) ─────
+
+    /// Context whose reload reports the given outcome on every tick and
+    /// counts render invocations.
+    fn ctx_with_reload_outcome(
+        dist_root: PathBuf,
+        rendered: Vec<RenderedPage>,
+        render_calls: Arc<AtomicUsize>,
+        outcome: RefreshOutcome,
+    ) -> BuildContext {
+        BuildContext {
+            dist_root,
+            render_pages: Arc::new(move |_pages: &[PageId]| {
+                render_calls.fetch_add(1, Ordering::SeqCst);
+                Ok(rendered.clone())
+            }),
+            run_css: None,
+            run_islands: None,
+            reload_renderer: Some(Arc::new(move || Ok(outcome.clone()))),
+        }
+    }
+
+    fn single_page_plan() -> RebuildPlan {
+        let mut sel = BTreeSet::new();
+        sel.insert(pid("/p/a.tsx"));
+        RebuildPlan {
+            pages: PageSelection::Specific(sel),
+            rerun_css: false,
+            rerun_islands: false,
+            renderer_fresh: false,
+            ssr_reload_needed: false,
+            prune_paths: vec![],
+            triggers: vec![],
+        }
+    }
+
+    /// A `Skipped` reload must bypass the render fan-out entirely: the
+    /// render callback is never invoked, no HTML is written, and nothing
+    /// already on disk is pruned (gate (c) — an unrendered URL must not
+    /// be mistaken for a vanished one).
+    #[test]
+    fn skipped_reload_bypasses_render_and_prunes_nothing() {
+        let dir = tempdir().unwrap();
+        let pipeline = DevAssetPipeline::new();
+        let rendered = vec![RenderedPage {
+            page: pid("/p/a.tsx"),
+            output_path: RelDistPath::new("a/index.html").unwrap(),
+            html: "<h1>A</h1>".into(),
+            content_type: None,
+        }];
+        let plan = single_page_plan();
+
+        // Tick 1: a real refresh renders and writes as usual.
+        let calls1 = Arc::new(AtomicUsize::new(0));
+        let ctx1 = ctx_with_reload_outcome(
+            dir.path().to_path_buf(),
+            rendered.clone(),
+            calls1.clone(),
+            RefreshOutcome::Refreshed { vanished: vec![] },
+        );
+        let first = pipeline.apply(&plan, &ctx1).unwrap();
+        assert_eq!(first.pages_rendered, 1);
+        assert!(dir.path().join("a/index.html").exists());
+
+        // Tick 2: byte-identical bundle → Skipped. No render, no write,
+        // no prune; the existing HTML stays on disk.
+        let calls2 = Arc::new(AtomicUsize::new(0));
+        let ctx2 = ctx_with_reload_outcome(
+            dir.path().to_path_buf(),
+            rendered,
+            calls2.clone(),
+            RefreshOutcome::Skipped,
+        );
+        let second = pipeline.apply(&plan, &ctx2).unwrap();
+        assert_eq!(
+            calls2.load(Ordering::SeqCst),
+            0,
+            "Skipped tick must not invoke the render callback"
+        );
+        assert_eq!(second.pages_rendered, 0, "no pages rendered on skip");
+        assert!(second.pages_written.is_empty(), "no HTML written on skip");
+        assert!(
+            second.pages_pruned.is_empty(),
+            "skip must not treat unrendered URLs as vanished; pruned={:?}",
+            second.pages_pruned,
+        );
+        assert!(
+            dir.path().join("a/index.html").exists(),
+            "existing HTML must survive a skipped tick"
+        );
+    }
+
+    /// A `Skipped` reload bypasses only the render loop — CSS and islands
+    /// requested by the plan must still run.
+    #[test]
+    fn skipped_reload_still_runs_css_and_islands() {
+        let dir = tempdir().unwrap();
+        let pipeline = DevAssetPipeline::new();
+        let render_calls = Arc::new(AtomicUsize::new(0));
+        let render_calls_cb = render_calls.clone();
+        let css_calls = Arc::new(AtomicUsize::new(0));
+        let css_calls_cb = css_calls.clone();
+        let islands_calls = Arc::new(AtomicUsize::new(0));
+        let islands_calls_cb = islands_calls.clone();
+        let ctx = BuildContext {
+            dist_root: dir.path().to_path_buf(),
+            render_pages: Arc::new(move |_pages: &[PageId]| {
+                render_calls_cb.fetch_add(1, Ordering::SeqCst);
+                Ok(vec![])
+            }),
+            run_css: Some(Arc::new(move || {
+                css_calls_cb.fetch_add(1, Ordering::SeqCst);
+                Ok(true)
+            })),
+            run_islands: Some(Arc::new(move || {
+                islands_calls_cb.fetch_add(1, Ordering::SeqCst);
+                Ok(None)
+            })),
+            reload_renderer: Some(Arc::new(|| Ok(RefreshOutcome::Skipped))),
+        };
+
+        let mut plan = single_page_plan();
+        plan.rerun_css = true;
+        plan.rerun_islands = true;
+
+        let outcome = pipeline.apply(&plan, &ctx).unwrap();
+        assert_eq!(render_calls.load(Ordering::SeqCst), 0, "render bypassed");
+        assert!(outcome.css_rerun, "CSS still reruns on a skipped tick");
+        assert_eq!(css_calls.load(Ordering::SeqCst), 1);
+        assert!(
+            outcome.islands_rerun,
+            "islands still rerun on a skipped tick"
+        );
+        assert_eq!(islands_calls.load(Ordering::SeqCst), 1);
+    }
+
+    /// Plan-carried prune paths (issue #804 P2) are still processed when
+    /// the reload reports `Skipped`. Defensive: a discovery refresh sets
+    /// `renderer_fresh` so the combination cannot occur in production
+    /// wiring, but the pipeline contract is "prune paths always honoured".
+    #[test]
+    fn skipped_reload_still_processes_plan_prune_paths() {
+        let dir = tempdir().unwrap();
+        let pipeline = DevAssetPipeline::new();
+        let stale = dir.path().join("stale.html");
+        std::fs::write(&stale, "<p>stale</p>").unwrap();
+
+        let calls = Arc::new(AtomicUsize::new(0));
+        let ctx = ctx_with_reload_outcome(
+            dir.path().to_path_buf(),
+            vec![],
+            calls.clone(),
+            RefreshOutcome::Skipped,
+        );
+        let mut plan = single_page_plan();
+        plan.prune_paths = vec![stale.clone()];
+
+        let outcome = pipeline.apply(&plan, &ctx).unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 0, "render bypassed");
+        assert!(!stale.exists(), "plan prune path must still be deleted");
+        assert!(
+            outcome.pages_pruned.contains(&stale),
+            "pages_pruned must report the plan prune path; got {:?}",
+            outcome.pages_pruned,
+        );
+    }
+
+    /// SSR-only tick (no SSG pages, `ssr_reload_needed`): a `Skipped`
+    /// reload leaves the dist tree untouched — nothing vanished because
+    /// the route table did not move.
+    #[test]
+    fn ssr_only_skipped_reload_prunes_nothing() {
+        let dir = tempdir().unwrap();
+        let pipeline = DevAssetPipeline::new();
+        let existing = dir.path().join("page.html");
+        std::fs::write(&existing, "<p>live</p>").unwrap();
+
+        let ctx = BuildContext {
+            dist_root: dir.path().to_path_buf(),
+            render_pages: Arc::new(|_| Ok(vec![])),
+            run_css: None,
+            run_islands: None,
+            reload_renderer: Some(Arc::new(|| Ok(RefreshOutcome::Skipped))),
+        };
+        let mut plan = single_page_plan();
+        plan.pages = PageSelection::none();
+        plan.ssr_reload_needed = true;
+
+        let outcome = pipeline.apply(&plan, &ctx).unwrap();
+        assert!(outcome.pages_pruned.is_empty(), "nothing vanished on skip");
+        assert!(existing.exists(), "existing output must survive");
+    }
+
+    /// A `Refreshed` reload (even with nothing vanished) renders as
+    /// before — the skip bypass only fires on the explicit `Skipped`
+    /// state.
+    #[test]
+    fn refreshed_reload_renders_as_before() {
+        let dir = tempdir().unwrap();
+        let pipeline = DevAssetPipeline::new();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let ctx = ctx_with_reload_outcome(
+            dir.path().to_path_buf(),
+            vec![RenderedPage {
+                page: pid("/p/a.tsx"),
+                output_path: RelDistPath::new("a/index.html").unwrap(),
+                html: "<h1>A</h1>".into(),
+                content_type: None,
+            }],
+            calls.clone(),
+            RefreshOutcome::Refreshed { vanished: vec![] },
+        );
+        let outcome = pipeline.apply(&single_page_plan(), &ctx).unwrap();
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "render ran");
+        assert_eq!(outcome.pages_rendered, 1);
+        assert!(dir.path().join("a/index.html").exists());
     }
 }

--- a/crates/zfb-build/src/pipeline/dev.rs
+++ b/crates/zfb-build/src/pipeline/dev.rs
@@ -460,10 +460,12 @@ mod tests {
     ) -> BuildContext {
         BuildContext {
             dist_root,
-            render_pages: Arc::new(move |_pages: &[PageId], _: Option<&crate::ContentNarrowing>| {
-                invocations.fetch_add(1, Ordering::SeqCst);
-                Ok(rendered.clone())
-            }),
+            render_pages: Arc::new(
+                move |_pages: &[PageId], _: Option<&crate::ContentNarrowing>| {
+                    invocations.fetch_add(1, Ordering::SeqCst);
+                    Ok(rendered.clone())
+                },
+            ),
             run_css: None,
             run_islands: None,
             reload_renderer: None,
@@ -872,10 +874,12 @@ mod tests {
     ) -> BuildContext {
         BuildContext {
             dist_root,
-            render_pages: Arc::new(move |_pages: &[PageId], _: Option<&crate::ContentNarrowing>| {
-                render_calls.fetch_add(1, Ordering::SeqCst);
-                Ok(rendered.clone())
-            }),
+            render_pages: Arc::new(
+                move |_pages: &[PageId], _: Option<&crate::ContentNarrowing>| {
+                    render_calls.fetch_add(1, Ordering::SeqCst);
+                    Ok(rendered.clone())
+                },
+            ),
             run_css: None,
             run_islands: None,
             reload_renderer: Some(Arc::new(move || Ok(outcome.clone()))),
@@ -970,10 +974,12 @@ mod tests {
         let islands_calls_cb = islands_calls.clone();
         let ctx = BuildContext {
             dist_root: dir.path().to_path_buf(),
-            render_pages: Arc::new(move |_pages: &[PageId], _: Option<&crate::ContentNarrowing>| {
-                render_calls_cb.fetch_add(1, Ordering::SeqCst);
-                Ok(vec![])
-            }),
+            render_pages: Arc::new(
+                move |_pages: &[PageId], _: Option<&crate::ContentNarrowing>| {
+                    render_calls_cb.fetch_add(1, Ordering::SeqCst);
+                    Ok(vec![])
+                },
+            ),
             run_css: Some(Arc::new(move || {
                 css_calls_cb.fetch_add(1, Ordering::SeqCst);
                 Ok(true)

--- a/crates/zfb-build/src/pipeline/dev.rs
+++ b/crates/zfb-build/src/pipeline/dev.rs
@@ -122,7 +122,7 @@ impl AssetPipeline for DevAssetPipeline {
                 // nothing to prune.
                 let vanished = match reload()? {
                     RefreshOutcome::Skipped => Vec::new(),
-                    RefreshOutcome::Refreshed { vanished } => vanished,
+                    RefreshOutcome::Refreshed { vanished, .. } => vanished,
                 };
                 if !vanished.is_empty() {
                     outcome.pages_pruned.extend(vanished.iter().cloned());
@@ -169,6 +169,17 @@ impl AssetPipeline for DevAssetPipeline {
         // already makes. CSS, islands, and plan prune paths still run.
         let mut renderer_refresh_skipped = false;
 
+        // Content-narrowing hint for the render callback (issue #958).
+        // Defensive G6: the hint must never coexist with a discovery-
+        // refreshed renderer (`renderer_fresh`) — the discovery regime
+        // implies created files, which the orchestrator never produces a
+        // hint for, but if both ever appear together the safe direction
+        // is full fan-out.
+        let mut narrowing: Option<&crate::ContentNarrowing> = plan.content_narrowing.as_ref();
+        if plan.renderer_fresh {
+            narrowing = None;
+        }
+
         if !pages.is_empty() {
             // Reload the SSR renderer (embedded V8 host) before rendering
             // pages whenever the dirty set is non-empty — UNLESS the
@@ -191,7 +202,22 @@ impl AssetPipeline for DevAssetPipeline {
                 if let Some(reload) = &ctx.reload_renderer {
                     match reload()? {
                         RefreshOutcome::Skipped => renderer_refresh_skipped = true,
-                        RefreshOutcome::Refreshed { vanished } => {
+                        RefreshOutcome::Refreshed {
+                            vanished,
+                            changed_sources,
+                        } => {
+                            // Fallback G5 (issue #958): the refresh ran
+                            // BEFORE the render, so the route table the
+                            // narrowing would match against is the
+                            // post-edit one — but if the refresh reports
+                            // that any source's route-entry set changed
+                            // (or any output path vanished), the route
+                            // structure moved this tick and narrowing
+                            // could orphan a brand-new URL. Render the
+                            // full selected set instead.
+                            if !vanished.is_empty() || !changed_sources.is_empty() {
+                                narrowing = None;
+                            }
                             route_vanished.extend(vanished);
                         }
                     }
@@ -205,7 +231,7 @@ impl AssetPipeline for DevAssetPipeline {
         // stale-output candidates nor the live-dests bookkeeping run — an
         // unrendered URL can never be mistaken for a vanished one.
         if !pages.is_empty() && !renderer_refresh_skipped {
-            let rendered = (ctx.render_pages)(&pages)?;
+            let rendered = (ctx.render_pages)(&pages, narrowing)?;
             outcome.pages_rendered = rendered.len();
 
             // Collect prune candidates and the live dest set during the
@@ -434,7 +460,7 @@ mod tests {
     ) -> BuildContext {
         BuildContext {
             dist_root,
-            render_pages: Arc::new(move |_pages: &[PageId]| {
+            render_pages: Arc::new(move |_pages: &[PageId], _: Option<&crate::ContentNarrowing>| {
                 invocations.fetch_add(1, Ordering::SeqCst);
                 Ok(rendered.clone())
             }),
@@ -470,6 +496,7 @@ mod tests {
             ssr_reload_needed: false,
             prune_paths: vec![],
             triggers: vec![],
+            content_narrowing: None,
         };
 
         let outcome = pipeline.apply(&plan, &ctx).unwrap();
@@ -505,6 +532,7 @@ mod tests {
             ssr_reload_needed: false,
             prune_paths: vec![],
             triggers: vec![],
+            content_narrowing: None,
         };
 
         let first = pipeline.apply(&plan, &ctx).unwrap();
@@ -524,7 +552,7 @@ mod tests {
         let css_calls_cb = css_calls.clone();
         let ctx = BuildContext {
             dist_root: dir.path().to_path_buf(),
-            render_pages: Arc::new(|_| Ok(vec![])),
+            render_pages: Arc::new(|_, _| Ok(vec![])),
             run_css: Some(Arc::new(move || {
                 css_calls_cb.fetch_add(1, Ordering::SeqCst);
                 Ok(true)
@@ -541,6 +569,7 @@ mod tests {
             ssr_reload_needed: false,
             prune_paths: vec![],
             triggers: vec![],
+            content_narrowing: None,
         };
 
         let outcome = pipeline.apply(&plan, &ctx).unwrap();
@@ -577,6 +606,7 @@ mod tests {
             ssr_reload_needed: false,
             prune_paths: vec![],
             triggers: vec![],
+            content_narrowing: None,
         };
         let first = pipeline.apply(&plan, &ctx_a).unwrap();
         assert_eq!(first.pages_written.len(), 1);
@@ -642,6 +672,7 @@ mod tests {
             ssr_reload_needed: false,
             prune_paths: vec![],
             triggers: vec![],
+            content_narrowing: None,
         };
         let first = pipeline.apply(&plan, &ctx).unwrap();
         let second = pipeline.apply(&plan, &ctx).unwrap();
@@ -698,6 +729,7 @@ mod tests {
             ssr_reload_needed: false,
             prune_paths: vec![],
             triggers: vec![],
+            content_narrowing: None,
         };
         let first = pipeline.apply(&plan, &ctx1).unwrap();
         assert_eq!(first.pages_written.len(), 2);
@@ -771,7 +803,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let ctx = BuildContext {
             dist_root: dir.path().to_path_buf(),
-            render_pages: Arc::new(|_| Ok(vec![])),
+            render_pages: Arc::new(|_, _| Ok(vec![])),
             run_css: None,
             run_islands: None,
             reload_renderer: None,
@@ -784,6 +816,7 @@ mod tests {
             ssr_reload_needed: false,
             prune_paths: vec![],
             triggers: vec![],
+            content_narrowing: None,
         };
         assert!(pipeline.apply(&plan, &ctx).is_err());
     }
@@ -798,7 +831,7 @@ mod tests {
         let dir = tempdir().unwrap();
         let ctx = BuildContext {
             dist_root: dir.path().to_path_buf(),
-            render_pages: Arc::new(|_| Ok(vec![])),
+            render_pages: Arc::new(|_, _| Ok(vec![])),
             run_css: Some(Arc::new(|| Ok(true))),
             run_islands: Some(Arc::new(|| {
                 Ok(Some(crate::pipeline::IslandsBundleInfo {
@@ -817,6 +850,7 @@ mod tests {
             ssr_reload_needed: false,
             prune_paths: vec![],
             triggers: vec![],
+            content_narrowing: None,
         };
         let outcome = pipeline.apply(&plan, &ctx).unwrap();
         assert!(
@@ -838,7 +872,7 @@ mod tests {
     ) -> BuildContext {
         BuildContext {
             dist_root,
-            render_pages: Arc::new(move |_pages: &[PageId]| {
+            render_pages: Arc::new(move |_pages: &[PageId], _: Option<&crate::ContentNarrowing>| {
                 render_calls.fetch_add(1, Ordering::SeqCst);
                 Ok(rendered.clone())
             }),
@@ -859,6 +893,7 @@ mod tests {
             ssr_reload_needed: false,
             prune_paths: vec![],
             triggers: vec![],
+            content_narrowing: None,
         }
     }
 
@@ -884,7 +919,10 @@ mod tests {
             dir.path().to_path_buf(),
             rendered.clone(),
             calls1.clone(),
-            RefreshOutcome::Refreshed { vanished: vec![] },
+            RefreshOutcome::Refreshed {
+                vanished: vec![],
+                changed_sources: vec![],
+            },
         );
         let first = pipeline.apply(&plan, &ctx1).unwrap();
         assert_eq!(first.pages_rendered, 1);
@@ -932,7 +970,7 @@ mod tests {
         let islands_calls_cb = islands_calls.clone();
         let ctx = BuildContext {
             dist_root: dir.path().to_path_buf(),
-            render_pages: Arc::new(move |_pages: &[PageId]| {
+            render_pages: Arc::new(move |_pages: &[PageId], _: Option<&crate::ContentNarrowing>| {
                 render_calls_cb.fetch_add(1, Ordering::SeqCst);
                 Ok(vec![])
             }),
@@ -1005,7 +1043,7 @@ mod tests {
 
         let ctx = BuildContext {
             dist_root: dir.path().to_path_buf(),
-            render_pages: Arc::new(|_| Ok(vec![])),
+            render_pages: Arc::new(|_, _| Ok(vec![])),
             run_css: None,
             run_islands: None,
             reload_renderer: Some(Arc::new(|| Ok(RefreshOutcome::Skipped))),
@@ -1036,11 +1074,238 @@ mod tests {
                 content_type: None,
             }],
             calls.clone(),
-            RefreshOutcome::Refreshed { vanished: vec![] },
+            RefreshOutcome::Refreshed {
+                vanished: vec![],
+                changed_sources: vec![],
+            },
         );
         let outcome = pipeline.apply(&single_page_plan(), &ctx).unwrap();
         assert_eq!(calls.load(Ordering::SeqCst), 1, "render ran");
         assert_eq!(outcome.pages_rendered, 1);
         assert!(dir.path().join("a/index.html").exists());
+    }
+
+    // ── Content-narrowing hint forwarding (issue #958) ───────────────────
+
+    /// Context whose render callback records the narrowing hint it
+    /// received and whose reloader reports the given outcome.
+    fn ctx_recording_narrowing(
+        dist_root: PathBuf,
+        outcome: RefreshOutcome,
+        seen: Arc<Mutex<Vec<Option<crate::ContentNarrowing>>>>,
+    ) -> BuildContext {
+        BuildContext {
+            dist_root,
+            render_pages: Arc::new(
+                move |_pages: &[PageId], narrowing: Option<&crate::ContentNarrowing>| {
+                    seen.lock().unwrap().push(narrowing.cloned());
+                    Ok(vec![])
+                },
+            ),
+            run_css: None,
+            run_islands: None,
+            reload_renderer: Some(Arc::new(move || Ok(outcome.clone()))),
+        }
+    }
+
+    fn narrowed_plan() -> RebuildPlan {
+        let mut plan = single_page_plan();
+        plan.content_narrowing = Some(crate::ContentNarrowing {
+            changed_content: vec![PathBuf::from("/proj/content/post.md")],
+        });
+        plan
+    }
+
+    /// Happy path: a plan-carried narrowing hint reaches the render
+    /// callback verbatim when the refresh reports no structural change.
+    #[test]
+    fn narrowing_hint_reaches_render_callback() {
+        let dir = tempdir().unwrap();
+        let pipeline = DevAssetPipeline::new();
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let ctx = ctx_recording_narrowing(
+            dir.path().to_path_buf(),
+            RefreshOutcome::Refreshed {
+                vanished: vec![],
+                changed_sources: vec![],
+            },
+            seen.clone(),
+        );
+        pipeline.apply(&narrowed_plan(), &ctx).unwrap();
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen.len(), 1, "render callback invoked once");
+        assert_eq!(
+            seen[0],
+            Some(crate::ContentNarrowing {
+                changed_content: vec![PathBuf::from("/proj/content/post.md")],
+            }),
+            "the hint must be forwarded when the route table did not move"
+        );
+    }
+
+    /// Fallback G5 (issue #958): a refresh that reports changed source
+    /// route sets disables narrowing for the tick — the render callback
+    /// must see `None`.
+    #[test]
+    fn refresh_changed_sources_disable_narrowing() {
+        let dir = tempdir().unwrap();
+        let pipeline = DevAssetPipeline::new();
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let ctx = ctx_recording_narrowing(
+            dir.path().to_path_buf(),
+            RefreshOutcome::Refreshed {
+                vanished: vec![],
+                changed_sources: vec![pid("/p/blog/[slug].tsx")],
+            },
+            seen.clone(),
+        );
+        pipeline.apply(&narrowed_plan(), &ctx).unwrap();
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen.len(), 1);
+        assert_eq!(
+            seen[0], None,
+            "non-empty changed_sources must force full fan-out (G5)"
+        );
+    }
+
+    /// Fallback G5, vanished arm: globally-vanished routes also mean the
+    /// route structure moved — no narrowing this tick.
+    #[test]
+    fn refresh_vanished_routes_disable_narrowing() {
+        let dir = tempdir().unwrap();
+        let pipeline = DevAssetPipeline::new();
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let ctx = ctx_recording_narrowing(
+            dir.path().to_path_buf(),
+            RefreshOutcome::Refreshed {
+                vanished: vec![dir.path().join("gone/index.html")],
+                changed_sources: vec![],
+            },
+            seen.clone(),
+        );
+        pipeline.apply(&narrowed_plan(), &ctx).unwrap();
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen.len(), 1);
+        assert_eq!(
+            seen[0], None,
+            "non-empty vanished must force full fan-out (G5)"
+        );
+    }
+
+    /// Fallback G6 (defensive): a hint must never survive on a
+    /// renderer-fresh tick (discovery regime) — the callback sees `None`.
+    #[test]
+    fn renderer_fresh_tick_drops_narrowing_hint() {
+        let dir = tempdir().unwrap();
+        let pipeline = DevAssetPipeline::new();
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let ctx = ctx_recording_narrowing(
+            dir.path().to_path_buf(),
+            RefreshOutcome::Refreshed {
+                vanished: vec![],
+                changed_sources: vec![],
+            },
+            seen.clone(),
+        );
+        let mut plan = narrowed_plan();
+        plan.renderer_fresh = true;
+        pipeline.apply(&plan, &ctx).unwrap();
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen.len(), 1);
+        assert_eq!(
+            seen[0], None,
+            "renderer_fresh must drop the narrowing hint (G6)"
+        );
+    }
+
+    /// Prune-safety on a narrowed tick (issue #958 §7 / #727): when the
+    /// render callback returns only a SUBSET of the selected pages (the
+    /// narrowed set), the sibling pages' on-disk HTML and pipeline
+    /// bookkeeping (`last_bytes` / `last_output_path`) must survive
+    /// untouched — an unrendered sibling URL is never treated as
+    /// vanished, and a later full tick still byte-dedups it.
+    #[test]
+    fn narrowed_tick_leaves_sibling_outputs_and_bookkeeping_intact() {
+        let dir = tempdir().unwrap();
+        let pipeline = DevAssetPipeline::new();
+
+        let page_a = RenderedPage {
+            page: pid("blog/a/index.html"),
+            output_path: RelDistPath::new("blog/a/index.html").unwrap(),
+            html: "<p>A v1</p>".into(),
+            content_type: None,
+        };
+        let page_b = RenderedPage {
+            page: pid("blog/b/index.html"),
+            output_path: RelDistPath::new("blog/b/index.html").unwrap(),
+            html: "<p>B v1</p>".into(),
+            content_type: None,
+        };
+
+        let mut sel = BTreeSet::new();
+        sel.insert(pid("/p/blog/[slug].tsx"));
+        let mut plan = RebuildPlan::empty();
+        plan.pages = PageSelection::Specific(sel);
+
+        // Tick 1: full fan-out renders A and B.
+        let full = vec![page_a.clone(), page_b.clone()];
+        let ctx1 = ctx_with_renderer(
+            dir.path().to_path_buf(),
+            full,
+            Arc::new(AtomicUsize::new(0)),
+        );
+        let first = pipeline.apply(&plan, &ctx1).unwrap();
+        assert_eq!(first.pages_written.len(), 2);
+        assert!(dir.path().join("blog/b/index.html").exists());
+
+        // Tick 2: narrowed — the callback returns ONLY A (new bytes).
+        let narrowed = vec![RenderedPage {
+            html: "<p>A v2</p>".into(),
+            ..page_a.clone()
+        }];
+        let ctx2 = ctx_with_renderer(
+            dir.path().to_path_buf(),
+            narrowed,
+            Arc::new(AtomicUsize::new(0)),
+        );
+        let second = pipeline.apply(&plan, &ctx2).unwrap();
+        assert_eq!(second.pages_written, vec![page_a.page.clone()]);
+        assert!(
+            second.pages_pruned.is_empty(),
+            "an unrendered sibling must never be treated as vanished; pruned={:?}",
+            second.pages_pruned,
+        );
+        assert!(
+            dir.path().join("blog/b/index.html").exists(),
+            "sibling HTML must survive a narrowed tick"
+        );
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join("blog/b/index.html")).unwrap(),
+            "<p>B v1</p>",
+        );
+
+        // Tick 3: full fan-out again with byte-identical content — the
+        // sibling's `last_bytes` slot survived the narrowed tick, so B
+        // byte-dedups (not re-written); A's v2 bytes also dedup.
+        let full_again = vec![
+            RenderedPage {
+                html: "<p>A v2</p>".into(),
+                ..page_a
+            },
+            page_b,
+        ];
+        let ctx3 = ctx_with_renderer(
+            dir.path().to_path_buf(),
+            full_again,
+            Arc::new(AtomicUsize::new(0)),
+        );
+        let third = pipeline.apply(&plan, &ctx3).unwrap();
+        assert!(
+            third.pages_written.is_empty(),
+            "bookkeeping intact: a later full tick byte-skips unchanged \
+             siblings; written={:?}",
+            third.pages_written,
+        );
+        assert!(third.pages_pruned.is_empty());
     }
 }

--- a/crates/zfb-build/src/pipeline/dev.rs
+++ b/crates/zfb-build/src/pipeline/dev.rs
@@ -133,14 +133,13 @@ impl AssetPipeline for DevAssetPipeline {
                             })
                             .remove(prev);
                         {
-                            let mut last_out =
-                                self.last_output_path.lock().unwrap_or_else(|p| {
-                                    tracing::warn!(
-                                        site = "DevAssetPipeline.last_output_path (ssr-only-prune)",
-                                        "mutex poisoned, recovering"
-                                    );
-                                    p.into_inner()
-                                });
+                            let mut last_out = self.last_output_path.lock().unwrap_or_else(|p| {
+                                tracing::warn!(
+                                    site = "DevAssetPipeline.last_output_path (ssr-only-prune)",
+                                    "mutex poisoned, recovering"
+                                );
+                                p.into_inner()
+                            });
                             last_out.retain(|_, v| v != prev);
                         }
                     }

--- a/crates/zfb-build/src/pipeline/mod.rs
+++ b/crates/zfb-build/src/pipeline/mod.rs
@@ -65,7 +65,7 @@
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 use zfb_graph::PageId;
 
 use crate::plan::RebuildPlan;
@@ -245,8 +245,7 @@ pub struct RenderedPage {
 /// the renderer can decide to render them serially (cheap, dev) or in
 /// parallel (production). Errors abort the tick — the watcher stays
 /// alive but the rebuild is reported as failed.
-pub type PageRenderer =
-    Arc<dyn Fn(&[PageId]) -> Result<Vec<RenderedPage>> + Send + Sync + 'static>;
+pub type PageRenderer = Arc<dyn Fn(&[PageId]) -> Result<Vec<RenderedPage>> + Send + Sync + 'static>;
 
 /// Function that runs the CSS pipeline once and returns whether the
 /// emitted asset is new (i.e. whether the asset URL changed).
@@ -294,8 +293,7 @@ pub struct IslandsBundleInfo {
 /// shape when the bundler ran but the output was byte-identical to the
 /// previous run; the orchestrator records the rerun in
 /// [`BuildOutcome::islands_rerun`] but emits no SSE event.
-pub type IslandsRunner =
-    Arc<dyn Fn() -> Result<Option<IslandsBundleInfo>> + Send + Sync + 'static>;
+pub type IslandsRunner = Arc<dyn Fn() -> Result<Option<IslandsBundleInfo>> + Send + Sync + 'static>;
 
 /// Function the dev pipeline calls before re-rendering pages, when
 /// the SSR worker bundle on disk may have changed (a `.tsx` page edit,
@@ -315,7 +313,8 @@ pub type IslandsRunner =
 /// before the refresh but are absent from every source's new entry set.
 /// The dev pipeline prunes those files from disk and evicts them from the
 /// in-memory page cache. An empty `Vec` means no routes were lost this tick.
-pub type RendererReloader = Arc<dyn Fn() -> Result<Vec<std::path::PathBuf>> + Send + Sync + 'static>;
+pub type RendererReloader =
+    Arc<dyn Fn() -> Result<Vec<std::path::PathBuf>> + Send + Sync + 'static>;
 
 /// Per-build-tick context handed to [`AssetPipeline::apply`].
 ///

--- a/crates/zfb-build/src/pipeline/mod.rs
+++ b/crates/zfb-build/src/pipeline/mod.rs
@@ -297,6 +297,34 @@ pub struct IslandsBundleInfo {
 pub type IslandsRunner =
     Arc<dyn Fn() -> Result<Option<IslandsBundleInfo>> + Send + Sync + 'static>;
 
+/// Outcome of one [`RendererReloader`] invocation (issue #956).
+///
+/// An explicit three-state result — deliberately not a bare
+/// `bool + Vec` — so "skipped", "refreshed, nothing vanished", and
+/// "refreshed with vanished routes" stay unambiguous at every call
+/// site (`renderer_fresh` handling, discovery refreshes, and
+/// plan-carried prune paths all read differently against these
+/// states).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RefreshOutcome {
+    /// The reloader determined nothing observable changed (e.g. the
+    /// Phase-B byte-identical-bundle check, issue #940) and left the
+    /// live renderer and route tables untouched. The dev pipeline
+    /// bypasses the render fan-out for the tick: re-rendering against
+    /// an identical bundle would re-emit identical HTML — the same
+    /// determinism assumption [`dev::DevAssetPipeline`]'s byte-dedup
+    /// cache already makes.
+    Skipped,
+    /// The renderer bundle was rebuilt and the route tables refreshed.
+    /// `vanished` carries the **absolute** dist paths whose output
+    /// routes vanished globally after the route-table rebuild — i.e.
+    /// paths that existed before the refresh but are absent from every
+    /// source's new entry set. The dev pipeline prunes those files from
+    /// disk and evicts them from the in-memory page cache. An empty
+    /// `vanished` means refreshed-no-vanish.
+    Refreshed { vanished: Vec<std::path::PathBuf> },
+}
+
 /// Function the dev pipeline calls before re-rendering pages, when
 /// the SSR worker bundle on disk may have changed (a `.tsx` page edit,
 /// layout edit, or exported-handler change).
@@ -310,12 +338,11 @@ pub type IslandsRunner =
 /// is non-empty; the pipeline does not call it for CSS-only or
 /// islands-only ticks (those don't move the SSR bundle).
 ///
-/// Returns the set of **absolute** dist paths whose output routes vanished
-/// globally after this tick's route-table rebuild — i.e. paths that existed
-/// before the refresh but are absent from every source's new entry set.
-/// The dev pipeline prunes those files from disk and evicts them from the
-/// in-memory page cache. An empty `Vec` means no routes were lost this tick.
-pub type RendererReloader = Arc<dyn Fn() -> Result<Vec<std::path::PathBuf>> + Send + Sync + 'static>;
+/// Returns a [`RefreshOutcome`]: `Refreshed { vanished }` after a real
+/// refresh (see the variant docs for the vanished-paths contract), or
+/// `Skipped` when the implementation proved nothing observable changed
+/// and the pipeline may bypass the render fan-out (issue #956).
+pub type RendererReloader = Arc<dyn Fn() -> Result<RefreshOutcome> + Send + Sync + 'static>;
 
 /// Per-build-tick context handed to [`AssetPipeline::apply`].
 ///

--- a/crates/zfb-build/src/pipeline/mod.rs
+++ b/crates/zfb-build/src/pipeline/mod.rs
@@ -245,8 +245,21 @@ pub struct RenderedPage {
 /// the renderer can decide to render them serially (cheap, dev) or in
 /// parallel (production). Errors abort the tick — the watcher stays
 /// alive but the rebuild is reported as failed.
-pub type PageRenderer =
-    Arc<dyn Fn(&[PageId]) -> Result<Vec<RenderedPage>> + Send + Sync + 'static>;
+///
+/// The second argument is the tick's optional content-narrowing hint
+/// (issue #958, see [`crate::ContentNarrowing`]): when `Some`, the
+/// renderer MAY narrow each dynamic source's route fan-out to the routes
+/// derived from the changed entries — but narrowing only ever removes
+/// routes from the selected render set, never adds. `None` means "render
+/// every selected page fully" (today's behaviour); implementations that
+/// don't narrow simply ignore the argument. The production pipeline
+/// always passes `None`.
+pub type PageRenderer = Arc<
+    dyn Fn(&[PageId], Option<&crate::ContentNarrowing>) -> Result<Vec<RenderedPage>>
+        + Send
+        + Sync
+        + 'static,
+>;
 
 /// Function that runs the CSS pipeline once and returns whether the
 /// emitted asset is new (i.e. whether the asset URL changed).
@@ -322,7 +335,16 @@ pub enum RefreshOutcome {
     /// source's new entry set. The dev pipeline prunes those files from
     /// disk and evicts them from the in-memory page cache. An empty
     /// `vanished` means refreshed-no-vanish.
-    Refreshed { vanished: Vec<std::path::PathBuf> },
+    Refreshed {
+        vanished: Vec<std::path::PathBuf>,
+        /// Source [`PageId`]s whose route-entry set changed in this
+        /// tick's route-table rebuild (issue #958). Non-empty means the
+        /// route structure moved — a body edit CAN change `paths()`
+        /// output — so the dev pipeline must disable content narrowing
+        /// for the tick (fallback G5): narrowing against a moved route
+        /// table could orphan a brand-new URL.
+        changed_sources: Vec<PageId>,
+    },
 }
 
 /// Function the dev pipeline calls before re-rendering pages, when

--- a/crates/zfb-build/src/pipeline/orchestrator.rs
+++ b/crates/zfb-build/src/pipeline/orchestrator.rs
@@ -147,16 +147,13 @@ pub fn apply_prod_asset_pipeline(
     // determinism helps `BuildOutcome::pages_written`).
     let dist_root = dist_dir.to_path_buf();
     let pages_for_callback = pages.clone();
-    // Local type alias would require naming the concrete closure, which is not possible.
-    #[allow(clippy::type_complexity)]
-    let render_pages: Arc<
-        dyn Fn(&[PageId]) -> Result<Vec<RenderedPage>> + Send + Sync + 'static,
-    > = Arc::new(move |_requested: &[PageId]| {
+    let render_pages: crate::pipeline::PageRenderer = Arc::new(move |_requested: &[PageId], _narrowing| {
         // The plan's page set MUST already cover every page in
         // `pages_for_callback` (we constructed the plan that way), so
         // we ignore `_requested` and return the full list. The plan
         // ordering doesn't matter; `apply` just iterates the result
-        // verbatim.
+        // verbatim. The narrowing hint is ignored — production renders
+        // every page in full (issue #958).
         let mut out = Vec::with_capacity(pages_for_callback.len());
         for entry in &pages_for_callback {
             let on_disk = dist_root.join(entry.output_path.as_path());
@@ -210,6 +207,7 @@ pub fn apply_prod_asset_pipeline(
         ssr_reload_needed: false,
         prune_paths: vec![],
         triggers: vec![],
+        content_narrowing: None,
     };
 
     pipeline.apply(&plan, &ctx)

--- a/crates/zfb-build/src/pipeline/orchestrator.rs
+++ b/crates/zfb-build/src/pipeline/orchestrator.rs
@@ -147,31 +147,32 @@ pub fn apply_prod_asset_pipeline(
     // determinism helps `BuildOutcome::pages_written`).
     let dist_root = dist_dir.to_path_buf();
     let pages_for_callback = pages.clone();
-    let render_pages: crate::pipeline::PageRenderer = Arc::new(move |_requested: &[PageId], _narrowing| {
-        // The plan's page set MUST already cover every page in
-        // `pages_for_callback` (we constructed the plan that way), so
-        // we ignore `_requested` and return the full list. The plan
-        // ordering doesn't matter; `apply` just iterates the result
-        // verbatim. The narrowing hint is ignored — production renders
-        // every page in full (issue #958).
-        let mut out = Vec::with_capacity(pages_for_callback.len());
-        for entry in &pages_for_callback {
-            let on_disk = dist_root.join(entry.output_path.as_path());
-            let html = std::fs::read_to_string(&on_disk).with_context(|| {
-                format!(
-                    "prod orchestrator: failed to read rendered page from disk at {}",
-                    on_disk.display()
-                )
-            })?;
-            out.push(RenderedPage {
-                page: entry.page.clone(),
-                output_path: entry.output_path.clone(),
-                html,
-                content_type: None,
-            });
-        }
-        Ok(out)
-    });
+    let render_pages: crate::pipeline::PageRenderer =
+        Arc::new(move |_requested: &[PageId], _narrowing| {
+            // The plan's page set MUST already cover every page in
+            // `pages_for_callback` (we constructed the plan that way), so
+            // we ignore `_requested` and return the full list. The plan
+            // ordering doesn't matter; `apply` just iterates the result
+            // verbatim. The narrowing hint is ignored — production renders
+            // every page in full (issue #958).
+            let mut out = Vec::with_capacity(pages_for_callback.len());
+            for entry in &pages_for_callback {
+                let on_disk = dist_root.join(entry.output_path.as_path());
+                let html = std::fs::read_to_string(&on_disk).with_context(|| {
+                    format!(
+                        "prod orchestrator: failed to read rendered page from disk at {}",
+                        on_disk.display()
+                    )
+                })?;
+                out.push(RenderedPage {
+                    page: entry.page.clone(),
+                    output_path: entry.output_path.clone(),
+                    html,
+                    content_type: None,
+                });
+            }
+            Ok(out)
+        });
 
     let ctx = BuildContext {
         dist_root: dist_dir.to_path_buf(),

--- a/crates/zfb-build/src/pipeline/prod.rs
+++ b/crates/zfb-build/src/pipeline/prod.rs
@@ -364,7 +364,11 @@ fn boundary_replace(haystack: &str, from: &str, to: &str) -> String {
     let mut last_copied = 0usize;
     while i < bytes.len() {
         if i + from_bytes.len() <= bytes.len() && &bytes[i..i + from_bytes.len()] == from_bytes {
-            let before = if i == 0 { None } else { bytes.get(i - 1).copied() };
+            let before = if i == 0 {
+                None
+            } else {
+                bytes.get(i - 1).copied()
+            };
             let after = bytes.get(i + from_bytes.len()).copied();
             let is_leading_boundary = is_url_boundary_byte(before);
             let is_trailing_boundary = is_url_boundary_byte(after);
@@ -458,7 +462,10 @@ fn ship_asset(
     // `validate_output_path` the entry used, so a planted symlink inside
     // dist cannot redirect the write outside dist_root.
     if !asset.companions.is_empty() {
-        let entry_rel_dir = hashed_relative.parent().map(|p| p.to_path_buf()).unwrap_or_default();
+        let entry_rel_dir = hashed_relative
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_default();
         for companion in &asset.companions {
             if companion.filename.is_empty()
                 || companion.filename.contains('/')
@@ -472,8 +479,8 @@ fn ship_asset(
                 ));
             }
             let companion_rel = entry_rel_dir.join(&companion.filename);
-            let companion_dest =
-                validate_output_path(&ctx.dist_root, &companion_rel).with_context(|| {
+            let companion_dest = validate_output_path(&ctx.dist_root, &companion_rel)
+                .with_context(|| {
                     format!(
                         "production: refused to write companion relative path {}",
                         companion_rel.display()
@@ -506,10 +513,7 @@ fn ship_asset(
 /// + `deadbeef` → `assets/styles-deadbeef.css`. Paths without an
 ///   extension get `-<hash>` appended to the file stem.
 fn insert_hash_before_extension(path: &std::path::Path, hash: &str) -> PathBuf {
-    let mut out = path
-        .parent()
-        .map(|p| p.to_path_buf())
-        .unwrap_or_default();
+    let mut out = path.parent().map(|p| p.to_path_buf()).unwrap_or_default();
     let stem = path
         .file_stem()
         .map(|s| s.to_string_lossy().into_owned())
@@ -531,7 +535,11 @@ fn insert_hash_before_extension(path: &std::path::Path, hash: &str) -> PathBuf {
 /// layout (e.g. `/cdn/` mounted onto `dist/assets/`). The unhashed
 /// filename is always present in `stable_url` by definition (the emitter
 /// declared it), so we replace just that suffix.
-fn rewrite_url(stable_url: &str, relative: &std::path::Path, hashed_relative: &std::path::Path) -> String {
+fn rewrite_url(
+    stable_url: &str,
+    relative: &std::path::Path,
+    hashed_relative: &std::path::Path,
+) -> String {
     let unhashed_filename = relative
         .file_name()
         .map(|s| s.to_string_lossy().into_owned())
@@ -660,10 +668,7 @@ mod tests {
         let html = r#"<img srcset="/img/a.png 1x,/img/b.png 2x">"#;
         let out_a = boundary_replace(html, "/img/a.png", "/img/a-1.png");
         let out_b = boundary_replace(&out_a, "/img/b.png", "/img/b-2.png");
-        assert_eq!(
-            out_b,
-            r#"<img srcset="/img/a-1.png 1x,/img/b-2.png 2x">"#
-        );
+        assert_eq!(out_b, r#"<img srcset="/img/a-1.png 1x,/img/b-2.png 2x">"#);
     }
 
     #[test]
@@ -673,7 +678,6 @@ mod tests {
         let out = boundary_replace(css, "/foo.css", "/foo-abc.css");
         assert_eq!(out, "background:url(/foo-abc.css);");
     }
-
 
     fn pid(s: &str) -> PageId {
         PageId::new(PathBuf::from(s))
@@ -748,7 +752,9 @@ mod tests {
         let (kind, url) = &outcome.hashed_asset_urls[0];
         assert_eq!(*kind, AssetKind::Css);
         assert!(
-            url.starts_with("/assets/styles-") && url.ends_with(".css") && url.len() == "/assets/styles-12345678.css".len(),
+            url.starts_with("/assets/styles-")
+                && url.ends_with(".css")
+                && url.len() == "/assets/styles-12345678.css".len(),
             "expected /assets/styles-<8hex>.css; got {url}",
         );
 
@@ -817,7 +823,10 @@ mod tests {
             let outcome = pipeline.apply(&plan, &ctx).unwrap();
             outcome.hashed_asset_urls[0].1.clone()
         };
-        assert_eq!(url_a, url_a2, "byte-identical assets must produce the same URL");
+        assert_eq!(
+            url_a, url_a2,
+            "byte-identical assets must produce the same URL"
+        );
 
         // Differing bytes → differing URL.
         let url_b = {
@@ -878,21 +887,21 @@ mod tests {
         let outcome = pipeline.apply(&plan, &ctx).unwrap();
 
         assert_eq!(outcome.hashed_asset_urls.len(), 2);
-        let kinds: Vec<AssetKind> = outcome
-            .hashed_asset_urls
-            .iter()
-            .map(|(k, _)| *k)
-            .collect();
+        let kinds: Vec<AssetKind> = outcome.hashed_asset_urls.iter().map(|(k, _)| *k).collect();
         assert!(kinds.contains(&AssetKind::Css));
         assert!(kinds.contains(&AssetKind::Islands));
 
         let dist_html = std::fs::read_to_string(dir.path().join("index.html")).unwrap();
         assert!(
-            !dist_html.contains("/assets/styles.css\"") && !dist_html.contains("/assets/islands.js\""),
+            !dist_html.contains("/assets/styles.css\"")
+                && !dist_html.contains("/assets/islands.js\""),
             "stable URLs leaked: {dist_html}",
         );
         for (_, url) in &outcome.hashed_asset_urls {
-            assert!(dist_html.contains(url), "hashed url {url} missing from HTML: {dist_html}");
+            assert!(
+                dist_html.contains(url),
+                "hashed url {url} missing from HTML: {dist_html}"
+            );
         }
 
         // Both hashed files exist on disk with no stable copies left
@@ -902,8 +911,12 @@ mod tests {
             .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
             .collect();
         assert_eq!(assets.len(), 2);
-        assert!(assets.iter().any(|n| n.starts_with("styles-") && n.ends_with(".css")));
-        assert!(assets.iter().any(|n| n.starts_with("islands-") && n.ends_with(".js")));
+        assert!(assets
+            .iter()
+            .any(|n| n.starts_with("styles-") && n.ends_with(".css")));
+        assert!(assets
+            .iter()
+            .any(|n| n.starts_with("islands-") && n.ends_with(".js")));
     }
 
     /// Companion files are written verbatim beside the hashed entry —
@@ -941,9 +954,15 @@ mod tests {
             .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
             .collect();
         // Hashed entry + verbatim chunk.
-        assert_eq!(assets.len(), 2, "expected hashed entry + chunk; got {assets:?}");
+        assert_eq!(
+            assets.len(),
+            2,
+            "expected hashed entry + chunk; got {assets:?}"
+        );
         assert!(
-            assets.iter().any(|n| n.starts_with("islands-") && n.ends_with(".js") && !n.contains("chunk")),
+            assets
+                .iter()
+                .any(|n| n.starts_with("islands-") && n.ends_with(".js") && !n.contains("chunk")),
             "hashed entry missing: {assets:?}",
         );
         assert!(
@@ -951,7 +970,8 @@ mod tests {
             "verbatim chunk missing: {assets:?}",
         );
         // Chunk bytes are byte-identical to the input — never rewritten.
-        let on_disk = std::fs::read(dir.path().join("assets").join("islands-chunk-AAAA1111.js")).unwrap();
+        let on_disk =
+            std::fs::read(dir.path().join("assets").join("islands-chunk-AAAA1111.js")).unwrap();
         assert_eq!(on_disk, chunk_bytes);
     }
 
@@ -1083,7 +1103,10 @@ mod tests {
         let from = "/assets/styles.css";
         let rel = std::path::Path::new("assets/styles.css");
         let hashed = std::path::Path::new("assets/styles-deadbeef.css");
-        assert_eq!(rewrite_url(from, rel, hashed), "/assets/styles-deadbeef.css");
+        assert_eq!(
+            rewrite_url(from, rel, hashed),
+            "/assets/styles-deadbeef.css"
+        );
 
         // Stable URL on a CDN prefix decoupled from the on-disk path.
         let cdn = "https://cdn.example.test/v1/styles.css";

--- a/crates/zfb-build/src/pipeline/prod.rs
+++ b/crates/zfb-build/src/pipeline/prod.rs
@@ -256,7 +256,9 @@ impl AssetPipeline for ProductionAssetPipeline {
         let rendered = if pages.is_empty() {
             Vec::new()
         } else {
-            (ctx.render_pages)(&pages)?
+            // Production never narrows (issue #958): every selected
+            // page renders in full.
+            (ctx.render_pages)(&pages, None)?
         };
         outcome.pages_rendered = rendered.len();
 
@@ -691,7 +693,9 @@ mod tests {
     fn ctx_with_pages(dist_root: PathBuf, pages: Vec<RenderedPage>) -> BuildContext {
         BuildContext {
             dist_root,
-            render_pages: Arc::new(move |_pages: &[PageId]| Ok(pages.clone())),
+            render_pages: Arc::new(move |_pages: &[PageId], _: Option<&crate::ContentNarrowing>| {
+                Ok(pages.clone())
+            }),
             run_css: None,
             run_islands: None,
             reload_renderer: None,
@@ -711,6 +715,7 @@ mod tests {
             ssr_reload_needed: false,
             prune_paths: vec![],
             triggers: vec![],
+            content_narrowing: None,
         }
     }
 
@@ -1000,7 +1005,7 @@ mod tests {
         let calls_cb = bool_runner_calls.clone();
         let ctx = BuildContext {
             dist_root: dir.path().to_path_buf(),
-            render_pages: Arc::new(|_| Ok(vec![])),
+            render_pages: Arc::new(|_, _| Ok(vec![])),
             run_css: Some(Arc::new(move || {
                 calls_cb.fetch_add(1, Ordering::SeqCst);
                 Ok(true)
@@ -1043,7 +1048,7 @@ mod tests {
         let pipeline = ProductionAssetPipeline::empty();
         let ctx = BuildContext {
             dist_root: dir.path().to_path_buf(),
-            render_pages: Arc::new(|_| Ok(vec![])),
+            render_pages: Arc::new(|_, _| Ok(vec![])),
             run_css: None,
             run_islands: None,
             reload_renderer: None,
@@ -1056,6 +1061,7 @@ mod tests {
             ssr_reload_needed: false,
             prune_paths: vec![],
             triggers: vec![],
+            content_narrowing: None,
         };
         assert!(pipeline.apply(&plan, &ctx).is_err());
     }

--- a/crates/zfb-build/src/pipeline/prod.rs
+++ b/crates/zfb-build/src/pipeline/prod.rs
@@ -693,9 +693,9 @@ mod tests {
     fn ctx_with_pages(dist_root: PathBuf, pages: Vec<RenderedPage>) -> BuildContext {
         BuildContext {
             dist_root,
-            render_pages: Arc::new(move |_pages: &[PageId], _: Option<&crate::ContentNarrowing>| {
-                Ok(pages.clone())
-            }),
+            render_pages: Arc::new(
+                move |_pages: &[PageId], _: Option<&crate::ContentNarrowing>| Ok(pages.clone()),
+            ),
             run_css: None,
             run_islands: None,
             reload_renderer: None,

--- a/crates/zfb-build/src/plan.rs
+++ b/crates/zfb-build/src/plan.rs
@@ -13,6 +13,21 @@ use std::path::PathBuf;
 
 use zfb_graph::{DirtySet, PageId};
 
+/// Hint that this tick was caused exclusively by in-place edits
+/// (`ChangeKind::Modified`) to content-collection files
+/// (`PathClass::Content`). Carries the changed paths so the dev render
+/// callback can narrow each dynamic source's fan-out to the routes
+/// derived from these entries (issue #958). `None` = no narrowing
+/// (render every selected page fully — today's behaviour). Purely
+/// advisory: must not affect `is_noop()`/merge logic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ContentNarrowing {
+    /// Paths of the Modified content files exactly as the watcher
+    /// delivered them (absolute; same representation recorded in
+    /// [`RebuildPlan::triggers`]).
+    pub changed_content: Vec<PathBuf>,
+}
+
 /// What the orchestrator wants the asset pipeline to do for the next
 /// rebuild tick.
 ///
@@ -56,6 +71,10 @@ pub struct RebuildPlan {
     /// The raw paths that triggered this plan, kept around purely for
     /// diagnostics. Not consumed by the pipeline.
     pub triggers: Vec<PathBuf>,
+
+    /// See [`ContentNarrowing`]. [`RebuildPlan::empty`] and
+    /// [`RebuildPlan::full_rebuild`] set `None`.
+    pub content_narrowing: Option<ContentNarrowing>,
 }
 
 /// Which pages to re-render this tick.
@@ -120,6 +139,7 @@ impl RebuildPlan {
             ssr_reload_needed: false,
             prune_paths: Vec::new(),
             triggers: Vec::new(),
+            content_narrowing: None,
         }
     }
 
@@ -133,6 +153,7 @@ impl RebuildPlan {
             ssr_reload_needed: true,
             prune_paths: Vec::new(),
             triggers: Vec::new(),
+            content_narrowing: None,
         }
     }
 
@@ -200,6 +221,17 @@ mod tests {
     #[test]
     fn empty_plan_is_noop() {
         assert!(RebuildPlan::empty().is_noop());
+    }
+
+    /// The content-narrowing hint is purely advisory (issue #958): a plan
+    /// that carries one but selects nothing must stay a no-op.
+    #[test]
+    fn content_narrowing_hint_does_not_affect_is_noop() {
+        let mut plan = RebuildPlan::empty();
+        plan.content_narrowing = Some(ContentNarrowing {
+            changed_content: vec![PathBuf::from("/proj/content/post.md")],
+        });
+        assert!(plan.is_noop());
     }
 
     #[test]

--- a/crates/zfb-build/src/plugin_runner.rs
+++ b/crates/zfb-build/src/plugin_runner.rs
@@ -383,10 +383,7 @@ impl PluginHost {
     ///
     /// `hook_timeout` is the maximum time any single hook reply is awaited.
     /// Pass `None` to auto-resolve from `ZFB_PLUGIN_HOOK_TIMEOUT` / 120s default.
-    pub async fn spawn(
-        plugins: Vec<PluginSpec>,
-        node_binary: Option<OsString>,
-    ) -> Result<Self> {
+    pub async fn spawn(plugins: Vec<PluginSpec>, node_binary: Option<OsString>) -> Result<Self> {
         Self::spawn_with_timeout(plugins, node_binary, None).await
     }
 
@@ -512,10 +509,7 @@ impl PluginHost {
     /// Run every plugin's `preBuild` hook (in declaration order).
     pub async fn run_pre_build(&self, ctx: &BuildHookContext) -> Result<()> {
         let _ = self
-            .request_typed::<serde_json::Value>(
-                "preBuild",
-                serde_json::json!({ "ctx": ctx }),
-            )
+            .request_typed::<serde_json::Value>("preBuild", serde_json::json!({ "ctx": ctx }))
             .await?;
         Ok(())
     }
@@ -527,10 +521,7 @@ impl PluginHost {
     /// emitted route table (#262).
     pub async fn run_post_build(&self, ctx: &BuildHookContext) -> Result<()> {
         let _ = self
-            .request_typed::<serde_json::Value>(
-                "postBuild",
-                serde_json::json!({ "ctx": ctx }),
-            )
+            .request_typed::<serde_json::Value>("postBuild", serde_json::json!({ "ctx": ctx }))
             .await?;
         Ok(())
     }
@@ -574,10 +565,7 @@ impl PluginHost {
                 loader_id: String,
             },
             #[serde(rename = "injectRoute")]
-            InjectRoute {
-                pattern: String,
-                entrypoint: String,
-            },
+            InjectRoute { pattern: String, entrypoint: String },
         }
 
         #[derive(Deserialize)]
@@ -641,10 +629,7 @@ impl PluginHost {
     /// resolver) call this from their respective module-resolution
     /// paths when an import specifier matches a registered
     /// virtual-module entry.
-    pub async fn invoke_virtual_loader(
-        &self,
-        loader_id: &VirtualLoaderId,
-    ) -> Result<String> {
+    pub async fn invoke_virtual_loader(&self, loader_id: &VirtualLoaderId) -> Result<String> {
         #[derive(Deserialize)]
         struct Reply {
             source: String,
@@ -669,10 +654,7 @@ impl PluginHost {
             registrations: Vec<DevRegistration>,
         }
         let reply: Reply = self
-            .request_typed(
-                "devRegister",
-                serde_json::json!({ "ctx": ctx }),
-            )
+            .request_typed("devRegister", serde_json::json!({ "ctx": ctx }))
             .await?;
         Ok(reply.registrations)
     }
@@ -764,8 +746,8 @@ impl PluginHost {
                 }
             }
         }
-        let mut line = serde_json::to_string(&envelope)
-            .context("plugin host: serialise request")?;
+        let mut line =
+            serde_json::to_string(&envelope).context("plugin host: serialise request")?;
         line.push('\n');
         let write_outcome: Result<()> = {
             let mut stdin = self.inner.stdin.lock().await;
@@ -841,19 +823,17 @@ impl PluginHost {
             }
         };
         match parsed {
-            HostLine::Log(LogLine { log }) => {
-                match log.level.as_str() {
-                    "warn" => {
-                        warn!(target: "zfb_plugin", plugin = %log.plugin, "{}", log.message);
-                    }
-                    "error" => {
-                        error!(target: "zfb_plugin", plugin = %log.plugin, "{}", log.message);
-                    }
-                    _ => {
-                        info!(target: "zfb_plugin", plugin = %log.plugin, "{}", log.message);
-                    }
+            HostLine::Log(LogLine { log }) => match log.level.as_str() {
+                "warn" => {
+                    warn!(target: "zfb_plugin", plugin = %log.plugin, "{}", log.message);
                 }
-            }
+                "error" => {
+                    error!(target: "zfb_plugin", plugin = %log.plugin, "{}", log.message);
+                }
+                _ => {
+                    info!(target: "zfb_plugin", plugin = %log.plugin, "{}", log.message);
+                }
+            },
             HostLine::Reply(reply) => {
                 let id = reply.id;
                 let mut pend = inner.pending.lock().await;
@@ -1028,7 +1008,11 @@ mod tests {
         let pe = extract_plugin_error(&err).expect("PluginError carried in chain");
         assert_eq!(pe.plugin, "thrower");
         assert_eq!(pe.hook, "preBuild");
-        assert!(pe.message.contains("boom from preBuild"), "msg: {}", pe.message);
+        assert!(
+            pe.message.contains("boom from preBuild"),
+            "msg: {}",
+            pe.message
+        );
         host.shutdown().await.ok();
     }
 
@@ -1178,7 +1162,10 @@ mod tests {
             .expect("invoke ok");
         assert!(!resp.passthrough);
         assert_eq!(resp.status, 200);
-        assert_eq!(resp.headers.get("x-method").map(|s| s.as_str()), Some("GET"));
+        assert_eq!(
+            resp.headers.get("x-method").map(|s| s.as_str()),
+            Some("GET")
+        );
         assert_eq!(resp.body, "hello /echo?x=1");
 
         host.shutdown().await.ok();
@@ -1360,7 +1347,13 @@ mod tests {
             .await
             .expect_err("conflicting alias must error");
         let msg = format!("{err:#}");
-        assert!(msg.contains("alias") && msg.contains("@/x") && msg.contains("`a`") && msg.contains("`b`"), "got: {msg}");
+        assert!(
+            msg.contains("alias")
+                && msg.contains("@/x")
+                && msg.contains("`a`")
+                && msg.contains("`b`"),
+            "got: {msg}"
+        );
         host.shutdown().await.ok();
     }
 
@@ -1558,8 +1551,11 @@ mod tests {
         assert_eq!(routes[0]["extension"], "html");
         assert_eq!(routes[0]["source"], "pages/index.tsx");
         // params must be absent for a static route.
-        assert!(routes[0].get("params").is_none() || routes[0]["params"].is_null(),
-            "static route must not carry params, got: {}", routes[0]);
+        assert!(
+            routes[0].get("params").is_none() || routes[0]["params"].is_null(),
+            "static route must not carry params, got: {}",
+            routes[0]
+        );
     }
 
     /// Dynamic route params surface as string scalars; catchall params
@@ -1599,10 +1595,16 @@ mod tests {
         .expect("host spawns");
 
         let mut dyn_params = std::collections::BTreeMap::new();
-        dyn_params.insert("slug".to_string(), PostBuildParamValue::Scalar("hello-world".to_string()));
+        dyn_params.insert(
+            "slug".to_string(),
+            PostBuildParamValue::Scalar("hello-world".to_string()),
+        );
 
         let mut catchall_params = std::collections::BTreeMap::new();
-        catchall_params.insert("rest".to_string(), PostBuildParamValue::Array(vec!["a".to_string(), "b".to_string()]));
+        catchall_params.insert(
+            "rest".to_string(),
+            PostBuildParamValue::Array(vec!["a".to_string(), "b".to_string()]),
+        );
 
         let manifest = PostBuildRouteManifest {
             routes: vec![
@@ -1647,12 +1649,18 @@ mod tests {
         assert_eq!(routes.len(), 3);
 
         // Dynamic route: slug is a string scalar.
-        let dyn_r = routes.iter().find(|r| r["url"] == "/blog/hello-world").unwrap();
+        let dyn_r = routes
+            .iter()
+            .find(|r| r["url"] == "/blog/hello-world")
+            .unwrap();
         assert_eq!(dyn_r["params"]["slug"], "hello-world");
 
         // Catchall route: rest is a string array.
         let ca_r = routes.iter().find(|r| r["url"] == "/docs/a/b").unwrap();
-        assert!(ca_r["params"]["rest"].is_array(), "catchall param must be array");
+        assert!(
+            ca_r["params"]["rest"].is_array(),
+            "catchall param must be array"
+        );
         let rest = ca_r["params"]["rest"].as_array().unwrap();
         assert_eq!(rest, &[serde_json::json!("a"), serde_json::json!("b")]);
 
@@ -1660,14 +1668,20 @@ mod tests {
         let xml_r = routes.iter().find(|r| r["url"] == "/sitemap.xml").unwrap();
         assert_eq!(xml_r["extension"], "xml");
         assert_eq!(xml_r["output"], "sitemap.xml");
-        assert!(xml_r.get("params").is_none() || xml_r["params"].is_null(),
-            "non-HTML static route must not carry params, got: {}", xml_r);
+        assert!(
+            xml_r.get("params").is_none() || xml_r["params"].is_null(),
+            "non-HTML static route must not carry params, got: {}",
+            xml_r
+        );
 
         // prerender field is present on all routes and serialises as a
         // boolean (not omitted, not null).
         for r in routes {
-            assert!(r["prerender"].is_boolean(),
-                "prerender must be a boolean, got: {}", r);
+            assert!(
+                r["prerender"].is_boolean(),
+                "prerender must be a boolean, got: {}",
+                r
+            );
         }
     }
 
@@ -1745,12 +1759,20 @@ mod tests {
         assert_eq!(routes.len(), 2);
 
         let ssg = routes.iter().find(|r| r["url"] == "/").unwrap();
-        assert_eq!(ssg["prerender"], serde_json::json!(true),
-            "SSG route must have prerender=true, got: {}", ssg);
+        assert_eq!(
+            ssg["prerender"],
+            serde_json::json!(true),
+            "SSG route must have prerender=true, got: {}",
+            ssg
+        );
 
         let ssr = routes.iter().find(|r| r["url"] == "/api/search").unwrap();
-        assert_eq!(ssr["prerender"], serde_json::json!(false),
-            "SSR route must have prerender=false, got: {}", ssr);
+        assert_eq!(
+            ssr["prerender"],
+            serde_json::json!(false),
+            "SSR route must have prerender=false, got: {}",
+            ssr
+        );
     }
 
     // --- Timeout tests (no node required) -----------------------------------

--- a/crates/zfb-build/src/policy.rs
+++ b/crates/zfb-build/src/policy.rs
@@ -479,7 +479,11 @@ mod tests {
     #[test]
     fn no_content_roots_preserves_legacy_module_walk() {
         assert_eq!(
-            classify_change(Path::new("/proj/src/mdx/notes/foo.mdx"), proj(), never_global),
+            classify_change(
+                Path::new("/proj/src/mdx/notes/foo.mdx"),
+                proj(),
+                never_global
+            ),
             PathClass::Module
         );
     }
@@ -516,11 +520,7 @@ mod tests {
             PathClass::Page,
         );
         assert_eq!(
-            classify_change(
-                Path::new("/proj/pages/llms.txt.tsx"),
-                proj(),
-                never_global,
-            ),
+            classify_change(Path::new("/proj/pages/llms.txt.tsx"), proj(), never_global,),
             PathClass::Page,
         );
     }
@@ -674,11 +674,7 @@ mod tests {
         // fires. The classifier must skip the root-segment walk for
         // out-of-root paths and drop straight to extension sniff.
         assert_eq!(
-            classify_change(
-                Path::new("/srv/shared/public/foo.md"),
-                proj(),
-                never_global,
-            ),
+            classify_change(Path::new("/srv/shared/public/foo.md"), proj(), never_global,),
             PathClass::Content,
         );
         assert_eq!(
@@ -758,11 +754,7 @@ mod tests {
         );
         // No extension at all under an extra watch root → External.
         assert_eq!(
-            classify_change(
-                Path::new("/srv/shared/Makefile"),
-                proj(),
-                never_global,
-            ),
+            classify_change(Path::new("/srv/shared/Makefile"), proj(), never_global,),
             PathClass::External,
         );
     }

--- a/crates/zfb-build/src/renderer.rs
+++ b/crates/zfb-build/src/renderer.rs
@@ -305,7 +305,9 @@ impl Default for Backend {
     /// is provided so builders / test harnesses can use `..Default::default()`
     /// in struct literals without specifying every field.
     fn default() -> Self {
-        Backend::Existing { base_url: String::new() }
+        Backend::Existing {
+            base_url: String::new(),
+        }
     }
 }
 
@@ -338,9 +340,7 @@ enum BackendHandle {
     ///
     /// Gated behind `embed_v8` (issue #371, sub-task 4.1a).
     #[cfg(feature = "embed_v8")]
-    EmbeddedV8 {
-        guard: EmbeddedV8Guard,
-    },
+    EmbeddedV8 { guard: EmbeddedV8Guard },
     /// Unit-test stub: answers requests with a closure.
     Stub {
         handler: Arc<dyn Fn(&str) -> HttpResponseLike + Send + Sync>,
@@ -352,13 +352,10 @@ impl BackendHandle {
         match self {
             BackendHandle::Http { base_url, client } => {
                 let url = join_url(base_url, url_path);
-                let resp = client
-                    .get(&url)
-                    .send()
-                    .map_err(|e| RendererError::Http {
-                        url: url.clone(),
-                        source: e,
-                    })?;
+                let resp = client.get(&url).send().map_err(|e| RendererError::Http {
+                    url: url.clone(),
+                    source: e,
+                })?;
                 let status = resp.status().as_u16();
                 let content_type = resp
                     .headers()
@@ -386,18 +383,22 @@ impl BackendHandle {
                         source: e,
                     })?
                     .to_vec();
-                Ok(HttpResponseLike { status, content_type, headers, body })
+                Ok(HttpResponseLike {
+                    status,
+                    content_type,
+                    headers,
+                    body,
+                })
             }
             #[cfg(feature = "embed_v8")]
             BackendHandle::EmbeddedV8 { guard } => {
-                let host = guard.host.as_mut().expect(
-                    "EmbeddedV8 host has been terminated; dispatch called after shutdown"
-                );
+                let host = guard
+                    .host
+                    .as_mut()
+                    .expect("EmbeddedV8 host has been terminated; dispatch called after shutdown");
                 host.dispatch_fetch(url_path)
             }
-            BackendHandle::Stub { handler } => {
-                Ok(handler(url_path))
-            }
+            BackendHandle::Stub { handler } => Ok(handler(url_path)),
         }
     }
 
@@ -629,10 +630,7 @@ pub fn render_all(input: RendererInput) -> Result<RendererOutput, RendererError>
     let mut ssg_routes: Vec<RouteUniverseEntry> = Vec::new();
     let mut ssr_routes: Vec<SsrRouteEntry> = Vec::new();
     for entry in route_universe {
-        let prerender = prerender_map
-            .get(&entry.route_key)
-            .copied()
-            .unwrap_or(true);
+        let prerender = prerender_map.get(&entry.route_key).copied().unwrap_or(true);
         if prerender {
             ssg_routes.push(entry);
         } else {
@@ -762,9 +760,10 @@ impl RendererState {
     #[cfg(feature = "embed_v8")]
     pub fn embedded_v8_host_mut(&mut self) -> Option<&mut dyn EmbeddedV8Host> {
         match &mut self.handle {
-            BackendHandle::EmbeddedV8 { guard } => {
-                guard.host.as_deref_mut().map(|h| h as &mut dyn EmbeddedV8Host)
-            }
+            BackendHandle::EmbeddedV8 { guard } => guard
+                .host
+                .as_deref_mut()
+                .map(|h| h as &mut dyn EmbeddedV8Host),
             _ => None,
         }
     }
@@ -781,10 +780,7 @@ pub fn start(input: RendererStartInput) -> Result<RendererState, RendererError> 
     let timeout = request_timeout.unwrap_or(Duration::from_secs(30));
     let handle = launch(&backend, &bundle_path, timeout)?;
     let sourcemap = load_sourcemap(&sourcemap_path);
-    Ok(RendererState {
-        sourcemap,
-        handle,
-    })
+    Ok(RendererState { sourcemap, handle })
 }
 
 /// Drive one route against an existing dev-mode state and write it to
@@ -1309,9 +1305,7 @@ mod tests {
 
     /// Build a [`Backend::Stub`] from a closure that maps URL path → response.
     /// The closure signature mirrors the public [`HttpResponseLike`] shape.
-    fn stub_backend(
-        f: impl Fn(&str) -> HttpResponseLike + Send + Sync + 'static,
-    ) -> Backend {
+    fn stub_backend(f: impl Fn(&str) -> HttpResponseLike + Send + Sync + 'static) -> Backend {
         Backend::Stub {
             handler: Arc::new(f),
         }
@@ -1460,9 +1454,9 @@ mod tests {
             url_path: "/".into(),
             output_path: PathBuf::from("index.html"),
             route_key: "/".into(),
-        static_html: false,
-        source_path: None,
-}];
+            static_html: false,
+            source_path: None,
+        }];
         let out = render_all(RendererInput {
             bundle_path: PathBuf::from("/dev/null"),
             sourcemap_path: PathBuf::from("/dev/null"),
@@ -1487,9 +1481,9 @@ mod tests {
             url_path: "/error".into(),
             output_path: PathBuf::from("error/index.html"),
             route_key: "/error".into(),
-        static_html: false,
-        source_path: None,
-}];
+            static_html: false,
+            source_path: None,
+        }];
         let err = render_all(RendererInput {
             bundle_path: PathBuf::from("/dev/null"),
             sourcemap_path: PathBuf::from("/dev/null"),
@@ -1673,9 +1667,9 @@ mod tests {
             url_path: "/".into(),
             output_path: PathBuf::from("index.html"),
             route_key: "/".into(),
-        static_html: false,
-        source_path: None,
-}];
+            static_html: false,
+            source_path: None,
+        }];
         render_all(RendererInput {
             bundle_path: PathBuf::from("/dev/null"),
             sourcemap_path: PathBuf::from("/dev/null"),
@@ -1709,9 +1703,9 @@ mod tests {
             url_path: "/".into(),
             output_path: PathBuf::from("index.html"),
             route_key: "/".into(),
-        static_html: false,
-        source_path: None,
-}];
+            static_html: false,
+            source_path: None,
+        }];
         let assets = crate::head_inject::ProdHeadAssets {
             css_url: Some("/assets/styles.css".into()),
             island_module_urls: vec!["/assets/islands.js".into()],
@@ -1807,9 +1801,9 @@ mod tests {
             url_path: "/feed.xml".into(),
             output_path: PathBuf::from("feed.xml"),
             route_key: "/feed.xml".into(),
-        static_html: false,
-        source_path: None,
-}];
+            static_html: false,
+            source_path: None,
+        }];
         let assets = crate::head_inject::ProdHeadAssets {
             css_url: Some("/assets/styles.css".into()),
             island_module_urls: vec![],
@@ -1846,7 +1840,10 @@ mod tests {
         // builder API.
         let mut builder = sourcemap::SourceMapBuilder::new(None);
         let src_id = builder.add_source("pages/error.tsx");
-        builder.set_source_contents(src_id, Some("export function boom() { throw new Error('x'); }"));
+        builder.set_source_contents(
+            src_id,
+            Some("export function boom() { throw new Error('x'); }"),
+        );
         // dst (generated) line 0 col 0 maps to src (original) line 4
         // col 2 (both 0-based in the builder). That corresponds to
         // user-visible line 5 col 3.
@@ -1895,7 +1892,10 @@ mod tests {
 
         let mut builder = sourcemap::SourceMapBuilder::new(None);
         let src_id = builder.add_source("pages/error.tsx");
-        builder.set_source_contents(src_id, Some("export function boom() { throw new Error('x'); }"));
+        builder.set_source_contents(
+            src_id,
+            Some("export function boom() { throw new Error('x'); }"),
+        );
         builder.add_raw(0, 0, 4, 2, Some(src_id), None, false);
         let mut buf = Vec::new();
         builder.into_sourcemap().to_writer(&mut buf).unwrap();
@@ -1910,9 +1910,9 @@ mod tests {
             url_path: "/".into(),
             output_path: PathBuf::from("index.html"),
             route_key: "/".into(),
-        static_html: false,
-        source_path: None,
-}];
+            static_html: false,
+            source_path: None,
+        }];
 
         let err = render_all(RendererInput {
             bundle_path,
@@ -1934,7 +1934,11 @@ mod tests {
         .unwrap_err();
 
         match err {
-            RendererError::RenderFailed { user_location, body, .. } => {
+            RendererError::RenderFailed {
+                user_location,
+                body,
+                ..
+            } => {
                 let loc = user_location.expect("expected user_location to be projected");
                 assert!(
                     loc.starts_with("pages/error.tsx:5:"),
@@ -1970,9 +1974,9 @@ mod tests {
             url_path: "/foo".into(),
             output_path: PathBuf::from("foo/index.html"),
             route_key: "/foo".into(),
-        static_html: false,
-        source_path: None,
-}];
+            static_html: false,
+            source_path: None,
+        }];
 
         let err = render_all(RendererInput {
             bundle_path: PathBuf::from("/dev/null"),
@@ -2045,7 +2049,8 @@ mod tests {
             static_html: false,
             source_path: None,
         };
-        let written = render_one(&mut reloaded, &entry, dist.path(), dist.path()).expect("render_one");
+        let written =
+            render_one(&mut reloaded, &entry, dist.path(), dist.path()).expect("render_one");
         let body = fs::read_to_string(written).unwrap();
         assert!(body.contains("after"), "expected 'after' body, got: {body}");
 
@@ -2171,8 +2176,14 @@ mod tests {
 
         let written = fs::read_to_string(dist.path().join("about/index.html")).unwrap();
         // Frontmatter should be stripped; body should be verbatim.
-        assert!(!written.contains("title: About"), "frontmatter must be stripped");
-        assert!(written.contains("<!doctype html>"), "body must start with <!doctype html>");
+        assert!(
+            !written.contains("title: About"),
+            "frontmatter must be stripped"
+        );
+        assert!(
+            written.contains("<!doctype html>"),
+            "body must start with <!doctype html>"
+        );
         assert!(written.contains("About"), "body content must be preserved");
     }
 
@@ -2215,5 +2226,4 @@ mod tests {
         let written = fs::read_to_string(dist.path().join("index.html")).unwrap();
         assert!(written.contains("Home"), "body content must be preserved");
     }
-
 }

--- a/crates/zfb-build/tests/bundler_default_plugins.rs
+++ b/crates/zfb-build/tests/bundler_default_plugins.rs
@@ -227,8 +227,7 @@ fn bundler_threads_default_plugins_through_mdx_compile() {
     // default emit itself, not a cache-path check.
     let second_input = make_input(&root, &esbuild, "dist2");
     let second_out = bundle(second_input).expect("second bundle should succeed");
-    let second_body =
-        fs::read_to_string(&second_out.bundle_path).expect("read second bundle");
+    let second_body = fs::read_to_string(&second_out.bundle_path).expect("read second bundle");
     // Compare with the inherently-random shadow tempdir collapsed out (see
     // `normalize_shadow_paths`): esbuild embeds the bundler's per-run
     // `zfb-bundler-<rand>` shadow path in module-boundary comments, the only

--- a/crates/zfb-build/tests/bundler_exact_match_resolution.rs
+++ b/crates/zfb-build/tests/bundler_exact_match_resolution.rs
@@ -120,9 +120,7 @@ fn make_input(
 #[test]
 fn plugin_alias_does_not_match_prefix_with_slash() {
     let Some(esbuild) = locate_esbuild() else {
-        eprintln!(
-            "[bundler_exact_match_resolution] no esbuild binary available; skipping."
-        );
+        eprintln!("[bundler_exact_match_resolution] no esbuild binary available; skipping.");
         return;
     };
 
@@ -162,9 +160,7 @@ fn plugin_alias_does_not_match_prefix_with_slash() {
 #[test]
 fn plugin_alias_matches_exact_specifier() {
     let Some(esbuild) = locate_esbuild() else {
-        eprintln!(
-            "[bundler_exact_match_resolution] no esbuild binary available; skipping."
-        );
+        eprintln!("[bundler_exact_match_resolution] no esbuild binary available; skipping.");
         return;
     };
 
@@ -208,9 +204,7 @@ fn plugin_alias_matches_exact_specifier() {
 #[test]
 fn plugin_virtual_module_does_not_match_prefix_with_slash() {
     let Some(esbuild) = locate_esbuild() else {
-        eprintln!(
-            "[bundler_exact_match_resolution] no esbuild binary available; skipping."
-        );
+        eprintln!("[bundler_exact_match_resolution] no esbuild binary available; skipping.");
         return;
     };
 
@@ -250,9 +244,7 @@ fn plugin_virtual_module_does_not_match_prefix_with_slash() {
 #[test]
 fn plugin_virtual_module_matches_exact_specifier() {
     let Some(esbuild) = locate_esbuild() else {
-        eprintln!(
-            "[bundler_exact_match_resolution] no esbuild binary available; skipping."
-        );
+        eprintln!("[bundler_exact_match_resolution] no esbuild binary available; skipping.");
         return;
     };
 
@@ -294,9 +286,7 @@ fn plugin_virtual_module_matches_exact_specifier() {
 #[test]
 fn user_tsconfig_paths_coexist_with_plugin_aliases() {
     let Some(esbuild) = locate_esbuild() else {
-        eprintln!(
-            "[bundler_exact_match_resolution] no esbuild binary available; skipping."
-        );
+        eprintln!("[bundler_exact_match_resolution] no esbuild binary available; skipping.");
         return;
     };
 
@@ -304,7 +294,14 @@ fn user_tsconfig_paths_coexist_with_plugin_aliases() {
     let root = tmp.path().to_path_buf();
     // Build a project tree with TWO aliased targets — one resolved
     // via the user's tsconfig paths entry, one via a plugin alias.
-    for d in ["pages", "content", "components", "layouts", "src", "src/components"] {
+    for d in [
+        "pages",
+        "content",
+        "components",
+        "layouts",
+        "src",
+        "src/components",
+    ] {
         fs::create_dir_all(root.join(d)).unwrap();
     }
     fs::write(
@@ -319,11 +316,7 @@ fn user_tsconfig_paths_coexist_with_plugin_aliases() {
     )
     .unwrap();
     // Plugin-alias target: `@/data` → `<root>/src/data.ts` (absolute).
-    fs::write(
-        root.join("src/data.ts"),
-        "export default { ok: true };\n",
-    )
-    .unwrap();
+    fs::write(root.join("src/data.ts"), "export default { ok: true };\n").unwrap();
     fs::write(
         root.join("pages/index.tsx"),
         "import Widget from \"@/components/widget\";\n\
@@ -383,9 +376,7 @@ fn user_tsconfig_paths_coexist_with_plugin_aliases() {
 #[test]
 fn user_tsconfig_paths_win_over_plugin_alias_on_collision() {
     let Some(esbuild) = locate_esbuild() else {
-        eprintln!(
-            "[bundler_exact_match_resolution] no esbuild binary available; skipping."
-        );
+        eprintln!("[bundler_exact_match_resolution] no esbuild binary available; skipping.");
         return;
     };
 

--- a/crates/zfb-build/tests/bundler_integration.rs
+++ b/crates/zfb-build/tests/bundler_integration.rs
@@ -196,7 +196,12 @@ fn end_to_end_bundles_aliases_mdx_islands_and_define() {
 
     // 3. Manifest reports the single route.
     assert_eq!(out.manifest.framework, "preact");
-    assert_eq!(out.manifest.routes.len(), 1, "manifest routes: {:?}", out.manifest.routes);
+    assert_eq!(
+        out.manifest.routes.len(),
+        1,
+        "manifest routes: {:?}",
+        out.manifest.routes
+    );
     assert_eq!(out.manifest.routes[0].route, "/");
     assert_eq!(
         out.manifest.routes[0].source_path,

--- a/crates/zfb-build/tests/bundler_main_fields.rs
+++ b/crates/zfb-build/tests/bundler_main_fields.rs
@@ -134,7 +134,12 @@ fn main_fields_knob_resolves_cjs_main_only_dep_fails_without_passes_with() {
     let tmp_fail = tempfile::tempdir().expect("tempdir");
     scaffold_project_importing(tmp_fail.path(), "badcjs");
     write_cjs_only_package(tmp_fail.path(), "badcjs");
-    let fail = bundle(make_input(tmp_fail.path(), esbuild.clone(), Vec::new(), Vec::new()));
+    let fail = bundle(make_input(
+        tmp_fail.path(),
+        esbuild.clone(),
+        Vec::new(),
+        Vec::new(),
+    ));
     assert!(
         fail.is_err(),
         "WITHOUT bundle.mainFields the Preact/neutral pass has an empty \
@@ -183,8 +188,16 @@ fn external_knob_lets_build_skip_cjs_main_only_dep() {
     let tmp_fail = tempfile::tempdir().expect("tempdir");
     scaffold_project_importing(tmp_fail.path(), "badcjs");
     write_cjs_only_package(tmp_fail.path(), "badcjs");
-    let fail = bundle(make_input(tmp_fail.path(), esbuild.clone(), Vec::new(), Vec::new()));
-    assert!(fail.is_err(), "negative control: must fail without any knob");
+    let fail = bundle(make_input(
+        tmp_fail.path(),
+        esbuild.clone(),
+        Vec::new(),
+        Vec::new(),
+    ));
+    assert!(
+        fail.is_err(),
+        "negative control: must fail without any knob"
+    );
 
     // --- With external = [badcjs] → must PASS, dep left unresolved. ---
     let tmp_pass = tempfile::tempdir().expect("tempdir");

--- a/crates/zfb-build/tests/bundler_markdown_diagnostics.rs
+++ b/crates/zfb-build/tests/bundler_markdown_diagnostics.rs
@@ -1,0 +1,247 @@
+//! Bundler-wiring integration tests for the markdown-diagnostics drain +
+//! severity policy (zfb#953).
+//!
+//! Pins the contract that when `BundlerInput::pipeline_spec` is armed with
+//! build-context roots and a filesystem-dependent feature (transclude /
+//! imageDimensions), the bundler:
+//!
+//! - **Transclude error (Error severity):** armed pipeline + missing include
+//!   file → `bundle()` returns `Err`; error message names the file.
+//! - **imageDimensions warning (Warning severity):** armed pipeline + missing
+//!   image file → `bundle()` succeeds; warning emitted to stderr, build
+//!   continues.
+//! - **Unarmed config (no build_context_roots):** same fixture → zero new
+//!   behavior; bundle succeeds with no diagnostics.
+//!
+//! ## Esbuild gating
+//!
+//! Same precedence as other bundler integration tests: `ZFB_ESBUILD_BIN` env
+//! var → `crates/zfb/binaries/esbuild/esbuild` slot → `which esbuild` PATH
+//! fallback.  If no binary is available the test prints a skip note and
+//! returns early rather than failing.
+
+use std::collections::{BTreeMap, HashMap};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use zfb_build::{bundle, BundleMode, BundlerInput, ContentCollectionSpec};
+use zfb_content::{ImageDimensionsConfig, MarkdownFeaturesConfig, PipelineSpec, TranscludeConfig};
+use zfb_render::adapters::Framework;
+use zfb_test_utils::locate_esbuild;
+
+// ── Shared fixture helpers ──────────────────────────────────────────────────
+
+/// Create the standard project tree used by all tests.
+///
+/// - `pages/index.mdx` — minimal page (route anchor).
+/// - `content/docs/` — content collection root (populated per test).
+/// - `layouts/default.tsx` — a minimal layout stub.
+fn write_common_dirs(root: &Path) {
+    for d in ["pages", "content/docs", "components", "layouts"] {
+        fs::create_dir_all(root.join(d)).unwrap();
+    }
+    fs::write(
+        root.join("layouts/default.tsx"),
+        "export default function DefaultLayout({ children }) { return children; }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("pages/index.mdx"),
+        "---\ntitle: Home\n---\n\nWelcome.\n",
+    )
+    .unwrap();
+}
+
+/// Base `BundlerInput` with the standard collection wiring.
+fn make_base_input(
+    root: &Path,
+    esbuild: &Path,
+    outdir_name: &str,
+    pipeline_spec: PipelineSpec,
+) -> BundlerInput {
+    BundlerInput {
+        main_fields: Vec::new(),
+        project_root: root.to_path_buf(),
+        pages_dir: PathBuf::from("pages"),
+        content_dir: PathBuf::from("content"),
+        components_dir: PathBuf::from("components"),
+        layouts_dir: PathBuf::from("layouts"),
+        framework: Framework::Preact,
+        define_vars: HashMap::new(),
+        tsconfig_paths: BTreeMap::new(),
+        external: vec![
+            "preact".into(),
+            "preact-render-to-string".into(),
+            "@takazudo/zfb-runtime".into(),
+        ],
+        outdir: root.join(outdir_name),
+        mode: BundleMode::Production,
+        minify: false,
+        esbuild_binary: Some(esbuild.to_path_buf()),
+        mock_subprocess_output: None,
+        content_snapshot_json: None,
+        node_modules_dir: None,
+        node_modules_preserve_symlinks: false,
+        content_collections: vec![ContentCollectionSpec::new(
+            "docs",
+            PathBuf::from("content/docs"),
+        )],
+        pipeline_spec,
+        resolve_markdown_links: None,
+        site: None,
+        prefetch_disabled: false,
+        plugin_alias_entries: Vec::new(),
+        plugin_virtual_modules: Vec::new(),
+        worker_only_routes: None,
+        bundle_basename: None,
+        css_module_class_maps: HashMap::new(),
+        mdx_components_file: None,
+        bundle_exclude: Vec::new(),
+    }
+}
+
+/// Arm `PipelineSpec` with transclude enabled and build-context roots at
+/// `project_root` (public dir at `<root>/public`).
+fn armed_transclude_spec(root: &Path) -> PipelineSpec {
+    PipelineSpec {
+        features: Some(MarkdownFeaturesConfig {
+            transclude: Some(TranscludeConfig::default()),
+            ..Default::default()
+        }),
+        build_context_roots: Some((root.to_path_buf(), root.join("public"))),
+        ..PipelineSpec::default()
+    }
+}
+
+/// Arm `PipelineSpec` with imageDimensions enabled and build-context roots.
+fn armed_image_dimensions_spec(root: &Path) -> PipelineSpec {
+    PipelineSpec {
+        features: Some(MarkdownFeaturesConfig {
+            image_dimensions: Some(ImageDimensionsConfig::default()),
+            ..Default::default()
+        }),
+        build_context_roots: Some((root.to_path_buf(), root.join("public"))),
+        ..PipelineSpec::default()
+    }
+}
+
+// ── (a) Transclude error fails the build ───────────────────────────────────
+
+/// Armed pipeline + missing transclude include → bundle fails; error message
+/// names the missing file.
+///
+/// Transclude plugin emits `DiagnosticSeverity::Error` when the included
+/// file cannot be read (file not found). The A3 severity policy gates on
+/// `Error` and returns `bail!` listing every finding after all walks
+/// complete.
+#[test]
+fn armed_transclude_missing_include_fails_build() {
+    let Some(esbuild) = locate_esbuild() else {
+        eprintln!(
+            "[bundler_markdown_diagnostics] no esbuild binary available; \
+             set ZFB_ESBUILD_BIN or install esbuild on PATH. Skipping."
+        );
+        return;
+    };
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+    write_common_dirs(&root);
+    // A page in the content collection that transcludes a file that does NOT
+    // exist — the transclude plugin will emit an Error-severity diagnostic.
+    fs::write(
+        root.join("content/docs/index.mdx"),
+        "---\ntitle: Docs\n---\n\n:::include{file=\"./missing-snippet.md\"}\n",
+    )
+    .unwrap();
+
+    let spec = armed_transclude_spec(&root);
+    let input = make_base_input(&root, &esbuild, "dist-transclude-err", spec);
+    let err = bundle(input)
+        .expect_err("bundle should fail with a missing transclude include (Error severity)");
+    let msg = format!("{err:#}");
+
+    // The error message must mention "error(s)" and reference the file name.
+    assert!(
+        msg.contains("error") || msg.contains("Error"),
+        "error message should describe the failure; got: {msg}"
+    );
+    assert!(
+        msg.contains("transclude") || msg.contains("cannot read"),
+        "error message should mention transclude or the read failure; got: {msg}"
+    );
+}
+
+// ── (b) imageDimensions warning — build succeeds ───────────────────────────
+
+/// Armed pipeline + missing image file → imageDimensions emits a
+/// `DiagnosticSeverity::Warning` diagnostic; the build succeeds.
+///
+/// imageDimensions can't read a local image that doesn't exist, so it emits
+/// a warning and leaves the `<img>` unchanged.  The A3 policy emits the
+/// warning to stderr and continues.
+#[test]
+fn armed_image_dimensions_missing_image_warns_and_succeeds() {
+    let Some(esbuild) = locate_esbuild() else {
+        eprintln!("[bundler_markdown_diagnostics] no esbuild binary available; skipping.");
+        return;
+    };
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+    write_common_dirs(&root);
+    // Reference a local image path that does not exist on disk.  The plugin
+    // must warn and leave the <img> element unchanged (Warning severity).
+    fs::write(
+        root.join("content/docs/index.mdx"),
+        "---\ntitle: Docs\n---\n\n![missing image](./does-not-exist.png)\n",
+    )
+    .unwrap();
+
+    let spec = armed_image_dimensions_spec(&root);
+    let input = make_base_input(&root, &esbuild, "dist-imgdim-warn", spec);
+    // Must succeed — Warning severity must not fail the build.
+    let out = bundle(input)
+        .expect("bundle should succeed with imageDimensions warning (Warning severity)");
+    assert!(
+        out.bundle_path.exists(),
+        "bundle.mjs must be written even when imageDimensions warns"
+    );
+}
+
+// ── (c) Unarmed config — zero behavior change ──────────────────────────────
+
+/// Unarmed config (no `build_context_roots`, no `features`) → the same
+/// fixture with an invalid transclude directive compiles without emitting
+/// any markdown diagnostics (the transclude plugin is not wired).
+///
+/// This guards against accidentally enabling feature plugins or the context
+/// plumbing when the config doesn't opt in.
+#[test]
+fn unarmed_config_no_new_diagnostics() {
+    let Some(esbuild) = locate_esbuild() else {
+        eprintln!("[bundler_markdown_diagnostics] no esbuild binary available; skipping.");
+        return;
+    };
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+    write_common_dirs(&root);
+    // Same fixture as the transclude test — but with an UNARMED pipeline.
+    // The :::include directive is not processed; it passes through as text,
+    // and the missing-snippet file never triggers a read → no diagnostic.
+    fs::write(
+        root.join("content/docs/index.mdx"),
+        "---\ntitle: Docs\n---\n\n:::include{file=\"./missing-snippet.md\"}\n",
+    )
+    .unwrap();
+
+    // Default (unarmed) spec — no features, no build_context_roots.
+    let input = make_base_input(&root, &esbuild, "dist-unarmed", PipelineSpec::default());
+    // Must succeed with no errors — unarmed pipeline ignores the directive.
+    let out = bundle(input).expect("unarmed bundle should succeed (no new diagnostics)");
+    assert!(
+        out.bundle_path.exists(),
+        "bundle.mjs must be written for unarmed config"
+    );
+}

--- a/crates/zfb-build/tests/bundler_md_pages.rs
+++ b/crates/zfb-build/tests/bundler_md_pages.rs
@@ -109,7 +109,12 @@ fn md_page_bundles_successfully() {
     assert!(!body.is_empty(), "bundle should be non-empty");
 
     // Route manifest includes /about.
-    let routes: Vec<&str> = out.manifest.routes.iter().map(|r| r.route.as_str()).collect();
+    let routes: Vec<&str> = out
+        .manifest
+        .routes
+        .iter()
+        .map(|r| r.route.as_str())
+        .collect();
     assert!(
         routes.contains(&"/about"),
         "manifest must include /about; got {routes:?}"
@@ -238,7 +243,12 @@ fn mdx_pages_still_work_after_md_change() {
     let body = fs::read_to_string(&out.bundle_path).expect("read bundle");
 
     // Route manifest includes /post.
-    let routes: Vec<&str> = out.manifest.routes.iter().map(|r| r.route.as_str()).collect();
+    let routes: Vec<&str> = out
+        .manifest
+        .routes
+        .iter()
+        .map(|r| r.route.as_str())
+        .collect();
     assert!(
         routes.contains(&"/post"),
         "manifest must include /post; got {routes:?}"

--- a/crates/zfb-build/tests/bundler_resolve_links.rs
+++ b/crates/zfb-build/tests/bundler_resolve_links.rs
@@ -229,9 +229,7 @@ fn resolve_links_good_link_rewrites_to_route_url() {
 #[test]
 fn resolve_links_warn_mode_succeeds_despite_broken_link() {
     let Some(esbuild) = locate_esbuild() else {
-        eprintln!(
-            "[bundler_resolve_links] no esbuild binary available; skipping."
-        );
+        eprintln!("[bundler_resolve_links] no esbuild binary available; skipping.");
         return;
     };
 
@@ -250,9 +248,7 @@ fn resolve_links_warn_mode_succeeds_despite_broken_link() {
 #[test]
 fn resolve_links_error_mode_fails_on_broken_link() {
     let Some(esbuild) = locate_esbuild() else {
-        eprintln!(
-            "[bundler_resolve_links] no esbuild binary available; skipping."
-        );
+        eprintln!("[bundler_resolve_links] no esbuild binary available; skipping.");
         return;
     };
 
@@ -261,9 +257,8 @@ fn resolve_links_error_mode_fails_on_broken_link() {
     write_fixture_project(&root);
 
     let input = make_input_with_resolve(&root, &esbuild, "dist-c", OnBrokenLinks::Error);
-    let err = bundle(input).expect_err(
-        "bundle should fail with onBrokenLinks: error when broken links exist",
-    );
+    let err = bundle(input)
+        .expect_err("bundle should fail with onBrokenLinks: error when broken links exist");
     let msg = format!("{err:#}");
     // The error message must identify the broken link.
     assert!(
@@ -281,9 +276,7 @@ fn resolve_links_error_mode_fails_on_broken_link() {
 #[test]
 fn resolve_links_disabled_preserves_raw_mdx_hrefs() {
     let Some(esbuild) = locate_esbuild() else {
-        eprintln!(
-            "[bundler_resolve_links] no esbuild binary available; skipping."
-        );
+        eprintln!("[bundler_resolve_links] no esbuild binary available; skipping.");
         return;
     };
 

--- a/crates/zfb-build/tests/bundler_strip_md_ext.rs
+++ b/crates/zfb-build/tests/bundler_strip_md_ext.rs
@@ -204,9 +204,7 @@ fn strip_md_ext_off_preserves_md_hrefs() {
     // verbatim into the bundle. This pins the "opt-in by default"
     // contract from the issue.
     let Some(esbuild) = locate_esbuild() else {
-        eprintln!(
-            "[bundler_strip_md_ext] no esbuild binary available; skipping."
-        );
+        eprintln!("[bundler_strip_md_ext] no esbuild binary available; skipping.");
         return;
     };
 

--- a/crates/zfb-build/tests/embedded_v8_snapshot_e2e.rs
+++ b/crates/zfb-build/tests/embedded_v8_snapshot_e2e.rs
@@ -227,16 +227,8 @@ fn snapshot_json_is_deterministic_across_calls() {
     fs::create_dir_all(&docs).unwrap();
     fs::create_dir_all(&blog).unwrap();
 
-    fs::write(
-        docs.join("zz-last.md"),
-        "---\ntitle: \"Z\"\n---\nlast\n",
-    )
-    .unwrap();
-    fs::write(
-        docs.join("aa-first.md"),
-        "---\ntitle: \"A\"\n---\nfirst\n",
-    )
-    .unwrap();
+    fs::write(docs.join("zz-last.md"), "---\ntitle: \"Z\"\n---\nlast\n").unwrap();
+    fs::write(docs.join("aa-first.md"), "---\ntitle: \"A\"\n---\nfirst\n").unwrap();
     fs::write(
         blog.join("beta.md"),
         "---\ntitle: \"Beta\"\n---\nbeta body\n",
@@ -323,16 +315,8 @@ fn snapshot_json_is_stable_under_reversed_config_order() {
     let b_dir = fixture_tmp.path().join("b");
     fs::create_dir_all(&a_dir).unwrap();
     fs::create_dir_all(&b_dir).unwrap();
-    fs::write(
-        a_dir.join("one.md"),
-        "---\ntitle: \"One\"\n---\none\n",
-    )
-    .unwrap();
-    fs::write(
-        b_dir.join("two.md"),
-        "---\ntitle: \"Two\"\n---\ntwo\n",
-    )
-    .unwrap();
+    fs::write(a_dir.join("one.md"), "---\ntitle: \"One\"\n---\none\n").unwrap();
+    fs::write(b_dir.join("two.md"), "---\ntitle: \"Two\"\n---\ntwo\n").unwrap();
 
     let forward = vec![
         CollectionConfig::new("a", &a_dir),
@@ -343,14 +327,10 @@ fn snapshot_json_is_stable_under_reversed_config_order() {
         CollectionConfig::new("a", &a_dir),
     ];
 
-    let json_fwd = serde_json::to_string(
-        &build_snapshot(&forward).expect("forward snapshot"),
-    )
-    .expect("serialize forward");
-    let json_rev = serde_json::to_string(
-        &build_snapshot(&reversed).expect("reversed snapshot"),
-    )
-    .expect("serialize reversed");
+    let json_fwd = serde_json::to_string(&build_snapshot(&forward).expect("forward snapshot"))
+        .expect("serialize forward");
+    let json_rev = serde_json::to_string(&build_snapshot(&reversed).expect("reversed snapshot"))
+        .expect("serialize reversed");
 
     let hash_fwd = {
         let mut h = Sha256::new();
@@ -680,8 +660,7 @@ async fn embedded_v8_renders_page_with_snapshot_data() {
     };
 
     let out = bundle(input).expect("bundle should succeed for fixture project");
-    let bundle_source = fs::read_to_string(&out.bundle_path)
-        .expect("read produced bundle.mjs");
+    let bundle_source = fs::read_to_string(&out.bundle_path).expect("read produced bundle.mjs");
 
     // Spot-check: the snapshot literal made it into the bundle. This
     // guarantees the bundler-level wiring is correct; the V8 host
@@ -705,7 +684,8 @@ async fn embedded_v8_renders_page_with_snapshot_data() {
         .unwrap_or_else(|e| panic!("dispatch / failed: {e}"));
 
     assert_eq!(
-        resp.status, 200,
+        resp.status,
+        200,
         "homepage must render 200; got status {}, body={:?}",
         resp.status,
         resp.body_utf8(),
@@ -876,7 +856,8 @@ async fn embedded_v8_md_page_renders_to_html() {
         .unwrap_or_else(|e| panic!("dispatch /about failed: {e}"));
 
     assert_eq!(
-        resp.status, 200,
+        resp.status,
+        200,
         "/about must render 200; got status {}, body={:?}",
         resp.status,
         resp.body_utf8(),
@@ -932,9 +913,7 @@ fn html_page_written_verbatim_via_render_all() {
     // never reach the backend for the legal route.
     let backend = Backend::Stub {
         handler: Arc::new(|path: &str| {
-            panic!(
-                "backend must not be dispatched for static_html routes; got path: {path}"
-            )
+            panic!("backend must not be dispatched for static_html routes; got path: {path}")
         }),
     };
 
@@ -1364,8 +1343,8 @@ async fn paths_worker_resolves_collection_across_dual_zfb_instances() {
          zfb/content instance broke the snapshot bridge again. body: {body}"
     );
 
-    let json: serde_json::Value =
-        serde_json::from_str(&body).unwrap_or_else(|e| panic!("paths() body is not JSON: {e} — body: {body}"));
+    let json: serde_json::Value = serde_json::from_str(&body)
+        .unwrap_or_else(|e| panic!("paths() body is not JSON: {e} — body: {body}"));
     let arr = json
         .as_array()
         .unwrap_or_else(|| panic!("paths() must return a JSON array; got: {body}"));

--- a/crates/zfb-build/tests/integration_dev_loop.rs
+++ b/crates/zfb-build/tests/integration_dev_loop.rs
@@ -115,7 +115,10 @@ fn touching_a_md_file_only_rerenders_its_page() {
     // The post.html exists on disk.
     let post_html = project.join("dist/post.html");
     assert!(post_html.exists(), "post.html should exist");
-    assert_eq!(std::fs::read_to_string(&post_html).unwrap(), "<h1>post</h1>");
+    assert_eq!(
+        std::fs::read_to_string(&post_html).unwrap(),
+        "<h1>post</h1>"
+    );
 }
 
 #[test]
@@ -130,10 +133,7 @@ fn editing_a_global_css_file_triggers_css_only_rebuild() {
 
     // Graph has one page that does NOT depend on the CSS file directly.
     let mut g = DependencyGraph::new();
-    g.upsert(PageDeps::new(
-        pid(project.join("pages/index.tsx")),
-        vec![],
-    ));
+    g.upsert(PageDeps::new(pid(project.join("pages/index.tsx")), vec![]));
     let graph = Arc::new(Mutex::new(g));
 
     let css_runs = Arc::new(AtomicUsize::new(0));
@@ -273,7 +273,11 @@ fn editing_a_use_client_component_re_bundles_islands_without_full_rerender() {
     assert!(rendered_pages.contains(&pid(project.join("pages/a.tsx"))));
     assert!(!rendered_pages.contains(&pid(project.join("pages/b.tsx"))));
 
-    assert_eq!(css_runs.load(Ordering::SeqCst), 0, "css callback not called");
+    assert_eq!(
+        css_runs.load(Ordering::SeqCst),
+        0,
+        "css callback not called"
+    );
     assert_eq!(islands_runs.load(Ordering::SeqCst), 1);
 }
 
@@ -682,7 +686,11 @@ fn created_content_file_with_discovery_emits_new_url() {
 
     // The discovery hook saw exactly the created path, once.
     let invs = hook_invocations.lock().unwrap();
-    assert_eq!(invs.len(), 1, "discovery hook called once for the Created tick");
+    assert_eq!(
+        invs.len(),
+        1,
+        "discovery hook called once for the Created tick"
+    );
     assert_eq!(invs[0], vec![new_post]);
 }
 
@@ -865,7 +873,11 @@ fn route_deletion_prunes_stale_html() {
         .tick(vec![md_path.clone()], &ctx)
         .expect("tick ok")
         .expect("non-noop");
-    assert_eq!(outcome1.pages_written.len(), 1, "initial render wrote post.html");
+    assert_eq!(
+        outcome1.pages_written.len(),
+        1,
+        "initial render wrote post.html"
+    );
     assert!(
         project.join("dist/post.html").exists(),
         "post.html must exist after initial render",
@@ -874,7 +886,10 @@ fn route_deletion_prunes_stale_html() {
     // Simulate content file deletion: clear the route table (as
     // `refresh_bundle_and_routes` would do) and set the vanished path so
     // reload_renderer reports it.
-    routes.lock().unwrap().remove(&project.join("pages/post.tsx"));
+    routes
+        .lock()
+        .unwrap()
+        .remove(&project.join("pages/post.tsx"));
     vanished.lock().unwrap().push(PathBuf::from("post.html"));
 
     // Tick 2: content file Removed.
@@ -885,11 +900,7 @@ fn route_deletion_prunes_stale_html() {
     // returning [dist/post.html]. The route table is empty so the render
     // produces nothing. The prune loop then deletes dist/post.html.
     let outcome2 = orch
-        .tick_with_kinds(
-            vec![(md_path, ChangeKind::Removed)],
-            &ctx,
-            None,
-        )
+        .tick_with_kinds(vec![(md_path, ChangeKind::Removed)], &ctx, None)
         .expect("tick ok")
         .expect("Removed tick must be non-noop — former consumer is in the plan");
 
@@ -899,7 +910,9 @@ fn route_deletion_prunes_stale_html() {
         outcome2.pages_pruned,
     );
     assert!(
-        outcome2.pages_pruned.contains(&project.join("dist/post.html")),
+        outcome2
+            .pages_pruned
+            .contains(&project.join("dist/post.html")),
         "pages_pruned must contain dist/post.html; got {:?}",
         outcome2.pages_pruned,
     );
@@ -926,10 +939,7 @@ fn route_rename_prunes_old_and_writes_new() {
 
     // Initial: slug.tsx → old.html
     let mut t = std::collections::HashMap::new();
-    t.insert(
-        project.join("pages/slug.tsx"),
-        vec!["old.html".to_string()],
-    );
+    t.insert(project.join("pages/slug.tsx"), vec!["old.html".to_string()]);
     let routes = Arc::new(Mutex::new(t));
     let vanished: Arc<Mutex<Vec<PathBuf>>> = Arc::new(Mutex::new(Vec::new()));
 
@@ -946,15 +956,15 @@ fn route_rename_prunes_old_and_writes_new() {
         .expect("tick ok")
         .expect("non-noop");
     assert_eq!(outcome1.pages_written.len(), 1);
-    assert!(project.join("dist/old.html").exists(), "old.html must exist");
+    assert!(
+        project.join("dist/old.html").exists(),
+        "old.html must exist"
+    );
 
     // Rename: route table changes to new.html; old.html is vanished.
     {
         let mut t = routes.lock().unwrap();
-        t.insert(
-            project.join("pages/slug.tsx"),
-            vec!["new.html".to_string()],
-        );
+        t.insert(project.join("pages/slug.tsx"), vec!["new.html".to_string()]);
     }
     vanished.lock().unwrap().push(PathBuf::from("old.html"));
 
@@ -979,7 +989,9 @@ fn route_rename_prunes_old_and_writes_new() {
         "new.html must exist after rename",
     );
     assert!(
-        outcome2.pages_pruned.contains(&project.join("dist/old.html")),
+        outcome2
+            .pages_pruned
+            .contains(&project.join("dist/old.html")),
         "pages_pruned must contain old.html",
     );
 }
@@ -1011,10 +1023,7 @@ fn lose_gain_same_path_keeps_html_alive() {
 
     // Initial state: A → shared.html; B → b.html
     let mut t = std::collections::HashMap::new();
-    t.insert(
-        project.join("pages/a.tsx"),
-        vec!["shared.html".to_string()],
-    );
+    t.insert(project.join("pages/a.tsx"), vec!["shared.html".to_string()]);
     t.insert(project.join("pages/b.tsx"), vec!["b.html".to_string()]);
     let routes = Arc::new(Mutex::new(t));
     let vanished: Arc<Mutex<Vec<PathBuf>>> = Arc::new(Mutex::new(Vec::new()));
@@ -1041,10 +1050,7 @@ fn lose_gain_same_path_keeps_html_alive() {
     {
         let mut t = routes.lock().unwrap();
         t.insert(project.join("pages/a.tsx"), vec!["a.html".to_string()]);
-        t.insert(
-            project.join("pages/b.tsx"),
-            vec!["shared.html".to_string()],
-        );
+        t.insert(project.join("pages/b.tsx"), vec!["shared.html".to_string()]);
     }
     vanished.lock().unwrap().push(PathBuf::from("shared.html"));
 
@@ -1120,13 +1126,9 @@ fn removed_content_file_drops_graph_edge() {
     let md_path = project.join("content/post.md");
 
     // Tick 1: Modified → consumer page re-renders.
-    orch.tick_with_kinds(
-        vec![(md_path.clone(), ChangeKind::Modified)],
-        &ctx,
-        None,
-    )
-    .expect("tick ok")
-    .expect("non-noop");
+    orch.tick_with_kinds(vec![(md_path.clone(), ChangeKind::Modified)], &ctx, None)
+        .expect("tick ok")
+        .expect("non-noop");
     assert_eq!(
         render_calls.lock().unwrap().len(),
         1,
@@ -1139,11 +1141,7 @@ fn removed_content_file_drops_graph_edge() {
     // consumer, but future ticks that modify the removed content file will
     // no longer dirty the consumer (the edge is gone).
     let outcome2 = orch
-        .tick_with_kinds(
-            vec![(md_path.clone(), ChangeKind::Removed)],
-            &ctx,
-            None,
-        )
+        .tick_with_kinds(vec![(md_path.clone(), ChangeKind::Removed)], &ctx, None)
         .expect("tick ok");
     // The tick is non-noop because the former consumer is in the plan.
     assert!(
@@ -1160,11 +1158,7 @@ fn removed_content_file_drops_graph_edge() {
     // After remove_node, the deleted content path is no longer in the graph.
     // A later edit of the same path must NOT dirty the consumer.
     let outcome3 = orch
-        .tick_with_kinds(
-            vec![(md_path, ChangeKind::Modified)],
-            &ctx,
-            None,
-        )
+        .tick_with_kinds(vec![(md_path, ChangeKind::Modified)], &ctx, None)
         .expect("tick ok");
     // The path is now an unknown in the graph, so plan_for_changes falls
     // back to All (conservative policy for unknowns). This is acceptable —
@@ -1559,7 +1553,11 @@ fn ssr_only_project_css_only_tick_does_not_reload_renderer() {
         "CSS-only change must NOT reload the renderer; got {:?}",
         reload_events.lock().unwrap()
     );
-    assert_eq!(css_runs.load(Ordering::SeqCst), 1, "CSS callback must run once");
+    assert_eq!(
+        css_runs.load(Ordering::SeqCst),
+        1,
+        "CSS callback must run once"
+    );
 }
 
 /// Global change on an SSR-only project: `full_rebuild` sets `ssr_reload_needed`,

--- a/crates/zfb-build/tests/integration_dev_loop.rs
+++ b/crates/zfb-build/tests/integration_dev_loop.rs
@@ -18,7 +18,8 @@ use std::time::Duration;
 use tempfile::tempdir;
 use zfb_build::{
     AssetPipeline, BuildContext, BuildOrchestrator, DevAssetPipeline, DiscoveryHook,
-    DiscoveryOutcome, OrchestratorConfig, PageSelection, RebuildPlan, RelDistPath, RenderedPage,
+    DiscoveryOutcome, OrchestratorConfig, PageSelection, RebuildPlan, RefreshOutcome, RelDistPath,
+    RenderedPage,
 };
 use zfb_graph::{DepKind, DependencyGraph, PageDeps, PageId};
 use zfb_watcher::{ChangeKind, Watcher};
@@ -827,7 +828,7 @@ fn ctx_with_route_prune(
                 .drain(..)
                 .map(|rel| dist_for_reload.join(rel))
                 .collect();
-            Ok(paths)
+            Ok(RefreshOutcome::Refreshed { vanished: paths })
         })),
     }
 }
@@ -1233,7 +1234,7 @@ impl ReloadProbe {
             run_islands: None,
             reload_renderer: Some(Arc::new(move || {
                 reload_events.lock().unwrap().push("reload");
-                Ok(vec![])
+                Ok(RefreshOutcome::Refreshed { vanished: vec![] })
             })),
         }
     }
@@ -1481,7 +1482,7 @@ fn ssr_only_project_edit_tick_reloads_renderer() {
         run_islands: None,
         reload_renderer: Some(Arc::new(move || {
             reload_events_cb.lock().unwrap().push("reload");
-            Ok(vec![])
+            Ok(RefreshOutcome::Refreshed { vanished: vec![] })
         })),
     };
 
@@ -1540,7 +1541,7 @@ fn ssr_only_project_css_only_tick_does_not_reload_renderer() {
         run_islands: None,
         reload_renderer: Some(Arc::new(move || {
             reload_events_cb.lock().unwrap().push("reload");
-            Ok(vec![])
+            Ok(RefreshOutcome::Refreshed { vanished: vec![] })
         })),
     };
 
@@ -1591,7 +1592,7 @@ fn ssr_only_project_global_change_reloads_renderer() {
         run_islands: None,
         reload_renderer: Some(Arc::new(move || {
             reload_events_cb.lock().unwrap().push("reload");
-            Ok(vec![])
+            Ok(RefreshOutcome::Refreshed { vanished: vec![] })
         })),
     };
 
@@ -1660,7 +1661,7 @@ fn removed_stylesheet_only_tick_reruns_css() {
         run_islands: None,
         reload_renderer: Some(Arc::new(move || {
             reload_events_cb.lock().unwrap().push("reload");
-            Ok(vec![])
+            Ok(RefreshOutcome::Refreshed { vanished: vec![] })
         })),
     };
 
@@ -1714,7 +1715,9 @@ fn removed_islands_module_only_tick_reruns_islands() {
             islands_runs_cb.fetch_add(1, Ordering::SeqCst);
             Ok(None)
         })),
-        reload_renderer: Some(Arc::new(|| Ok(vec![]))),
+        reload_renderer: Some(Arc::new(|| {
+            Ok(RefreshOutcome::Refreshed { vanished: vec![] })
+        })),
     };
 
     let outcome = orch
@@ -1766,7 +1769,7 @@ fn removed_ssr_source_only_tick_reloads_renderer() {
         run_islands: None,
         reload_renderer: Some(Arc::new(move || {
             reload_events_cb.lock().unwrap().push("reload");
-            Ok(vec![])
+            Ok(RefreshOutcome::Refreshed { vanished: vec![] })
         })),
     };
 

--- a/crates/zfb-build/tests/integration_dev_loop.rs
+++ b/crates/zfb-build/tests/integration_dev_loop.rs
@@ -828,7 +828,10 @@ fn ctx_with_route_prune(
                 .drain(..)
                 .map(|rel| dist_for_reload.join(rel))
                 .collect();
-            Ok(RefreshOutcome::Refreshed { vanished: paths, changed_sources: vec![] })
+            Ok(RefreshOutcome::Refreshed {
+                vanished: paths,
+                changed_sources: vec![],
+            })
         })),
     }
 }
@@ -1234,7 +1237,10 @@ impl ReloadProbe {
             run_islands: None,
             reload_renderer: Some(Arc::new(move || {
                 reload_events.lock().unwrap().push("reload");
-                Ok(RefreshOutcome::Refreshed { vanished: vec![], changed_sources: vec![] })
+                Ok(RefreshOutcome::Refreshed {
+                    vanished: vec![],
+                    changed_sources: vec![],
+                })
             })),
         }
     }
@@ -1482,7 +1488,10 @@ fn ssr_only_project_edit_tick_reloads_renderer() {
         run_islands: None,
         reload_renderer: Some(Arc::new(move || {
             reload_events_cb.lock().unwrap().push("reload");
-            Ok(RefreshOutcome::Refreshed { vanished: vec![], changed_sources: vec![] })
+            Ok(RefreshOutcome::Refreshed {
+                vanished: vec![],
+                changed_sources: vec![],
+            })
         })),
     };
 
@@ -1541,7 +1550,10 @@ fn ssr_only_project_css_only_tick_does_not_reload_renderer() {
         run_islands: None,
         reload_renderer: Some(Arc::new(move || {
             reload_events_cb.lock().unwrap().push("reload");
-            Ok(RefreshOutcome::Refreshed { vanished: vec![], changed_sources: vec![] })
+            Ok(RefreshOutcome::Refreshed {
+                vanished: vec![],
+                changed_sources: vec![],
+            })
         })),
     };
 
@@ -1592,7 +1604,10 @@ fn ssr_only_project_global_change_reloads_renderer() {
         run_islands: None,
         reload_renderer: Some(Arc::new(move || {
             reload_events_cb.lock().unwrap().push("reload");
-            Ok(RefreshOutcome::Refreshed { vanished: vec![], changed_sources: vec![] })
+            Ok(RefreshOutcome::Refreshed {
+                vanished: vec![],
+                changed_sources: vec![],
+            })
         })),
     };
 
@@ -1661,7 +1676,10 @@ fn removed_stylesheet_only_tick_reruns_css() {
         run_islands: None,
         reload_renderer: Some(Arc::new(move || {
             reload_events_cb.lock().unwrap().push("reload");
-            Ok(RefreshOutcome::Refreshed { vanished: vec![], changed_sources: vec![] })
+            Ok(RefreshOutcome::Refreshed {
+                vanished: vec![],
+                changed_sources: vec![],
+            })
         })),
     };
 
@@ -1716,7 +1734,10 @@ fn removed_islands_module_only_tick_reruns_islands() {
             Ok(None)
         })),
         reload_renderer: Some(Arc::new(|| {
-            Ok(RefreshOutcome::Refreshed { vanished: vec![], changed_sources: vec![] })
+            Ok(RefreshOutcome::Refreshed {
+                vanished: vec![],
+                changed_sources: vec![],
+            })
         })),
     };
 
@@ -1769,7 +1790,10 @@ fn removed_ssr_source_only_tick_reloads_renderer() {
         run_islands: None,
         reload_renderer: Some(Arc::new(move || {
             reload_events_cb.lock().unwrap().push("reload");
-            Ok(RefreshOutcome::Refreshed { vanished: vec![], changed_sources: vec![] })
+            Ok(RefreshOutcome::Refreshed {
+                vanished: vec![],
+                changed_sources: vec![],
+            })
         })),
     };
 

--- a/crates/zfb-build/tests/integration_dev_loop.rs
+++ b/crates/zfb-build/tests/integration_dev_loop.rs
@@ -68,7 +68,7 @@ fn touching_a_md_file_only_rerenders_its_page() {
     let project_path = project.to_path_buf();
     let ctx = BuildContext {
         dist_root: project.join("dist"),
-        render_pages: Arc::new(move |pages: &[PageId]| {
+        render_pages: Arc::new(move |pages: &[PageId], _narrowing| {
             render_calls_for_cb.lock().unwrap().push(pages.to_vec());
             Ok(pages
                 .iter()
@@ -153,7 +153,7 @@ fn editing_a_global_css_file_triggers_css_only_rebuild() {
 
     let ctx = BuildContext {
         dist_root: project.join("dist"),
-        render_pages: Arc::new(move |_| {
+        render_pages: Arc::new(move |_, _| {
             render_runs_cb.fetch_add(1, Ordering::SeqCst);
             Ok(vec![])
         }),
@@ -228,7 +228,7 @@ fn editing_a_use_client_component_re_bundles_islands_without_full_rerender() {
 
     let ctx = BuildContext {
         dist_root: project.join("dist"),
-        render_pages: Arc::new(move |pages: &[PageId]| {
+        render_pages: Arc::new(move |pages: &[PageId], _narrowing| {
             render_calls_cb.lock().unwrap().push(pages.to_vec());
             Ok(pages
                 .iter()
@@ -329,7 +329,7 @@ async fn touching_md_via_real_watcher_triggers_one_page_rebuild() {
 
     let ctx = BuildContext {
         dist_root: project.join("dist"),
-        render_pages: Arc::new(move |pages: &[PageId]| {
+        render_pages: Arc::new(move |pages: &[PageId], _narrowing| {
             render_calls_cb.lock().unwrap().push(pages.to_vec());
             Ok(pages
                 .iter()
@@ -511,7 +511,7 @@ fn fanout_ctx(
 ) -> BuildContext {
     BuildContext {
         dist_root: project.join("dist"),
-        render_pages: Arc::new(move |pages: &[PageId]| {
+        render_pages: Arc::new(move |pages: &[PageId], _narrowing| {
             render_calls.lock().unwrap().push(pages.to_vec());
             let table = routes.lock().unwrap();
             let mut out = Vec::new();
@@ -801,7 +801,7 @@ fn ctx_with_route_prune(
     let vanished_for_reload = vanished.clone();
     BuildContext {
         dist_root: dist,
-        render_pages: Arc::new(move |pages: &[PageId]| {
+        render_pages: Arc::new(move |pages: &[PageId], _narrowing| {
             let table = routes_for_render.lock().unwrap();
             let mut out = Vec::new();
             for p in pages {
@@ -828,7 +828,7 @@ fn ctx_with_route_prune(
                 .drain(..)
                 .map(|rel| dist_for_reload.join(rel))
                 .collect();
-            Ok(RefreshOutcome::Refreshed { vanished: paths })
+            Ok(RefreshOutcome::Refreshed { vanished: paths, changed_sources: vec![] })
         })),
     }
 }
@@ -1101,7 +1101,7 @@ fn removed_content_file_drops_graph_edge() {
     let render_calls_cb = render_calls.clone();
     let ctx = BuildContext {
         dist_root: project.join("dist"),
-        render_pages: Arc::new(move |pages: &[PageId]| {
+        render_pages: Arc::new(move |pages: &[PageId], _narrowing| {
             render_calls_cb.lock().unwrap().push(pages.to_vec());
             Ok(pages
                 .iter()
@@ -1214,7 +1214,7 @@ impl ReloadProbe {
         let reload_events = self.events.clone();
         BuildContext {
             dist_root: project.join("dist"),
-            render_pages: Arc::new(move |pages: &[PageId]| {
+            render_pages: Arc::new(move |pages: &[PageId], _narrowing| {
                 render_events.lock().unwrap().push("render");
                 Ok(pages
                     .iter()
@@ -1234,7 +1234,7 @@ impl ReloadProbe {
             run_islands: None,
             reload_renderer: Some(Arc::new(move || {
                 reload_events.lock().unwrap().push("reload");
-                Ok(RefreshOutcome::Refreshed { vanished: vec![] })
+                Ok(RefreshOutcome::Refreshed { vanished: vec![], changed_sources: vec![] })
             })),
         }
     }
@@ -1477,12 +1477,12 @@ fn ssr_only_project_edit_tick_reloads_renderer() {
     let ctx = BuildContext {
         dist_root: project.join("dist"),
         // SSR-only: render_pages returns nothing (no SSG pages).
-        render_pages: Arc::new(|_pages| Ok(vec![])),
+        render_pages: Arc::new(|_pages, _| Ok(vec![])),
         run_css: None,
         run_islands: None,
         reload_renderer: Some(Arc::new(move || {
             reload_events_cb.lock().unwrap().push("reload");
-            Ok(RefreshOutcome::Refreshed { vanished: vec![] })
+            Ok(RefreshOutcome::Refreshed { vanished: vec![], changed_sources: vec![] })
         })),
     };
 
@@ -1533,7 +1533,7 @@ fn ssr_only_project_css_only_tick_does_not_reload_renderer() {
     let css_runs_cb = css_runs.clone();
     let ctx = BuildContext {
         dist_root: project.join("dist"),
-        render_pages: Arc::new(|_| Ok(vec![])),
+        render_pages: Arc::new(|_, _| Ok(vec![])),
         run_css: Some(Arc::new(move || {
             css_runs_cb.fetch_add(1, Ordering::SeqCst);
             Ok(true)
@@ -1541,7 +1541,7 @@ fn ssr_only_project_css_only_tick_does_not_reload_renderer() {
         run_islands: None,
         reload_renderer: Some(Arc::new(move || {
             reload_events_cb.lock().unwrap().push("reload");
-            Ok(RefreshOutcome::Refreshed { vanished: vec![] })
+            Ok(RefreshOutcome::Refreshed { vanished: vec![], changed_sources: vec![] })
         })),
     };
 
@@ -1587,12 +1587,12 @@ fn ssr_only_project_global_change_reloads_renderer() {
     );
     let ctx = BuildContext {
         dist_root: project.join("dist"),
-        render_pages: Arc::new(|_| Ok(vec![])),
+        render_pages: Arc::new(|_, _| Ok(vec![])),
         run_css: None,
         run_islands: None,
         reload_renderer: Some(Arc::new(move || {
             reload_events_cb.lock().unwrap().push("reload");
-            Ok(RefreshOutcome::Refreshed { vanished: vec![] })
+            Ok(RefreshOutcome::Refreshed { vanished: vec![], changed_sources: vec![] })
         })),
     };
 
@@ -1653,7 +1653,7 @@ fn removed_stylesheet_only_tick_reruns_css() {
     );
     let ctx = BuildContext {
         dist_root: project.join("dist"),
-        render_pages: Arc::new(|_| Ok(vec![])),
+        render_pages: Arc::new(|_, _| Ok(vec![])),
         run_css: Some(Arc::new(move || {
             css_runs_cb.fetch_add(1, Ordering::SeqCst);
             Ok(true)
@@ -1661,7 +1661,7 @@ fn removed_stylesheet_only_tick_reruns_css() {
         run_islands: None,
         reload_renderer: Some(Arc::new(move || {
             reload_events_cb.lock().unwrap().push("reload");
-            Ok(RefreshOutcome::Refreshed { vanished: vec![] })
+            Ok(RefreshOutcome::Refreshed { vanished: vec![], changed_sources: vec![] })
         })),
     };
 
@@ -1709,14 +1709,14 @@ fn removed_islands_module_only_tick_reruns_islands() {
     );
     let ctx = BuildContext {
         dist_root: project.join("dist"),
-        render_pages: Arc::new(|_| Ok(vec![])),
+        render_pages: Arc::new(|_, _| Ok(vec![])),
         run_css: None,
         run_islands: Some(Arc::new(move || {
             islands_runs_cb.fetch_add(1, Ordering::SeqCst);
             Ok(None)
         })),
         reload_renderer: Some(Arc::new(|| {
-            Ok(RefreshOutcome::Refreshed { vanished: vec![] })
+            Ok(RefreshOutcome::Refreshed { vanished: vec![], changed_sources: vec![] })
         })),
     };
 
@@ -1764,12 +1764,12 @@ fn removed_ssr_source_only_tick_reloads_renderer() {
     );
     let ctx = BuildContext {
         dist_root: project.join("dist"),
-        render_pages: Arc::new(|_| Ok(vec![])),
+        render_pages: Arc::new(|_, _| Ok(vec![])),
         run_css: None,
         run_islands: None,
         reload_renderer: Some(Arc::new(move || {
             reload_events_cb.lock().unwrap().push("reload");
-            Ok(RefreshOutcome::Refreshed { vanished: vec![] })
+            Ok(RefreshOutcome::Refreshed { vanished: vec![], changed_sources: vec![] })
         })),
     };
 

--- a/crates/zfb-build/tests/migration_fixes_integration_confirm.rs
+++ b/crates/zfb-build/tests/migration_fixes_integration_confirm.rs
@@ -44,7 +44,10 @@ use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::PathBuf;
 
-use zfb_build::{bundle, BundleMode, BundlerInput, ContentCollectionSpec, OnBrokenLinks, ResolveMarkdownLinksRoute, ResolveMarkdownLinksSpec};
+use zfb_build::{
+    bundle, BundleMode, BundlerInput, ContentCollectionSpec, OnBrokenLinks,
+    ResolveMarkdownLinksRoute, ResolveMarkdownLinksSpec,
+};
 use zfb_render::adapters::Framework;
 use zfb_test_utils::locate_esbuild;
 
@@ -92,9 +95,7 @@ fn write_cjs_only_pkg_for_confirm(root: &std::path::Path, name: &str) {
     fs::create_dir_all(pkg.join("dist")).unwrap();
     fs::write(
         pkg.join("package.json"),
-        format!(
-            r#"{{ "name": "{name}", "version": "6.3.0", "main": "dist/index.js" }}"#
-        ),
+        format!(r#"{{ "name": "{name}", "version": "6.3.0", "main": "dist/index.js" }}"#),
     )
     .unwrap();
     // CJS body — top-level module.exports, no ESM fallback.
@@ -424,10 +425,7 @@ fn write_full_fixture(root: &std::path::Path) {
 }
 
 /// Build the bundler input for the full integration fixture.
-fn make_full_fixture_input(
-    root: &std::path::Path,
-    esbuild: &std::path::Path,
-) -> BundlerInput {
+fn make_full_fixture_input(root: &std::path::Path, esbuild: &std::path::Path) -> BundlerInput {
     BundlerInput {
         main_fields: Vec::new(),
         project_root: root.to_path_buf(),
@@ -533,9 +531,7 @@ fn full_fixture_bundles_without_error() {
 #[test]
 fn full_fixture_bundle_contains_inspiredgithub_class() {
     let Some(esbuild) = locate_esbuild() else {
-        eprintln!(
-            "[migration_fixes_integration_confirm] no esbuild binary; skipping."
-        );
+        eprintln!("[migration_fixes_integration_confirm] no esbuild binary; skipping.");
         return;
     };
 
@@ -564,9 +560,7 @@ fn full_fixture_bundle_contains_inspiredgithub_class() {
 #[test]
 fn full_fixture_bundle_rewrites_good_mdx_link() {
     let Some(esbuild) = locate_esbuild() else {
-        eprintln!(
-            "[migration_fixes_integration_confirm] no esbuild binary; skipping."
-        );
+        eprintln!("[migration_fixes_integration_confirm] no esbuild binary; skipping.");
         return;
     };
 
@@ -602,9 +596,7 @@ fn full_fixture_bundle_rewrites_good_mdx_link() {
 #[test]
 fn full_fixture_bundle_contains_admonition_title() {
     let Some(esbuild) = locate_esbuild() else {
-        eprintln!(
-            "[migration_fixes_integration_confirm] no esbuild binary; skipping."
-        );
+        eprintln!("[migration_fixes_integration_confirm] no esbuild binary; skipping.");
         return;
     };
 
@@ -632,9 +624,7 @@ fn full_fixture_bundle_contains_admonition_title() {
 #[test]
 fn full_fixture_bundle_contains_gfm_table_components() {
     let Some(esbuild) = locate_esbuild() else {
-        eprintln!(
-            "[migration_fixes_integration_confirm] no esbuild binary; skipping."
-        );
+        eprintln!("[migration_fixes_integration_confirm] no esbuild binary; skipping.");
         return;
     };
 
@@ -720,12 +710,11 @@ fn zzmod_all_five_migration_fixes_compose() {
             };
         "#;
 
-        let val = ThreadedConfigEvaluator::eval_bundle(config_js)
-            .expect(
-                "#663 regression: new URL(...) must be available in the config-eval isolate — \
+        let val = ThreadedConfigEvaluator::eval_bundle(config_js).expect(
+            "#663 regression: new URL(...) must be available in the config-eval isolate — \
                  the WEB_POLYFILLS bootstrap in ThreadedConfigEvaluator must install URL before \
-                 the user's config bundle runs"
-            );
+                 the user's config bundle runs",
+        );
 
         assert_eq!(
             val["_urlPathnameCheck"], "/docs/",

--- a/crates/zfb-build/tests/prod_asset_graph_e2e.rs
+++ b/crates/zfb-build/tests/prod_asset_graph_e2e.rs
@@ -167,7 +167,10 @@ fn discover_css_source_files(project_root: &Path) -> Vec<PathBuf> {
         if !dir.is_dir() {
             continue;
         }
-        for entry in walkdir::WalkDir::new(&dir).into_iter().filter_map(|r| r.ok()) {
+        for entry in walkdir::WalkDir::new(&dir)
+            .into_iter()
+            .filter_map(|r| r.ok())
+        {
             if !entry.file_type().is_file() {
                 continue;
             }
@@ -701,7 +704,11 @@ fn prod_asset_graph_with_real_tailwind_binary_against_fixture() {
     let mut tw_cfg = TailwindSubprocessConfig::default()
         .with_working_dir(fixture.project_root.path().to_path_buf())
         .with_content_globs(content_globs);
-    let global_css = fixture.project_root.path().join("styles").join("global.css");
+    let global_css = fixture
+        .project_root
+        .path()
+        .join("styles")
+        .join("global.css");
     if global_css.is_file() {
         tw_cfg = tw_cfg.with_input_css(global_css);
     }
@@ -851,7 +858,12 @@ fn prod_asset_graph_ships_dynamic_import_chunks_verbatim() {
         .unwrap_or_else(|| panic!("no hashed CSS file in {entries:?}"));
     let islands_entry_name = entries
         .iter()
-        .find(|n| n.starts_with("islands-") && n.ends_with(".js") && n.contains('-') && !n.contains("chunk"))
+        .find(|n| {
+            n.starts_with("islands-")
+                && n.ends_with(".js")
+                && n.contains('-')
+                && !n.contains("chunk")
+        })
         .unwrap_or_else(|| panic!("no hashed islands entry in {entries:?}"));
     let chunk_on_disk = entries
         .iter()
@@ -873,7 +885,10 @@ fn prod_asset_graph_ships_dynamic_import_chunks_verbatim() {
 
     // The hashed entry exists and is non-empty.
     let entry_bytes_on_disk = fs::read(assets_dir.join(islands_entry_name)).unwrap();
-    assert!(!entry_bytes_on_disk.is_empty(), "hashed islands entry must be non-empty");
+    assert!(
+        !entry_bytes_on_disk.is_empty(),
+        "hashed islands entry must be non-empty"
+    );
 
     // HTML references only the HASHED ENTRY — never a chunk filename.
     let hashed_islands_url = format!("/assets/{islands_entry_name}");

--- a/crates/zfb-build/tests/worker_only_routes_filter.rs
+++ b/crates/zfb-build/tests/worker_only_routes_filter.rs
@@ -134,8 +134,7 @@ fn ssr_catchall_survives_worker_only_routes_filter() {
         .find(|r| r.route == "/api/admin/[...adminPath]")
         .expect("catch-all route should be in the manifest");
     assert_eq!(
-        catchall_entry.entry_key,
-        "/api/admin/:adminPath{.+}",
+        catchall_entry.entry_key, "/api/admin/:adminPath{.+}",
         "entry_key must be Hono-form so worker_only_routes filter can match catch-alls"
     );
 
@@ -145,10 +144,7 @@ fn ssr_catchall_survives_worker_only_routes_filter() {
     //    this string would be absent from the bundle body.
     assert!(out.bundle_path.exists(), "bundle.mjs should exist");
     let body = fs::read_to_string(&out.bundle_path).expect("read bundle");
-    assert!(
-        !body.is_empty(),
-        "bundle body should be non-empty"
-    );
+    assert!(!body.is_empty(), "bundle body should be non-empty");
     assert!(
         body.contains(":adminPath{.+}"),
         "bundle must contain the catch-all Hono route template `:adminPath{{.+}}` — \

--- a/crates/zfb-content/src/collection.rs
+++ b/crates/zfb-content/src/collection.rs
@@ -319,6 +319,53 @@ pub fn maybe_strip_specifier_suffix(specifier: &str, suffix: Option<&str>) -> St
     format!("{scheme}://{col}/{stripped_slug}#{hash}")
 }
 
+/// Derive the slug the collection walker would assign to `file` under the
+/// collection root `root`, or `None` when the walker would not pick the
+/// file up at all: outside `root`, not a recognised entry extension
+/// (`.md` / `.mdx` / `.tsx`), inside a dot-directory or itself a dotfile
+/// (mirroring `collect_collection_files`'s skip), or rejected by the
+/// filter's include / exclude globs.
+///
+/// Mirrors `parse_entry`'s derivation exactly — POSIX-normalised relative
+/// path, one trailing `.md` / `.mdx` / `.tsx` stripped in that order, then
+/// [`maybe_strip_slug_suffix`]. Issue #958's content-edit narrowing maps
+/// a changed file back to its route params through this helper; routing
+/// the candidate derivation through here keeps it drift-free against the
+/// walker's semantics.
+#[must_use]
+pub fn derive_slug_for_file(root: &Path, file: &Path, filter: &CollectionFilter) -> Option<String> {
+    let rel_path = file.strip_prefix(root).ok()?;
+    // The walker skips dotfiles and never recurses into dot-directories
+    // (`collect_collection_files`); a dot-component anywhere below the
+    // root means the file is not a collection member.
+    if rel_path
+        .components()
+        .any(|c| c.as_os_str().to_str().is_none_or(|s| s.starts_with('.')))
+    {
+        return None;
+    }
+    if !is_collection_entry(file) {
+        return None;
+    }
+    let lossy = rel_path.to_string_lossy();
+    let posix = if std::path::MAIN_SEPARATOR == '/' {
+        lossy.into_owned()
+    } else {
+        lossy.replace(std::path::MAIN_SEPARATOR, "/")
+    };
+    if !filter.matches(&posix) {
+        return None;
+    }
+    let stripped = ["md", "mdx", "tsx"]
+        .iter()
+        .find_map(|ext| {
+            let needle = format!(".{ext}");
+            posix.strip_suffix(&needle).map(str::to_owned)
+        })
+        .unwrap_or(posix);
+    Some(maybe_strip_slug_suffix(&stripped, filter.id_strip_suffix()).to_string())
+}
+
 /// Walk a collection directory, parsing + validating each `.md`, `.mdx`,
 /// or `.tsx` file.
 ///
@@ -1615,5 +1662,66 @@ declare module \"zfb/content\" {\n\
         let out: Vec<Entry<TestSchema>> = walk_collection(tmp.path(), None).unwrap();
         assert_eq!(out.len(), 1, "only entry.md should be returned; data files must be skipped");
         assert_eq!(out[0].slug, "entry");
+    }
+
+    /// `derive_slug_for_file` (issue #958) must mirror the walker's slug
+    /// derivation: posix relative path, one trailing `.md|.mdx|.tsx`
+    /// stripped, `idStripSuffix` applied — and reject everything the
+    /// walker would not pick up.
+    #[test]
+    fn derive_slug_for_file_mirrors_walker_semantics() {
+        let root = Path::new("/proj/content/blog");
+        let none = CollectionFilter::none();
+
+        // Plain entries, nested entries, all three extensions.
+        assert_eq!(
+            derive_slug_for_file(root, Path::new("/proj/content/blog/hello.mdx"), &none),
+            Some("hello".to_string()),
+        );
+        assert_eq!(
+            derive_slug_for_file(root, Path::new("/proj/content/blog/a/b/index.md"), &none),
+            Some("a/b/index".to_string()),
+        );
+        assert_eq!(
+            derive_slug_for_file(root, Path::new("/proj/content/blog/widget.tsx"), &none),
+            Some("widget".to_string()),
+        );
+
+        // Outside the root / wrong extension / dotfile or dot-dir → None.
+        assert_eq!(
+            derive_slug_for_file(root, Path::new("/proj/pages/index.tsx"), &none),
+            None,
+        );
+        assert_eq!(
+            derive_slug_for_file(root, Path::new("/proj/content/blog/data.yaml"), &none),
+            None,
+        );
+        assert_eq!(
+            derive_slug_for_file(root, Path::new("/proj/content/blog/.draft.mdx"), &none),
+            None,
+        );
+        assert_eq!(
+            derive_slug_for_file(root, Path::new("/proj/content/blog/.git/x.mdx"), &none),
+            None,
+        );
+
+        // idStripSuffix applies exactly like the walker's parse_entry.
+        let strip = CollectionFilter::new(None, None, Some(".en")).unwrap();
+        assert_eq!(
+            derive_slug_for_file(root, Path::new("/proj/content/blog/post.en.mdx"), &strip),
+            Some("post".to_string()),
+        );
+
+        // include / exclude globs gate membership.
+        let only_en =
+            CollectionFilter::new(Some(&["**/*.en.mdx".to_string()]), None, Some(".en")).unwrap();
+        assert_eq!(
+            derive_slug_for_file(root, Path::new("/proj/content/blog/post.en.mdx"), &only_en),
+            Some("post".to_string()),
+        );
+        assert_eq!(
+            derive_slug_for_file(root, Path::new("/proj/content/blog/post.mdx"), &only_en),
+            None,
+        );
     }
 }

--- a/crates/zfb-content/src/collection.rs
+++ b/crates/zfb-content/src/collection.rs
@@ -521,10 +521,7 @@ where
 pub fn emit_types_dts(out_path: &Path, collection_names: &[&str]) -> Result<(), CollectionError> {
     let collections: Vec<CollectionTypeInfo<'_>> = collection_names
         .iter()
-        .map(|name| CollectionTypeInfo {
-            name,
-            schema: None,
-        })
+        .map(|name| CollectionTypeInfo { name, schema: None })
         .collect();
     emit_types_dts_with_schemas(out_path, &collections)
 }
@@ -720,18 +717,18 @@ where
 
     // Dispatch to the unified frontmatter API. YAML for .md/.mdx,
     // `export const frontmatter` for .tsx — both normalised to JSON.
-    let uf = frontmatter::extract(path, &raw).map_err(|e| frontmatter_to_collection_error(path, e))?;
+    let uf =
+        frontmatter::extract(path, &raw).map_err(|e| frontmatter_to_collection_error(path, e))?;
 
     // serde_json::from_value clones the JSON into the typed schema. We
     // route through JSON instead of bypassing it (e.g. via untyped
     // YAML) so schema validation downstream sees the exact same value
     // shape regardless of source kind.
-    let data: T = serde_json::from_value(uf.value.clone()).map_err(|e| {
-        CollectionError::Frontmatter {
+    let data: T =
+        serde_json::from_value(uf.value.clone()).map_err(|e| CollectionError::Frontmatter {
             path: path.to_path_buf(),
             message: e.to_string(),
-        }
-    })?;
+        })?;
 
     data.validate().map_err(|report| CollectionError::Schema {
         path: path.to_path_buf(),
@@ -797,12 +794,10 @@ where
             // emitter entirely. #46 plumbs an optional
             // [`Pipeline`] through; today's callers pass `None`.
             let compiled = compile_mdx_to_jsx_module_cached(&md_body, path, cache, pipeline)
-                .map_err(|e| {
-                CollectionError::Mdx {
+                .map_err(|e| CollectionError::Mdx {
                     path: path.to_path_buf(),
                     message: e.to_string(),
-                }
-            })?;
+                })?;
             // Derive the specifier from THIS entry's file path + the
             // JSX hash rather than reusing `compiled.specifier`
             // directly. The compile cache keys on `sha256(body)` and
@@ -1340,7 +1335,10 @@ declare module \"zfb/content\" {\n\
             s.contains("sidebar_position?: number;"),
             "docs schema (optional number): {s}",
         );
-        assert!(s.contains("draft?: boolean;"), "docs schema (optional boolean): {s}");
+        assert!(
+            s.contains("draft?: boolean;"),
+            "docs schema (optional boolean): {s}"
+        );
         assert!(s.contains("tags?: string[];"), "docs schema (array): {s}");
 
         // blog: no schema → falls back to Record<string, unknown>.
@@ -1571,10 +1569,8 @@ declare module \"zfb/content\" {\n\
     /// scheme + collection + hash bytes untouched.
     #[test]
     fn maybe_strip_specifier_suffix_rewrites_slug_only() {
-        let stripped = maybe_strip_specifier_suffix(
-            "mdx://notes-en/col003-mixers.en#deadbeef",
-            Some(".en"),
-        );
+        let stripped =
+            maybe_strip_specifier_suffix("mdx://notes-en/col003-mixers.en#deadbeef", Some(".en"));
         assert_eq!(stripped, "mdx://notes-en/col003-mixers#deadbeef");
 
         // Non-matching suffix → returned unchanged.
@@ -1613,7 +1609,11 @@ declare module \"zfb/content\" {\n\
         tmp.write("data.toml", "[section]\nkey = \"value\"\n");
 
         let out: Vec<Entry<TestSchema>> = walk_collection(tmp.path(), None).unwrap();
-        assert_eq!(out.len(), 1, "only entry.md should be returned; data files must be skipped");
+        assert_eq!(
+            out.len(),
+            1,
+            "only entry.md should be returned; data files must be skipped"
+        );
         assert_eq!(out[0].slug, "entry");
     }
 }

--- a/crates/zfb-content/src/content_bridge.rs
+++ b/crates/zfb-content/src/content_bridge.rs
@@ -287,6 +287,13 @@ pub fn build_snapshot_with_config(
             collection: cfg.name.clone(),
             source,
         })?;
+        // `pipeline` is intentionally NOT drained here — the snapshot walk
+        // runs first and its per-collection pipelines are dropped undrained.
+        // Compile-cache replay (`mdx_jsx_emit.rs` — `replay_markdown_diagnostics`)
+        // re-injects the same diagnostics into the bundler's walk when it hits
+        // cached entries, so bundler-only reporting is sufficient and avoids
+        // double-reporting the same finding on every dev tick (A1 decision,
+        // zfb#951; implementation in zfb#953).
 
         let mut snapshots: Vec<EntrySnapshot> = entries
             .into_iter()
@@ -529,8 +536,8 @@ mod tests {
             }),
             ..Default::default()
         };
-        let on = build_snapshot_with_config(&[collection()], &on_cfg)
-            .expect("snapshot (features on)");
+        let on =
+            build_snapshot_with_config(&[collection()], &on_cfg).expect("snapshot (features on)");
 
         let spec_off = &off.collections.get("docs").expect("docs off")[0].module_specifier;
         let spec_on = &on.collections.get("docs").expect("docs on")[0].module_specifier;
@@ -845,17 +852,17 @@ mod tests {
             // constructs. Hash must agree byte-for-byte.
             let mut pipeline =
                 crate::pipeline::Pipeline::with_defaults_and_theme_and_gfm(None, resolved);
-            let compiled =
-                compile_mdx_to_jsx_module_cached(body, &path, None, Some(&mut pipeline))
-                    .expect("bundler-style compile must succeed");
+            let compiled = compile_mdx_to_jsx_module_cached(body, &path, None, Some(&mut pipeline))
+                .expect("bundler-style compile must succeed");
 
-            let snap_spec = parse_mdx_specifier(&entry.module_specifier)
-                .expect("snapshot specifier parses");
-            let bridge_spec = parse_mdx_specifier(&compiled.specifier)
-                .expect("bundler specifier parses");
+            let snap_spec =
+                parse_mdx_specifier(&entry.module_specifier).expect("snapshot specifier parses");
+            let bridge_spec =
+                parse_mdx_specifier(&compiled.specifier).expect("bundler specifier parses");
 
             assert_eq!(
-                snap_spec.content_hash, bridge_spec.content_hash,
+                snap_spec.content_hash,
+                bridge_spec.content_hash,
                 "snapshot ↔ bundler hash divergence under gfm={label}: \
                  snapshot={snap}, bundler={bridge} — this is the \
                  sub-#61 / zfb#132 hazard (see content_bridge.rs:118-153)",

--- a/crates/zfb-content/src/content_bridge.rs
+++ b/crates/zfb-content/src/content_bridge.rs
@@ -529,8 +529,8 @@ mod tests {
             }),
             ..Default::default()
         };
-        let on = build_snapshot_with_config(&[collection()], &on_cfg)
-            .expect("snapshot (features on)");
+        let on =
+            build_snapshot_with_config(&[collection()], &on_cfg).expect("snapshot (features on)");
 
         let spec_off = &off.collections.get("docs").expect("docs off")[0].module_specifier;
         let spec_on = &on.collections.get("docs").expect("docs on")[0].module_specifier;
@@ -845,17 +845,17 @@ mod tests {
             // constructs. Hash must agree byte-for-byte.
             let mut pipeline =
                 crate::pipeline::Pipeline::with_defaults_and_theme_and_gfm(None, resolved);
-            let compiled =
-                compile_mdx_to_jsx_module_cached(body, &path, None, Some(&mut pipeline))
-                    .expect("bundler-style compile must succeed");
+            let compiled = compile_mdx_to_jsx_module_cached(body, &path, None, Some(&mut pipeline))
+                .expect("bundler-style compile must succeed");
 
-            let snap_spec = parse_mdx_specifier(&entry.module_specifier)
-                .expect("snapshot specifier parses");
-            let bridge_spec = parse_mdx_specifier(&compiled.specifier)
-                .expect("bundler specifier parses");
+            let snap_spec =
+                parse_mdx_specifier(&entry.module_specifier).expect("snapshot specifier parses");
+            let bridge_spec =
+                parse_mdx_specifier(&compiled.specifier).expect("bundler specifier parses");
 
             assert_eq!(
-                snap_spec.content_hash, bridge_spec.content_hash,
+                snap_spec.content_hash,
+                bridge_spec.content_hash,
                 "snapshot ↔ bundler hash divergence under gfm={label}: \
                  snapshot={snap}, bundler={bridge} — this is the \
                  sub-#61 / zfb#132 hazard (see content_bridge.rs:118-153)",

--- a/crates/zfb-content/src/dep_manifest.rs
+++ b/crates/zfb-content/src/dep_manifest.rs
@@ -185,7 +185,10 @@ mod tests {
         let rec = ReadRecorder::new();
         assert_eq!(rec.record_file(&dep), ReadOutcome::Missing);
         let m = manifest_of(&rec);
-        assert!(m.still_valid(), "still-missing dep must keep the entry valid");
+        assert!(
+            m.still_valid(),
+            "still-missing dep must keep the entry valid"
+        );
         std::fs::write(&dep, b"now it exists").expect("create");
         assert!(!m.still_valid(), "created dep must invalidate");
     }

--- a/crates/zfb-content/src/frontmatter.rs
+++ b/crates/zfb-content/src/frontmatter.rs
@@ -67,7 +67,9 @@ pub enum FrontmatterError {
     Yaml(#[from] serde_yaml::Error),
     #[error("TSX frontmatter error: {0}")]
     Tsx(#[from] TsxFrontmatterError),
-    #[error("unsupported file extension `.{0}` for frontmatter extraction (expected md, mdx, or tsx)")]
+    #[error(
+        "unsupported file extension `.{0}` for frontmatter extraction (expected md, mdx, or tsx)"
+    )]
     UnsupportedExtension(String),
     #[error("missing file extension; cannot dispatch frontmatter extraction")]
     MissingExtension,

--- a/crates/zfb-content/src/lib.rs
+++ b/crates/zfb-content/src/lib.rs
@@ -22,9 +22,7 @@ pub use content_bridge::{
 };
 pub use pipeline_spec::{PipelineSpec, PipelineSpecError};
 
-pub use pipeline::{
-    constructs_for_jsx_emit, constructs_for_pipeline, ResolvedGfmConstructs,
-};
+pub use pipeline::{constructs_for_jsx_emit, constructs_for_pipeline, ResolvedGfmConstructs};
 pub use plugins::{ExternalLinksConfig, ExternalLinksPlugin};
 
 pub use plugins::toc::TocConfig;
@@ -34,8 +32,9 @@ pub use plugins::toc::TocConfig;
 // threading `markdown.features` into the feature-aware pipeline constructor,
 // without taking a direct dependency on `zfb-md-ast` / `zfb-md-extras`.
 pub use zfb_md_extras::{
-    directives_enabled, heading_id_strategy, DirectiveFullSpec, DirectiveSpec, DirectiveSpecKind,
-    FeatureToggle, HeadingIdStrategy, HeadingIdsConfig, MarkdownFeaturesConfig, into_directive_def,
+    directives_enabled, heading_id_strategy, into_directive_def, DirectiveFullSpec, DirectiveSpec,
+    DirectiveSpecKind, FeatureToggle, HeadingIdStrategy, HeadingIdsConfig, ImageDimensionsConfig,
+    LinkValidationConfig, MarkdownFeaturesConfig, TranscludeConfig,
 };
 
 // Read-recorder surface (zfb#942): the recorder + outcome types live in
@@ -56,4 +55,3 @@ pub use tsx_frontmatter::{
     extract as extract_tsx_frontmatter, filename_extension_candidate, TsxFrontmatter,
     TsxFrontmatterError,
 };
-

--- a/crates/zfb-content/src/lib.rs
+++ b/crates/zfb-content/src/lib.rs
@@ -22,9 +22,7 @@ pub use content_bridge::{
 };
 pub use pipeline_spec::{PipelineSpec, PipelineSpecError};
 
-pub use pipeline::{
-    constructs_for_jsx_emit, constructs_for_pipeline, ResolvedGfmConstructs,
-};
+pub use pipeline::{constructs_for_jsx_emit, constructs_for_pipeline, ResolvedGfmConstructs};
 pub use plugins::{ExternalLinksConfig, ExternalLinksPlugin};
 
 pub use plugins::toc::TocConfig;
@@ -34,8 +32,8 @@ pub use plugins::toc::TocConfig;
 // threading `markdown.features` into the feature-aware pipeline constructor,
 // without taking a direct dependency on `zfb-md-ast` / `zfb-md-extras`.
 pub use zfb_md_extras::{
-    directives_enabled, heading_id_strategy, DirectiveFullSpec, DirectiveSpec, DirectiveSpecKind,
-    FeatureToggle, HeadingIdStrategy, HeadingIdsConfig, MarkdownFeaturesConfig, into_directive_def,
+    directives_enabled, heading_id_strategy, into_directive_def, DirectiveFullSpec, DirectiveSpec,
+    DirectiveSpecKind, FeatureToggle, HeadingIdStrategy, HeadingIdsConfig, MarkdownFeaturesConfig,
 };
 
 // Read-recorder surface (zfb#942): the recorder + outcome types live in
@@ -56,4 +54,3 @@ pub use tsx_frontmatter::{
     extract as extract_tsx_frontmatter, filename_extension_candidate, TsxFrontmatter,
     TsxFrontmatterError,
 };
-

--- a/crates/zfb-content/src/mdx_jsx_emit.rs
+++ b/crates/zfb-content/src/mdx_jsx_emit.rs
@@ -359,7 +359,12 @@ fn mdx_to_jsx_module_inner(
         }
         let mut bridge = HastJsxBridge::new();
         let body = bridge.emit_root(&hast);
-        (body, bridge.html_tags, bridge.component_names, bridge.hoisted_esm)
+        (
+            body,
+            bridge.html_tags,
+            bridge.component_names,
+            bridge.hoisted_esm,
+        )
     } else {
         let mut emitter = JsxEmitter::new();
         let body = emitter.emit_children_block(&children);
@@ -956,11 +961,7 @@ fn align_style(align: &AlignKind) -> Option<&'static str> {
 /// ```
 ///
 /// Matches the canonical shape from zfb#136 / issue #193.
-fn emit_table_jsx(
-    emitter: &mut JsxEmitter,
-    rows: &[MdastNode],
-    align: &[AlignKind],
-) -> String {
+fn emit_table_jsx(emitter: &mut JsxEmitter, rows: &[MdastNode], align: &[AlignKind]) -> String {
     let mut out = String::new();
 
     // Build a style attr string for column index `col`.
@@ -1271,16 +1272,52 @@ fn starts_with_block_level_tag(s: &str) -> bool {
     // Block-level elements per HTML5 content model. Conservative list
     // — anything not on it falls through to <span> (the inline default).
     const BLOCK_TAGS: &[&str] = &[
-        "address", "article", "aside", "blockquote", "details", "dialog",
-        "div", "dl", "dt", "dd", "fieldset", "figcaption", "figure",
-        "footer", "form", "h1", "h2", "h3", "h4", "h5", "h6", "header",
-        "hgroup", "hr", "li", "main", "nav", "ol", "p", "pre", "section",
-        "summary", "table", "thead", "tbody", "tfoot", "tr", "td", "th",
+        "address",
+        "article",
+        "aside",
+        "blockquote",
+        "details",
+        "dialog",
+        "div",
+        "dl",
+        "dt",
+        "dd",
+        "fieldset",
+        "figcaption",
+        "figure",
+        "footer",
+        "form",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "header",
+        "hgroup",
+        "hr",
+        "li",
+        "main",
+        "nav",
+        "ol",
+        "p",
+        "pre",
+        "section",
+        "summary",
+        "table",
+        "thead",
+        "tbody",
+        "tfoot",
+        "tr",
+        "td",
+        "th",
         "ul",
     ];
     let trimmed = s.trim_start();
     let bytes = trimmed.as_bytes();
-    if bytes.first() != Some(&b'<') { return false; }
+    if bytes.first() != Some(&b'<') {
+        return false;
+    }
     let after_lt = &trimmed[1..];
     let tag_end = after_lt
         .find(|c: char| [' ', '>', '/', '\t', '\n', '\r'].contains(&c))
@@ -1661,7 +1698,11 @@ fn jsx_render_table(t: &markdown::mdast::Table, ctx: &SlugCtx) -> String {
                 continue;
             };
             let style = style_attr(col);
-            let inner: String = tc.children.iter().map(|c| jsx_render_child(c, ctx)).collect();
+            let inner: String = tc
+                .children
+                .iter()
+                .map(|c| jsx_render_child(c, ctx))
+                .collect();
             out.push_str(&format!(
                 "<_components.{cell_tag}{style}>{inner}</_components.{cell_tag}>"
             ));
@@ -1695,7 +1736,10 @@ fn jsx_render_table(t: &markdown::mdast::Table, ctx: &SlugCtx) -> String {
 fn jsx_wrap_children(tag: &str, attrs: &str, children: &[MdastNode], ctx: &SlugCtx) -> String {
     format!(
         "<_components.{tag}{attrs}>{}</_components.{tag}>",
-        children.iter().map(|c| jsx_render_child(c, ctx)).collect::<String>(),
+        children
+            .iter()
+            .map(|c| jsx_render_child(c, ctx))
+            .collect::<String>(),
     )
 }
 
@@ -2631,7 +2675,11 @@ mod tests {
             third.jsx_source, "__SENTINEL__",
             "edited dep must be a cache miss (recompile)"
         );
-        assert_eq!(cache.len(), 1, "recompile overwrites the stale entry in place");
+        assert_eq!(
+            cache.len(),
+            1,
+            "recompile overwrites the stale entry in place"
+        );
 
         // The recompile re-recorded the manifest against v2: with the
         // dep untouched since, the entry must hit again.
@@ -2796,7 +2844,11 @@ mod tests {
             Some(&mut p3),
         )
         .expect("compile c");
-        assert_eq!(cache.len(), 2, "same-dir identical body must not add an entry");
+        assert_eq!(
+            cache.len(),
+            2,
+            "same-dir identical body must not add an entry"
+        );
         assert_eq!(
             third.jsx_source, "__SENTINEL__",
             "same-dir identical body must be served from the shared entry"
@@ -2818,8 +2870,7 @@ mod tests {
             Path::new("/stale/leftover.md"),
             zfb_md_ast::ReadOutcome::Error,
         );
-        compile_mdx_to_jsx_module_cached(src, path, Some(&cache), Some(&mut p))
-            .expect("compile");
+        compile_mdx_to_jsx_module_cached(src, path, Some(&cache), Some(&mut p)).expect("compile");
         assert_eq!(
             cache.len(),
             1,
@@ -2838,10 +2889,7 @@ mod tests {
     /// Feature-config pipeline with context roots armed at `project_root`
     /// (public dir at `<root>/public`). Fresh per compile, mirroring the
     /// dev-tick shape (same config ⇒ same fingerprint).
-    fn fs_features_pipeline(
-        features_json: serde_json::Value,
-        project_root: &Path,
-    ) -> Pipeline {
+    fn fs_features_pipeline(features_json: serde_json::Value, project_root: &Path) -> Pipeline {
         let feats: zfb_md_extras::MarkdownFeaturesConfig =
             serde_json::from_value(features_json).expect("valid features config");
         let mut p = Pipeline::with_defaults_and_full_config(
@@ -2890,9 +2938,8 @@ mod tests {
         let feats = serde_json::json!({ "transclude": {} });
 
         let mut p = fs_features_pipeline(feats.clone(), root);
-        let first_a =
-            compile_mdx_to_jsx_module_cached(body_a, &path_a, Some(&cache), Some(&mut p))
-                .expect("compile a");
+        let first_a = compile_mdx_to_jsx_module_cached(body_a, &path_a, Some(&cache), Some(&mut p))
+            .expect("compile a");
         assert!(
             first_a.jsx_source.contains("Shared snippet v1."),
             "the transclude plugin must fire on the cached compile path; got: {}",
@@ -2917,9 +2964,8 @@ mod tests {
         // new content); the unrelated file stays a hit (sentinel).
         std::fs::write(root.join("snippet.md"), "Shared snippet v2.\n").expect("edit snippet");
         let mut p = fs_features_pipeline(feats.clone(), root);
-        let fresh_a =
-            compile_mdx_to_jsx_module_cached(body_a, &path_a, Some(&cache), Some(&mut p))
-                .expect("recompile a");
+        let fresh_a = compile_mdx_to_jsx_module_cached(body_a, &path_a, Some(&cache), Some(&mut p))
+            .expect("recompile a");
         assert!(
             fresh_a.jsx_source.contains("Shared snippet v2."),
             "editing the snippet must recompile its dependent; got: {}",
@@ -3196,13 +3242,17 @@ mod tests {
         let src = "## Intro\n\nhi\n";
         let path = Path::new("/virtual/blog/intro.mdx");
 
-        let plain = compile_mdx_to_jsx_module_cached(src, path, Some(&cache), None)
-            .expect("compile plain");
+        let plain =
+            compile_mdx_to_jsx_module_cached(src, path, Some(&cache), None).expect("compile plain");
         let mut p = full_config_pipeline(None);
         let piped = compile_mdx_to_jsx_module_cached(src, path, Some(&cache), Some(&mut p))
             .expect("compile piped");
 
-        assert_eq!(cache.len(), 2, "no-pipeline and pipeline'd keys must differ");
+        assert_eq!(
+            cache.len(),
+            2,
+            "no-pipeline and pipeline'd keys must differ"
+        );
         assert_ne!(
             plain.jsx_source, piped.jsx_source,
             "sanity: the two paths emit different JSX for a heading"
@@ -3500,9 +3550,18 @@ mod tests {
         let out = emit(src);
 
         // All table-related tags registered in _components map.
-        assert!(out.contains("table: \"table\","), "table tag missing: {out}");
-        assert!(out.contains("thead: \"thead\","), "thead tag missing: {out}");
-        assert!(out.contains("tbody: \"tbody\","), "tbody tag missing: {out}");
+        assert!(
+            out.contains("table: \"table\","),
+            "table tag missing: {out}"
+        );
+        assert!(
+            out.contains("thead: \"thead\","),
+            "thead tag missing: {out}"
+        );
+        assert!(
+            out.contains("tbody: \"tbody\","),
+            "tbody tag missing: {out}"
+        );
         assert!(out.contains("tr: \"tr\","), "tr tag missing: {out}");
         assert!(out.contains("th: \"th\","), "th tag missing: {out}");
         assert!(out.contains("td: \"td\","), "td tag missing: {out}");
@@ -3518,10 +3577,7 @@ mod tests {
             out.contains("<_components.thead>"),
             "missing <thead>: {out}"
         );
-        assert!(
-            out.contains("<_components.th>"),
-            "missing <th>: {out}"
-        );
+        assert!(out.contains("<_components.th>"), "missing <th>: {out}");
         assert!(
             out.contains("{\"Key\"}"),
             "header cell 'Key' missing: {out}"
@@ -3536,10 +3592,7 @@ mod tests {
             out.contains("<_components.tbody>"),
             "missing <tbody>: {out}"
         );
-        assert!(
-            out.contains("<_components.td>"),
-            "missing <td>: {out}"
-        );
+        assert!(out.contains("<_components.td>"), "missing <td>: {out}");
         assert!(
             out.contains("{\"docs\"}"),
             "body cell 'docs' missing: {out}"
@@ -3578,7 +3631,10 @@ mod tests {
         let style_count = out.matches("style=\"text-align:").count();
         // 4 columns × 2 rows (head + body) = 8 cells, but only 3 columns
         // have alignment → 3 × 2 = 6 `style=` occurrences.
-        assert_eq!(style_count, 6, "expected 6 style attrs (3 cols × 2 rows): {out}");
+        assert_eq!(
+            style_count, 6,
+            "expected 6 style attrs (3 cols × 2 rows): {out}"
+        );
     }
 
     // ─── HastNode::Raw block-aware wrapper tests (#1490) ────────────────────
@@ -3589,9 +3645,7 @@ mod tests {
     #[test]
     fn raw_pre_emits_div_wrapper() {
         let mut bridge = HastJsxBridge::new();
-        let node = HastNode::Raw(
-            r#"<pre class="syntect-x"><code>1</code></pre>"#.to_string(),
-        );
+        let node = HastNode::Raw(r#"<pre class="syntect-x"><code>1</code></pre>"#.to_string());
         let out = bridge.emit_node(&node);
         assert!(
             out.starts_with("<div dangerouslySetInnerHTML"),
@@ -3671,8 +3725,7 @@ mod tests {
         // We rely only on the returned len(), not on map iteration order.
         for i in 0..MDX_MODULE_CACHE_CAP {
             let src = format!("word{i}\n");
-            compile_mdx_to_jsx_module_cached(&src, path, Some(&cache), None)
-                .expect("compile fill");
+            compile_mdx_to_jsx_module_cached(&src, path, Some(&cache), None).expect("compile fill");
         }
         assert_eq!(
             cache.len(),

--- a/crates/zfb-content/src/mdx_jsx_emit.rs
+++ b/crates/zfb-content/src/mdx_jsx_emit.rs
@@ -48,6 +48,7 @@ use std::sync::{LazyLock, Mutex, MutexGuard};
 use markdown::mdast::{AlignKind, AttributeContent, AttributeValue, Node as MdastNode};
 use sha2::{Digest, Sha256};
 use zfb_md_ast::diagnostics::{CollectingSink, MarkdownDiagnostic};
+use zfb_md_ast::heading_registry::{HeadingEntry as RegistryHeadingEntry, HeadingRegistry};
 use zfb_md_ast::BuildContext;
 
 use crate::dep_manifest::DependencyManifest;
@@ -246,18 +247,27 @@ fn mdx_to_jsx_module_inner(
     // default), so output is byte-identical for every other plugin.
     // Without armed roots this is all skipped — context-free behaviour,
     // byte-for-byte.
+    //
+    // Cache-safety of anchor verdicts: the per-compile-local registry
+    // (seeded below from `collect_headings`) derives only from the
+    // post-mdast tree of THIS compile — input bytes + config fingerprint
+    // + transcluded content already covered by the read-recorder manifest.
+    // Anchor verdicts are therefore pure functions of the cache key and
+    // replay correctly. BUILD-scoped cross-file registry remains deferred
+    // (#960).
     let context_roots = pipeline_mut.as_deref().and_then(|p| {
         p.build_context_roots()
             .map(|(root, public)| (root.to_path_buf(), public.to_path_buf()))
     });
     let mut context_sink = CollectingSink::new();
+    // Per-compile-local registry for same-file anchor validation (#954).
+    // Cross-file (build-scoped) registry is deferred to #960.
+    let mut local_heading_registry = HeadingRegistry::new();
     let mut build_ctx = context_roots.map(|(project_root, public_dir)| BuildContext {
         source_path: opts.source_path.clone(),
         project_root,
         public_dir,
-        // Per-build orchestration state; cross-file anchor validation
-        // through the compile cache is follow-up work (zfb#944).
-        heading_registry: None,
+        heading_registry: Some(&mut local_heading_registry),
         diagnostics: Some(&mut context_sink),
     });
 
@@ -311,6 +321,34 @@ fn mdx_to_jsx_module_inner(
         nested_slugs,
     } = collect_headings(&children, strategy);
 
+    // Seed the per-compile registry from collect_headings' canonical
+    // walk: it covers JSX-nested headings (rendered ids stamped by
+    // jsx_render_child) that hast-phase HeadingLinksPlugin never sees.
+    // h1 entries are seeded too: a top-level h1 renders NO id, so its
+    // anchor passes silently rather than false-positively (h1 inside a
+    // JSX body DOES render the id, and the slug here matches it).
+    if let Some(ctx) = build_ctx.as_mut() {
+        if let (Some(reg), Some(src)) =
+            (ctx.heading_registry.as_deref_mut(), ctx.source_path.clone())
+        {
+            for h in &headings {
+                if !h.slug.is_empty() {
+                    reg.insert(
+                        src.clone(),
+                        RegistryHeadingEntry {
+                            id: h.slug.clone(),
+                            text: h.text.clone(),
+                            depth: h.depth,
+                        },
+                    );
+                }
+            }
+        }
+    }
+    // (`headings` is only borrowed above; its later use for the export is unaffected.
+    // HeadingLinksPlugin's `visit_with_context` will ALSO insert top-level h2–h6 entries
+    // during the hast pass — exact duplicates by the slug-lockstep invariant; harmless.)
+
     let (body, html_tags, component_names, hoisted_esm) = if take_hast_detour {
         // Wrap children back into a Root so `mdast_to_hast_with` can
         // recurse through them as a single node — its public signature
@@ -359,7 +397,12 @@ fn mdx_to_jsx_module_inner(
         }
         let mut bridge = HastJsxBridge::new();
         let body = bridge.emit_root(&hast);
-        (body, bridge.html_tags, bridge.component_names, bridge.hoisted_esm)
+        (
+            body,
+            bridge.html_tags,
+            bridge.component_names,
+            bridge.hoisted_esm,
+        )
     } else {
         let mut emitter = JsxEmitter::new();
         let body = emitter.emit_children_block(&children);
@@ -956,11 +999,7 @@ fn align_style(align: &AlignKind) -> Option<&'static str> {
 /// ```
 ///
 /// Matches the canonical shape from zfb#136 / issue #193.
-fn emit_table_jsx(
-    emitter: &mut JsxEmitter,
-    rows: &[MdastNode],
-    align: &[AlignKind],
-) -> String {
+fn emit_table_jsx(emitter: &mut JsxEmitter, rows: &[MdastNode], align: &[AlignKind]) -> String {
     let mut out = String::new();
 
     // Build a style attr string for column index `col`.
@@ -1271,16 +1310,52 @@ fn starts_with_block_level_tag(s: &str) -> bool {
     // Block-level elements per HTML5 content model. Conservative list
     // — anything not on it falls through to <span> (the inline default).
     const BLOCK_TAGS: &[&str] = &[
-        "address", "article", "aside", "blockquote", "details", "dialog",
-        "div", "dl", "dt", "dd", "fieldset", "figcaption", "figure",
-        "footer", "form", "h1", "h2", "h3", "h4", "h5", "h6", "header",
-        "hgroup", "hr", "li", "main", "nav", "ol", "p", "pre", "section",
-        "summary", "table", "thead", "tbody", "tfoot", "tr", "td", "th",
+        "address",
+        "article",
+        "aside",
+        "blockquote",
+        "details",
+        "dialog",
+        "div",
+        "dl",
+        "dt",
+        "dd",
+        "fieldset",
+        "figcaption",
+        "figure",
+        "footer",
+        "form",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "header",
+        "hgroup",
+        "hr",
+        "li",
+        "main",
+        "nav",
+        "ol",
+        "p",
+        "pre",
+        "section",
+        "summary",
+        "table",
+        "thead",
+        "tbody",
+        "tfoot",
+        "tr",
+        "td",
+        "th",
         "ul",
     ];
     let trimmed = s.trim_start();
     let bytes = trimmed.as_bytes();
-    if bytes.first() != Some(&b'<') { return false; }
+    if bytes.first() != Some(&b'<') {
+        return false;
+    }
     let after_lt = &trimmed[1..];
     let tag_end = after_lt
         .find(|c: char| [' ', '>', '/', '\t', '\n', '\r'].contains(&c))
@@ -1661,7 +1736,11 @@ fn jsx_render_table(t: &markdown::mdast::Table, ctx: &SlugCtx) -> String {
                 continue;
             };
             let style = style_attr(col);
-            let inner: String = tc.children.iter().map(|c| jsx_render_child(c, ctx)).collect();
+            let inner: String = tc
+                .children
+                .iter()
+                .map(|c| jsx_render_child(c, ctx))
+                .collect();
             out.push_str(&format!(
                 "<_components.{cell_tag}{style}>{inner}</_components.{cell_tag}>"
             ));
@@ -1695,7 +1774,10 @@ fn jsx_render_table(t: &markdown::mdast::Table, ctx: &SlugCtx) -> String {
 fn jsx_wrap_children(tag: &str, attrs: &str, children: &[MdastNode], ctx: &SlugCtx) -> String {
     format!(
         "<_components.{tag}{attrs}>{}</_components.{tag}>",
-        children.iter().map(|c| jsx_render_child(c, ctx)).collect::<String>(),
+        children
+            .iter()
+            .map(|c| jsx_render_child(c, ctx))
+            .collect::<String>(),
     )
 }
 
@@ -2631,7 +2713,11 @@ mod tests {
             third.jsx_source, "__SENTINEL__",
             "edited dep must be a cache miss (recompile)"
         );
-        assert_eq!(cache.len(), 1, "recompile overwrites the stale entry in place");
+        assert_eq!(
+            cache.len(),
+            1,
+            "recompile overwrites the stale entry in place"
+        );
 
         // The recompile re-recorded the manifest against v2: with the
         // dep untouched since, the entry must hit again.
@@ -2796,7 +2882,11 @@ mod tests {
             Some(&mut p3),
         )
         .expect("compile c");
-        assert_eq!(cache.len(), 2, "same-dir identical body must not add an entry");
+        assert_eq!(
+            cache.len(),
+            2,
+            "same-dir identical body must not add an entry"
+        );
         assert_eq!(
             third.jsx_source, "__SENTINEL__",
             "same-dir identical body must be served from the shared entry"
@@ -2818,8 +2908,7 @@ mod tests {
             Path::new("/stale/leftover.md"),
             zfb_md_ast::ReadOutcome::Error,
         );
-        compile_mdx_to_jsx_module_cached(src, path, Some(&cache), Some(&mut p))
-            .expect("compile");
+        compile_mdx_to_jsx_module_cached(src, path, Some(&cache), Some(&mut p)).expect("compile");
         assert_eq!(
             cache.len(),
             1,
@@ -2838,10 +2927,7 @@ mod tests {
     /// Feature-config pipeline with context roots armed at `project_root`
     /// (public dir at `<root>/public`). Fresh per compile, mirroring the
     /// dev-tick shape (same config ⇒ same fingerprint).
-    fn fs_features_pipeline(
-        features_json: serde_json::Value,
-        project_root: &Path,
-    ) -> Pipeline {
+    fn fs_features_pipeline(features_json: serde_json::Value, project_root: &Path) -> Pipeline {
         let feats: zfb_md_extras::MarkdownFeaturesConfig =
             serde_json::from_value(features_json).expect("valid features config");
         let mut p = Pipeline::with_defaults_and_full_config(
@@ -2890,9 +2976,8 @@ mod tests {
         let feats = serde_json::json!({ "transclude": {} });
 
         let mut p = fs_features_pipeline(feats.clone(), root);
-        let first_a =
-            compile_mdx_to_jsx_module_cached(body_a, &path_a, Some(&cache), Some(&mut p))
-                .expect("compile a");
+        let first_a = compile_mdx_to_jsx_module_cached(body_a, &path_a, Some(&cache), Some(&mut p))
+            .expect("compile a");
         assert!(
             first_a.jsx_source.contains("Shared snippet v1."),
             "the transclude plugin must fire on the cached compile path; got: {}",
@@ -2917,9 +3002,8 @@ mod tests {
         // new content); the unrelated file stays a hit (sentinel).
         std::fs::write(root.join("snippet.md"), "Shared snippet v2.\n").expect("edit snippet");
         let mut p = fs_features_pipeline(feats.clone(), root);
-        let fresh_a =
-            compile_mdx_to_jsx_module_cached(body_a, &path_a, Some(&cache), Some(&mut p))
-                .expect("recompile a");
+        let fresh_a = compile_mdx_to_jsx_module_cached(body_a, &path_a, Some(&cache), Some(&mut p))
+            .expect("recompile a");
         assert!(
             fresh_a.jsx_source.contains("Shared snippet v2."),
             "editing the snippet must recompile its dependent; got: {}",
@@ -3196,13 +3280,17 @@ mod tests {
         let src = "## Intro\n\nhi\n";
         let path = Path::new("/virtual/blog/intro.mdx");
 
-        let plain = compile_mdx_to_jsx_module_cached(src, path, Some(&cache), None)
-            .expect("compile plain");
+        let plain =
+            compile_mdx_to_jsx_module_cached(src, path, Some(&cache), None).expect("compile plain");
         let mut p = full_config_pipeline(None);
         let piped = compile_mdx_to_jsx_module_cached(src, path, Some(&cache), Some(&mut p))
             .expect("compile piped");
 
-        assert_eq!(cache.len(), 2, "no-pipeline and pipeline'd keys must differ");
+        assert_eq!(
+            cache.len(),
+            2,
+            "no-pipeline and pipeline'd keys must differ"
+        );
         assert_ne!(
             plain.jsx_source, piped.jsx_source,
             "sanity: the two paths emit different JSX for a heading"
@@ -3500,9 +3588,18 @@ mod tests {
         let out = emit(src);
 
         // All table-related tags registered in _components map.
-        assert!(out.contains("table: \"table\","), "table tag missing: {out}");
-        assert!(out.contains("thead: \"thead\","), "thead tag missing: {out}");
-        assert!(out.contains("tbody: \"tbody\","), "tbody tag missing: {out}");
+        assert!(
+            out.contains("table: \"table\","),
+            "table tag missing: {out}"
+        );
+        assert!(
+            out.contains("thead: \"thead\","),
+            "thead tag missing: {out}"
+        );
+        assert!(
+            out.contains("tbody: \"tbody\","),
+            "tbody tag missing: {out}"
+        );
         assert!(out.contains("tr: \"tr\","), "tr tag missing: {out}");
         assert!(out.contains("th: \"th\","), "th tag missing: {out}");
         assert!(out.contains("td: \"td\","), "td tag missing: {out}");
@@ -3518,10 +3615,7 @@ mod tests {
             out.contains("<_components.thead>"),
             "missing <thead>: {out}"
         );
-        assert!(
-            out.contains("<_components.th>"),
-            "missing <th>: {out}"
-        );
+        assert!(out.contains("<_components.th>"), "missing <th>: {out}");
         assert!(
             out.contains("{\"Key\"}"),
             "header cell 'Key' missing: {out}"
@@ -3536,10 +3630,7 @@ mod tests {
             out.contains("<_components.tbody>"),
             "missing <tbody>: {out}"
         );
-        assert!(
-            out.contains("<_components.td>"),
-            "missing <td>: {out}"
-        );
+        assert!(out.contains("<_components.td>"), "missing <td>: {out}");
         assert!(
             out.contains("{\"docs\"}"),
             "body cell 'docs' missing: {out}"
@@ -3578,7 +3669,10 @@ mod tests {
         let style_count = out.matches("style=\"text-align:").count();
         // 4 columns × 2 rows (head + body) = 8 cells, but only 3 columns
         // have alignment → 3 × 2 = 6 `style=` occurrences.
-        assert_eq!(style_count, 6, "expected 6 style attrs (3 cols × 2 rows): {out}");
+        assert_eq!(
+            style_count, 6,
+            "expected 6 style attrs (3 cols × 2 rows): {out}"
+        );
     }
 
     // ─── HastNode::Raw block-aware wrapper tests (#1490) ────────────────────
@@ -3589,9 +3683,7 @@ mod tests {
     #[test]
     fn raw_pre_emits_div_wrapper() {
         let mut bridge = HastJsxBridge::new();
-        let node = HastNode::Raw(
-            r#"<pre class="syntect-x"><code>1</code></pre>"#.to_string(),
-        );
+        let node = HastNode::Raw(r#"<pre class="syntect-x"><code>1</code></pre>"#.to_string());
         let out = bridge.emit_node(&node);
         assert!(
             out.starts_with("<div dangerouslySetInnerHTML"),
@@ -3671,8 +3763,7 @@ mod tests {
         // We rely only on the returned len(), not on map iteration order.
         for i in 0..MDX_MODULE_CACHE_CAP {
             let src = format!("word{i}\n");
-            compile_mdx_to_jsx_module_cached(&src, path, Some(&cache), None)
-                .expect("compile fill");
+            compile_mdx_to_jsx_module_cached(&src, path, Some(&cache), None).expect("compile fill");
         }
         assert_eq!(
             cache.len(),
@@ -3687,6 +3778,155 @@ mod tests {
             cache.len(),
             1,
             "overflow past CAP must clear the map; only the triggering entry remains"
+        );
+    }
+
+    // ── zfb#954: same-file anchor validation ─────────────────────────────────
+
+    // zfb#954: a valid same-file anchor passes; an invalid one is BrokenLink.
+    #[test]
+    fn armed_same_file_anchor_validates_against_local_registry() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        let body = "## Setup\n\n[ok](#setup)\n[bad](#nope)\n";
+        let path = root.join("page.mdx");
+        std::fs::write(&path, body).expect("write page");
+        let feats = serde_json::json!({ "linkValidation": {} });
+
+        let mut p = fs_features_pipeline(feats, root);
+        compile_mdx_to_jsx_module_cached(body, &path, Some(&MdxModuleCache::new()), Some(&mut p))
+            .expect("compile");
+        let diags = p.take_markdown_diagnostics();
+        assert_eq!(
+            diags
+                .iter()
+                .filter(|d| matches!(d, MarkdownDiagnostic::BrokenLink { .. }))
+                .count(),
+            1,
+            "exactly one BrokenLink expected: {diags:?}"
+        );
+        assert!(
+            diags
+                .iter()
+                .any(|d| matches!(d, MarkdownDiagnostic::BrokenLink { url, .. } if url == "#nope")),
+            "#nope must be reported as BrokenLink: {diags:?}"
+        );
+    }
+
+    // zfb#954: a heading inside a JSX body has its id rendered and must
+    // NOT produce a false-positive when linked from the same file.
+    #[test]
+    fn armed_same_file_anchor_inside_jsx_body_no_false_positive() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        // The `<Note>` component is PascalCase — not mapped through
+        // `_components`; it comes from the caller's `components` prop and
+        // triggers a runtime throw if missing, but compile succeeds.
+        let body = "<Note>\n\n## Inside\n\n</Note>\n\n[ok](#inside)\n";
+        let path = root.join("page.mdx");
+        std::fs::write(&path, body).expect("write page");
+        let feats = serde_json::json!({ "linkValidation": {} });
+
+        let mut p = fs_features_pipeline(feats, root);
+        compile_mdx_to_jsx_module_cached(body, &path, Some(&MdxModuleCache::new()), Some(&mut p))
+            .expect("compile");
+        let diags = p.take_markdown_diagnostics();
+        assert!(
+            diags
+                .iter()
+                .all(|d| !matches!(d, MarkdownDiagnostic::BrokenLink { .. })),
+            "JSX-nested heading anchor must not produce BrokenLink: {diags:?}"
+        );
+    }
+
+    // zfb#954: a top-level h1 anchor passes silently even though no id
+    // renders (h1 is intentionally left alone by HeadingLinksPlugin).
+    #[test]
+    fn armed_top_level_h1_anchor_passes_silently() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        let body = "# Title\n\n[top](#title)\n";
+        let path = root.join("page.mdx");
+        std::fs::write(&path, body).expect("write page");
+        let feats = serde_json::json!({ "linkValidation": {} });
+
+        let mut p = fs_features_pipeline(feats, root);
+        compile_mdx_to_jsx_module_cached(body, &path, Some(&MdxModuleCache::new()), Some(&mut p))
+            .expect("compile");
+        let diags = p.take_markdown_diagnostics();
+        assert!(
+            diags
+                .iter()
+                .all(|d| !matches!(d, MarkdownDiagnostic::BrokenLink { .. })),
+            "h1-slug anchor must pass silently: {diags:?}"
+        );
+    }
+
+    // zfb#954: with resolveMarkdownLinks ON, rewritten hrefs become
+    // URL-space and are skipped — zero BrokenLink diagnostics for valid links.
+    #[test]
+    fn armed_url_space_href_no_diagnostic() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        // Write the target file WITH a heading that can be linked.
+        std::fs::write(root.join("other.md"), "## Existing Heading\n").expect("write other");
+        let body = "[x](./other.md)\n[y](./other.md#existing-heading)\n";
+        let path = root.join("page.mdx");
+        std::fs::write(&path, body).expect("write page");
+        let feats = serde_json::json!({ "linkValidation": {} });
+
+        let mut p = fs_features_pipeline(feats, root);
+        // Add ResolveLinksPlugin mapping other.md → a URL-space href.
+        let mut map = HashMap::new();
+        map.insert(root.join("other.md"), "/docs/other/".to_string());
+        p.add_resolve_links(map);
+        p.set_resolve_links_source_dir(root.to_path_buf());
+
+        compile_mdx_to_jsx_module_cached(body, &path, Some(&MdxModuleCache::new()), Some(&mut p))
+            .expect("compile");
+        let diags = p.take_markdown_diagnostics();
+        assert!(
+            diags
+                .iter()
+                .all(|d| !matches!(d, MarkdownDiagnostic::BrokenLink { .. })),
+            "URL-space hrefs after resolve must not report BrokenLink: {diags:?}"
+        );
+    }
+
+    // zfb#954: same-file anchor verdict replays correctly on a cache hit.
+    #[test]
+    fn armed_same_file_anchor_verdict_replays_on_cache_hit() {
+        let cache = MdxModuleCache::new();
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+        let body = "## Setup\n\n[bad](#nope)\n";
+        let path = root.join("page.mdx");
+        std::fs::write(&path, body).expect("write page");
+        let feats = serde_json::json!({ "linkValidation": {} });
+
+        let mut p1 = fs_features_pipeline(feats.clone(), root);
+        compile_mdx_to_jsx_module_cached(body, &path, Some(&cache), Some(&mut p1))
+            .expect("compile 1");
+        let fresh = p1.take_markdown_diagnostics();
+        assert!(
+            fresh
+                .iter()
+                .any(|d| matches!(d, MarkdownDiagnostic::BrokenLink { url, .. } if url == "#nope")),
+            "fresh compile must report the broken anchor: {fresh:?}"
+        );
+
+        poke_sentinel(&cache);
+        let mut p2 = fs_features_pipeline(feats, root);
+        let second = compile_mdx_to_jsx_module_cached(body, &path, Some(&cache), Some(&mut p2))
+            .expect("compile 2");
+        assert_eq!(
+            second.jsx_source, "__SENTINEL__",
+            "must be a true cache hit"
+        );
+        assert_eq!(
+            p2.take_markdown_diagnostics(),
+            fresh,
+            "BrokenLink must replay identically on the cache hit"
         );
     }
 }

--- a/crates/zfb-content/src/pipeline.rs
+++ b/crates/zfb-content/src/pipeline.rs
@@ -1031,10 +1031,11 @@ impl Pipeline {
     /// produce different output/diagnostics per file. See the key-shape
     /// docs on `compile_mdx_to_jsx_module_cached`.
     ///
-    /// The heading registry is deliberately NOT threaded here — it is
-    /// per-build orchestration state; cross-file anchor validation
-    /// through the cache is follow-up work. The per-compile context
-    /// carries `heading_registry: None`.
+    /// The per-compile context carries a compile-local `HeadingRegistry`
+    /// seeded from `collect_headings` (same-file anchor validation, zfb#954).
+    /// BUILD-scoped cross-file registry (validating `./other.md#frag` across
+    /// files) remains deferred to #960 — structurally incompatible with
+    /// cache-hit replay today (HeadingLinksPlugin never runs on a hit).
     ///
     /// Production pipelines (`PipelineSpec::build_pipeline` — bundler and
     /// snapshot walker; `zfb dev` is the bundler in Development mode) arm

--- a/crates/zfb-content/src/pipeline.rs
+++ b/crates/zfb-content/src/pipeline.rs
@@ -112,9 +112,7 @@ impl Default for ResolvedGfmConstructs {
 /// output. The JSX-emit path enables `math_flow` / `math_text`
 /// separately, where the JSX emitter has dedicated arms for them.
 #[must_use]
-pub fn constructs_for_pipeline(
-    resolved: ResolvedGfmConstructs,
-) -> markdown::Constructs {
+pub fn constructs_for_pipeline(resolved: ResolvedGfmConstructs) -> markdown::Constructs {
     markdown::Constructs {
         gfm_strikethrough: resolved.strikethrough,
         gfm_table: resolved.table,
@@ -134,9 +132,7 @@ pub fn constructs_for_pipeline(
 /// and `$…$` parse into dedicated `Math` / `InlineMath` mdast nodes
 /// (zfb#93).
 #[must_use]
-pub fn constructs_for_jsx_emit(
-    resolved: ResolvedGfmConstructs,
-) -> markdown::Constructs {
+pub fn constructs_for_jsx_emit(resolved: ResolvedGfmConstructs) -> markdown::Constructs {
     markdown::Constructs {
         math_flow: true,
         math_text: true,
@@ -370,7 +366,6 @@ fn sort_value_keys(value: &mut serde_json::Value) {
     }
 }
 
-
 // HastNode, MdastVisitor, HastVisitor, and BuildContext live in
 // `zfb-md-ast` so downstream plugin crates (zfb-md-extras) can depend on
 // the visitor contract without depending on zfb-content. The
@@ -517,9 +512,7 @@ impl Pipeline {
     /// label-start means the parser sees `[^a]: body` but never the
     /// `[^a]` reference at the use site.
     #[must_use]
-    pub fn with_resolved_gfm_constructs(
-        resolved: ResolvedGfmConstructs,
-    ) -> Self {
+    pub fn with_resolved_gfm_constructs(resolved: ResolvedGfmConstructs) -> Self {
         let constructs = constructs_for_pipeline(resolved);
         Self {
             mdast_visitors: Vec::new(),
@@ -1043,12 +1036,17 @@ impl Pipeline {
     /// through the cache is follow-up work. The per-compile context
     /// carries `heading_registry: None`.
     ///
-    /// Production pipelines (`PipelineSpec::build_pipeline` — bundler,
-    /// snapshot walker, dev loader) do NOT arm this yet: the plugins
-    /// were already inert on the context-free production emit path
-    /// before zfb#944, and wiring real roots through the config surface
-    /// (plus draining `take_markdown_diagnostics` and the
-    /// heading-registry decision) is tracked in zfb#948.
+    /// Production pipelines (`PipelineSpec::build_pipeline` — bundler and
+    /// snapshot walker; `zfb dev` is the bundler in Development mode) arm
+    /// this when a filesystem-dependent feature is enabled in the config
+    /// (transclude / imageDimensions / linkValidation).  Unarmed pipelines
+    /// leave the plugins inert and the fingerprint byte-identical to the
+    /// pre-arming shape (zfb#952).
+    ///
+    /// The `zfb-render ModuleLoader` (`crates/zfb-render/src/loader.rs`) is
+    /// a library/embedder path that does NOT go through `PipelineSpec`; it
+    /// stays unarmed by design — embedder callers do not have a
+    /// `project_root` at hand.
     pub fn set_build_context_roots(
         &mut self,
         project_root: PathBuf,
@@ -1398,9 +1396,7 @@ impl Pipeline {
     ///    AFTER `SyntectPlugin` on the per-line `<span class="line">`
     ///    structure — e.g. wave-5 diff markers and line-highlighting)*
     #[must_use]
-    pub fn with_defaults_and_features(
-        features: &zfb_md_extras::MarkdownFeaturesConfig,
-    ) -> Self {
+    pub fn with_defaults_and_features(features: &zfb_md_extras::MarkdownFeaturesConfig) -> Self {
         // Default theme, conservative GFM, no themes_dir, CJK on — the shape
         // Wave 2/3 hard-coded here. The chain itself now lives in
         // [`Pipeline::with_defaults_and_full_config`] so the bundler, snapshot
@@ -1794,10 +1790,7 @@ impl Pipeline {
 /// [`Pipeline::add_mdast_visitor`]). The feature-aware constructor routes
 /// through the non-invalidating internal variant instead and covers the
 /// whole `features` value in its final base descriptor.
-pub fn register_features(
-    p: &mut Pipeline,
-    features: &zfb_md_extras::MarkdownFeaturesConfig,
-) {
+pub fn register_features(p: &mut Pipeline, features: &zfb_md_extras::MarkdownFeaturesConfig) {
     // No read-recorder on this path: the manual registration makes the
     // pipeline uncacheable anyway, so there is no dependency manifest to
     // feed (the compile cache never stores entries for it).
@@ -1835,7 +1828,9 @@ fn register_features_config_derived(
     //   HeadingLinksPlugin. Since HeadingLinksPlugin was added first in the
     //   caller's hast chain, any hast visitor appended here runs after it.
 
-    use zfb_md_ast::{directives_enabled, feature_enabled, heading_marker_toc_enabled, reading_time_enabled};
+    use zfb_md_ast::{
+        directives_enabled, feature_enabled, heading_marker_toc_enabled, reading_time_enabled,
+    };
 
     // ── mdast phase ────────────────────────────────────────────────────────
     // transclude MUST run FIRST in the mdast phase — before code_tabs,
@@ -1924,9 +1919,7 @@ fn register_features_config_derived(
         ));
     }
     if feature_enabled(&features.mermaid) {
-        p.push_config_derived_hast_visitor(Box::new(
-            zfb_md_extras::mermaid::MermaidPlugin::new(),
-        ));
+        p.push_config_derived_hast_visitor(Box::new(zfb_md_extras::mermaid::MermaidPlugin::new()));
     }
     // Wave 5 (#574): GitHub-style autolinks — #NNN, user/repo#NNN, SHA.
     // Uses Option<GithubAutolinksConfig> (not FeatureToggle), so gated with
@@ -2101,9 +2094,11 @@ fn mdast_to_hast_inner(node: &MdastNode, strategy: &JsxEmitStrategy<'_>) -> Hast
         MdastNode::Emphasis(e) => {
             element("em", vec![], convert_children_with(&e.children, strategy))
         }
-        MdastNode::Strong(s) => {
-            element("strong", vec![], convert_children_with(&s.children, strategy))
-        }
+        MdastNode::Strong(s) => element(
+            "strong",
+            vec![],
+            convert_children_with(&s.children, strategy),
+        ),
         MdastNode::Delete(d) => {
             element("del", vec![], convert_children_with(&d.children, strategy))
         }
@@ -2222,10 +2217,7 @@ fn mdast_to_hast_inner(node: &MdastNode, strategy: &JsxEmitStrategy<'_>) -> Hast
         // an added `language-math math-inline` class.
         MdastNode::InlineMath(m) => HastNode::Element {
             tag: "code".to_string(),
-            attrs: vec![(
-                "class".to_string(),
-                "language-math math-inline".to_string(),
-            )],
+            attrs: vec![("class".to_string(), "language-math math-inline".to_string())],
             children: vec![HastNode::Text(m.value.clone())],
             void: false,
         },
@@ -2235,7 +2227,10 @@ fn mdast_to_hast_inner(node: &MdastNode, strategy: &JsxEmitStrategy<'_>) -> Hast
         MdastNode::Table(t) => {
             let align = &t.align;
             let style_attr = |col: usize| -> Option<(String, String)> {
-                let kind = align.get(col).copied().unwrap_or(markdown::mdast::AlignKind::None);
+                let kind = align
+                    .get(col)
+                    .copied()
+                    .unwrap_or(markdown::mdast::AlignKind::None);
                 let s = match kind {
                     markdown::mdast::AlignKind::Left => Some("left"),
                     markdown::mdast::AlignKind::Right => Some("right"),
@@ -2246,13 +2241,27 @@ fn mdast_to_hast_inner(node: &MdastNode, strategy: &JsxEmitStrategy<'_>) -> Hast
             };
 
             let row_to_cells = |row: &MdastNode, tag: &str| -> Vec<HastNode> {
-                let MdastNode::TableRow(tr) = row else { return Vec::new(); };
-                tr.children.iter().enumerate().filter_map(|(col, cell)| {
-                    let MdastNode::TableCell(tc) = cell else { return None; };
-                    let mut attrs: Vec<(String, String)> = Vec::new();
-                    if let Some(s) = style_attr(col) { attrs.push(s); }
-                    Some(element(tag, attrs, convert_children_with(&tc.children, strategy)))
-                }).collect()
+                let MdastNode::TableRow(tr) = row else {
+                    return Vec::new();
+                };
+                tr.children
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(col, cell)| {
+                        let MdastNode::TableCell(tc) = cell else {
+                            return None;
+                        };
+                        let mut attrs: Vec<(String, String)> = Vec::new();
+                        if let Some(s) = style_attr(col) {
+                            attrs.push(s);
+                        }
+                        Some(element(
+                            tag,
+                            attrs,
+                            convert_children_with(&tc.children, strategy),
+                        ))
+                    })
+                    .collect()
             };
 
             let mut thead_children: Vec<HastNode> = Vec::new();
@@ -2288,10 +2297,7 @@ fn mdast_to_hast_inner(node: &MdastNode, strategy: &JsxEmitStrategy<'_>) -> Hast
 
 /// Convert a slice of mdast children into a vec of hast children
 /// using the given strategy for the JSX-shaped arms.
-fn convert_children_with(
-    children: &[MdastNode],
-    strategy: &JsxEmitStrategy<'_>,
-) -> Vec<HastNode> {
+fn convert_children_with(children: &[MdastNode], strategy: &JsxEmitStrategy<'_>) -> Vec<HastNode> {
     children
         .iter()
         .map(|c| mdast_to_hast_inner(c, strategy))
@@ -2538,9 +2544,7 @@ mod tests {
     // parser leaves `~~text~~` as bare text — no `Delete` node.
     #[test]
     fn strikethrough_disabled_emits_no_delete_node() {
-        let mut p = Pipeline::with_resolved_gfm_constructs(
-            ResolvedGfmConstructs::ALL_OFF,
-        );
+        let mut p = Pipeline::with_resolved_gfm_constructs(ResolvedGfmConstructs::ALL_OFF);
         let h = p.run("a ~~b~~ c").expect("parse ok");
         // Walk the tree and assert there is no `<del>` anywhere — the
         // raw `~~` characters live inside a Text node instead.
@@ -2757,9 +2761,7 @@ mod tests {
     #[test]
     fn with_defaults_seeds_no_directive_vocabulary() {
         let mut p = Pipeline::with_defaults();
-        let h = p
-            .run(":::note\n\nbody\n\n:::\n")
-            .expect("pipeline runs ok");
+        let h = p.run(":::note\n\nbody\n\n:::\n").expect("pipeline runs ok");
         let mut raws = Vec::new();
         collect_raw(&h, &mut raws);
         assert!(
@@ -2776,9 +2778,7 @@ mod tests {
         // caller picks the no-plugins constructor — the paragraph runs
         // through to hast as plain `<p>:::note</p>` etc.
         for mut p in [Pipeline::new(), Pipeline::with_mdx()] {
-            let h = p
-                .run(":::note\n\nbody\n\n:::\n")
-                .expect("pipeline runs ok");
+            let h = p.run(":::note\n\nbody\n\n:::\n").expect("pipeline runs ok");
             let mut raws = Vec::new();
             collect_raw(&h, &mut raws);
             assert!(
@@ -2855,8 +2855,7 @@ mod tests {
         let default_html = crate::serializer::serialize(&default_hast);
 
         // Non-default theme pipeline — InspiredGitHub.
-        let mut themed_pipeline =
-            Pipeline::with_defaults_and_theme(Some("InspiredGitHub"));
+        let mut themed_pipeline = Pipeline::with_defaults_and_theme(Some("InspiredGitHub"));
         let themed_hast = themed_pipeline.run(mdx).expect("themed pipeline ok");
         let themed_html = crate::serializer::serialize(&themed_hast);
 

--- a/crates/zfb-content/src/pipeline_spec.rs
+++ b/crates/zfb-content/src/pipeline_spec.rs
@@ -137,6 +137,17 @@ pub struct PipelineSpec {
     /// heading-marker TOC) are OFF (the post-epic opt-in default,
     /// #583 / #586).
     pub features: Option<zfb_md_extras::MarkdownFeaturesConfig>,
+    /// Resolved `(project_root, public_dir)` pair handed to
+    /// [`Pipeline::set_build_context_roots`] at construction time so the
+    /// context-aware feature plugins (transclude, imageDimensions,
+    /// linkValidation) receive a concrete filesystem anchor.
+    ///
+    /// `None` (the default) leaves the pipeline unarmed — the plugins are
+    /// inert and no filesystem reads occur.  Set **only** when a
+    /// filesystem-dependent feature is enabled in the config so unarmed
+    /// projects keep byte-identical fingerprints and shared cache keys, and
+    /// so roots and the #942 `ReadRecorder` always co-occur (zfb#952).
+    pub build_context_roots: Option<(PathBuf, PathBuf)>,
 }
 
 impl Default for PipelineSpec {
@@ -152,6 +163,7 @@ impl Default for PipelineSpec {
             cjk_friendly: true,
             hard_breaks: false,
             features: None,
+            build_context_roots: None,
         }
     }
 }
@@ -193,6 +205,7 @@ impl PipelineSpec {
             cjk_friendly,
             hard_breaks,
             features,
+            build_context_roots,
         } = self;
 
         // Single feature-aware entry point. `features = None` is an empty
@@ -232,6 +245,9 @@ impl PipelineSpec {
         }
         if let Some((cfg, site)) = external_links {
             pipeline.add_external_links(cfg.clone(), site.as_deref());
+        }
+        if let Some((root, public)) = build_context_roots.clone() {
+            pipeline.set_build_context_roots(root, public);
         }
         Ok(pipeline)
     }
@@ -312,4 +328,71 @@ mod tests {
             "resolve-links output differs from the default shape — keys must split"
         );
     }
+
+    /// zfb#952: two PipelineSpecs carrying the same `build_context_roots` pair
+    /// must produce byte-identical config fingerprints — this is the property
+    /// the bundler-walk and snapshot-walker surfaces rely on (they both call
+    /// `PipelineSpec::build_pipeline` on the same spec, so structural parity is
+    /// guaranteed, but the fingerprint must also be deterministic across calls).
+    #[test]
+    fn build_context_roots_armed_spec_is_fingerprint_stable() {
+        let spec = PipelineSpec {
+            build_context_roots: Some((
+                PathBuf::from("/tmp/proj"),
+                PathBuf::from("/tmp/proj/public"),
+            )),
+            ..Default::default()
+        };
+        let a = spec.build_pipeline().expect("builds").config_fingerprint();
+        let b = spec.build_pipeline().expect("builds").config_fingerprint();
+        assert!(a.is_some(), "armed spec must be fingerprintable (zfb#952)");
+        assert_eq!(a, b, "same roots across builds must share one fingerprint");
+        // Armed spec must produce a different fingerprint than an unarmed one.
+        assert_ne!(
+            a,
+            PipelineSpec::default()
+                .build_pipeline()
+                .expect("builds")
+                .config_fingerprint(),
+            "armed roots must extend the fingerprint (zfb#952)"
+        );
+    }
+
+    /// zfb#952: an absolute `publicDir` value is passed through unchanged by
+    /// `resolve_under_root` — verified here by checking that the path stored in
+    /// `build_context_roots` equals the input absolute path verbatim.
+    #[test]
+    fn absolute_public_dir_passthrough_in_build_context_roots() {
+        // An absolute publicDir must appear unchanged in the fingerprint.
+        let absolute_public = PathBuf::from("/var/www/public");
+        let spec = PipelineSpec {
+            build_context_roots: Some((PathBuf::from("/tmp/proj"), absolute_public.clone())),
+            ..Default::default()
+        };
+        let pipeline = spec.build_pipeline().expect("builds");
+        let (_, resolved_public) = pipeline.build_context_roots().expect("roots must be armed");
+        assert_eq!(
+            resolved_public, absolute_public,
+            "absolute publicDir must pass through unchanged (zfb#952)"
+        );
+        // Relative public dir is joined to project root.
+        let root = PathBuf::from("/tmp/proj");
+        let relative_public = PathBuf::from("static");
+        let expected_joined = root.join(&relative_public);
+        let spec_relative = PipelineSpec {
+            build_context_roots: Some((root.clone(), expected_joined.clone())),
+            ..Default::default()
+        };
+        let pipeline_rel = spec_relative.build_pipeline().expect("builds");
+        let (_, resolved_rel) = pipeline_rel
+            .build_context_roots()
+            .expect("roots must be armed");
+        assert_eq!(
+            resolved_rel, expected_joined,
+            "relative publicDir must be joined to project root (zfb#952)"
+        );
+    }
+    // Note: `default_spec_matches_bare_full_config_constructor` (above) is the
+    // acceptance-criteria test for unarmed configs keeping byte-identical
+    // fingerprints — it exercises `build_context_roots: None` (the Default).
 }

--- a/crates/zfb-content/src/plugins.rs
+++ b/crates/zfb-content/src/plugins.rs
@@ -9,9 +9,9 @@
 
 pub mod cjk_friendly;
 pub mod code_title;
-pub mod hard_breaks;
 pub mod directives;
 pub mod external_links;
+pub mod hard_breaks;
 pub mod heading_links;
 pub mod mermaid;
 pub mod resolve_links;
@@ -21,13 +21,13 @@ pub mod toc;
 pub mod util;
 
 pub use cjk_friendly::CjkFriendlyPlugin;
-pub use hard_breaks::HardBreaksPlugin;
 pub use code_title::CodeTitlePlugin;
 pub use directives::{
     AttrSchema, AttrType, AttrValidationResult, DirectiveDef, DirectiveDiagnostic, DirectiveKind,
     DirectiveRegistry, ValidatedAttrValue,
 };
 pub use external_links::{ExternalLinksConfig, ExternalLinksPlugin};
+pub use hard_breaks::HardBreaksPlugin;
 pub use heading_links::HeadingLinksPlugin;
 pub use mermaid::MermaidPlugin;
 pub use resolve_links::{BrokenLinkDiagnostic, ResolveLinksPlugin, ResolveMarkdownLinksOptions};

--- a/crates/zfb-content/src/plugins/cjk_friendly.rs
+++ b/crates/zfb-content/src/plugins/cjk_friendly.rs
@@ -581,7 +581,10 @@ mod tests {
     #[test]
     fn mixed_script_unchanged() {
         let h = run("日本語 mixed with English **bold** text 日本語");
-        assert_eq!(dump(&h), "日本語 mixed with English [STRONG:bold] text 日本語");
+        assert_eq!(
+            dump(&h),
+            "日本語 mixed with English [STRONG:bold] text 日本語"
+        );
     }
 
     #[test]
@@ -898,7 +901,9 @@ mod tests {
     #[test]
     fn cjk_punct_close_inside_heading() {
         let h = run_root("# **テスト。**テスト\n");
-        let MdastNode::Root(r) = &h else { unreachable!() };
+        let MdastNode::Root(r) = &h else {
+            unreachable!()
+        };
         let MdastNode::Heading(head) = &r.children[0] else {
             unreachable!("expected Heading, got {:?}", r.children[0])
         };
@@ -916,7 +921,9 @@ mod tests {
     fn cjk_punct_close_inside_list_item() {
         let h = run_root("- **テスト。**テスト\n");
         // Walk to the list item paragraph.
-        let MdastNode::Root(r) = &h else { unreachable!() };
+        let MdastNode::Root(r) = &h else {
+            unreachable!()
+        };
         let MdastNode::List(l) = &r.children[0] else {
             unreachable!()
         };
@@ -938,7 +945,9 @@ mod tests {
     #[test]
     fn cjk_punct_close_inside_blockquote() {
         let h = run_root("> **テスト。**テスト\n");
-        let MdastNode::Root(r) = &h else { unreachable!() };
+        let MdastNode::Root(r) = &h else {
+            unreachable!()
+        };
         let MdastNode::Blockquote(b) = &r.children[0] else {
             unreachable!()
         };
@@ -971,8 +980,8 @@ mod tests {
     }
 
     fn run_root(input: &str) -> MdastNode {
-        let mut mdast = markdown::to_mdast(input, &markdown::ParseOptions::mdx())
-            .expect("markdown-rs parse");
+        let mut mdast =
+            markdown::to_mdast(input, &markdown::ParseOptions::mdx()).expect("markdown-rs parse");
         CjkFriendlyPlugin::new().visit(&mut mdast);
         mdast
     }

--- a/crates/zfb-content/src/plugins/directives.rs
+++ b/crates/zfb-content/src/plugins/directives.rs
@@ -153,21 +153,15 @@ impl DirectiveRegistry {
                 if let Some(def) = self.defs.get(&parsed.name).cloned() {
                     if def.kind == DirectiveKind::Container {
                         // Find matching `:::` close.
-                        if let Some(close_idx) = (i + 1..children.len())
-                            .find(|j| is_container_close(&children[*j]))
+                        if let Some(close_idx) =
+                            (i + 1..children.len()).find(|j| is_container_close(&children[*j]))
                         {
                             let (line, column) = paragraph_line_col(&children[i]);
-                            let validated_opt =
-                                self.run_validation(&def, &parsed, line, column);
+                            let validated_opt = self.run_validation(&def, &parsed, line, column);
                             let body: Vec<MdastNode> = children.drain(i..=close_idx).collect();
                             // Strip open + close paragraphs.
                             let inner = body[1..body.len() - 1].to_vec();
-                            let jsx = build_flow_jsx(
-                                &def,
-                                &parsed,
-                                inner,
-                                validated_opt.as_ref(),
-                            );
+                            let jsx = build_flow_jsx(&def, &parsed, inner, validated_opt.as_ref());
                             children.insert(i, jsx);
                             i += 1;
                             continue;
@@ -210,14 +204,8 @@ impl DirectiveRegistry {
                     if def.kind == DirectiveKind::Leaf {
                         let position = paragraph_position(&children[i]);
                         let (line, column) = paragraph_line_col(&children[i]);
-                        let validated_opt =
-                            self.run_validation(&def, &parsed, line, column);
-                        let jsx = build_leaf_jsx(
-                            &def,
-                            &parsed,
-                            position,
-                            validated_opt.as_ref(),
-                        );
+                        let validated_opt = self.run_validation(&def, &parsed, line, column);
+                        let jsx = build_leaf_jsx(&def, &parsed, position, validated_opt.as_ref());
                         children[i] = jsx;
                         i += 1;
                         continue;
@@ -292,8 +280,7 @@ impl DirectiveRegistry {
                             }
                             // Inline text directives have no source position
                             // from the text scanner — pass None for both.
-                            let validated_opt =
-                                self.run_validation(&def, &parsed, None, None);
+                            let validated_opt = self.run_validation(&def, &parsed, None, None);
                             out.push(build_text_jsx(&def, &parsed, validated_opt.as_ref()));
                             i = end;
                             last_emit = end;
@@ -502,10 +489,7 @@ fn parse_text_directive(source: &str, start: usize) -> Option<(ParsedDirective, 
         return None;
     }
 
-    Some((
-        ParsedDirective { name, label, attrs },
-        i,
-    ))
+    Some((ParsedDirective { name, label, attrs }, i))
 }
 
 /// Find the index of the matching `}` in `s`, treating `"…"` runs as
@@ -996,10 +980,7 @@ mod tests {
     fn leaf_with_label_and_attrs() {
         let mut r = DirectiveRegistry::new();
         r.register(DirectiveDef::leaf("badge", "Badge"));
-        let out = run_with_registry(
-            &mut r,
-            vec![text_para("::badge[Label]{variant=success}")],
-        );
+        let out = run_with_registry(&mut r, vec![text_para("::badge[Label]{variant=success}")]);
         assert_eq!(out.len(), 1);
         let j = flow(&out[0]);
         assert_eq!(j.name.as_deref(), Some("Badge"));
@@ -1080,11 +1061,7 @@ mod tests {
         // No registrations.
         let out = run_with_registry(
             &mut r,
-            vec![
-                text_para(":::nope"),
-                text_para("body"),
-                text_para(":::"),
-            ],
+            vec![text_para(":::nope"), text_para("body"), text_para(":::")],
         );
         // Source preserved.
         assert_eq!(out.len(), 3);
@@ -1182,10 +1159,7 @@ mod tests {
     #[test]
     fn missing_close_left_alone() {
         let mut r = registry_with_admonitions();
-        let out = run_with_registry(
-            &mut r,
-            vec![text_para(":::note"), text_para("body")],
-        );
+        let out = run_with_registry(&mut r, vec![text_para(":::note"), text_para("body")]);
         assert_eq!(out.len(), 2);
         // First is still a paragraph.
         assert!(matches!(out[0], MdastNode::Paragraph(_)));
@@ -1196,11 +1170,7 @@ mod tests {
         let mut r = registry_with_admonitions();
         // Build a blockquote that contains the admonition paragraphs.
         let bq = MdastNode::Blockquote(markdown::mdast::Blockquote {
-            children: vec![
-                text_para(":::note"),
-                text_para("inner"),
-                text_para(":::"),
-            ],
+            children: vec![text_para(":::note"), text_para("inner"), text_para(":::")],
             position: None,
         });
         let out = run_with_registry(&mut r, vec![bq]);
@@ -1346,7 +1316,11 @@ mod tests {
         assert!(matches!(out[0], MdastNode::Paragraph(_)));
         // A diagnostic must be emitted.
         let diags = r.take_diagnostics();
-        assert_eq!(diags.len(), 1, "expected exactly one diagnostic, got {diags:?}");
+        assert_eq!(
+            diags.len(),
+            1,
+            "expected exactly one diagnostic, got {diags:?}"
+        );
         assert!(
             diags[0].message.contains("blank lines"),
             "diagnostic should mention blank lines, got: {:?}",
@@ -1423,11 +1397,7 @@ mod tests {
         // `:::note` is NOT registered — left untransformed (zero defaults).
         let out2 = run_with_registry(
             &mut r,
-            vec![
-                text_para(":::note"),
-                text_para("body"),
-                text_para(":::"),
-            ],
+            vec![text_para(":::note"), text_para("body"), text_para(":::")],
         );
         // Should still be 3 paragraphs (no transformation).
         assert_eq!(out2.len(), 3, ":::note must stay as-is when not registered");

--- a/crates/zfb-content/src/plugins/external_links.rs
+++ b/crates/zfb-content/src/plugins/external_links.rs
@@ -139,9 +139,7 @@ fn extract_origin(url: &str) -> Option<String> {
     // rest starts with `//`; skip it.
     let rest = rest.strip_prefix("//")?;
     // authority ends at the first `/`, `?`, `#`, or end of string.
-    let authority_end = rest
-        .find(['/', '?', '#'])
-        .unwrap_or(rest.len());
+    let authority_end = rest.find(['/', '?', '#']).unwrap_or(rest.len());
     let authority = &rest[..authority_end];
     // Strip userinfo (`user:pass@`) if present — origin never includes it.
     let host_and_port = if let Some(at) = authority.rfind('@') {
@@ -165,10 +163,7 @@ fn split_scheme(url: &str) -> Option<(&str, &str)> {
 
 fn is_http_scheme(scheme: &str) -> bool {
     // Case-insensitive per RFC 3986 §3.1.
-    matches!(
-        scheme.to_ascii_lowercase().as_str(),
-        "http" | "https"
-    )
+    matches!(scheme.to_ascii_lowercase().as_str(), "http" | "https")
 }
 
 /// Classify an href as external given an optional site origin.
@@ -298,7 +293,10 @@ mod tests {
         let HastNode::Element { attrs, .. } = node else {
             return None;
         };
-        attrs.iter().find(|(k, _)| k == key).map(|(_, v)| v.as_str())
+        attrs
+            .iter()
+            .find(|(k, _)| k == key)
+            .map(|(_, v)| v.as_str())
     }
 
     fn plugin_no_site() -> ExternalLinksPlugin {
@@ -375,7 +373,11 @@ mod tests {
         let mut tree = root(vec![a("https://example.com/foo")]);
         plugin_with_site("https://example.com").visit(&mut tree);
         let link = first_child(&tree);
-        assert_eq!(attr(link, "target"), None, "same-origin must not get target");
+        assert_eq!(
+            attr(link, "target"),
+            None,
+            "same-origin must not get target"
+        );
         assert_eq!(attr(link, "rel"), None, "same-origin must not get rel");
     }
 
@@ -442,10 +444,7 @@ mod tests {
         )]);
         plugin_no_site().visit(&mut tree);
         // Configured tokens already present → no duplication.
-        assert_eq!(
-            attr(first_child(&tree), "rel"),
-            Some("noopener noreferrer")
-        );
+        assert_eq!(attr(first_child(&tree), "rel"), Some("noopener noreferrer"));
     }
 
     // --- origin helpers ----------------------------------------------------

--- a/crates/zfb-content/src/plugins/hard_breaks.rs
+++ b/crates/zfb-content/src/plugins/hard_breaks.rs
@@ -165,9 +165,15 @@ mod tests {
         let h = run("first\nsecond\n");
         let p = first_paragraph_children(&h);
         assert_eq!(p.len(), 3, "expected Text+Break+Text, got {p:?}");
-        assert!(matches!(&p[0], MdastNode::Text(t) if t.value == "first"), "p[0]: {p:?}");
+        assert!(
+            matches!(&p[0], MdastNode::Text(t) if t.value == "first"),
+            "p[0]: {p:?}"
+        );
         assert!(matches!(&p[1], MdastNode::Break(_)), "p[1]: {p:?}");
-        assert!(matches!(&p[2], MdastNode::Text(t) if t.value == "second"), "p[2]: {p:?}");
+        assert!(
+            matches!(&p[2], MdastNode::Text(t) if t.value == "second"),
+            "p[2]: {p:?}"
+        );
     }
 
     #[test]
@@ -196,15 +202,21 @@ mod tests {
     fn blank_line_separation_unaffected() {
         // Blank-line paragraph separation → still two Paragraph nodes; no Break added.
         let h = run("para one\n\npara two\n");
-        let MdastNode::Root(r) = &h else { unreachable!() };
+        let MdastNode::Root(r) = &h else {
+            unreachable!()
+        };
         assert_eq!(
             r.children.len(),
             2,
             "expected 2 paragraphs, got {:?}",
             r.children
         );
-        let MdastNode::Paragraph(p1) = &r.children[0] else { unreachable!() };
-        let MdastNode::Paragraph(p2) = &r.children[1] else { unreachable!() };
+        let MdastNode::Paragraph(p1) = &r.children[0] else {
+            unreachable!()
+        };
+        let MdastNode::Paragraph(p2) = &r.children[1] else {
+            unreachable!()
+        };
         // Neither paragraph should contain a Break.
         for node in p1.children.iter().chain(p2.children.iter()) {
             assert!(
@@ -242,13 +254,13 @@ mod tests {
 
     #[test]
     fn fenced_code_not_split() {
-        let mut mdast = markdown::to_mdast(
-            "```\nfirst\nsecond\n```\n",
-            &markdown::ParseOptions::mdx(),
-        )
-        .unwrap();
+        let mut mdast =
+            markdown::to_mdast("```\nfirst\nsecond\n```\n", &markdown::ParseOptions::mdx())
+                .unwrap();
         HardBreaksPlugin::new().visit(&mut mdast);
-        let MdastNode::Root(r) = &mdast else { unreachable!() };
+        let MdastNode::Root(r) = &mdast else {
+            unreachable!()
+        };
         let MdastNode::Code(c) = &r.children[0] else {
             unreachable!("expected Code, got {:?}", r.children[0])
         };

--- a/crates/zfb-content/src/plugins/heading_links.rs
+++ b/crates/zfb-content/src/plugins/heading_links.rs
@@ -170,7 +170,11 @@ impl HastVisitor for HeadingLinksPlugin {
     /// Zero-cost when `ctx.heading_registry` is `None` — no registry writes
     /// are performed.
     fn visit_with_context(&mut self, node: &mut HastNode, ctx: &mut BuildContext<'_>) {
-        self.visit_node(node, ctx.heading_registry.as_deref_mut(), ctx.source_path.clone());
+        self.visit_node(
+            node,
+            ctx.heading_registry.as_deref_mut(),
+            ctx.source_path.clone(),
+        );
     }
 }
 

--- a/crates/zfb-content/src/plugins/resolve_links.rs
+++ b/crates/zfb-content/src/plugins/resolve_links.rs
@@ -205,9 +205,8 @@ impl MdastVisitor for ResolveLinksPlugin {
                 Ok(Some(rewritten)) => l.url = rewritten,
                 Err(()) => {
                     // .md/.mdx link that is not in the source map → broken.
-                    self.broken_links.push(BrokenLinkDiagnostic {
-                        url: l.url.clone(),
-                    });
+                    self.broken_links
+                        .push(BrokenLinkDiagnostic { url: l.url.clone() });
                 }
                 Ok(None) => {}
             }

--- a/crates/zfb-content/src/plugins/syntect_plugin.rs
+++ b/crates/zfb-content/src/plugins/syntect_plugin.rs
@@ -208,9 +208,7 @@ mod tests {
                 .any(|(k, v)| k == "class" && v.starts_with("syntect-")),
             "pre must have class=\"syntect-…\": {pre_attrs:?}"
         );
-        let code_el = pre_children
-            .first()
-            .expect("pre must have a child <code>");
+        let code_el = pre_children.first().expect("pre must have a child <code>");
         let HastNode::Element {
             tag: code_tag,
             children: code_children,
@@ -232,9 +230,7 @@ mod tests {
             };
             assert_eq!(span_tag, "span", "line {i}: span tag must be span");
             assert!(
-                span_attrs
-                    .iter()
-                    .any(|(k, v)| k == "class" && v == "line"),
+                span_attrs.iter().any(|(k, v)| k == "class" && v == "line"),
                 "line {i}: span must have class=\"line\": {span_attrs:?}"
             );
             assert_eq!(
@@ -355,7 +351,13 @@ mod tests {
             code_children.len()
         );
         for (i, span) in code_children.iter().enumerate() {
-            let HastNode::Element { tag, attrs, children: span_children, .. } = span else {
+            let HastNode::Element {
+                tag,
+                attrs,
+                children: span_children,
+                ..
+            } = span
+            else {
                 panic!("line {i}: expected Element<span>, got {span:?}");
             };
             assert_eq!(tag, "span", "line {i}: wrong tag");

--- a/crates/zfb-content/src/schema.rs
+++ b/crates/zfb-content/src/schema.rs
@@ -69,11 +69,7 @@ fn schema_to_ts_inner(schema: &JsonValue, indent: usize) -> String {
     ts_type
 }
 
-fn single_type_to_ts(
-    ty: &str,
-    obj: &serde_json::Map<String, JsonValue>,
-    indent: usize,
-) -> String {
+fn single_type_to_ts(ty: &str, obj: &serde_json::Map<String, JsonValue>, indent: usize) -> String {
     match ty {
         "string" => "string".to_string(),
         "number" | "integer" => "number".to_string(),
@@ -209,12 +205,7 @@ pub fn validate(value: &JsonValue, schema: &JsonValue) -> Vec<SchemaIssue> {
     out
 }
 
-fn validate_inner(
-    value: &JsonValue,
-    schema: &JsonValue,
-    path: &str,
-    out: &mut Vec<SchemaIssue>,
-) {
+fn validate_inner(value: &JsonValue, schema: &JsonValue, path: &str, out: &mut Vec<SchemaIssue>) {
     let JsonValue::Object(schema_obj) = schema else {
         // Non-object schemas (`true`, missing, etc.) accept anything.
         return;
@@ -226,7 +217,11 @@ fn validate_inner(
             let parts: Vec<String> = values.iter().map(literal_to_ts).collect();
             out.push(SchemaIssue {
                 path: path.to_string(),
-                message: format!("expected one of {}, got {}", parts.join(" | "), describe(value)),
+                message: format!(
+                    "expected one of {}, got {}",
+                    parts.join(" | "),
+                    describe(value)
+                ),
             });
         }
         return;
@@ -298,7 +293,8 @@ fn value_matches_type(value: &JsonValue, ty: &str) -> bool {
     match ty {
         "string" => value.is_string(),
         "number" => value.is_number(),
-        "integer" => value.as_i64().is_some()
+        "integer" => {
+            value.as_i64().is_some()
             || value.as_u64().is_some()
             // Also accept JSON `1.0` which is technically integral, but
             // only when it actually fits in an integer lane — otherwise
@@ -312,7 +308,8 @@ fn value_matches_type(value: &JsonValue, ty: &str) -> bool {
                         && f >= i64::MIN as f64
                         && f <= u64::MAX as f64
                 })
-                .unwrap_or(false),
+                .unwrap_or(false)
+        }
         "boolean" => value.is_boolean(),
         "null" => value.is_null(),
         "array" => value.is_array(),

--- a/crates/zfb-content/src/syntect_highlight.rs
+++ b/crates/zfb-content/src/syntect_highlight.rs
@@ -333,9 +333,7 @@ fn theme_slug(name: &str) -> String {
 /// tokenization error). Splits `code` on `LinesWithEndings` so the per-line
 /// vector has the same granularity as the normal path.
 fn fallback_lines(code: &str, slug: &str) -> HighlightedLines {
-    let lines: Vec<String> = LinesWithEndings::from(code)
-        .map(escape_html)
-        .collect();
+    let lines: Vec<String> = LinesWithEndings::from(code).map(escape_html).collect();
     HighlightedLines {
         theme_slug: slug.to_string(),
         lines,

--- a/crates/zfb-content/src/tsx_frontmatter.rs
+++ b/crates/zfb-content/src/tsx_frontmatter.rs
@@ -124,7 +124,9 @@ pub enum TsxFrontmatterError {
     /// nested value inside it) is not a literal. The error names the
     /// export, the file, the offending span, and a short reason that
     /// describes which non-literal shape was encountered.
-    #[error("{file}:{line}:{col}: non-literal value not allowed in `export const {export}` ({reason})")]
+    #[error(
+        "{file}:{line}:{col}: non-literal value not allowed in `export const {export}` ({reason})"
+    )]
     ComputedValue {
         file: String,
         export: String,
@@ -476,11 +478,7 @@ fn expect_object<'a>(
 
 /// Expect an expression to be a string literal (or a substitution-free
 /// template literal). `extension` and `contentType` go through here.
-fn expect_string(
-    expr: &Expr,
-    export: &str,
-    ctx: &Ctx<'_>,
-) -> Result<String, TsxFrontmatterError> {
+fn expect_string(expr: &Expr, export: &str, ctx: &Ctx<'_>) -> Result<String, TsxFrontmatterError> {
     match unwrap_ts_wrappers(expr) {
         Expr::Lit(Lit::Str(s)) => Ok(wtf8_to_string(&s.value)),
         Expr::Tpl(tpl) if tpl.exprs.is_empty() => Ok(tpl_quasi_to_string(tpl)),
@@ -583,11 +581,9 @@ fn prop_name_to_string(
             export,
             "BigInt property keys are not representable in JSON",
         )),
-        PropName::Computed(c) => Err(ctx.computed(
-            c.span,
-            export,
-            "computed property keys are not allowed",
-        )),
+        PropName::Computed(c) => {
+            Err(ctx.computed(c.span, export, "computed property keys are not allowed"))
+        }
     }
 }
 
@@ -621,11 +617,7 @@ fn expr_to_json(
                         // `[1, , 3]` — a "hole". JSON has no concept
                         // of holes, and silently coercing one into
                         // `null` would lie about what the source said.
-                        return Err(ctx.computed(
-                            arr.span,
-                            export,
-                            "array holes are not allowed",
-                        ));
+                        return Err(ctx.computed(arr.span, export, "array holes are not allowed"));
                     }
                 }
             }
@@ -666,81 +658,47 @@ fn expr_to_json(
                     "unary operator only allowed in front of a numeric literal",
                 )),
             },
-            _ => Err(ctx.computed(
-                u.span,
-                export,
-                "unary operator is not a literal value",
-            )),
+            _ => Err(ctx.computed(u.span, export, "unary operator is not a literal value")),
         },
         // Everything below requires runtime evaluation or is otherwise
         // not a literal; report with a kind-specific reason so the
         // page author sees what they used.
-        Expr::Ident(i) => Err(ctx.computed(
-            i.span,
-            export,
-            "identifier reference is not a literal",
-        )),
+        Expr::Ident(i) => {
+            Err(ctx.computed(i.span, export, "identifier reference is not a literal"))
+        }
         Expr::Call(c) => Err(ctx.computed(c.span, export, "function call is not a literal")),
         Expr::New(n) => Err(ctx.computed(n.span, export, "`new` expression is not a literal")),
-        Expr::Member(m) => Err(ctx.computed(
-            m.span,
-            export,
-            "member access is not a literal",
-        )),
-        Expr::Bin(b) => Err(ctx.computed(
-            b.span,
-            export,
-            "binary expression is not a literal",
-        )),
-        Expr::Cond(c) => Err(ctx.computed(
-            c.span,
-            export,
-            "conditional expression is not a literal",
-        )),
+        Expr::Member(m) => Err(ctx.computed(m.span, export, "member access is not a literal")),
+        Expr::Bin(b) => Err(ctx.computed(b.span, export, "binary expression is not a literal")),
+        Expr::Cond(c) => {
+            Err(ctx.computed(c.span, export, "conditional expression is not a literal"))
+        }
         Expr::Arrow(a) => Err(ctx.computed(a.span, export, "arrow function is not a literal")),
         Expr::Fn(f) => Err(ctx.computed(
             f.function.span,
             export,
             "function expression is not a literal",
         )),
-        Expr::Class(c) => Err(ctx.computed(
-            c.class.span,
-            export,
-            "class expression is not a literal",
-        )),
+        Expr::Class(c) => {
+            Err(ctx.computed(c.class.span, export, "class expression is not a literal"))
+        }
         Expr::This(t) => Err(ctx.computed(t.span, export, "`this` is not a literal")),
-        Expr::Update(u) => Err(ctx.computed(
-            u.span,
-            export,
-            "update expression is not a literal",
-        )),
-        Expr::Assign(a) => Err(ctx.computed(
-            a.span,
-            export,
-            "assignment expression is not a literal",
-        )),
-        Expr::Seq(s) => Err(ctx.computed(
-            s.span,
-            export,
-            "sequence expression is not a literal",
-        )),
+        Expr::Update(u) => Err(ctx.computed(u.span, export, "update expression is not a literal")),
+        Expr::Assign(a) => {
+            Err(ctx.computed(a.span, export, "assignment expression is not a literal"))
+        }
+        Expr::Seq(s) => Err(ctx.computed(s.span, export, "sequence expression is not a literal")),
         Expr::Yield(y) => Err(ctx.computed(y.span, export, "`yield` is not a literal")),
         Expr::Await(a) => Err(ctx.computed(a.span, export, "`await` is not a literal")),
-        Expr::TaggedTpl(t) => Err(ctx.computed(
-            t.span,
-            export,
-            "tagged template literal is not a literal",
-        )),
-        Expr::JSXElement(j) => Err(ctx.computed(
-            j.span,
-            export,
-            "JSX element is not a literal value",
-        )),
-        Expr::JSXFragment(j) => Err(ctx.computed(
-            j.span,
-            export,
-            "JSX fragment is not a literal value",
-        )),
+        Expr::TaggedTpl(t) => {
+            Err(ctx.computed(t.span, export, "tagged template literal is not a literal"))
+        }
+        Expr::JSXElement(j) => {
+            Err(ctx.computed(j.span, export, "JSX element is not a literal value"))
+        }
+        Expr::JSXFragment(j) => {
+            Err(ctx.computed(j.span, export, "JSX fragment is not a literal value"))
+        }
         // Catch-all for anything not enumerated above; we still emit a
         // span so the page author can find it.
         other => Err(ctx.computed(
@@ -754,11 +712,7 @@ fn expr_to_json(
 /// Convert a single literal node into a JSON value. Regex / BigInt /
 /// raw JSXText literals can't survive a round-trip through JSON, so
 /// they're rejected.
-fn lit_to_json(
-    lit: &Lit,
-    export: &str,
-    ctx: &Ctx<'_>,
-) -> Result<JsonValue, TsxFrontmatterError> {
+fn lit_to_json(lit: &Lit, export: &str, ctx: &Ctx<'_>) -> Result<JsonValue, TsxFrontmatterError> {
     match lit {
         Lit::Str(s) => Ok(JsonValue::String(wtf8_to_string(&s.value))),
         Lit::Bool(b) => Ok(JsonValue::Bool(b.value)),
@@ -775,16 +729,10 @@ fn lit_to_json(
             export,
             "BigInt literal is not representable in JSON",
         )),
-        Lit::Regex(r) => Err(ctx.computed(
-            r.span,
-            export,
-            "regex literal is not representable in JSON",
-        )),
-        Lit::JSXText(j) => Err(ctx.computed(
-            j.span,
-            export,
-            "JSX text is not a literal value",
-        )),
+        Lit::Regex(r) => {
+            Err(ctx.computed(r.span, export, "regex literal is not representable in JSON"))
+        }
+        Lit::JSXText(j) => Err(ctx.computed(j.span, export, "JSX text is not a literal value")),
     }
 }
 
@@ -1218,9 +1166,8 @@ mod tests {
             export const frontmatter = { title: "X" };
             export const prerender = decide();
         "#;
-        let out = extract(src, "page.tsx").expect(
-            "computed prerender must not error — it should fall back to the default",
-        );
+        let out = extract(src, "page.tsx")
+            .expect("computed prerender must not error — it should fall back to the default");
         assert!(
             out.prerender,
             "computed prerender should fall back to default `true`, not silently flip to `false`",
@@ -1267,9 +1214,8 @@ mod tests {
             export const frontmatter = { title: "X" };
             export const prerender = !true;
         "#;
-        let out = extract(src, "page.tsx").expect(
-            "unary-not prerender must not error — it should fall back to the default",
-        );
+        let out = extract(src, "page.tsx")
+            .expect("unary-not prerender must not error — it should fall back to the default");
         assert!(
             out.prerender,
             "`!true` is not a literal — should fall back to default `true`",

--- a/crates/zfb-content/tests/cjk.rs
+++ b/crates/zfb-content/tests/cjk.rs
@@ -273,4 +273,3 @@ fn bold_at_cjk_boundary_default() {
     let html = render(input);
     assert_contains(&html, "<strong>強調</strong>するテキスト", input);
 }
-

--- a/crates/zfb-content/tests/collection_filter_parity.rs
+++ b/crates/zfb-content/tests/collection_filter_parity.rs
@@ -77,8 +77,8 @@ fn snapshot_module_specifier_has_id_strip_suffix_applied() {
         exclude: None,
         id_strip_suffix: Some(".en".into()),
     };
-    let snap = build_snapshot_with_config(&[cfg], &PipelineSpec::default())
-        .expect("snapshot build");
+    let snap =
+        build_snapshot_with_config(&[cfg], &PipelineSpec::default()).expect("snapshot build");
     let entries = snap.collections.get("notes-en").expect("collection");
 
     // Two EN entries survive (JA sibling excluded). Snapshot is sorted
@@ -152,8 +152,8 @@ fn snapshot_specifier_unchanged_when_id_strip_suffix_absent() {
     );
 
     let cfg = CollectionConfig::new("notes", col_dir.clone());
-    let snap = build_snapshot_with_config(&[cfg], &PipelineSpec::default())
-        .expect("snapshot build");
+    let snap =
+        build_snapshot_with_config(&[cfg], &PipelineSpec::default()).expect("snapshot build");
     let entries = snap.collections.get("notes").expect("collection");
     assert_eq!(entries.len(), 1);
     assert!(

--- a/crates/zfb-content/tests/directives_typed_attrs.rs
+++ b/crates/zfb-content/tests/directives_typed_attrs.rs
@@ -107,7 +107,11 @@ fn validate_string_attr_passes_through() {
 fn validate_enum_attr_valid_value() {
     let def = DirectiveDef::container("callout", "Callout").with_attrs(vec![schema(
         "tone",
-        AttrType::Enum(vec!["info".to_string(), "warn".to_string(), "tip".to_string()]),
+        AttrType::Enum(vec![
+            "info".to_string(),
+            "warn".to_string(),
+            "tip".to_string(),
+        ]),
         None,
         true,
     )]);
@@ -133,8 +137,14 @@ fn validate_enum_attr_invalid_value_emits_error() {
     let (result, _warnings) = def.validate_attrs(&raw);
     let errors = result.expect_err("invalid enum value should produce error");
     assert_eq!(errors.len(), 1);
-    assert!(errors[0].message.contains("oops"), "error mentions bad value");
-    assert!(errors[0].message.contains("tone"), "error mentions attr name");
+    assert!(
+        errors[0].message.contains("oops"),
+        "error mentions bad value"
+    );
+    assert!(
+        errors[0].message.contains("tone"),
+        "error mentions attr name"
+    );
 }
 
 #[test]
@@ -277,10 +287,7 @@ fn validate_optional_attr_missing_no_default_absent_from_map() {
     let (result, warnings) = def.validate_attrs(&raw);
     assert!(warnings.is_empty());
     let map = result.expect("optional missing attr should not error");
-    assert!(
-        !map.contains_key("subtitle"),
-        "absent optional not in map"
-    );
+    assert!(!map.contains_key("subtitle"), "absent optional not in map");
 }
 
 #[test]
@@ -332,12 +339,7 @@ fn validate_unknown_attr_emits_warning_not_error() {
 fn validate_multiple_errors_all_collected() {
     let def = DirectiveDef::container("widget", "Widget").with_attrs(vec![
         schema("id", AttrType::String, None, true), // required, missing
-        schema(
-            "count",
-            AttrType::Number,
-            None,
-            false,
-        ), // present, but bad value
+        schema("count", AttrType::Number, None, false), // present, but bad value
     ]);
     let raw = vec![("count".to_string(), "notanumber".to_string())];
     let (result, _) = def.validate_attrs(&raw);
@@ -476,19 +478,14 @@ fn container_validation_error_falls_back_to_raw_attrs_and_emits_diagnostic() {
 #[test]
 fn leaf_with_boolean_attr_emits_normalised_string() {
     let mut reg = DirectiveRegistry::new();
-    reg.register(
-        DirectiveDef::leaf("badge", "Badge").with_attrs(vec![schema(
-            "outline",
-            AttrType::Boolean,
-            None,
-            false,
-        )]),
-    );
+    reg.register(DirectiveDef::leaf("badge", "Badge").with_attrs(vec![schema(
+        "outline",
+        AttrType::Boolean,
+        None,
+        false,
+    )]));
 
-    let out = run_registry(
-        &mut reg,
-        vec![text_para("::badge[Label]{outline=true}")],
-    );
+    let out = run_registry(&mut reg, vec![text_para("::badge[Label]{outline=true}")]);
     assert_eq!(out.len(), 1);
     let j = flow(&out[0]);
     assert_eq!(attr_value(j, "outline").as_deref(), Some("true"));
@@ -507,10 +504,7 @@ fn number_type_coercion_failure_emits_diagnostic_and_fallback() {
         )]),
     );
 
-    let out = run_registry(
-        &mut reg,
-        vec![text_para("::progress{value=notanumber}")],
-    );
+    let out = run_registry(&mut reg, vec![text_para("::progress{value=notanumber}")]);
     // Fallback: raw attr still emitted.
     assert_eq!(out.len(), 1);
     let j = flow(&out[0]);
@@ -691,10 +685,7 @@ fn defaults_applied_for_all_four_types_when_absent() {
         map.get("size"),
         Some(&ValidatedAttrValue::Enum("sm".to_string()))
     );
-    assert_eq!(
-        map.get("visible"),
-        Some(&ValidatedAttrValue::Boolean(true))
-    );
+    assert_eq!(map.get("visible"), Some(&ValidatedAttrValue::Boolean(true)));
     assert_eq!(
         map.get("count"),
         Some(&ValidatedAttrValue::Number("0".to_string()))
@@ -706,12 +697,10 @@ fn jsx_attr_order_schema_attrs_first_then_unknown() {
     // When validation succeeds: schema-declared attrs appear first (in
     // schema declaration order), then unknown/pass-through attrs.
     let mut reg = DirectiveRegistry::new();
-    reg.register(
-        DirectiveDef::container("box", "Box").with_attrs(vec![
-            schema("id", AttrType::String, None, false),
-            schema("class", AttrType::String, None, false),
-        ]),
-    );
+    reg.register(DirectiveDef::container("box", "Box").with_attrs(vec![
+        schema("id", AttrType::String, None, false),
+        schema("class", AttrType::String, None, false),
+    ]));
 
     let out = run_registry(
         &mut reg,

--- a/crates/zfb-content/tests/dts_snapshot.rs
+++ b/crates/zfb-content/tests/dts_snapshot.rs
@@ -30,8 +30,8 @@ fn fixture_dir() -> PathBuf {
 #[test]
 fn snapshot_two_collections_with_schemas() {
     let dir = fixture_dir();
-    let schemas_text = std::fs::read_to_string(dir.join("schemas.json"))
-        .expect("schemas.json fixture must exist");
+    let schemas_text =
+        std::fs::read_to_string(dir.join("schemas.json")).expect("schemas.json fixture must exist");
     // Use BTreeMap so iteration over the schemas is alphabetical and
     // deterministic across runs. The fixture file order is also
     // alphabetical (`blog`, `docs`), but we want to emit in a stable

--- a/crates/zfb-content/tests/hard_breaks.rs
+++ b/crates/zfb-content/tests/hard_breaks.rs
@@ -110,7 +110,10 @@ fn blank_line_paragraph_separation_unaffected_when_on() {
     assert_lacks(&html, "<br/>", input);
     // Two separate <p> elements.
     let p_count = html.matches("<p>").count();
-    assert_eq!(p_count, 2, "expected 2 paragraphs; got {p_count} in {html:?}");
+    assert_eq!(
+        p_count, 2,
+        "expected 2 paragraphs; got {p_count} in {html:?}"
+    );
 }
 
 /// Blank-line paragraph separation also unaffected when off.
@@ -122,7 +125,10 @@ fn blank_line_paragraph_separation_unaffected_when_off() {
     // Structural output (paragraphs) should be the same regardless of hardBreaks.
     let on_p = on.matches("<p>").count();
     let off_p = off.matches("<p>").count();
-    assert_eq!(on_p, off_p, "paragraph count must match; on={on:?} off={off:?}");
+    assert_eq!(
+        on_p, off_p,
+        "paragraph count must match; on={on:?} off={off:?}"
+    );
 }
 
 /// `\n` inside fenced code block must NOT become `<br/>`.

--- a/crates/zfb-content/tests/integration_pipeline.rs
+++ b/crates/zfb-content/tests/integration_pipeline.rs
@@ -471,12 +471,10 @@ fn run_without_context_is_byte_identical_to_run() {
     };
     pipeline.reset_per_entry();
     let html_with_ctx = {
-        let mut ctx = BuildContext::for_paths(
-            "/docs/page.md",
-            "/project",
-            "/project/public",
-        );
-        let hast = pipeline.run_with_context(md, &mut ctx).expect("run_with_context ok");
+        let mut ctx = BuildContext::for_paths("/docs/page.md", "/project", "/project/public");
+        let hast = pipeline
+            .run_with_context(md, &mut ctx)
+            .expect("run_with_context ok");
         serialize(&hast)
     };
 
@@ -503,7 +501,9 @@ fn heading_links_populates_registry_when_present() {
     };
 
     let mut pipeline = Pipeline::with_defaults();
-    pipeline.run_with_context(md, &mut ctx).expect("pipeline ok");
+    pipeline
+        .run_with_context(md, &mut ctx)
+        .expect("pipeline ok");
 
     let entries = registry.get(&source).expect("entries must be recorded");
     assert_eq!(entries.len(), 3, "expected 3 headings: {entries:?}");
@@ -523,7 +523,9 @@ fn heading_links_zero_writes_without_registry() {
     // heading_registry is None — no writes should occur.
 
     let mut pipeline = Pipeline::with_defaults();
-    pipeline.run_with_context(md, &mut ctx).expect("pipeline ok");
+    pipeline
+        .run_with_context(md, &mut ctx)
+        .expect("pipeline ok");
     // No registry to query — this test just asserts no panic + context is accessible.
     assert!(ctx.source_path.as_deref() == Some(std::path::Path::new("/docs/page.md")));
 }
@@ -538,11 +540,7 @@ fn diagnostics_sink_smoke_test() {
     impl HastVisitor for ParagraphWarner {
         fn visit(&mut self, _node: &mut HastNode) {}
 
-        fn visit_with_context(
-            &mut self,
-            node: &mut HastNode,
-            ctx: &mut BuildContext<'_>,
-        ) {
+        fn visit_with_context(&mut self, node: &mut HastNode, ctx: &mut BuildContext<'_>) {
             match node {
                 HastNode::Element { tag, children, .. } if tag == "p" => {
                     if let Some(sink) = ctx.diagnostics.as_deref_mut() {
@@ -575,7 +573,9 @@ fn diagnostics_sink_smoke_test() {
 
     let mut pipeline = Pipeline::with_mdx();
     pipeline.add_hast_visitor(Box::new(ParagraphWarner));
-    pipeline.run_with_context(md, &mut ctx).expect("pipeline ok");
+    pipeline
+        .run_with_context(md, &mut ctx)
+        .expect("pipeline ok");
 
     let diags = sink.take();
     assert!(
@@ -602,11 +602,7 @@ fn context_survives_through_pipeline() {
     impl HastVisitor for ContextChecker {
         fn visit(&mut self, _node: &mut HastNode) {}
 
-        fn visit_with_context(
-            &mut self,
-            _node: &mut HastNode,
-            ctx: &mut BuildContext<'_>,
-        ) {
+        fn visit_with_context(&mut self, _node: &mut HastNode, ctx: &mut BuildContext<'_>) {
             self.saw_path = ctx.source_path.clone();
         }
     }
@@ -628,10 +624,14 @@ fn context_survives_through_pipeline() {
     };
 
     let mut pipeline = Pipeline::with_defaults();
-    pipeline.run_with_context(md, &mut ctx).expect("pipeline ok");
+    pipeline
+        .run_with_context(md, &mut ctx)
+        .expect("pipeline ok");
 
     // The registry was populated from context — proving context reached the visitor.
-    let entries = registry.get(&source).expect("context must have reached HeadingLinksPlugin");
+    let entries = registry
+        .get(&source)
+        .expect("context must have reached HeadingLinksPlugin");
     assert_eq!(entries[0].id, "check");
     drop(checker); // suppress unused warning
 }

--- a/crates/zfb-content/tests/large_mdx_fallback_regression.rs
+++ b/crates/zfb-content/tests/large_mdx_fallback_regression.rs
@@ -204,10 +204,7 @@ size, not unique tokenization edge cases.\n\n";
 /// connector prose and inline-code spans. Result is one `- ` line
 /// followed by a single newline so markdown parses it as a single
 /// list item with one paragraph child.
-fn build_long_single_line_bullet(
-    html_spans: &[&str],
-    brace_spans: &[&str],
-) -> String {
+fn build_long_single_line_bullet(html_spans: &[&str], brace_spans: &[&str]) -> String {
     const CONNECTOR: &str = " — and combined with this connector phrase the surrounding prose grows long enough to push the bullet over the kilobyte mark while still mixing inline code with explanatory text — ";
     let mut bullet = String::with_capacity(1500);
     bullet.push_str("- ");
@@ -299,10 +296,7 @@ fn heuristic_says_jsx_breaks(jsx: &str) -> bool {
             if j < bytes.len() && bytes[j] == b'-' {
                 j += 1;
             }
-            if j + 1 < bytes.len()
-                && bytes[j] == b'\\'
-                && bytes[j + 1].is_ascii_alphabetic()
-            {
+            if j + 1 < bytes.len() && bytes[j] == b'\\' && bytes[j + 1].is_ascii_alphabetic() {
                 return true;
             }
         }
@@ -383,12 +377,11 @@ fn large_mdx_with_inline_code_html_curly_braces_does_not_fall_back() {
         cjk_friendly: true,
         hard_breaks: false,
         features: None,
+        build_context_roots: None,
     };
-    let snap = build_snapshot_with_config(
-        &[CollectionConfig::new("docs", &root)],
-        &pipeline_config,
-    )
-    .expect("build_snapshot must succeed");
+    let snap =
+        build_snapshot_with_config(&[CollectionConfig::new("docs", &root)], &pipeline_config)
+            .expect("build_snapshot must succeed");
     let docs = snap.collections.get("docs").expect("docs collection");
     assert_eq!(docs.len(), 1, "exactly one entry in fixture");
     let entry = &docs[0];
@@ -397,9 +390,8 @@ fn large_mdx_with_inline_code_html_curly_braces_does_not_fall_back() {
     let mut pipeline = Pipeline::with_defaults();
     pipeline.add_strip_md_ext();
     pipeline.reset_per_entry();
-    let compiled =
-        compile_mdx_to_jsx_module_cached(&body, &path, None, Some(&mut pipeline))
-            .expect("independent compile must succeed");
+    let compiled = compile_mdx_to_jsx_module_cached(&body, &path, None, Some(&mut pipeline))
+        .expect("independent compile must succeed");
 
     // (a) Heuristic must NOT flag the compiled JSX. A trip here
     // would mean the bundler skips this file in the bridge map and
@@ -418,12 +410,13 @@ fn large_mdx_with_inline_code_html_curly_braces_does_not_fall_back() {
     );
 
     // (b) Snapshot hash must equal bundler-side hash.
-    let snap_spec = parse_mdx_specifier(&entry.module_specifier)
-        .expect("snapshot specifier parses");
-    let bundle_spec = parse_mdx_specifier(&compiled.specifier)
-        .expect("bundler-style specifier parses");
+    let snap_spec =
+        parse_mdx_specifier(&entry.module_specifier).expect("snapshot specifier parses");
+    let bundle_spec =
+        parse_mdx_specifier(&compiled.specifier).expect("bundler-style specifier parses");
     assert_eq!(
-        snap_spec.content_hash, bundle_spec.content_hash,
+        snap_spec.content_hash,
+        bundle_spec.content_hash,
         "snapshot module_specifier hash ({snap}) must equal bundler bridge-key hash ({bundle}). \
          A divergence here means `bridge.get(specifier)` will miss and the page will fall \
          back to <pre data-zfb-content-fallback>. This is a pipeline-shape mismatch in the \

--- a/crates/zfb-content/tests/mdx_jsx_emit.rs
+++ b/crates/zfb-content/tests/mdx_jsx_emit.rs
@@ -504,11 +504,8 @@ fn real_world_fixtures_round_trip_through_emitter() {
             .body
             .unwrap_or_else(|| panic!("md/mdx fixture must have a body: {path:?}"));
         let label = path.file_name().unwrap().to_string_lossy().into_owned();
-        let jsx = mdx_to_jsx_module(
-            &body,
-            MdxJsxOptions::default().with_filename(label.clone()),
-        )
-        .unwrap_or_else(|e| panic!("emit {label}: {e}"));
+        let jsx = mdx_to_jsx_module(&body, MdxJsxOptions::default().with_filename(label.clone()))
+            .unwrap_or_else(|e| panic!("emit {label}: {e}"));
         assert!(
             jsx.contains("export default function MDXContent"),
             "{label}: missing default export"

--- a/crates/zfb-content/tests/mdx_jsx_emit_cache.rs
+++ b/crates/zfb-content/tests/mdx_jsx_emit_cache.rs
@@ -186,7 +186,11 @@ fn config_built_pipeline_uses_the_cache() {
     let second =
         compile_mdx_to_jsx_module_cached(src, &path, Some(&cache), Some(&mut equally_configured))
             .unwrap();
-    assert_eq!(cache.len(), 1, "same config + same input must hit, not re-insert");
+    assert_eq!(
+        cache.len(),
+        1,
+        "same config + same input must hit, not re-insert"
+    );
     assert_eq!(first, second, "cached value must match the original");
 }
 

--- a/crates/zfb-content/tests/mdx_jsx_emit_hast.rs
+++ b/crates/zfb-content/tests/mdx_jsx_emit_hast.rs
@@ -69,8 +69,7 @@ fn heading_links_plugin_fires_on_jsx_path() {
 
 #[test]
 fn code_title_plugin_fires_on_jsx_path() {
-    let out =
-        emit_with_defaults("```rust title=\"main.rs\"\nfn main() {}\n```\n");
+    let out = emit_with_defaults("```rust title=\"main.rs\"\nfn main() {}\n```\n");
     assert!(
         out.contains("class=\"code-block-container\""),
         "code-title plugin should wrap titled <pre> in a container:\n{out}",
@@ -168,12 +167,8 @@ fn bare_pipeline_runs_no_plugins_on_jsx_path() {
     // visitor mutated it — so heading-links / code-title / etc. must
     // NOT fire.
     let mut p = Pipeline::with_mdx();
-    let out = mdx_to_jsx_module_with_pipeline(
-        "## Hello\n",
-        MdxJsxOptions::default(),
-        &mut p,
-    )
-    .expect("emit ok");
+    let out = mdx_to_jsx_module_with_pipeline("## Hello\n", MdxJsxOptions::default(), &mut p)
+        .expect("emit ok");
     assert!(
         !out.contains("id=\"hello\""),
         "bare pipeline must NOT add heading-links id:\n{out}",
@@ -189,9 +184,7 @@ fn defaults_compose_for_titled_rust_block() {
     // code-title MUST run before syntect: the title wrapper survives
     // and the inner <pre> becomes syntect HTML inside dangerously-set
     // inner HTML.
-    let out = emit_with_defaults(
-        "```rust title=\"main.rs\"\nfn main() {}\n```\n",
-    );
+    let out = emit_with_defaults("```rust title=\"main.rs\"\nfn main() {}\n```\n");
     assert!(
         out.contains("class=\"code-block-container\""),
         "container must survive composition:\n{out}",
@@ -239,8 +232,7 @@ fn jsx_with_hast_detour_compiles_via_swc() {
           A-->B;\n\
         ```\n";
     let out = emit_with_defaults(src);
-    let opts =
-        CompileOptions::default().with_filename("hast-detour.tsx".to_string());
+    let opts = CompileOptions::default().with_filename("hast-detour.tsx".to_string());
     let compiled = pipeline_compile
         .compile(&out, &opts)
         .unwrap_or_else(|e| panic!("SWC rejected hast-detour output: {e}\n--- src ---\n{out}"));
@@ -391,7 +383,9 @@ fn lowercase_mdx_jsx_tags_route_through_components() {
 /// its attributes intact.
 #[test]
 fn lowercase_mdx_jsx_with_attrs_routes_through_components() {
-    let out = emit_with_defaults("<table className=\"x\"><tbody><tr><td>cell</td></tr></tbody></table>\n");
+    let out = emit_with_defaults(
+        "<table className=\"x\"><tbody><tr><td>cell</td></tr></tbody></table>\n",
+    );
     assert!(
         out.contains("<_components.table"),
         "<table> must route through `_components.table`:\n{out}",
@@ -471,7 +465,9 @@ fn nested_markdown_in_mdx_jsx_routes_through_components() {
     }
     // Bare HTML tags must NOT leak through alongside the routed forms —
     // this negative assertion is what catches a future regression.
-    for bare in ["<h2>", "<h2 ", "<p>", "<ul>", "<li>", "</h2>", "</p>", "</ul>", "</li>"] {
+    for bare in [
+        "<h2>", "<h2 ", "<p>", "<ul>", "<li>", "</h2>", "</p>", "</ul>", "</li>",
+    ] {
         assert!(
             !out.contains(bare),
             "bare `{bare}` must not leak alongside the `_components` route:\n{out}",
@@ -609,7 +605,10 @@ fn multiple_and_deeply_nested_headings_in_one_jsx_pop_correct_slugs() {
     let a = out.find("slug: \"alpha\"").unwrap();
     let b = out.find("slug: \"beta\"").unwrap();
     let g = out.find("slug: \"gamma\"").unwrap();
-    assert!(a < b && b < g, "TOC headings must be in document order:\n{out}");
+    assert!(
+        a < b && b < g,
+        "TOC headings must be in document order:\n{out}"
+    );
 
     let opts = CompileOptions::default().with_filename("multi-nested.tsx".to_string());
     SwcPipeline::new()
@@ -640,14 +639,15 @@ fn ruby_caret_and_toc_export_together_on_jsx_compile_path() {
     // converts mdast → hast. `with_defaults()` ships no mdast visitors so
     // this registration is safe to do right after construction.
     p.add_mdast_visitor(Box::new(zfb_md_extras::ruby::RubyPlugin::new()));
-    p.add_hast_visitor(Box::new(
-        zfb_md_extras::toc_export::TocExportPlugin::new(TocExportConfig::default()),
-    ));
+    p.add_hast_visitor(Box::new(zfb_md_extras::toc_export::TocExportPlugin::new(
+        TocExportConfig::default(),
+    )));
 
     // The document contains both repro inputs:
     // - `これは^{これ}` — caret ruby syntax from #600 (Sub B repro, bare-base form)
     // - two headings so TocExportPlugin produces a non-empty toc array
-    let src = "## Introduction\n\nこれは^{これ} is ruby annotation.\n\n## Conclusion\n\nMore text.\n";
+    let src =
+        "## Introduction\n\nこれは^{これ} is ruby annotation.\n\n## Conclusion\n\nMore text.\n";
     let out = mdx_to_jsx_module_with_pipeline(src, MdxJsxOptions::default(), &mut p)
         .expect("pipeline emit with ruby + toc_export ok");
 
@@ -733,9 +733,9 @@ fn toc_export_plugin_emits_at_column_0_on_jsx_path() {
     // dedicated `add_toc_export` method — generic wiring is all the fix
     // requires, and it avoids touching files outside the scope of #602.
     let mut p = Pipeline::with_defaults();
-    p.add_hast_visitor(Box::new(
-        zfb_md_extras::toc_export::TocExportPlugin::new(TocExportConfig::default()),
-    ));
+    p.add_hast_visitor(Box::new(zfb_md_extras::toc_export::TocExportPlugin::new(
+        TocExportConfig::default(),
+    )));
     let src = "## Introduction\n\nSome body text.\n\n## Conclusion\n\nMore text.\n";
     let out = mdx_to_jsx_module_with_pipeline(src, MdxJsxOptions::default(), &mut p)
         .expect("pipeline emit with toc_export ok");
@@ -779,11 +779,9 @@ fn toc_export_plugin_emits_at_column_0_on_jsx_path() {
     // same class of error esbuild reported in #599:
     // `Expected "}" but found ":"` on the first colon in the JSON literal.
     let opts = CompileOptions::default().with_filename("toc-export.tsx".to_string());
-    SwcPipeline::new()
-        .compile(&out, &opts)
-        .unwrap_or_else(|e| {
-            panic!("SWC rejected toc-export output (#599 regression): {e}\n--- src ---\n{out}")
-        });
+    SwcPipeline::new().compile(&out, &opts).unwrap_or_else(|e| {
+        panic!("SWC rejected toc-export output (#599 regression): {e}\n--- src ---\n{out}")
+    });
 }
 
 /// zfb#871 headline acceptance: `features.headingIds.strategy =

--- a/crates/zfb-content/tests/pipeline_fingerprint.rs
+++ b/crates/zfb-content/tests/pipeline_fingerprint.rs
@@ -97,7 +97,13 @@ fn every_knob_changes_the_fingerprint() {
         ),
         (
             "cjk-off",
-            full_config(None, ResolvedGfmConstructs::CONSERVATIVE, false, false, None),
+            full_config(
+                None,
+                ResolvedGfmConstructs::CONSERVATIVE,
+                false,
+                false,
+                None,
+            ),
         ),
         (
             "hard-breaks",
@@ -160,7 +166,9 @@ fn every_knob_changes_the_fingerprint() {
                 ResolvedGfmConstructs::CONSERVATIVE,
                 true,
                 false,
-                Some(&features(json!({ "headingIds": { "strategy": "hierarchical" } }))),
+                Some(&features(
+                    json!({ "headingIds": { "strategy": "hierarchical" } }),
+                )),
             ),
         ),
         ("legacy-defaults-chain", Pipeline::with_defaults()),
@@ -193,10 +201,7 @@ fn every_knob_changes_the_fingerprint() {
     variants.push(("external-links-default", external));
 
     let mut external_site = baseline();
-    external_site.add_external_links(
-        ExternalLinksConfig::default(),
-        Some("https://example.com"),
-    );
+    external_site.add_external_links(ExternalLinksConfig::default(), Some("https://example.com"));
     variants.push(("external-links-with-site", external_site));
 
     let mut strategy = baseline();
@@ -488,9 +493,9 @@ fn filesystem_reading_features_keep_the_pipeline_cacheable() {
             false,
             Some(&feats),
         );
-        let fp = p.config_fingerprint().unwrap_or_else(|| {
-            panic!("features.{label} must keep a config fingerprint (zfb#944)")
-        });
+        let fp = p
+            .config_fingerprint()
+            .unwrap_or_else(|| panic!("features.{label} must keep a config fingerprint (zfb#944)"));
         assert!(
             p.read_recorder().is_some(),
             "features.{label} must wire a read-recorder so its reads join \
@@ -534,13 +539,18 @@ fn build_context_roots_join_the_fingerprint() {
 
     let mut a = baseline();
     a.set_build_context_roots("/proj".into(), "/proj/public".into());
-    let a = a.config_fingerprint().expect("armed pipeline stays fingerprinted");
+    let a = a
+        .config_fingerprint()
+        .expect("armed pipeline stays fingerprinted");
 
     let mut b = baseline();
     b.set_build_context_roots("/proj".into(), "/proj/public".into());
     let b = b.config_fingerprint().expect("fingerprinted");
     assert_eq!(a, b, "equal roots must share one fingerprint");
-    assert_ne!(a, unarmed, "arming context roots must split the fingerprint");
+    assert_ne!(
+        a, unarmed,
+        "arming context roots must split the fingerprint"
+    );
 
     let mut c = baseline();
     c.set_build_context_roots("/other".into(), "/other/public".into());
@@ -621,7 +631,9 @@ fn themes_dir_contents_are_part_of_the_fingerprint() {
     );
 
     // And a themes_dir-less pipeline must not collide with either.
-    let fp_none = Pipeline::with_defaults().config_fingerprint().expect("fingerprinted");
+    let fp_none = Pipeline::with_defaults()
+        .config_fingerprint()
+        .expect("fingerprinted");
     assert_ne!(fp_none, fp_a1);
     assert_ne!(fp_none, fp_b);
 }

--- a/crates/zfb-content/tests/walk_order_determinism.rs
+++ b/crates/zfb-content/tests/walk_order_determinism.rs
@@ -78,7 +78,9 @@ fn without_reset_repeated_heading_gets_different_slug_second_time() {
     // First document — heading slug should be "setup".
     let first = compile(doc_a_body(), &mut p);
     assert!(
-        first.contains("\"setup\"") || first.contains("id=\\\"setup\\\"") || first.contains("#setup"),
+        first.contains("\"setup\"")
+            || first.contains("id=\\\"setup\\\"")
+            || first.contains("#setup"),
         "first pass: heading id must be 'setup', got: {first:.200}"
     );
 
@@ -150,8 +152,7 @@ fn build_snapshot_resets_pipeline_per_entry_so_hashes_match_bundler() {
         std::fs::write(root.join(name), body).unwrap();
     }
 
-    let snap =
-        build_snapshot(&[CollectionConfig::new("docs", &root)]).expect("snapshot ok");
+    let snap = build_snapshot(&[CollectionConfig::new("docs", &root)]).expect("snapshot ok");
     let entries = snap.collections.get("docs").expect("docs collection");
     assert_eq!(entries.len(), 5);
 
@@ -162,10 +163,15 @@ fn build_snapshot_resets_pipeline_per_entry_so_hashes_match_bundler() {
     for (i, (name, body)) in bodies.iter().enumerate() {
         bundler_pipeline.reset_per_entry();
         // Strip frontmatter the same way build_snapshot does.
-        let stripped = body.split_once("---\n").and_then(|(_, rest)| rest.split_once("---\n")).map(|(_, b)| b).unwrap_or(body);
+        let stripped = body
+            .split_once("---\n")
+            .and_then(|(_, rest)| rest.split_once("---\n"))
+            .map(|(_, b)| b)
+            .unwrap_or(body);
         let path = root.join(name);
-        let compiled = compile_mdx_to_jsx_module_cached(stripped, &path, None, Some(&mut bundler_pipeline))
-            .expect("compile ok");
+        let compiled =
+            compile_mdx_to_jsx_module_cached(stripped, &path, None, Some(&mut bundler_pipeline))
+                .expect("compile ok");
         let snap_entry = &entries[i];
         let snap_hash = snap_entry
             .module_specifier

--- a/crates/zfb-md-extras/src/code_enrichment.rs
+++ b/crates/zfb-md-extras/src/code_enrichment.rs
@@ -170,18 +170,17 @@ fn detect_and_strip_marker(raw_html: &str) -> Option<(LineDiff, String)> {
     // syntect tokenised the whole comment into one span. Fallback path
     // removes `PREFIX MARKER` text (preserving surrounding markup) so
     // languages with coarser tokenisation also strip cleanly.
-    let stripped = try_strip_whole_span(raw_html, marker, &comment_prefixes)
-        .unwrap_or_else(|| {
-            let mut out = raw_html.to_string();
-            for &prefix in &comment_prefixes {
-                let combined = format!("{prefix}{marker}");
-                if out.contains(&combined) {
-                    out = out.replace(&combined, "");
-                    return out.trim_end().to_string();
-                }
+    let stripped = try_strip_whole_span(raw_html, marker, &comment_prefixes).unwrap_or_else(|| {
+        let mut out = raw_html.to_string();
+        for &prefix in &comment_prefixes {
+            let combined = format!("{prefix}{marker}");
+            if out.contains(&combined) {
+                out = out.replace(&combined, "");
+                return out.trim_end().to_string();
             }
-            out
-        });
+        }
+        out
+    });
 
     // Trim trailing whitespace so that a line like `  x  ` after stripping
     // the trailing ` // [!code ++]` does not leave a dangling space run.
@@ -410,9 +409,7 @@ fn enrich_line_span(
         return;
     }
     // Only process elements that have class="line".
-    let is_line_span = attrs
-        .iter()
-        .any(|(k, v)| k == "class" && v == "line");
+    let is_line_span = attrs.iter().any(|(k, v)| k == "class" && v == "line");
     if !is_line_span {
         return;
     }
@@ -526,7 +523,10 @@ mod tests {
         let html = "const x = 1; // [!code ++]";
         let (diff, stripped) = detect_and_strip_marker(html).unwrap();
         assert_eq!(diff, LineDiff::Added);
-        assert!(!stripped.contains("[!code ++]"), "marker should be stripped");
+        assert!(
+            !stripped.contains("[!code ++]"),
+            "marker should be stripped"
+        );
     }
 
     #[test]
@@ -548,7 +548,10 @@ mod tests {
         let html = r#"<span style="color:#65737e">// [!code ++]</span>"#;
         let (diff, stripped) = detect_and_strip_marker(html).unwrap();
         assert_eq!(diff, LineDiff::Added);
-        assert!(!stripped.contains("[!code ++]"), "marker should be stripped: {stripped}");
+        assert!(
+            !stripped.contains("[!code ++]"),
+            "marker should be stripped: {stripped}"
+        );
     }
 
     #[test]
@@ -593,7 +596,10 @@ mod tests {
         let (diff, stripped) = detect_and_strip_marker(html).unwrap();
         assert_eq!(diff, LineDiff::Added);
         assert!(!stripped.contains("[!code ++]"));
-        assert!(!stripped.contains("# "), "comment prefix must be stripped: {stripped}");
+        assert!(
+            !stripped.contains("# "),
+            "comment prefix must be stripped: {stripped}"
+        );
     }
 
     /// Double-dash comment prefix (`-- `) is recognised — covers SQL, Lua.
@@ -603,7 +609,10 @@ mod tests {
         let (diff, stripped) = detect_and_strip_marker(html).unwrap();
         assert_eq!(diff, LineDiff::Removed);
         assert!(!stripped.contains("[!code --]"));
-        assert!(!stripped.contains("-- "), "comment prefix must be stripped: {stripped}");
+        assert!(
+            !stripped.contains("-- "),
+            "comment prefix must be stripped: {stripped}"
+        );
     }
 
     /// Fallback path (no whole-span match): the comment prefix is removed
@@ -616,7 +625,10 @@ mod tests {
         let html = "x = 1; // [!code ++]";
         let (_diff, stripped) = detect_and_strip_marker(html).unwrap();
         assert!(!stripped.contains("[!code ++]"));
-        assert!(!stripped.contains("// "), "fallback must strip prefix: {stripped}");
+        assert!(
+            !stripped.contains("// "),
+            "fallback must strip prefix: {stripped}"
+        );
     }
 
     // ── enrich_line_span ──────────────────────────────────────────────────────
@@ -634,9 +646,13 @@ mod tests {
     fn enrich_highlight_adds_attribute() {
         let mut span = make_line_span("const x = 1;");
         enrich_line_span(&mut span, 1, &[1, 3, 5], false);
-        let HastNode::Element { attrs, .. } = &span else { panic!() };
+        let HastNode::Element { attrs, .. } = &span else {
+            panic!()
+        };
         assert!(
-            attrs.iter().any(|(k, v)| k == "data-line-highlight" && v == "true"),
+            attrs
+                .iter()
+                .any(|(k, v)| k == "data-line-highlight" && v == "true"),
             "line 1 should be highlighted: {attrs:?}"
         );
     }
@@ -645,7 +661,9 @@ mod tests {
     fn enrich_no_highlight_when_not_in_set() {
         let mut span = make_line_span("const x = 1;");
         enrich_line_span(&mut span, 2, &[1, 3, 5], false);
-        let HastNode::Element { attrs, .. } = &span else { panic!() };
+        let HastNode::Element { attrs, .. } = &span else {
+            panic!()
+        };
         assert!(
             !attrs.iter().any(|(k, _)| k == "data-line-highlight"),
             "line 2 should NOT be highlighted"
@@ -656,26 +674,48 @@ mod tests {
     fn enrich_diff_marker_adds_attribute_and_strips() {
         let mut span = make_line_span("x = 1 // [!code ++]");
         enrich_line_span(&mut span, 1, &[], true);
-        let HastNode::Element { attrs, children, .. } = &span else { panic!() };
+        let HastNode::Element {
+            attrs, children, ..
+        } = &span
+        else {
+            panic!()
+        };
         assert!(
-            attrs.iter().any(|(k, v)| k == "data-line-diff" && v == "added"),
+            attrs
+                .iter()
+                .any(|(k, v)| k == "data-line-diff" && v == "added"),
             "should have data-line-diff=added: {attrs:?}"
         );
         // Marker must be stripped from children.
         let raw_content: String = children
             .iter()
-            .filter_map(|c| if let HastNode::Raw(s) = c { Some(s.as_str()) } else { None })
+            .filter_map(|c| {
+                if let HastNode::Raw(s) = c {
+                    Some(s.as_str())
+                } else {
+                    None
+                }
+            })
             .collect();
-        assert!(!raw_content.contains("[!code ++]"), "marker must be stripped: {raw_content}");
+        assert!(
+            !raw_content.contains("[!code ++]"),
+            "marker must be stripped: {raw_content}"
+        );
     }
 
     #[test]
     fn both_diff_and_highlight_can_apply_to_same_line() {
         let mut span = make_line_span("x = 1 // [!code ++]");
         enrich_line_span(&mut span, 1, &[1], true);
-        let HastNode::Element { attrs, .. } = &span else { panic!() };
-        assert!(attrs.iter().any(|(k, v)| k == "data-line-diff" && v == "added"));
-        assert!(attrs.iter().any(|(k, v)| k == "data-line-highlight" && v == "true"));
+        let HastNode::Element { attrs, .. } = &span else {
+            panic!()
+        };
+        assert!(attrs
+            .iter()
+            .any(|(k, v)| k == "data-line-diff" && v == "added"));
+        assert!(attrs
+            .iter()
+            .any(|(k, v)| k == "data-line-highlight" && v == "true"));
     }
 
     #[test]
@@ -690,8 +730,12 @@ mod tests {
         };
         plugin.visit(&mut root);
         // The line span should have no extra attributes.
-        let HastNode::Root { children } = &root else { panic!() };
-        let HastNode::Element { attrs, .. } = &children[0] else { panic!() };
+        let HastNode::Root { children } = &root else {
+            panic!()
+        };
+        let HastNode::Element { attrs, .. } = &children[0] else {
+            panic!()
+        };
         assert_eq!(attrs.len(), 1, "only class attribute expected: {attrs:?}");
     }
 }

--- a/crates/zfb-md-extras/src/code_tabs.rs
+++ b/crates/zfb-md-extras/src/code_tabs.rs
@@ -62,8 +62,8 @@
 //! `AttrType::String` and `required: false`.
 
 use markdown::mdast::{
-    AttributeContent, AttributeValue, AttributeValueExpression, MdxJsxAttribute,
-    MdxJsxFlowElement, Node as MdastNode, Text,
+    AttributeContent, AttributeValue, AttributeValueExpression, MdxJsxAttribute, MdxJsxFlowElement,
+    Node as MdastNode, Text,
 };
 use zfb_md_ast::{AttrSchema, AttrType, DirectiveDef, MdastVisitor};
 
@@ -206,7 +206,9 @@ fn rewrite_code_groups(children: &mut Vec<MdastNode>) {
         let tabs: Vec<String> = codes
             .iter()
             .map(|n| {
-                let MdastNode::Code(c) = n else { unreachable!() };
+                let MdastNode::Code(c) = n else {
+                    unreachable!()
+                };
                 tab_label_for_code(c)
             })
             .collect();
@@ -215,7 +217,9 @@ fn rewrite_code_groups(children: &mut Vec<MdastNode>) {
         let jsx_children: Vec<MdastNode> = codes
             .iter()
             .map(|n| {
-                let MdastNode::Code(c) = n else { unreachable!() };
+                let MdastNode::Code(c) = n else {
+                    unreachable!()
+                };
                 build_pre_element(c)
             })
             .collect();
@@ -627,10 +631,7 @@ mod tests {
     #[test]
     fn unclosed_code_group_is_left_unchanged() {
         // No `:::` closer — opener stays as paragraph.
-        let mut tree = make_root(vec![
-            para(":::code-group"),
-            code_node("ts", "x"),
-        ]);
+        let mut tree = make_root(vec![para(":::code-group"), code_node("ts", "x")]);
         CodeTabsPlugin::new().visit(&mut tree);
 
         let MdastNode::Root(root) = &tree else {
@@ -698,10 +699,7 @@ mod tests {
     fn empty_code_group_is_left_unchanged() {
         // A `:::code-group` with no fenced code blocks between the opener
         // and closer must not be rewritten — the 3 nodes remain as-is.
-        let mut tree = make_root(vec![
-            para(":::code-group"),
-            para(":::"),
-        ]);
+        let mut tree = make_root(vec![para(":::code-group"), para(":::")]);
         CodeTabsPlugin::new().visit(&mut tree);
 
         let MdastNode::Root(root) = &tree else {
@@ -726,7 +724,8 @@ mod tests {
         // `name` attribute on the `:::code-group` directive.
         // validate_attrs returns (Result<..., ...>, Vec<warnings>).
         let def = code_group_directive_def();
-        let (result, warnings) = def.validate_attrs(&[("name".to_string(), "my-group".to_string())]);
+        let (result, warnings) =
+            def.validate_attrs(&[("name".to_string(), "my-group".to_string())]);
         assert!(
             result.is_ok(),
             "valid `name` attribute must pass validation: {result:?}"

--- a/crates/zfb-md-extras/src/github_alerts.rs
+++ b/crates/zfb-md-extras/src/github_alerts.rs
@@ -89,9 +89,9 @@ fn parse_alert_prefix(text: &str) -> Option<(&'static str, &str)> {
     // Nothing else is allowed on the prefix line (e.g. `[!NOTE] title` is NOT
     // supported — the GFM alert spec has no inline title syntax).
     let after_bracket = &inner[close + 1..]; // everything after `]`
-    // Tolerate a CRLF line ending (Windows-authored markdown): the `markdown`
-    // crate preserves a literal `\r` in the text value, so `after_bracket` may
-    // begin with `\r\n` rather than `\n`.
+                                             // Tolerate a CRLF line ending (Windows-authored markdown): the `markdown`
+                                             // crate preserves a literal `\r` in the text value, so `after_bracket` may
+                                             // begin with `\r\n` rather than `\n`.
     let after = after_bracket.strip_prefix('\r').unwrap_or(after_bracket);
     // `after` must be either empty or start with `\n`
     if !after.is_empty() && !after.starts_with('\n') {
@@ -153,8 +153,7 @@ fn try_rewrite_blockquote(node: &mut MdastNode) -> bool {
     let mut bq_children = std::mem::take(&mut bq.children);
 
     // Mutate the first paragraph's first text node.
-    let first_para_children = if let Some(MdastNode::Paragraph(ref mut p)) =
-        bq_children.first_mut()
+    let first_para_children = if let Some(MdastNode::Paragraph(ref mut p)) = bq_children.first_mut()
     {
         // Update the text value.
         if let Some(MdastNode::Text(ref mut t)) = p.children.first_mut() {

--- a/crates/zfb-md-extras/src/github_autolinks.rs
+++ b/crates/zfb-md-extras/src/github_autolinks.rs
@@ -157,8 +157,7 @@ fn parse_segments(text: &str) -> Vec<Segment> {
         // ── Bare issue reference: `#NNN` ─────────────────────────────────────
         // `#` preceded by a non-word, non-`/` char (or SOT), followed by digits.
         if c == '#' {
-            let left_ok = i == 0
-                || (!is_word_char(chars[i - 1]) && chars[i - 1] != '/');
+            let left_ok = i == 0 || (!is_word_char(chars[i - 1]) && chars[i - 1] != '/');
             if left_ok {
                 let num_start = i + 1;
                 let mut j = num_start;
@@ -228,9 +227,7 @@ fn segments_to_hast(segments: Vec<Segment>, repo: &str) -> Vec<HastNode> {
                 number,
                 raw,
             } => {
-                let href = format!(
-                    "https://github.com/{owner}/{repo_name}/issues/{number}"
-                );
+                let href = format!("https://github.com/{owner}/{repo_name}/issues/{number}");
                 HastNode::Element {
                     tag: "a".to_string(),
                     attrs: vec![("href".to_string(), href)],
@@ -282,10 +279,7 @@ fn rewrite_node(node: &mut HastNode, repo: &str) {
         }
         // Text nodes are handled by the parent's rewrite_children call.
         // Leaf nodes with no children need no action.
-        HastNode::Text(_)
-        | HastNode::Raw(_)
-        | HastNode::JsxRaw(_)
-        | HastNode::Comment(_) => {}
+        HastNode::Text(_) | HastNode::Raw(_) | HastNode::JsxRaw(_) | HastNode::Comment(_) => {}
     }
 }
 
@@ -298,8 +292,8 @@ fn rewrite_children(children: Vec<HastNode>, repo: &str) -> Vec<HastNode> {
             HastNode::Text(text) => {
                 let segments = parse_segments(&text);
                 // Fast path: single plain segment — no rewrite needed.
-                let only_plain = segments.len() == 1
-                    && matches!(segments.first(), Some(Segment::Plain(_)));
+                let only_plain =
+                    segments.len() == 1 && matches!(segments.first(), Some(Segment::Plain(_)));
                 if only_plain {
                     result.push(HastNode::Text(text));
                     continue;
@@ -485,7 +479,9 @@ mod tests {
     fn hash_not_preceded_by_slash_is_bare_issue() {
         // When `#` is preceded by a space (not a `/`), it must be a bare issue.
         let segs = parse_segments("see #5");
-        assert!(segs.iter().any(|s| matches!(s, Segment::BareIssue { number: 5, .. })));
+        assert!(segs
+            .iter()
+            .any(|s| matches!(s, Segment::BareIssue { number: 5, .. })));
     }
 
     // ── segments_to_hast ──────────────────────────────────────────────────
@@ -498,12 +494,19 @@ mod tests {
         }];
         let nodes = segments_to_hast(segs, "owner/myrepo");
         assert_eq!(nodes.len(), 1);
-        let HastNode::Element { tag, attrs, children, .. } = &nodes[0] else {
+        let HastNode::Element {
+            tag,
+            attrs,
+            children,
+            ..
+        } = &nodes[0]
+        else {
             panic!("expected Element");
         };
         assert_eq!(tag, "a");
-        assert!(attrs.iter().any(|(k, v)| k == "href"
-            && v == "https://github.com/owner/myrepo/issues/123"));
+        assert!(attrs
+            .iter()
+            .any(|(k, v)| k == "href" && v == "https://github.com/owner/myrepo/issues/123"));
         assert_eq!(children, &vec![HastNode::Text("#123".to_string())]);
     }
 
@@ -516,7 +519,9 @@ mod tests {
             raw: "user/other#7".to_string(),
         }];
         let nodes = segments_to_hast(segs, "owner/myrepo");
-        let HastNode::Element { attrs, .. } = &nodes[0] else { panic!() };
+        let HastNode::Element { attrs, .. } = &nodes[0] else {
+            panic!()
+        };
         let href = attrs.iter().find(|(k, _)| k == "href").unwrap().1.clone();
         assert_eq!(href, "https://github.com/user/other/issues/7");
     }
@@ -527,7 +532,9 @@ mod tests {
             sha: "abc1234".to_string(),
         }];
         let nodes = segments_to_hast(segs, "owner/myrepo");
-        let HastNode::Element { attrs, .. } = &nodes[0] else { panic!() };
+        let HastNode::Element { attrs, .. } = &nodes[0] else {
+            panic!()
+        };
         let href = attrs.iter().find(|(k, _)| k == "href").unwrap().1.clone();
         assert_eq!(href, "https://github.com/owner/myrepo/commit/abc1234");
     }
@@ -544,7 +551,9 @@ mod tests {
         };
         rewrite_node(&mut node, "owner/myrepo");
         // Children must be unchanged.
-        let HastNode::Element { children, .. } = &node else { panic!() };
+        let HastNode::Element { children, .. } = &node else {
+            panic!()
+        };
         assert_eq!(children, &vec![HastNode::Text("#123".to_string())]);
     }
 
@@ -562,8 +571,16 @@ mod tests {
             void: false,
         };
         rewrite_node(&mut node, "owner/myrepo");
-        let HastNode::Element { children, .. } = &node else { panic!() };
-        let HastNode::Element { children: code_children, .. } = &children[0] else { panic!() };
+        let HastNode::Element { children, .. } = &node else {
+            panic!()
+        };
+        let HastNode::Element {
+            children: code_children,
+            ..
+        } = &children[0]
+        else {
+            panic!()
+        };
         assert_eq!(
             code_children,
             &vec![HastNode::Text("abc1234567def".to_string())]
@@ -579,7 +596,9 @@ mod tests {
             void: false,
         };
         rewrite_node(&mut node, "owner/myrepo");
-        let HastNode::Element { children, .. } = &node else { panic!() };
+        let HastNode::Element { children, .. } = &node else {
+            panic!()
+        };
         // Must remain a plain text child — not wrapped in another <a>.
         assert_eq!(children, &vec![HastNode::Text("#123".to_string())]);
     }
@@ -597,8 +616,16 @@ mod tests {
             }],
         };
         GithubAutolinksPlugin::new("owner/repo").visit(&mut root);
-        let HastNode::Root { children } = &root else { panic!() };
-        let HastNode::Element { children: p_children, .. } = &children[0] else { panic!() };
+        let HastNode::Root { children } = &root else {
+            panic!()
+        };
+        let HastNode::Element {
+            children: p_children,
+            ..
+        } = &children[0]
+        else {
+            panic!()
+        };
         // Should contain plain "see " + anchor for #42.
         assert_eq!(p_children.len(), 2);
         assert!(matches!(&p_children[0], HastNode::Text(t) if t == "see "));

--- a/crates/zfb-md-extras/src/link_validation.rs
+++ b/crates/zfb-md-extras/src/link_validation.rs
@@ -4,11 +4,24 @@
 //! validates that:
 //!
 //! - **Bare anchor fragments** (`#section`) match a heading ID in the current
-//!   file's heading-ID registry entry.
+//!   file's heading-ID registry entry. Skipped silently when the registry has
+//!   no entry for the source file (distinguishes "no headings tracked" from
+//!   "file not tracked" — entry-presence contract). Empty and percent-encoded
+//!   fragments (`#`, `#a%20b`) are also skipped (dummy links / undecodable).
 //! - **File-relative links with anchor** (`./other.md#section`) resolve to an
 //!   existing source file whose registry entry contains that heading ID.
+//!   Degrades to existence-only when the registry has no entry for the target
+//!   file (mirrors the bare-anchor contract; kills false positives until a
+//!   build-scoped cross-file registry lands in #960).
 //! - **File-relative links without anchor** (`./other.md`) resolve to an
-//!   existing file on disk (under `project_root`).
+//!   existing file on disk (under `project_root`). Query strings
+//!   (`./other.md?x=1`) are stripped before the path check.
+//! - **URL-space hrefs** — site-absolute paths (`/docs/intro/`),
+//!   protocol-relative URLs (`//host/x`), and bare-query/empty hrefs (`?x=1`,
+//!   ``) — are skipped silently. These are rewrite products of
+//!   `ResolveLinksPlugin` or hand-authored site URLs, never on-disk file
+//!   references. Site-absolute `<img src="/img/x.png">` public-dir assets are
+//!   also skipped — their validation belongs to `imageDimensions`, not here.
 //! - **External URLs** (`http://`, `https://`, `mailto:`, etc.) are always
 //!   skipped silently — network validation is out of scope.
 //!
@@ -92,6 +105,11 @@ fn is_external_url(href: &str) -> bool {
 enum ParsedLink {
     /// External URL — skip validation.
     External,
+    /// URL-space href — site-absolute path (`/docs/intro/`), protocol-relative
+    /// (`//host/x`), or empty-path query-only href. These are rewrite products
+    /// (ResolveLinksPlugin) or hand-authored site URLs, never on-disk file
+    /// references — skip validation.
+    UrlSpace,
     /// Bare anchor fragment (e.g. `#intro`). Path part is empty.
     BareFragment(String),
     /// File path without an anchor (e.g. `./other.md`).
@@ -101,27 +119,43 @@ enum ParsedLink {
 }
 
 fn parse_link(href: &str) -> ParsedLink {
+    // 1. External URL (scheme-prefixed) — skip validation.
     if is_external_url(href) {
         return ParsedLink::External;
     }
+    // 2. URL-space: site-absolute paths (`/docs/x/`) and protocol-relative
+    //    URLs (`//host/x`) can never be on-disk relative references.
+    if href.starts_with('/') {
+        return ParsedLink::UrlSpace;
+    }
+    // 3. Bare fragment — everything after the leading `#` is the fragment.
     if let Some(fragment) = href.strip_prefix('#') {
         return ParsedLink::BareFragment(fragment.to_string());
     }
-    // Split on `#` for file-relative links.
-    if let Some(pos) = href.find('#') {
-        let (path, rest) = href.split_at(pos);
-        let fragment = &rest[1..]; // strip the `#`
-        if path.is_empty() {
-            // Shouldn't happen here (bare `#` already handled above), but
-            // defensively treat empty path as bare fragment.
-            return ParsedLink::BareFragment(fragment.to_string());
-        }
-        return ParsedLink::FileWithFragment {
+    // 4. Split on the first `#` to separate path+query from fragment.
+    let (path_and_query, fragment_opt) = match href.find('#') {
+        Some(pos) => (&href[..pos], Some(&href[pos + 1..])),
+        None => (href, None),
+    };
+    // 5. Strip query from the path part (query is never part of an on-disk path).
+    let path = match path_and_query.find('?') {
+        Some(pos) => &path_and_query[..pos],
+        None => path_and_query,
+    };
+    // 6. Classify by (path, fragment).
+    match (path.is_empty(), fragment_opt) {
+        // Empty path with fragment — defensive bare-fragment (mirrors existing behaviour).
+        (true, Some(f)) => ParsedLink::BareFragment(f.to_string()),
+        // Empty path, no fragment — bare-query href (`?x=1`) or empty href.
+        (true, None) => ParsedLink::UrlSpace,
+        // Non-empty path with fragment.
+        (false, Some(f)) => ParsedLink::FileWithFragment {
             path: path.to_string(),
-            fragment: fragment.to_string(),
-        };
+            fragment: f.to_string(),
+        },
+        // Non-empty path, no fragment.
+        (false, None) => ParsedLink::FilePath(path.to_string()),
     }
-    ParsedLink::FilePath(href.to_string())
 }
 
 // ── Path resolution ───────────────────────────────────────────────────────────
@@ -284,6 +318,12 @@ fn validate_link(href: &str, env: &ValidationEnv<'_>, ctx: &mut BuildContext<'_>
         ParsedLink::External => {
             // External URLs are always skipped — network validation is out of scope.
         }
+        ParsedLink::UrlSpace => {
+            // Site-absolute and protocol-relative hrefs are rewrite products or
+            // hand-authored site URLs — never on-disk references. Site-absolute
+            // img srcs (`/img/x.png`) resolve against `public_dir` in URL space;
+            // their validation is imageDimensions' job, not linkValidation's.
+        }
         ParsedLink::BareFragment(fragment) => {
             if is_img {
                 // Bare fragment on an <img> (e.g. `#icon`) — no file to check,
@@ -324,16 +364,19 @@ fn validate_fragment_in_file(
     env: &ValidationEnv<'_>,
     ctx: &mut BuildContext<'_>,
 ) {
-    let registry = match ctx.heading_registry.as_ref() {
-        Some(r) => r,
-        None => return, // no registry → skip validation
+    if fragment.is_empty() || fragment.contains('%') {
+        return; // `href="#"` dummy links; percent-encoded fragments (registry stores raw text)
+    }
+    let entries = match ctx
+        .heading_registry
+        .as_ref()
+        .and_then(|r| r.get(env.source_path))
+    {
+        Some(e) => e,
+        None => return, // no registry entry for this file → cannot distinguish
+                        // "file has no headings" from "file not tracked" → skip
     };
-    let known = registry
-        .get(env.source_path)
-        .map(|entries| entries.iter().any(|e| e.id == fragment))
-        .unwrap_or(false);
-
-    if !known {
+    if !entries.iter().any(|e| e.id == fragment) {
         emit_broken_link(raw_href, env, ctx);
     }
 }
@@ -411,15 +454,16 @@ fn validate_file_with_fragment(
         return;
     }
 
-    // Check heading fragment in the target file's registry.
-    let known = ctx
-        .heading_registry
-        .as_ref()
-        .and_then(|r| r.get(&resolved))
-        .map(|entries| entries.iter().any(|e| e.id == fragment))
-        .unwrap_or(false);
-
-    if !known {
+    if fragment.is_empty() || fragment.contains('%') {
+        return; // existence already validated above
+    }
+    let entries = match ctx.heading_registry.as_ref().and_then(|r| r.get(&resolved)) {
+        Some(e) => e,
+        None => return, // no entry for the target file → existence-only
+                        // (mirrors the bare-anchor contract; kills the
+                        // `./other.md#frag` unwrap_or(false) false positive)
+    };
+    if !entries.iter().any(|e| e.id == fragment) {
         emit_broken_link(raw_href, env, ctx);
     }
 }
@@ -659,12 +703,117 @@ mod tests {
             "https://example.com/x",
             "mailto:a@b.com",
             "#fragment-only",
+            "/docs/intro/", // URL-space — never a filesystem read
             "../escape.md", // project-root escape rejected before any fs access
         ] {
             let reads = record_reads_for_href(href, dir.path(), &source);
             assert!(
                 reads.is_empty(),
                 "href {href:?} performs no filesystem read — nothing to record: {reads:?}"
+            );
+        }
+    }
+
+    // ── New tests: URL-space classification ───────────────────────────────
+
+    #[test]
+    fn parse_site_absolute_is_url_space() {
+        assert_eq!(parse_link("/docs/intro/"), ParsedLink::UrlSpace);
+        assert_eq!(parse_link("/docs/intro/#frag"), ParsedLink::UrlSpace);
+        assert_eq!(parse_link("//cdn.example.com/x"), ParsedLink::UrlSpace);
+    }
+
+    #[test]
+    fn parse_strips_query_string() {
+        assert_eq!(
+            parse_link("./other.md?x=1"),
+            ParsedLink::FilePath("./other.md".to_string())
+        );
+        assert_eq!(
+            parse_link("./other.md?x=1#frag"),
+            ParsedLink::FileWithFragment {
+                path: "./other.md".to_string(),
+                fragment: "frag".to_string(),
+            }
+        );
+        // bare-query href → URL-space (no path component)
+        assert_eq!(parse_link("?x=1"), ParsedLink::UrlSpace);
+    }
+
+    // ── New test: cross-file fragment with None registry ──────────────────
+
+    /// `./other.md#frag` with `heading_registry: None` must not report a
+    /// BrokenLink when the target exists (existence-only degradation), but
+    /// MUST report when the target is missing.
+    #[test]
+    fn cross_file_fragment_with_none_registry_checks_existence_only() {
+        use tempdir::TempDir;
+        use zfb_md_ast::{diagnostics::CollectingSink, HastVisitor};
+
+        let dir = TempDir::new("lv_none_reg").unwrap();
+        let source_path = dir.path().join("page.md");
+        std::fs::write(&source_path, "").unwrap();
+        let other_path = dir.path().join("other.md");
+        std::fs::write(&other_path, "# Other\n").unwrap();
+
+        // Scenario A: target exists, registry None → no diagnostic (existence-only).
+        {
+            let node = HastNode::Root {
+                children: vec![HastNode::Element {
+                    tag: "a".to_string(),
+                    attrs: vec![("href".to_string(), "./other.md#frag".to_string())],
+                    children: vec![],
+                    void: false,
+                }],
+            };
+            let mut root = node;
+            let mut sink = CollectingSink::new();
+            let mut ctx = BuildContext {
+                source_path: Some(source_path.clone()),
+                project_root: dir.path().to_path_buf(),
+                public_dir: dir.path().to_path_buf(),
+                heading_registry: None,
+                diagnostics: Some(&mut sink),
+            };
+            let mut plugin = LinkValidationPlugin::new(LinkValidationConfig::default());
+            plugin.visit_with_context(&mut root, &mut ctx);
+            let diags = sink.take();
+            assert!(
+                diags.is_empty(),
+                "existing target with None registry must not report broken: {diags:?}"
+            );
+        }
+
+        // Scenario B: target missing, registry None → BrokenLink (file not found).
+        {
+            let node = HastNode::Root {
+                children: vec![HastNode::Element {
+                    tag: "a".to_string(),
+                    attrs: vec![("href".to_string(), "./missing.md#frag".to_string())],
+                    children: vec![],
+                    void: false,
+                }],
+            };
+            let mut root = node;
+            let mut sink = CollectingSink::new();
+            let mut ctx = BuildContext {
+                source_path: Some(source_path.clone()),
+                project_root: dir.path().to_path_buf(),
+                public_dir: dir.path().to_path_buf(),
+                heading_registry: None,
+                diagnostics: Some(&mut sink),
+            };
+            let mut plugin = LinkValidationPlugin::new(LinkValidationConfig::default());
+            plugin.visit_with_context(&mut root, &mut ctx);
+            let diags = sink.take();
+            assert_eq!(
+                diags.len(),
+                1,
+                "missing target must report BrokenLink: {diags:?}"
+            );
+            assert!(
+                matches!(&diags[0], MarkdownDiagnostic::BrokenLink { url, .. } if url == "./missing.md#frag"),
+                "url must be the raw href: {diags:?}"
             );
         }
     }

--- a/crates/zfb-md-extras/src/mermaid.rs
+++ b/crates/zfb-md-extras/src/mermaid.rs
@@ -15,7 +15,7 @@
 //! Moved from `zfb-content::plugins::mermaid` in Wave 3 (#570).
 //! Wire via `features.mermaid = true` in `zfb.config.ts`.
 
-use zfb_md_ast::{HastNode, HastVisitor, extract_text};
+use zfb_md_ast::{extract_text, HastNode, HastVisitor};
 
 /// Visitor that swaps mermaid `<pre>` blocks for `<div class="mermaid">`.
 #[derive(Debug, Default, Clone, Copy)]

--- a/crates/zfb-md-extras/src/reading_time.rs
+++ b/crates/zfb-md-extras/src/reading_time.rs
@@ -264,7 +264,7 @@ pub fn compute_reading_time_minutes(node: &MdastNode, wpm: u32) -> u32 {
     extract_mdast_text(node, &mut text);
     let words = count_words(&text);
     let wpm = wpm.max(1); // guard against divide-by-zero
-    // Ceiling division: always at least 1 minute.
+                          // Ceiling division: always at least 1 minute.
     words.div_ceil(wpm).max(1)
 }
 
@@ -332,9 +332,8 @@ impl MdastVisitor for ReadingTimePlugin {
         // Marker prefix `/* zfb-synth-export */` distinguishes this node
         // from user-authored MDX ESM nodes so the emitter can emit it
         // without re-emitting user imports/exports.
-        let esm_value = format!(
-            "/* zfb-synth-export */ export const readingTimeMinutes = {minutes};"
-        );
+        let esm_value =
+            format!("/* zfb-synth-export */ export const readingTimeMinutes = {minutes};");
         root.children.push(MdastNode::MdxjsEsm(MdxjsEsm {
             value: esm_value,
             position: None,

--- a/crates/zfb-md-extras/src/ruby.rs
+++ b/crates/zfb-md-extras/src/ruby.rs
@@ -128,9 +128,7 @@
 //! (text-syntax parsing happens in the mdast phase so the visitor can scan
 //! raw text before it is converted to hast elements).
 
-use markdown::mdast::{
-    AttributeContent, MdxJsxTextElement, Node as MdastNode, Paragraph, Text,
-};
+use markdown::mdast::{AttributeContent, MdxJsxTextElement, Node as MdastNode, Paragraph, Text};
 use zfb_md_ast::MdastVisitor;
 use zfb_types::escape_html;
 
@@ -191,8 +189,33 @@ fn parse_expression_as_ruby(value: &str) -> Option<(String, String)> {
 /// syntax rather than plain ruby text. Used to filter MDX expressions that
 /// happen to have a pipe but are not ruby annotations.
 fn has_js_operator_chars(s: &str) -> bool {
-    s.chars()
-        .any(|c| matches!(c, '&' | '?' | ':' | '=' | '<' | '>' | '(' | ')' | '[' | ']' | '{' | '}' | ';' | ',' | '\\' | '.' | '!' | '+' | '*' | '/' | '%' | '~' | '^'))
+    s.chars().any(|c| {
+        matches!(
+            c,
+            '&' | '?'
+                | ':'
+                | '='
+                | '<'
+                | '>'
+                | '('
+                | ')'
+                | '['
+                | ']'
+                | '{'
+                | '}'
+                | ';'
+                | ','
+                | '\\'
+                | '.'
+                | '!'
+                | '+'
+                | '*'
+                | '/'
+                | '%'
+                | '~'
+                | '^'
+        )
+    })
 }
 
 // ── mdast node builders ──────────────────────────────────────────────────────
@@ -420,12 +443,19 @@ fn split_text_node(value: &str) -> Option<Vec<MdastNode>> {
 
     while !rest.is_empty() {
         match next_token(rest) {
-            ParseResult::Ruby { base, ruby, rest: tail } => {
+            ParseResult::Ruby {
+                base,
+                ruby,
+                rest: tail,
+            } => {
                 found_any = true;
                 nodes.push(make_ruby_node(&base, &ruby));
                 rest = tail;
             }
-            ParseResult::Literal { consumed, rest: tail } => {
+            ParseResult::Literal {
+                consumed,
+                rest: tail,
+            } => {
                 if !consumed.is_empty() {
                     nodes.push(MdastNode::Text(Text {
                         value: consumed,
@@ -434,7 +464,10 @@ fn split_text_node(value: &str) -> Option<Vec<MdastNode>> {
                 }
                 rest = tail;
             }
-            ParseResult::Invalid { consumed, rest: tail } => {
+            ParseResult::Invalid {
+                consumed,
+                rest: tail,
+            } => {
                 nodes.push(MdastNode::Text(Text {
                     value: consumed,
                     position: None,
@@ -588,7 +621,9 @@ fn rewrite_inline_children(children: &mut Vec<MdastNode>) -> bool {
         // ── Caret syntax: `{base}^{ruby}` or `base^{ruby}` ────────────────
         // The pipe path above already declined this Expr (no `|`); now try the
         // caret look-behind. On success `i` is advanced past the inserted ruby.
-        if matches!(&children[i], MdastNode::MdxTextExpression(_)) && try_caret_rewrite(children, &mut i) {
+        if matches!(&children[i], MdastNode::MdxTextExpression(_))
+            && try_caret_rewrite(children, &mut i)
+        {
             changed = true;
             i += 1;
             continue;
@@ -881,8 +916,12 @@ mod tests {
             expr("これ"),
         ])]);
         RubyPlugin::new().visit(&mut tree);
-        let MdastNode::Root(root) = &tree else { panic!() };
-        let MdastNode::Paragraph(p) = &root.children[0] else { panic!() };
+        let MdastNode::Root(root) = &tree else {
+            panic!()
+        };
+        let MdastNode::Paragraph(p) = &root.children[0] else {
+            panic!()
+        };
         assert_eq!(p.children.len(), 1);
         assert!(matches!(p.children[0], MdastNode::MdxJsxTextElement(_)));
     }
@@ -896,8 +935,12 @@ mod tests {
             expr("これ"),
         ])]);
         RubyPlugin::new().visit(&mut tree);
-        let MdastNode::Root(root) = &tree else { panic!() };
-        let MdastNode::Paragraph(p) = &root.children[0] else { panic!() };
+        let MdastNode::Root(root) = &tree else {
+            panic!()
+        };
+        let MdastNode::Paragraph(p) = &root.children[0] else {
+            panic!()
+        };
         assert_eq!(p.children.len(), 1);
         assert!(matches!(p.children[0], MdastNode::MdxJsxTextElement(_)));
     }
@@ -917,7 +960,11 @@ mod tests {
         let mut tree = make_root(vec![make_para_children(vec![text("^"), expr("jsExpr")])]);
         let before = format!("{tree:?}");
         RubyPlugin::new().visit(&mut tree);
-        assert_eq!(format!("{tree:?}"), before, "^{{jsExpr}} must stay untouched");
+        assert_eq!(
+            format!("{tree:?}"),
+            before,
+            "^{{jsExpr}} must stay untouched"
+        );
     }
 
     #[test]
@@ -930,7 +977,11 @@ mod tests {
         ])]);
         let before = format!("{tree:?}");
         RubyPlugin::new().visit(&mut tree);
-        assert_eq!(format!("{tree:?}"), before, "{{a || b}}^{{c}} must stay untouched");
+        assert_eq!(
+            format!("{tree:?}"),
+            before,
+            "{{a || b}}^{{c}} must stay untouched"
+        );
     }
 
     #[test]
@@ -942,8 +993,12 @@ mod tests {
             text("と書く"),
         ])]);
         RubyPlugin::new().visit(&mut tree);
-        let MdastNode::Root(root) = &tree else { panic!() };
-        let MdastNode::Paragraph(p) = &root.children[0] else { panic!() };
+        let MdastNode::Root(root) = &tree else {
+            panic!()
+        };
+        let MdastNode::Paragraph(p) = &root.children[0] else {
+            panic!()
+        };
         assert_eq!(p.children.len(), 2);
         assert!(matches!(p.children[0], MdastNode::MdxJsxTextElement(_)));
         assert!(matches!(p.children[1], MdastNode::Text(_)));
@@ -1150,9 +1205,7 @@ mod tests {
 
     #[test]
     fn visitor_rewrites_multiple_text_annotations() {
-        let mut tree = make_root(vec![make_para_text(
-            "{東京|とうきょう}は{首都|しゅと}です",
-        )]);
+        let mut tree = make_root(vec![make_para_text("{東京|とうきょう}は{首都|しゅと}です")]);
         RubyPlugin::new().visit(&mut tree);
         let MdastNode::Root(root) = &tree else {
             panic!("expected Root");
@@ -1224,7 +1277,11 @@ mod tests {
         let mut tree = make_root(vec![make_para_expr("someJsExpr")]);
         let before = format!("{tree:?}");
         RubyPlugin::new().visit(&mut tree);
-        assert_eq!(format!("{tree:?}"), before, "non-ruby expression must not change");
+        assert_eq!(
+            format!("{tree:?}"),
+            before,
+            "non-ruby expression must not change"
+        );
     }
 
     // ── MdxFlowExpression (block-level) ───────────────────────────────────
@@ -1264,7 +1321,11 @@ mod tests {
         let mut tree = make_root(vec![make_flow_expr("someJsExpr")]);
         let before = format!("{tree:?}");
         RubyPlugin::new().visit(&mut tree);
-        assert_eq!(format!("{tree:?}"), before, "non-ruby flow expression must not change");
+        assert_eq!(
+            format!("{tree:?}"),
+            before,
+            "non-ruby flow expression must not change"
+        );
     }
 
     // ── escape_html ───────────────────────────────────────────────────────

--- a/crates/zfb-md-extras/src/test_harness.rs
+++ b/crates/zfb-md-extras/src/test_harness.rs
@@ -68,13 +68,11 @@ where
     let input_path = dir.join("input.md");
     let expected_path = dir.join("expected.html");
 
-    let input = std::fs::read_to_string(&input_path).unwrap_or_else(|e| {
-        panic!("failed to read {}: {e}", input_path.display())
-    });
+    let input = std::fs::read_to_string(&input_path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", input_path.display()));
 
-    let expected_raw = std::fs::read_to_string(&expected_path).unwrap_or_else(|e| {
-        panic!("failed to read {}: {e}", expected_path.display())
-    });
+    let expected_raw = std::fs::read_to_string(&expected_path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", expected_path.display()));
 
     let verbatim = is_verbatim(dir);
 
@@ -84,7 +82,8 @@ where
         // trailing whitespace that callers may rely on.
         let actual_raw = transform(&input);
         assert_eq!(
-            actual_raw, expected_raw,
+            actual_raw,
+            expected_raw,
             "fixture {}: verbatim output mismatch",
             dir.display()
         );
@@ -99,7 +98,8 @@ where
         let actual = normalize_html(&actual_raw);
         let expected = normalize_html(&expected_raw);
         assert_eq!(
-            actual, expected,
+            actual,
+            expected,
             "fixture {}: normalized HTML mismatch\n  actual:   {actual}\n  expected: {expected}",
             dir.display()
         );
@@ -124,9 +124,7 @@ fn is_verbatim(dir: &Path) -> bool {
 mod tests {
     use super::*;
     /// Helper: create a temporary fixture directory with given files.
-    fn make_fixture_dir(
-        files: &[(&str, &str)],
-    ) -> tempdir::TempDir {
+    fn make_fixture_dir(files: &[(&str, &str)]) -> tempdir::TempDir {
         let dir = tempdir::TempDir::new("zfb_fixture_test").expect("tempdir");
         for (name, content) in files {
             let path = dir.path().join(name);
@@ -141,10 +139,7 @@ mod tests {
     fn test_run_fixture_pass_on_match() {
         // A trivial transform: just pass through the input unchanged.
         // Input and expected are identical so the test must pass.
-        let dir = make_fixture_dir(&[
-            ("input.md", "hello"),
-            ("expected.html", "<p>hello</p>"),
-        ]);
+        let dir = make_fixture_dir(&[("input.md", "hello"), ("expected.html", "<p>hello</p>")]);
         // Use markdown::to_html as the transform — produces <p>hello</p>.
         run_fixture(dir.path(), markdown::to_html);
     }
@@ -192,17 +187,17 @@ mod tests {
             // Verbatim mode: raw strings are compared, so this must fail.
             run_fixture(dir.path(), |_| "different output".to_string());
         });
-        assert!(result.is_err(), "verbatim mode must panic on string mismatch");
+        assert!(
+            result.is_err(),
+            "verbatim mode must panic on string mismatch"
+        );
     }
 
     #[test]
     fn test_no_normalize_txt_uses_normalization() {
         // Without normalize.txt the comparison goes through normalize_html.
         // `<br>` and `<br />` are distinct raw strings but equal after normalization.
-        let dir = make_fixture_dir(&[
-            ("input.md", "test"),
-            ("expected.html", "<p>a<br>b</p>"),
-        ]);
+        let dir = make_fixture_dir(&[("input.md", "test"), ("expected.html", "<p>a<br>b</p>")]);
         // Transform returns the XHTML form; normalize_html makes them equal.
         run_fixture(dir.path(), |_| "<p>a<br />b</p>".to_string());
     }

--- a/crates/zfb-md-extras/src/transclude.rs
+++ b/crates/zfb-md-extras/src/transclude.rs
@@ -339,10 +339,7 @@ fn resolve_and_expand(
             }
             emit_error(
                 ctx,
-                format!(
-                    "transclude: cannot read \"{}\": {e}",
-                    resolved.display()
-                ),
+                format!("transclude: cannot read \"{}\": {e}", resolved.display()),
             );
             return Vec::new();
         }
@@ -402,10 +399,7 @@ fn resolve_and_expand(
             }
             emit_error(
                 ctx,
-                format!(
-                    "transclude: cannot read \"{}\": {e}",
-                    canonical.display()
-                ),
+                format!("transclude: cannot read \"{}\": {e}", canonical.display()),
             );
             return Vec::new();
         }
@@ -469,10 +463,20 @@ fn resolve_and_expand(
     // directly in the root's children vec rather than being missed by the
     // container-dispatch in `expand_includes_in_node` (which skips Paragraph
     // nodes — the `:::include` pattern appears as a top-level Paragraph).
-    let included_source_dir = canonical.parent().map(|p| p.to_path_buf()).unwrap_or_else(|| PathBuf::from("."));
+    let included_source_dir = canonical
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."));
     visited.insert(canonical.clone());
 
-    expand_includes_in_children(&mut nodes, &included_source_dir, env, visited, depth + 1, ctx);
+    expand_includes_in_children(
+        &mut nodes,
+        &included_source_dir,
+        env,
+        visited,
+        depth + 1,
+        ctx,
+    );
 
     visited.remove(&canonical);
 
@@ -535,7 +539,12 @@ fn parse_attrs_from_expression(expr_value: &str) -> Option<IncludeAttrs> {
     let code = attrs.get("code").map(|v| v == "true").unwrap_or(false);
     let lang = attrs.get("lang").cloned().filter(|l| !l.is_empty());
 
-    Some(IncludeAttrs { file, lines, code, lang })
+    Some(IncludeAttrs {
+        file,
+        lines,
+        code,
+        lang,
+    })
 }
 
 /// Parse a key="value" / key=value / key=true / key=false string into a map.
@@ -557,7 +566,9 @@ fn parse_attr_string(s: &str) -> std::collections::HashMap<String, String> {
         }
 
         // Read key
-        let key_end = rest.find(|c: char| c == '=' || c.is_whitespace()).unwrap_or(rest.len());
+        let key_end = rest
+            .find(|c: char| c == '=' || c.is_whitespace())
+            .unwrap_or(rest.len());
         let key = rest[..key_end].to_string();
         rest = &rest[key_end..];
 
@@ -569,20 +580,28 @@ fn parse_attr_string(s: &str) -> std::collections::HashMap<String, String> {
 
         if rest.starts_with('=') {
             rest = &rest[1..]; // consume '='
-            // Read value
+                               // Read value
             if rest.starts_with('"') {
                 // Quoted with "
                 rest = &rest[1..];
                 let end = rest.find('"').unwrap_or(rest.len());
                 let value = rest[..end].to_string();
-                rest = if end < rest.len() { &rest[end + 1..] } else { &rest[end..] };
+                rest = if end < rest.len() {
+                    &rest[end + 1..]
+                } else {
+                    &rest[end..]
+                };
                 map.insert(key, value);
             } else if rest.starts_with('\'') {
                 // Quoted with '
                 rest = &rest[1..];
                 let end = rest.find('\'').unwrap_or(rest.len());
                 let value = rest[..end].to_string();
-                rest = if end < rest.len() { &rest[end + 1..] } else { &rest[end..] };
+                rest = if end < rest.len() {
+                    &rest[end + 1..]
+                } else {
+                    &rest[end..]
+                };
                 map.insert(key, value);
             } else {
                 // Unquoted value (stops at whitespace)
@@ -826,7 +845,8 @@ mod tests {
     #[test]
     fn directive_def_validates_file_attr() {
         let def = include_directive_def();
-        let (result, warnings) = def.validate_attrs(&[("file".to_string(), "./foo.md".to_string())]);
+        let (result, warnings) =
+            def.validate_attrs(&[("file".to_string(), "./foo.md".to_string())]);
         assert!(result.is_ok(), "valid file attr must pass: {result:?}");
         assert!(warnings.is_empty());
     }
@@ -896,9 +916,15 @@ mod tests {
         );
         assert!(diags.is_empty(), "no diagnostics expected: {diags:?}");
 
-        let MdastNode::Root(root) = &tree else { panic!("expected Root") };
+        let MdastNode::Root(root) = &tree else {
+            panic!("expected Root")
+        };
         // snippet.md has h1 + paragraph → 2 nodes spliced in
-        assert_eq!(root.children.len(), 2, "expected 2 spliced nodes, got: {root:?}");
+        assert_eq!(
+            root.children.len(),
+            2,
+            "expected 2 spliced nodes, got: {root:?}"
+        );
         assert!(matches!(root.children[0], MdastNode::Heading(_)));
         assert!(matches!(root.children[1], MdastNode::Paragraph(_)));
     }
@@ -920,9 +946,13 @@ mod tests {
             TranscludeConfig::default(),
         );
         assert!(diags.is_empty(), "no diagnostics expected: {diags:?}");
-        let MdastNode::Root(root) = &tree else { panic!("expected Root") };
+        let MdastNode::Root(root) = &tree else {
+            panic!("expected Root")
+        };
         assert_eq!(root.children.len(), 1);
-        let MdastNode::Code(code) = &root.children[0] else { panic!("expected Code, got: {:?}", root.children[0]) };
+        let MdastNode::Code(code) = &root.children[0] else {
+            panic!("expected Code, got: {:?}", root.children[0])
+        };
         assert_eq!(code.lang.as_deref(), Some("rust"));
         assert!(code.value.contains("fn main()"));
     }
@@ -944,8 +974,12 @@ mod tests {
             TranscludeConfig::default(),
         );
         assert!(diags.is_empty(), "no diagnostics: {diags:?}");
-        let MdastNode::Root(root) = &tree else { panic!("expected Root") };
-        let MdastNode::Code(code) = &root.children[0] else { panic!("expected Code") };
+        let MdastNode::Root(root) = &tree else {
+            panic!("expected Root")
+        };
+        let MdastNode::Code(code) = &root.children[0] else {
+            panic!("expected Code")
+        };
         assert_eq!(code.value, "line2\nline3\nline4");
     }
 
@@ -972,7 +1006,10 @@ mod tests {
                 ..
             } if message.contains("cycle"))
         });
-        assert!(has_cycle_error, "expected cycle error diagnostic: {diags:?}");
+        assert!(
+            has_cycle_error,
+            "expected cycle error diagnostic: {diags:?}"
+        );
     }
 
     #[test]
@@ -1008,7 +1045,12 @@ mod tests {
         let source = dir.path().join("input.md");
         std::fs::write(&source, input).unwrap();
 
-        let (_, diags) = run_transclude(input, source, dir.path().to_path_buf(), TranscludeConfig::default());
+        let (_, diags) = run_transclude(
+            input,
+            source,
+            dir.path().to_path_buf(),
+            TranscludeConfig::default(),
+        );
         let has_err = diags.iter().any(|d| {
             matches!(d, zfb_md_ast::diagnostics::MarkdownDiagnostic::Generic {
                 severity: zfb_md_ast::diagnostics::DiagnosticSeverity::Error,
@@ -1026,17 +1068,28 @@ mod tests {
         // outer/secret.md exists but project_root is inner/
         std::fs::write(outer.path().join("secret.md"), "secret\n").unwrap();
 
-        let input = format!(r#":::include{{file="{}"}}"#, outer.path().join("secret.md").display());
+        let input = format!(
+            r#":::include{{file="{}"}}"#,
+            outer.path().join("secret.md").display()
+        );
         let source = inner.path().join("input.md");
         std::fs::write(&source, &input).unwrap();
 
         // project_root = inner dir, but file resolves to outer dir (absolute → rejected first)
-        let (_, diags) = run_transclude(&input, source, inner.path().to_path_buf(), TranscludeConfig::default());
+        let (_, diags) = run_transclude(
+            &input,
+            source,
+            inner.path().to_path_buf(),
+            TranscludeConfig::default(),
+        );
         let has_err = diags.iter().any(|d| {
-            matches!(d, zfb_md_ast::diagnostics::MarkdownDiagnostic::Generic {
-                severity: zfb_md_ast::diagnostics::DiagnosticSeverity::Error,
-                ..
-            })
+            matches!(
+                d,
+                zfb_md_ast::diagnostics::MarkdownDiagnostic::Generic {
+                    severity: zfb_md_ast::diagnostics::DiagnosticSeverity::Error,
+                    ..
+                }
+            )
         });
         assert!(has_err, "expected path error: {diags:?}");
     }
@@ -1052,9 +1105,16 @@ mod tests {
         let source = dir.path().join("root.md");
         std::fs::write(&source, input).unwrap();
 
-        let (tree, diags) = run_transclude(input, source, dir.path().to_path_buf(), TranscludeConfig::default());
+        let (tree, diags) = run_transclude(
+            input,
+            source,
+            dir.path().to_path_buf(),
+            TranscludeConfig::default(),
+        );
         assert!(diags.is_empty(), "no diagnostics: {diags:?}");
-        let MdastNode::Root(root) = &tree else { panic!("expected Root") };
+        let MdastNode::Root(root) = &tree else {
+            panic!("expected Root")
+        };
         // a.md inlines b.md which is "From B." → a paragraph
         assert!(!root.children.is_empty(), "expected inlined content");
     }
@@ -1098,8 +1158,7 @@ mod tests {
         let input = r#":::include{file="./snippet.md"}"#;
         std::fs::write(&source, input).unwrap();
 
-        let (_, diags, reads) =
-            run_transclude_recorded(input, source, dir.path().to_path_buf());
+        let (_, diags, reads) = run_transclude_recorded(input, source, dir.path().to_path_buf());
         assert!(diags.is_empty(), "no diagnostics: {diags:?}");
         let canonical = snippet.canonicalize().expect("canonicalize snippet");
         assert_eq!(
@@ -1116,8 +1175,7 @@ mod tests {
         let input = r#":::include{file="./not-yet.md"}"#;
         std::fs::write(&source, input).unwrap();
 
-        let (_, diags, reads) =
-            run_transclude_recorded(input, source, dir.path().to_path_buf());
+        let (_, diags, reads) = run_transclude_recorded(input, source, dir.path().to_path_buf());
         assert!(
             !diags.is_empty(),
             "a missing include must emit a diagnostic"
@@ -1140,13 +1198,18 @@ mod tests {
         let input = r#":::include{file="./b.md"}"#;
         std::fs::write(&source, input).unwrap();
 
-        let (_, diags, reads) =
-            run_transclude_recorded(input, source, dir.path().to_path_buf());
+        let (_, diags, reads) = run_transclude_recorded(input, source, dir.path().to_path_buf());
         assert!(diags.is_empty(), "no diagnostics: {diags:?}");
         let b = dir.path().join("b.md").canonicalize().unwrap();
         let c = dir.path().join("c.md").canonicalize().unwrap();
-        assert!(reads.contains_key(&b), "level-1 include must record: {reads:?}");
-        assert!(reads.contains_key(&c), "level-2 include must record: {reads:?}");
+        assert!(
+            reads.contains_key(&b),
+            "level-1 include must record: {reads:?}"
+        );
+        assert!(
+            reads.contains_key(&c),
+            "level-2 include must record: {reads:?}"
+        );
     }
 
     #[test]

--- a/crates/zfb-md-extras/tests/code_tabs.rs
+++ b/crates/zfb-md-extras/tests/code_tabs.rs
@@ -69,8 +69,7 @@ fn no_lang_fallback() {
 /// The opener paragraph remains as a plain paragraph in the output.
 #[test]
 fn disabled_leaves_code_group_unchanged() {
-    let input =
-        ":::code-group\n\n```ts\nconst x = 1;\n```\n\n:::\n";
+    let input = ":::code-group\n\n```ts\nconst x = 1;\n```\n\n:::\n";
     let mut p = pipeline_with_code_tabs(false);
     let hast = p.run(input).expect("pipeline failed");
     let html = serialize(&hast);

--- a/crates/zfb-md-extras/tests/cross_feature_integration.rs
+++ b/crates/zfb-md-extras/tests/cross_feature_integration.rs
@@ -45,11 +45,11 @@ use zfb_content::pipeline::Pipeline;
 use zfb_content::plugins::DirectiveRegistry;
 use zfb_content::serializer::serialize;
 use zfb_md_ast::{
+    diagnostics::{CollectingSink, DiagnosticSeverity, MarkdownDiagnostic},
+    heading_registry::HeadingRegistry,
     BuildContext, CodeEnrichmentConfig, DirectiveFullSpec, DirectiveSpec, DirectiveSpecKind,
     FeatureToggle, GithubAutolinksConfig, HeadingMarkerTocFeature, ImageDimensionsConfig,
     LinkValidationConfig, MarkdownFeaturesConfig, TocConfig, TocExportConfig, TranscludeConfig,
-    diagnostics::{CollectingSink, DiagnosticSeverity, MarkdownDiagnostic},
-    heading_registry::HeadingRegistry,
 };
 
 // ── Case 1: transclude + link_validation ────────────────────────────────────
@@ -71,11 +71,7 @@ fn transclude_link_validation_broken_link_in_snippet() {
 
     // Write the main document that includes the snippet.
     let input_path = tmpdir.path().join("input.md");
-    std::fs::write(
-        &input_path,
-        ":::include{file=\"./snippet.md\"}\n",
-    )
-    .expect("write input.md");
+    std::fs::write(&input_path, ":::include{file=\"./snippet.md\"}\n").expect("write input.md");
 
     let input = std::fs::read_to_string(&input_path).expect("read input.md");
 
@@ -96,7 +92,9 @@ fn transclude_link_validation_broken_link_in_snippet() {
         diagnostics: Some(&mut sink),
     };
 
-    let _hast = pipeline.run_with_context(&input, &mut ctx).expect("pipeline must not fail");
+    let _hast = pipeline
+        .run_with_context(&input, &mut ctx)
+        .expect("pipeline must not fail");
     let diags = sink.take();
 
     // At least one BrokenLink diagnostic must be present for the anchor from the snippet.
@@ -180,7 +178,10 @@ fn heading_marker_toc_and_toc_export_share_deduped_ids() {
 #[test]
 fn image_dimensions_injects_width_and_height() {
     // Use the fixture image from the image_dimensions fixtures directory.
-    let fixtures_dir = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/image_dimensions");
+    let fixtures_dir = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/image_dimensions"
+    );
 
     let features = MarkdownFeaturesConfig {
         image_dimensions: Some(ImageDimensionsConfig::default()),
@@ -199,7 +200,9 @@ fn image_dimensions_injects_width_and_height() {
         diagnostics: None,
     };
 
-    let hast = pipeline.run_with_context(input, &mut ctx).expect("pipeline must not fail");
+    let hast = pipeline
+        .run_with_context(input, &mut ctx)
+        .expect("pipeline must not fail");
     let html = serialize(&hast);
 
     // image_dimensions must have injected width and height.
@@ -340,10 +343,8 @@ fn transclude_cycle_produces_generic_not_broken_link() {
     // A and B include each other — classic cycle.
     let a_path = tmpdir.path().join("a.md");
     let b_path = tmpdir.path().join("b.md");
-    std::fs::write(&a_path, "A includes B.\n\n:::include{file=\"./b.md\"}\n")
-        .expect("write a.md");
-    std::fs::write(&b_path, "B includes A.\n\n:::include{file=\"./a.md\"}\n")
-        .expect("write b.md");
+    std::fs::write(&a_path, "A includes B.\n\n:::include{file=\"./b.md\"}\n").expect("write a.md");
+    std::fs::write(&b_path, "B includes A.\n\n:::include{file=\"./a.md\"}\n").expect("write b.md");
 
     // The main document includes a.md.
     let input_path = tmpdir.path().join("input.md");
@@ -371,7 +372,10 @@ fn transclude_cycle_produces_generic_not_broken_link() {
     let diags = sink.take();
 
     // Must have at least one diagnostic.
-    assert!(!diags.is_empty(), "cycle must produce at least one diagnostic");
+    assert!(
+        !diags.is_empty(),
+        "cycle must produce at least one diagnostic"
+    );
 
     // The cycle diagnostic must be a Generic variant with "cycle" in the message.
     let cycle_diags: Vec<_> = diags
@@ -533,11 +537,16 @@ fn all_features_on_does_not_crash() {
         diagnostics: Some(&mut sink),
     };
 
-    let hast = pipeline.run_with_context(input, &mut ctx).expect("all-features pipeline must not crash");
+    let hast = pipeline
+        .run_with_context(input, &mut ctx)
+        .expect("all-features pipeline must not crash");
     let html = serialize(&hast);
 
     // Must produce non-empty output.
-    assert!(!html.is_empty(), "all-features pipeline must produce output");
+    assert!(
+        !html.is_empty(),
+        "all-features pipeline must produce output"
+    );
 
     // The transcluded heading must appear.
     assert!(
@@ -546,10 +555,7 @@ fn all_features_on_does_not_crash() {
     );
 
     // ruby annotation must be processed.
-    assert!(
-        html.contains("<ruby>"),
-        "ruby must be processed: {html}"
-    );
+    assert!(html.contains("<ruby>"), "ruby must be processed: {html}");
 
     // heading elements must be present.
     assert!(
@@ -816,7 +822,10 @@ fn directives_feature_emits_components_and_unknown_diagnostic() {
         ("details", "Details"),
         ("caution", "Caution"),
     ] {
-        directives.insert(name.to_string(), DirectiveSpec::Short(component.to_string()));
+        directives.insert(
+            name.to_string(),
+            DirectiveSpec::Short(component.to_string()),
+        );
     }
 
     let input = concat!(
@@ -837,7 +846,9 @@ fn directives_feature_emits_components_and_unknown_diagnostic() {
     let hast = pipeline.run(input).expect("pipeline must not fail");
     let html = serialize(&hast);
 
-    for component in ["Note", "Tip", "Warning", "Danger", "Info", "Details", "Caution"] {
+    for component in [
+        "Note", "Tip", "Warning", "Danger", "Info", "Details", "Caution",
+    ] {
         assert!(
             html.contains(component),
             "directives map must emit <{component}>: {html}"
@@ -850,12 +861,14 @@ fn directives_feature_emits_components_and_unknown_diagnostic() {
     // not surfaced via `Pipeline::run`. We verify this at the registry level
     // directly, which is the canonical API for diagnostic inspection.
     let mut registry = DirectiveRegistry::new();
-    registry.register(zfb_content::plugins::DirectiveDef::container("note", "Note"));
+    registry.register(zfb_content::plugins::DirectiveDef::container(
+        "note", "Note",
+    ));
     // Use markdown-rs to parse the nope directive, then run the registry visit.
     let nope_input = ":::nope\n\nUnknown body.\n\n:::\n";
     let parse_opts = markdown::ParseOptions::mdx();
-    let mut mdast = markdown::to_mdast(nope_input, &parse_opts)
-        .expect("markdown parse must not fail");
+    let mut mdast =
+        markdown::to_mdast(nope_input, &parse_opts).expect("markdown parse must not fail");
     use zfb_content::pipeline::MdastVisitor;
     registry.visit(&mut mdast);
 

--- a/crates/zfb-md-extras/tests/github_alerts.rs
+++ b/crates/zfb-md-extras/tests/github_alerts.rs
@@ -23,7 +23,10 @@ use zfb_md_extras::{test_harness::run_fixture, DirectiveSpec, MarkdownFeaturesCo
 fn admonition_directives() -> Option<HashMap<String, DirectiveSpec>> {
     let mut m = HashMap::new();
     for (name, component) in [("note", "Note"), ("warning", "Warning")] {
-        m.insert(name.to_string(), DirectiveSpec::Short(component.to_string()));
+        m.insert(
+            name.to_string(),
+            DirectiveSpec::Short(component.to_string()),
+        );
     }
     Some(m)
 }
@@ -39,12 +42,8 @@ fn pipeline_with_alerts(enabled: bool) -> Pipeline {
 
 /// Run a fixture directory against the github_alerts-enabled pipeline.
 fn run(name: &str) {
-    let dir = concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/tests/fixtures/github_alerts/"
-    )
-    .to_string()
-        + name;
+    let dir =
+        concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/github_alerts/").to_string() + name;
     run_fixture(&dir, |input| {
         let mut p = pipeline_with_alerts(true);
         let hast = p.run(input).expect("pipeline failed");
@@ -158,7 +157,10 @@ fn parity_with_directives_single_paragraph() {
 
     let directive_html = {
         let mut p = Pipeline::with_defaults_and_features(&directive_features);
-        serialize(&p.run(":::note\n\nnote body\n\n:::").expect("pipeline failed"))
+        serialize(
+            &p.run(":::note\n\nnote body\n\n:::")
+                .expect("pipeline failed"),
+        )
     };
     let alert_html = {
         let mut p = Pipeline::with_defaults_and_features(&alert_features);

--- a/crates/zfb-md-extras/tests/image_dimensions.rs
+++ b/crates/zfb-md-extras/tests/image_dimensions.rs
@@ -57,12 +57,21 @@ fn get_attr<'a>(node: &'a HastNode, name: &str) -> Option<&'a str> {
     let HastNode::Element { attrs, .. } = node else {
         return None;
     };
-    attrs.iter().find(|(k, _)| k == name).map(|(_, v)| v.as_str())
+    attrs
+        .iter()
+        .find(|(k, _)| k == name)
+        .map(|(_, v)| v.as_str())
 }
 
 fn first_img(root: &HastNode) -> &HastNode {
-    let HastNode::Root { children } = root else { panic!("expected root") };
-    let HastNode::Element { children: p_children, .. } = &children[0] else {
+    let HastNode::Root { children } = root else {
+        panic!("expected root")
+    };
+    let HastNode::Element {
+        children: p_children,
+        ..
+    } = &children[0]
+    else {
         panic!("expected p");
     };
     &p_children[0]
@@ -103,7 +112,11 @@ fn injects_dimensions_jpg_via_public_dir() {
 
     let img = first_img(&tree);
     assert_eq!(get_attr(img, "width"), Some("60"), "JPEG width must be 60");
-    assert_eq!(get_attr(img, "height"), Some("40"), "JPEG height must be 40");
+    assert_eq!(
+        get_attr(img, "height"),
+        Some("40"),
+        "JPEG height must be 40"
+    );
 }
 
 /// Third format: GIF (80x30).
@@ -138,8 +151,16 @@ fn injects_dimensions_webp_via_public_dir() {
     plugin.visit_with_context(&mut tree, &mut ctx);
 
     let img = first_img(&tree);
-    assert_eq!(get_attr(img, "width"), Some("120"), "WebP width must be 120");
-    assert_eq!(get_attr(img, "height"), Some("90"), "WebP height must be 90");
+    assert_eq!(
+        get_attr(img, "width"),
+        Some("120"),
+        "WebP width must be 120"
+    );
+    assert_eq!(
+        get_attr(img, "height"),
+        Some("90"),
+        "WebP height must be 90"
+    );
 }
 
 /// Relative src resolved against the source file's directory.
@@ -175,8 +196,16 @@ fn injects_dimensions_wide_png() {
     plugin.visit_with_context(&mut tree, &mut ctx);
 
     let img = first_img(&tree);
-    assert_eq!(get_attr(img, "width"), Some("200"), "wide PNG width must be 200");
-    assert_eq!(get_attr(img, "height"), Some("150"), "wide PNG height must be 150");
+    assert_eq!(
+        get_attr(img, "width"),
+        Some("200"),
+        "wide PNG width must be 200"
+    );
+    assert_eq!(
+        get_attr(img, "height"),
+        Some("150"),
+        "wide PNG height must be 150"
+    );
 }
 
 /// Tiny 1x1 PNG.
@@ -193,8 +222,16 @@ fn injects_dimensions_tiny_png() {
     plugin.visit_with_context(&mut tree, &mut ctx);
 
     let img = first_img(&tree);
-    assert_eq!(get_attr(img, "width"), Some("1"), "tiny PNG width must be 1");
-    assert_eq!(get_attr(img, "height"), Some("1"), "tiny PNG height must be 1");
+    assert_eq!(
+        get_attr(img, "width"),
+        Some("1"),
+        "tiny PNG width must be 1"
+    );
+    assert_eq!(
+        get_attr(img, "height"),
+        Some("1"),
+        "tiny PNG height must be 1"
+    );
 }
 
 // ── acceptance: skip remote and data URLs ────────────────────────────────────
@@ -213,8 +250,16 @@ fn skips_https_url() {
     plugin.visit_with_context(&mut tree, &mut ctx);
 
     let img = first_img(&tree);
-    assert_eq!(get_attr(img, "width"), None, "remote img must not get width");
-    assert_eq!(get_attr(img, "height"), None, "remote img must not get height");
+    assert_eq!(
+        get_attr(img, "width"),
+        None,
+        "remote img must not get width"
+    );
+    assert_eq!(
+        get_attr(img, "height"),
+        None,
+        "remote img must not get height"
+    );
 }
 
 /// `<img src="http://example.com/foo.png">` must be left unchanged.
@@ -276,15 +321,25 @@ fn leaves_explicit_width_unchanged() {
     );
     plugin.visit_with_context(&mut tree, &mut ctx);
 
-    let HastNode::Root { children } = &tree else { panic!() };
+    let HastNode::Root { children } = &tree else {
+        panic!()
+    };
     let img = &children[0];
     let width_count = match img {
         HastNode::Element { attrs, .. } => attrs.iter().filter(|(k, _)| k == "width").count(),
         _ => panic!("expected element"),
     };
     assert_eq!(width_count, 1, "must not duplicate width attr");
-    assert_eq!(get_attr(img, "width"), Some("999"), "original width must be preserved");
-    assert_eq!(get_attr(img, "height"), None, "height must not be injected when width present");
+    assert_eq!(
+        get_attr(img, "width"),
+        Some("999"),
+        "original width must be preserved"
+    );
+    assert_eq!(
+        get_attr(img, "height"),
+        None,
+        "height must not be injected when width present"
+    );
 }
 
 /// `<img height="...">` must not get width or additional height attribute.
@@ -310,10 +365,20 @@ fn leaves_explicit_height_unchanged() {
     );
     plugin.visit_with_context(&mut tree, &mut ctx);
 
-    let HastNode::Root { children } = &tree else { panic!() };
+    let HastNode::Root { children } = &tree else {
+        panic!()
+    };
     let img = &children[0];
-    assert_eq!(get_attr(img, "width"), None, "width must not be injected when height present");
-    assert_eq!(get_attr(img, "height"), Some("999"), "original height must be preserved");
+    assert_eq!(
+        get_attr(img, "width"),
+        None,
+        "width must not be injected when height present"
+    );
+    assert_eq!(
+        get_attr(img, "height"),
+        Some("999"),
+        "original height must be preserved"
+    );
 }
 
 // ── acceptance: diagnostic on missing file ────────────────────────────────────
@@ -340,7 +405,11 @@ fn emits_warning_for_missing_file() {
     assert_eq!(diags[0].severity(), DiagnosticSeverity::Warning);
 
     let img = first_img(&tree);
-    assert_eq!(get_attr(img, "width"), None, "width must not be added for missing file");
+    assert_eq!(
+        get_attr(img, "width"),
+        None,
+        "width must not be added for missing file"
+    );
 }
 
 /// A non-image file (text) must emit a Warning diagnostic.
@@ -394,7 +463,9 @@ fn cache_hit_on_second_reference() {
     );
 
     // Both images must have dimensions injected.
-    let HastNode::Root { children } = &tree else { panic!() };
+    let HastNode::Root { children } = &tree else {
+        panic!()
+    };
     for (i, child) in children.iter().enumerate() {
         assert_eq!(
             get_attr(child, "width"),

--- a/crates/zfb-md-extras/tests/link_validation.rs
+++ b/crates/zfb-md-extras/tests/link_validation.rs
@@ -19,9 +19,9 @@ use std::path::PathBuf;
 
 use zfb_content::pipeline::{BuildContext, Pipeline};
 use zfb_md_ast::{
-    LinkValidationConfig, MarkdownFeaturesConfig,
     diagnostics::{CollectingSink, DiagnosticSeverity, MarkdownDiagnostic},
     heading_registry::{HeadingEntry, HeadingRegistry},
+    LinkValidationConfig, MarkdownFeaturesConfig,
 };
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -259,17 +259,22 @@ fn missing_file_emits_warning() {
 fn fail_on_broken_true_emits_error() {
     let source = PathBuf::from("/project/docs/page.md");
     let mut registry = HeadingRegistry::new();
+    // Pre-populate an entry for the source file so entry-presence gating
+    // allows the fragment check to fire (the fragment "no-such-heading"
+    // is intentionally absent to trigger the broken-link report).
+    registry.insert(
+        source.clone(),
+        HeadingEntry {
+            id: "other-heading".to_string(),
+            text: "Other Heading".to_string(),
+            depth: 2,
+        },
+    );
     let md = "[foo](#no-such-heading)\n";
     let cfg = LinkValidationConfig {
         fail_on_broken: Some(true),
     };
-    let diags = run(
-        md,
-        source,
-        PathBuf::from("/project"),
-        &mut registry,
-        cfg,
-    );
+    let diags = run(md, source, PathBuf::from("/project"), &mut registry, cfg);
     assert_eq!(diags.len(), 1, "expected one diagnostic: {diags:?}");
     assert_eq!(
         diags[0].severity(),
@@ -314,6 +319,17 @@ fn feature_disabled_no_diagnostics() {
 fn multiple_broken_links_all_emitted() {
     let source = PathBuf::from("/project/docs/page.md");
     let mut registry = HeadingRegistry::new();
+    // Pre-populate an entry for the source file so entry-presence gating
+    // allows fragment checks to fire. The tested hrefs (#missing-a, #missing-b)
+    // are intentionally absent so both produce a diagnostic.
+    registry.insert(
+        source.clone(),
+        HeadingEntry {
+            id: "some-heading".to_string(),
+            text: "Some Heading".to_string(),
+            depth: 2,
+        },
+    );
     let md = "[a](#missing-a)\n\n[b](#missing-b)\n";
     let diags = run(
         md,
@@ -390,5 +406,166 @@ fn path_traversal_outside_project_root_emits_diagnostic() {
         matches!(&diags[0], MarkdownDiagnostic::BrokenLink { url, .. }
             if url == "../outside.md"),
         "url must be the raw href: {diags:?}"
+    );
+}
+
+// ── Fixture 12: site-absolute hrefs are skipped (URL-space) ──────────────────
+
+/// `[x](/docs/intro/)` and `[x](/docs/intro/#section)` → no diagnostics.
+#[test]
+fn site_absolute_href_skipped() {
+    let source = PathBuf::from("/project/docs/page.md");
+    let mut registry = HeadingRegistry::new();
+    let md = "[x](/docs/intro/)\n\n[y](/docs/intro/#section)\n";
+    let diags = run(
+        md,
+        source,
+        PathBuf::from("/project"),
+        &mut registry,
+        LinkValidationConfig::default(),
+    );
+    assert!(
+        diags.is_empty(),
+        "site-absolute hrefs must not emit diagnostics: {diags:?}"
+    );
+}
+
+// ── Fixture 13: cross-file fragment degrades to existence-only when no entry ──
+
+/// Registry has entries for OTHER files only; `[x](./other.md#whatever)` with
+/// `other.md` on disk → no diagnostic (existence-only); with `other.md`
+/// absent → one BrokenLink.
+#[test]
+fn cross_file_fragment_without_target_entry_degrades_to_existence_only() {
+    let tmpdir = tempdir::TempDir::new("zfb-link-val-test").expect("tempdir");
+    let project_root = tmpdir.path().to_path_buf();
+    let source_path = tmpdir.path().join("page.md");
+    let other_path = tmpdir.path().join("other.md");
+    std::fs::write(&source_path, "").expect("write page.md");
+    std::fs::write(&other_path, "# Other\n").expect("write other.md");
+
+    let unrelated_path = tmpdir.path().join("unrelated.md");
+    let mut registry = HeadingRegistry::new();
+    // Registry has entries for a DIFFERENT file, not for `other.md`.
+    registry.insert(
+        unrelated_path,
+        HeadingEntry {
+            id: "something".to_string(),
+            text: "Something".to_string(),
+            depth: 2,
+        },
+    );
+
+    // other.md on disk, no entry for it → existence-only → no diagnostic.
+    let diags = run(
+        "[x](./other.md#whatever)\n",
+        source_path.clone(),
+        project_root.clone(),
+        &mut registry,
+        LinkValidationConfig::default(),
+    );
+    assert!(
+        diags.is_empty(),
+        "existing target without registry entry must not emit diagnostic: {diags:?}"
+    );
+
+    // Remove other.md → BrokenLink (file missing).
+    std::fs::remove_file(&other_path).expect("remove other.md");
+    let diags2 = run(
+        "[x](./other.md#whatever)\n",
+        source_path,
+        project_root,
+        &mut registry,
+        LinkValidationConfig::default(),
+    );
+    assert_eq!(
+        diags2.len(),
+        1,
+        "missing target must emit BrokenLink: {diags2:?}"
+    );
+    assert!(
+        matches!(&diags2[0], MarkdownDiagnostic::BrokenLink { url, .. }
+            if url == "./other.md#whatever"),
+        "url must be raw href: {diags2:?}"
+    );
+}
+
+// ── Fixture 14: bare fragment skipped when source has no registry entry ───────
+
+/// Registry `Some` but no entry for the source file; `[x](#anything)` → no
+/// diagnostic.
+#[test]
+fn bare_fragment_without_source_entry_skipped() {
+    let source = PathBuf::from("/project/docs/page.md");
+    let mut registry = HeadingRegistry::new();
+    // No entry for source — entry-presence gating must skip.
+    let md = "[x](#anything)\n";
+    let diags = run(
+        md,
+        source,
+        PathBuf::from("/project"),
+        &mut registry,
+        LinkValidationConfig::default(),
+    );
+    assert!(
+        diags.is_empty(),
+        "bare fragment with no source entry must not emit diagnostic: {diags:?}"
+    );
+}
+
+// ── Fixture 15: empty and percent-encoded fragments skipped ──────────────────
+
+/// `[x](#)` and `[x](#a%20b)` (entry for source present) → no diagnostics.
+#[test]
+fn empty_and_percent_encoded_fragments_skipped() {
+    let source = PathBuf::from("/project/docs/page.md");
+    let mut registry = HeadingRegistry::new();
+    // Pre-populate an entry so entry-presence gating fires.
+    registry.insert(
+        source.clone(),
+        HeadingEntry {
+            id: "existing".to_string(),
+            text: "Existing".to_string(),
+            depth: 2,
+        },
+    );
+    let md = "[x](#)\n\n[y](#a%20b)\n";
+    let diags = run(
+        md,
+        source,
+        PathBuf::from("/project"),
+        &mut registry,
+        LinkValidationConfig::default(),
+    );
+    assert!(
+        diags.is_empty(),
+        "empty and percent-encoded fragments must be skipped: {diags:?}"
+    );
+}
+
+// ── Fixture 16: query string file link validates path only ────────────────────
+
+/// `[x](./other.md?x=1)`, target on disk → no diagnostic (query stripped).
+#[test]
+fn query_string_file_link_validates_path_only() {
+    let tmpdir = tempdir::TempDir::new("zfb-link-val-test").expect("tempdir");
+    let project_root = tmpdir.path().to_path_buf();
+    let source_path = tmpdir.path().join("page.md");
+    let other_path = tmpdir.path().join("other.md");
+    std::fs::write(&source_path, "").expect("write page.md");
+    std::fs::write(&other_path, "# Other\n").expect("write other.md");
+
+    let mut registry = HeadingRegistry::new();
+    let md = "[x](./other.md?x=1)\n";
+    let diags = run(
+        md,
+        source_path,
+        project_root,
+        &mut registry,
+        LinkValidationConfig::default(),
+    );
+    assert!(
+        diags.is_empty(),
+        "query-string file link with existing target must not emit diagnostic: {diags:?}"
     );
 }

--- a/crates/zfb-md-extras/tests/reading_time.rs
+++ b/crates/zfb-md-extras/tests/reading_time.rs
@@ -19,8 +19,8 @@
 //! - Code blocks are excluded from the word count.
 //! - Short articles below 1 minute minimum return 1.
 
-use zfb_md_extras::test_harness::run_fixture;
 use zfb_md_extras::reading_time::compute_reading_time_minutes;
+use zfb_md_extras::test_harness::run_fixture;
 
 /// Default WPM used by all fixtures (matches `ReadingTimePlugin::new()`).
 const DEFAULT_WPM: u32 = 200;
@@ -28,12 +28,8 @@ const DEFAULT_WPM: u32 = 200;
 /// Run a fixture directory. The transform parses the markdown, computes
 /// reading-time minutes, and returns the result as `"N\n"`.
 fn run(name: &str) {
-    let dir = concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/tests/fixtures/reading_time/"
-    )
-    .to_string()
-        + name;
+    let dir =
+        concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/reading_time/").to_string() + name;
     run_fixture(&dir, |input| {
         let node = markdown::to_mdast(input, &markdown::ParseOptions::default())
             .expect("markdown parse failed");
@@ -109,10 +105,10 @@ fn disabled_does_not_append_esm_node() {
 /// time export is injected into the mdast tree.
 #[test]
 fn enabled_injects_export_in_mdast() {
-    use markdown::to_mdast;
     use markdown::mdast::Node as MdastNode;
-    use zfb_md_extras::reading_time::ReadingTimePlugin;
+    use markdown::to_mdast;
     use zfb_md_ast::MdastVisitor;
+    use zfb_md_extras::reading_time::ReadingTimePlugin;
 
     let words: String = std::iter::repeat("word ").take(200).collect();
     let mut node = to_mdast(&words, &markdown::ParseOptions::default()).unwrap();
@@ -127,7 +123,9 @@ fn enabled_injects_export_in_mdast() {
         "ReadingTimePlugin must append MdxjsEsm node, got: {:?}",
         last
     );
-    let MdastNode::MdxjsEsm(esm) = last else { unreachable!() };
+    let MdastNode::MdxjsEsm(esm) = last else {
+        unreachable!()
+    };
     assert!(
         esm.value.contains("readingTimeMinutes = 1"),
         "injected export must contain readingTimeMinutes = 1: {}",
@@ -150,12 +148,8 @@ fn jsx_module_contains_reading_time_export() {
         ..Default::default()
     };
     let mut pipeline = Pipeline::with_defaults_and_features(&features);
-    let jsx = mdx_to_jsx_module_with_pipeline(
-        &words,
-        MdxJsxOptions::default(),
-        &mut pipeline,
-    )
-    .expect("mdx_to_jsx_module failed");
+    let jsx = mdx_to_jsx_module_with_pipeline(&words, MdxJsxOptions::default(), &mut pipeline)
+        .expect("mdx_to_jsx_module failed");
 
     assert!(
         jsx.contains("export const readingTimeMinutes = 1;"),

--- a/crates/zfb-md-extras/tests/toc_export.rs
+++ b/crates/zfb-md-extras/tests/toc_export.rs
@@ -12,7 +12,7 @@
 
 use zfb_content::pipeline::Pipeline;
 use zfb_content::serializer::serialize;
-use zfb_md_extras::{MarkdownFeaturesConfig, TocExportConfig, test_harness::run_fixture};
+use zfb_md_extras::{test_harness::run_fixture, MarkdownFeaturesConfig, TocExportConfig};
 
 /// Build a pipeline with `tocExport` enabled using the given config.
 fn pipeline_with_toc_export(cfg: TocExportConfig) -> Pipeline {
@@ -30,12 +30,7 @@ fn run(name: &str) {
 
 /// Run a fixture directory with an explicit `TocExportConfig`.
 fn run_with_cfg(name: &str, cfg: TocExportConfig) {
-    let dir = concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/tests/fixtures/toc_export/"
-    )
-    .to_string()
-        + name;
+    let dir = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/toc_export/").to_string() + name;
     run_fixture(&dir, |input| {
         let mut p = pipeline_with_toc_export(cfg.clone());
         let hast = p.run(input).expect("pipeline failed");

--- a/crates/zfb-md-extras/tests/transclude.rs
+++ b/crates/zfb-md-extras/tests/transclude.rs
@@ -51,12 +51,10 @@ fn run_success_fixture(name: &str) {
     let source_path = input_path.clone();
     let project_root = dir.to_path_buf();
 
-    let input = std::fs::read_to_string(&input_path).unwrap_or_else(|e| {
-        panic!("failed to read {}: {e}", input_path.display())
-    });
-    let expected_raw = std::fs::read_to_string(&expected_path).unwrap_or_else(|e| {
-        panic!("failed to read {}: {e}", expected_path.display())
-    });
+    let input = std::fs::read_to_string(&input_path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", input_path.display()));
+    let expected_raw = std::fs::read_to_string(&expected_path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", expected_path.display()));
 
     let mut sink = CollectingSink::new();
     let mut ctx = BuildContext {
@@ -75,10 +73,7 @@ fn run_success_fixture(name: &str) {
 
     let diags = sink.take();
     if !diags.is_empty() {
-        panic!(
-            "fixture '{}': unexpected diagnostics: {diags:?}",
-            name
-        );
+        panic!("fixture '{}': unexpected diagnostics: {diags:?}", name);
     }
 
     let actual = normalize_html(&actual_raw);
@@ -106,12 +101,10 @@ fn run_error_fixture(name: &str, config: TranscludeConfig) {
     let source_path = input_path.clone();
     let project_root = dir.to_path_buf();
 
-    let input = std::fs::read_to_string(&input_path).unwrap_or_else(|e| {
-        panic!("failed to read {}: {e}", input_path.display())
-    });
-    let expected_error = std::fs::read_to_string(&expected_error_path).unwrap_or_else(|e| {
-        panic!("failed to read {}: {e}", expected_error_path.display())
-    });
+    let input = std::fs::read_to_string(&input_path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", input_path.display()));
+    let expected_error = std::fs::read_to_string(&expected_error_path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", expected_error_path.display()));
     let expected_fragment = expected_error.trim();
 
     let mut sink = CollectingSink::new();
@@ -191,7 +184,9 @@ fn code_block_wraps_in_pre() {
     };
 
     let mut pipeline = pipeline_with_transclude(TranscludeConfig::default());
-    let hast = pipeline.run_with_context(&input, &mut ctx).expect("pipeline ok");
+    let hast = pipeline
+        .run_with_context(&input, &mut ctx)
+        .expect("pipeline ok");
     let html = serialize(&hast);
 
     // The pipeline runs syntect, so the code block appears as highlighted HTML
@@ -232,16 +227,27 @@ fn lines_range_slices_content() {
     };
 
     let mut pipeline = pipeline_with_transclude(TranscludeConfig::default());
-    let hast = pipeline.run_with_context(&input, &mut ctx).expect("pipeline ok");
+    let hast = pipeline
+        .run_with_context(&input, &mut ctx)
+        .expect("pipeline ok");
     let html = serialize(&hast);
 
     // Lines 2-3 of data.rs: "fn second() {}" and "fn third() {}"
     // Syntect adds spans so we check just the identifiers, not the full pattern.
-    assert!(html.contains("second"), "expected line 2 identifier 'second': {html}");
-    assert!(html.contains("third"), "expected line 3 identifier 'third': {html}");
+    assert!(
+        html.contains("second"),
+        "expected line 2 identifier 'second': {html}"
+    );
+    assert!(
+        html.contains("third"),
+        "expected line 3 identifier 'third': {html}"
+    );
     // Line 1 and 4 should NOT appear
     assert!(!html.contains("first"), "line 1 should be excluded: {html}");
-    assert!(!html.contains("fourth"), "line 4 should be excluded: {html}");
+    assert!(
+        !html.contains("fourth"),
+        "line 4 should be excluded: {html}"
+    );
 
     let diags = sink.take();
     assert!(diags.is_empty(), "no diagnostics expected: {diags:?}");

--- a/crates/zfb-render/src/loader.rs
+++ b/crates/zfb-render/src/loader.rs
@@ -104,23 +104,19 @@ pub enum ResolverError {
 impl From<ResolverError> for RenderError {
     fn from(e: ResolverError) -> Self {
         match e {
-            ResolverError::NotFound { path } => {
-                RenderError::Resolve {
-                    specifier: path.to_string_lossy().into_owned(),
-                    importer: String::new(),
-                    line: None,
-                    col: None,
-                    tried: vec![path.to_string_lossy().into_owned()],
-                }
+            ResolverError::NotFound { path } => RenderError::Resolve {
+                specifier: path.to_string_lossy().into_owned(),
+                importer: String::new(),
+                line: None,
+                col: None,
+                tried: vec![path.to_string_lossy().into_owned()],
+            },
+            ResolverError::Io { path, source } => {
+                RenderError::Other(format!("i/o error reading {}: {source}", path.display()))
             }
-            ResolverError::Io { path, source } => RenderError::Other(format!(
-                "i/o error reading {}: {source}",
-                path.display()
-            )),
-            ResolverError::BadEncoding { path } => RenderError::Other(format!(
-                "file is not valid UTF-8: {}",
-                path.display()
-            )),
+            ResolverError::BadEncoding { path } => {
+                RenderError::Other(format!("file is not valid UTF-8: {}", path.display()))
+            }
         }
     }
 }
@@ -135,9 +131,9 @@ pub fn read_to_string(path: &Path) -> std::result::Result<String, ResolverError>
         Ok(bytes) => String::from_utf8(bytes).map_err(|_| ResolverError::BadEncoding {
             path: path.to_owned(),
         }),
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            Err(ResolverError::NotFound { path: path.to_owned() })
-        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(ResolverError::NotFound {
+            path: path.to_owned(),
+        }),
         Err(e) => Err(ResolverError::Io {
             path: path.to_owned(),
             source: e,
@@ -257,12 +253,18 @@ impl ModuleLoader {
     /// fire. `features = None` is an empty feature set: the three former-Core
     /// framework features are off (the opt-in default).
     ///
-    /// Note: the `zfb dev` CLI does NOT render through this loader — it threads
-    /// `markdown.features` via the V8 `RendererState` in `zfb-build`
-    /// (`BundlerInput::pipeline_spec.features`). This constructor is for library /
-    /// embedder callers of `zfb-render` who want feature-aware MDX loading; an
-    /// embedder still calling [`ModuleLoader::with_strip_md_ext_and_gfm_and_cjk`]
-    /// runs with the four framework features off.
+    /// Note: the `zfb dev` CLI does NOT render through this loader — `zfb dev`
+    /// is the bundler in Development mode and goes through the `zfb-build`
+    /// pipeline path (`BundlerInput::pipeline_spec`). This constructor is for
+    /// library / embedder callers of `zfb-render` who want feature-aware MDX
+    /// loading; an embedder still calling
+    /// [`ModuleLoader::with_strip_md_ext_and_gfm_and_cjk`] runs with the
+    /// former-Core framework features off.
+    ///
+    /// `build_context_roots` is intentionally NOT armed here — embedder callers
+    /// do not have a `project_root` + `public_dir` pair at hand, and the
+    /// context-aware plugins (transclude, imageDimensions, linkValidation)
+    /// remain inert by design in this path (zfb#952).
     pub fn with_strip_md_ext_and_gfm_and_cjk_and_features(
         jsx_runtime: JsxRuntime,
         strip_md_ext: bool,
@@ -369,7 +371,11 @@ impl ModuleLoader {
         let specifier_has_probe_ext = Path::new(specifier)
             .extension()
             .and_then(|e| e.to_str())
-            .is_some_and(|e| self.probe_exts.iter().any(|p| p.trim_start_matches('.') == e));
+            .is_some_and(|e| {
+                self.probe_exts
+                    .iter()
+                    .any(|p| p.trim_start_matches('.') == e)
+            });
         if !specifier_has_probe_ext {
             for ext in &self.probe_exts {
                 let mut probe = candidate.clone();

--- a/crates/zfb-server/src/livereload.rs
+++ b/crates/zfb-server/src/livereload.rs
@@ -241,6 +241,22 @@ mod tests {
         assert_eq!(outcome_to_events(&outcome), vec![ReloadEvent::Page]);
     }
 
+    /// Issue #958 — a NARROWED content-edit tick writes only the edited
+    /// entry's route (plus the always-rendered set); `pages_written`
+    /// holding just that page must still yield `ReloadEvent::Page` so
+    /// the browser livereloads the edited page exactly as on a full
+    /// fan-out tick.
+    #[test]
+    fn livereload_page_event_fires_for_narrowed_edit() {
+        let outcome = BuildOutcome {
+            // The narrowed tick's shape: one route rendered + written.
+            pages_rendered: 1,
+            pages_written: vec![pid("blog/a/index.html")],
+            ..Default::default()
+        };
+        assert_eq!(outcome_to_events(&outcome), vec![ReloadEvent::Page]);
+    }
+
     #[test]
     fn css_changed_emits_css_only() {
         let outcome = BuildOutcome {

--- a/crates/zfb-server/tests/watch_add_confirm.rs
+++ b/crates/zfb-server/tests/watch_add_confirm.rs
@@ -161,7 +161,7 @@ fn seed_graph(project: &Path) -> Arc<Mutex<DependencyGraph>> {
 fn make_ctx(html_root: PathBuf, routes: RouteTable) -> BuildContext {
     BuildContext {
         dist_root: html_root,
-        render_pages: Arc::new(move |pages: &[PageId]| {
+        render_pages: Arc::new(move |pages: &[PageId], _narrowing| {
             let table = routes.lock().unwrap();
             let mut out = Vec::new();
             for p in pages {
@@ -692,7 +692,7 @@ async fn real_watcher_inplace_edit_reaches_served_html_via_reload() {
         let reload_count = reload_count.clone();
         BuildContext {
             dist_root: html_root.clone(),
-            render_pages: Arc::new(move |pages: &[PageId]| {
+            render_pages: Arc::new(move |pages: &[PageId], _narrowing| {
                 let table = routes.lock().unwrap();
                 let body = snapshot_for_render.lock().unwrap().clone();
                 let mut out = Vec::new();
@@ -717,7 +717,7 @@ async fn real_watcher_inplace_edit_reaches_served_html_via_reload() {
                 let fresh = std::fs::read_to_string(&hello_for_reload)?;
                 *snapshot_for_reload.lock().unwrap() = fresh;
                 reload_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                Ok(RefreshOutcome::Refreshed { vanished: vec![] })
+                Ok(RefreshOutcome::Refreshed { vanished: vec![], changed_sources: vec![] })
             })),
         }
     };

--- a/crates/zfb-server/tests/watch_add_confirm.rs
+++ b/crates/zfb-server/tests/watch_add_confirm.rs
@@ -717,7 +717,10 @@ async fn real_watcher_inplace_edit_reaches_served_html_via_reload() {
                 let fresh = std::fs::read_to_string(&hello_for_reload)?;
                 *snapshot_for_reload.lock().unwrap() = fresh;
                 reload_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                Ok(RefreshOutcome::Refreshed { vanished: vec![], changed_sources: vec![] })
+                Ok(RefreshOutcome::Refreshed {
+                    vanished: vec![],
+                    changed_sources: vec![],
+                })
             })),
         }
     };

--- a/crates/zfb-server/tests/watch_add_confirm.rs
+++ b/crates/zfb-server/tests/watch_add_confirm.rs
@@ -81,8 +81,7 @@ use tokio::net::TcpListener;
 use tokio::sync::broadcast;
 use zfb_build::{
     BuildContext, BuildOrchestrator, DevAssetPipeline, DiscoveryHook, DiscoveryOutcome,
-    OrchestratorConfig,
-    RelDistPath, RenderedPage,
+    OrchestratorConfig, RefreshOutcome, RelDistPath, RenderedPage,
 };
 use zfb_graph::{DepKind, DependencyGraph, PageDeps, PageId};
 use zfb_server::livereload::ReloadEvent;
@@ -718,7 +717,7 @@ async fn real_watcher_inplace_edit_reaches_served_html_via_reload() {
                 let fresh = std::fs::read_to_string(&hello_for_reload)?;
                 *snapshot_for_reload.lock().unwrap() = fresh;
                 reload_count.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                Ok(vec![])
+                Ok(RefreshOutcome::Refreshed { vanished: vec![] })
             })),
         }
     };

--- a/crates/zfb-watcher/src/lib.rs
+++ b/crates/zfb-watcher/src/lib.rs
@@ -54,8 +54,9 @@ pub const DEFAULT_DEBOUNCE: Duration = Duration::from_millis(50);
 ///
 /// Collapses notify's many `EventKind` variants into the three things
 /// downstream rebuild logic actually cares about. Anything we cannot
-/// classify is treated as `Modified` — we'd rather rebuild
-/// unnecessarily than miss a real change.
+/// classify is treated as `Modified` — we'd rather rebuild unnecessarily
+/// than miss a real change. Pure-read [`notify::event::EventKind::Access`]
+/// variants (open, close-after-read) are dropped entirely; see `classify`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChangeKind {
     Created,
@@ -274,13 +275,28 @@ impl Drop for Watcher {
 
 /// Map a notify `EventKind` to our small enum. Unknown / "Any" / "Other"
 /// kinds collapse to `Modified` so we never silently drop a real change.
-fn classify(kind: &EventKind) -> ChangeKind {
+///
+/// Returns `None` for pure-read access events (open, close-after-read) that
+/// carry no mutation signal. On Linux inotify the [`notify`] crate maps
+/// `IN_OPEN` and `IN_CLOSE_NOWRITE` to [`EventKind::Access`] variants; if we
+/// treated those as `Modified`, every file read inside a tick would schedule
+/// another tick — an infinite churn loop that also poisons B3 content-edit
+/// narrowing by flooding `changed_content` with unrelated files (issue #B4).
+///
+/// `Access(Close(Write))` (inotify `IN_CLOSE_WRITE`) IS a write-completion
+/// event and is therefore kept as `Modified`.  Every other `Access` variant
+/// (Open, Close(Read), Read, Any, Other) is a pure-read; we drop them.
+fn classify(kind: &EventKind) -> Option<ChangeKind> {
+    use notify::event::{AccessKind, AccessMode};
     match kind {
-        EventKind::Create(_) => ChangeKind::Created,
-        EventKind::Remove(_) => ChangeKind::Removed,
-        EventKind::Modify(_) | EventKind::Access(_) | EventKind::Any | EventKind::Other => {
-            ChangeKind::Modified
-        }
+        EventKind::Create(_) => Some(ChangeKind::Created),
+        EventKind::Remove(_) => Some(ChangeKind::Removed),
+        EventKind::Modify(_) | EventKind::Any | EventKind::Other => Some(ChangeKind::Modified),
+        // Write-close = a mutation completed; treat like Modify.
+        EventKind::Access(AccessKind::Close(AccessMode::Write)) => Some(ChangeKind::Modified),
+        // Pure-read accesses: open, close-after-read, raw read, etc.
+        // Drop them to prevent the inotify Access→tick churn loop.
+        EventKind::Access(_) => None,
     }
 }
 
@@ -422,7 +438,11 @@ async fn debouncer_task(
                 };
                 match res {
                     Ok(evt) => {
-                        let kind = classify(&evt.kind);
+                        let Some(kind) = classify(&evt.kind) else {
+                            // Pure-read access event (e.g. IN_OPEN, IN_CLOSE_NOWRITE on
+                            // Linux inotify): drop silently to avoid the churn loop.
+                            continue;
+                        };
                         let now = Instant::now();
                         for path in evt.paths {
                             // Coalesce the incoming kind with any already-pending
@@ -481,20 +501,51 @@ mod tests {
     #[test]
     fn classify_create_is_created() {
         use notify::event::{CreateKind, EventKind};
-        assert_eq!(classify(&EventKind::Create(CreateKind::File)), ChangeKind::Created);
+        assert_eq!(classify(&EventKind::Create(CreateKind::File)), Some(ChangeKind::Created));
     }
 
     #[test]
     fn classify_remove_is_removed() {
         use notify::event::{EventKind, RemoveKind};
-        assert_eq!(classify(&EventKind::Remove(RemoveKind::File)), ChangeKind::Removed);
+        assert_eq!(classify(&EventKind::Remove(RemoveKind::File)), Some(ChangeKind::Removed));
     }
 
     #[test]
     fn classify_unknown_is_modified() {
         use notify::event::EventKind;
-        assert_eq!(classify(&EventKind::Any), ChangeKind::Modified);
-        assert_eq!(classify(&EventKind::Other), ChangeKind::Modified);
+        assert_eq!(classify(&EventKind::Any), Some(ChangeKind::Modified));
+        assert_eq!(classify(&EventKind::Other), Some(ChangeKind::Modified));
+    }
+
+    #[test]
+    fn classify_access_close_write_is_modified() {
+        use notify::event::{AccessKind, AccessMode, EventKind};
+        // IN_CLOSE_WRITE: a file was written and closed — treat as Modified.
+        assert_eq!(
+            classify(&EventKind::Access(AccessKind::Close(AccessMode::Write))),
+            Some(ChangeKind::Modified),
+            "IN_CLOSE_WRITE must surface as Modified",
+        );
+    }
+
+    #[test]
+    fn classify_pure_read_access_is_none() {
+        use notify::event::{AccessKind, AccessMode, EventKind};
+        // IN_OPEN: file opened for reading — must be dropped to prevent churn loop.
+        assert_eq!(
+            classify(&EventKind::Access(AccessKind::Open(AccessMode::Any))),
+            None,
+            "IN_OPEN must be dropped (pure read)",
+        );
+        // IN_CLOSE_NOWRITE: file closed after read-only access — must be dropped.
+        assert_eq!(
+            classify(&EventKind::Access(AccessKind::Close(AccessMode::Read))),
+            None,
+            "IN_CLOSE_NOWRITE must be dropped (pure read)",
+        );
+        // AccessKind::Read, Any, Other — pure read variants; also dropped.
+        assert_eq!(classify(&EventKind::Access(AccessKind::Any)), None);
+        assert_eq!(classify(&EventKind::Access(AccessKind::Other)), None);
     }
 
     // ---------------------------------------------------------------------------

--- a/crates/zfb/src/commands/bundler_input.rs
+++ b/crates/zfb/src/commands/bundler_input.rs
@@ -79,6 +79,29 @@ pub(crate) fn pipeline_spec_from_config(
         hard_breaks: crate::config::resolve_hard_breaks(config.markdown.as_ref()),
         // `markdown.features` (#586) — opt-in feature plugins (mermaid, …).
         features: config.markdown.as_ref().and_then(|m| m.features.clone()),
+        // Arm build-context roots iff a filesystem-dependent feature is enabled
+        // (transclude / imageDimensions / linkValidation).  Gating rationale:
+        // (a) unarmed projects keep byte-identical fingerprints; (b) roots and
+        // the #942 ReadRecorder then always co-occur — arming without a recorder
+        // stores an empty DependencyManifest and stale-cache hazards follow
+        // (zfb#952).
+        build_context_roots: {
+            let has_fs_feature = config
+                .markdown
+                .as_ref()
+                .and_then(|m| m.features.as_ref())
+                .map(|f| {
+                    f.transclude.is_some()
+                        || f.image_dimensions.is_some()
+                        || f.link_validation.is_some()
+                })
+                .unwrap_or(false);
+            has_fs_feature.then(|| {
+                let public_dir =
+                    crate::commands::resolve::resolve_under_root(project_root, &config.public_dir);
+                (project_root.to_path_buf(), public_dir)
+            })
+        },
     }
 }
 
@@ -195,8 +218,7 @@ pub(crate) fn assemble_bundler_input(
         }
     }
 
-    bundler_input.tsconfig_paths =
-        crate::commands::build::read_tsconfig_paths(project_root);
+    bundler_input.tsconfig_paths = crate::commands::build::read_tsconfig_paths(project_root);
 
     // Per-collection content materialisation feeds the MDX content bridge
     // (#506) — without this every doc page would render as raw markdown text
@@ -272,17 +294,16 @@ pub(crate) fn assemble_bundler_input(
             crate::config::OnBrokenLinks::Error => zfb_build::bundler::OnBrokenLinks::Error,
             crate::config::OnBrokenLinks::Ignore => zfb_build::bundler::OnBrokenLinks::Ignore,
         };
-        bundler_input.resolve_markdown_links =
-            Some(zfb_build::bundler::ResolveMarkdownLinksSpec {
-                routes: routes
-                    .into_iter()
-                    .map(|r| zfb_build::bundler::ResolveMarkdownLinksRoute {
-                        docs_dir: r.dir,
-                        route_prefix: r.route_prefix,
-                    })
-                    .collect(),
-                on_broken_links,
-            });
+        bundler_input.resolve_markdown_links = Some(zfb_build::bundler::ResolveMarkdownLinksSpec {
+            routes: routes
+                .into_iter()
+                .map(|r| zfb_build::bundler::ResolveMarkdownLinksRoute {
+                    docs_dir: r.dir,
+                    route_prefix: r.route_prefix,
+                })
+                .collect(),
+            on_broken_links,
+        });
     }
 
     // Thread the optional `site` canonical-origin URL from `zfb.config.ts`
@@ -302,19 +323,19 @@ pub(crate) fn assemble_bundler_input(
     // #664 / #672 — thread `bundle.exclude` so the bundler keeps the listed
     // project-relative globs out of the esbuild graph (both the shadow-tree
     // copy and the #665 import.meta.glob expansion).  Empty → skip nothing.
-    bundler_input.bundle_exclude =
-        crate::config::resolve_bundle_exclude(config.bundle.as_ref());
+    bundler_input.bundle_exclude = crate::config::resolve_bundle_exclude(config.bundle.as_ref());
 
     // #676 — thread `bundle.mainFields` / `bundle.external` so hosts can make
     // the `--platform=neutral` page/SSR pass resolve (or externalize)
     // CJS-main-only deps (e.g. `msw` -> `path-to-regexp@6`).  main_fields
     // applies to every framework when set; external is APPENDED so any
     // framework-required externals are preserved.  Empty → byte-identical.
-    bundler_input.main_fields =
-        crate::config::resolve_bundle_main_fields(config.bundle.as_ref());
+    bundler_input.main_fields = crate::config::resolve_bundle_main_fields(config.bundle.as_ref());
     bundler_input
         .external
-        .extend(crate::config::resolve_bundle_external(config.bundle.as_ref()));
+        .extend(crate::config::resolve_bundle_external(
+            config.bundle.as_ref(),
+        ));
 
     // #268 — thread plugin-registered aliases and virtual modules into the
     // main bundler's esbuild invocation so page / layout / shared SSR-only
@@ -355,4 +376,3 @@ pub(crate) fn assemble_bundler_input(
         _esbuild_handle,
     })
 }
-

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -396,7 +396,7 @@ pub async fn run(args: &DevArgs) -> Result<()> {
         // `dist_root`, so per-route dev renders do not overwrite the
         // production HTML files that `pnpm preview` serves.
         Some(session) => make_render_callback(session.clone(), dev_html_root.clone()),
-        None => Arc::new(|_pages: &[PageId]| Ok(Vec::new())),
+        None => Arc::new(|_pages: &[PageId], _narrowing| Ok(Vec::new())),
     };
 
     // Issue #377 — dev-mode initial-load islands bundling.
@@ -819,8 +819,13 @@ pub async fn run(args: &DevArgs) -> Result<()> {
                     "edit-tick refresh found globally-vanished routes"
                 );
             }
+            // Issue #958 — propagate the refresh's changed-source set
+            // instead of dropping it: a non-empty set means the route
+            // structure moved this tick, so the dev pipeline must
+            // disable content narrowing (fallback G5).
             Ok(RefreshOutcome::Refreshed {
                 vanished: vanished_abs,
+                changed_sources: changed,
             })
         }) as RendererReloader
     });
@@ -1216,6 +1221,22 @@ struct DevRenderSession {
     inner: Arc<DevRenderInner>,
 }
 
+/// One expanded route plus its `paths()` provenance (issue #958).
+///
+/// The provenance is what lets a content edit narrow a dynamic source's
+/// render fan-out to the routes whose params match the edited entry's
+/// slug candidates — see [`compute_tick_narrowing`].
+#[derive(Debug, Clone)]
+struct DevRouteEntry {
+    entry: RouteUniverseEntry,
+    /// Per-URL params retained from `DynamicExpansion::resolved_with_params`
+    /// (issue #958). `None` for static routes and for any expansion whose
+    /// parallel `resolved` / `resolved_with_params` vectors disagreed in
+    /// length (fallback S1 — the whole source then always renders in
+    /// full).
+    params: Option<crate::render_pipeline::ResolvedRouteParams>,
+}
+
 /// The dev session's source→route + SSR route tables.
 ///
 /// Issue #659 — wrapped in a single [`RwLock`] inside [`DevRenderInner`]
@@ -1240,7 +1261,10 @@ struct DevRouteTables {
     /// resolves to one entry per `paths()` URL. `render_one` emits one
     /// `RenderedPage` per entry on each tick so every fanned-out URL
     /// reaches `dist/` (and thus the dev server's disk fallback).
-    routes_by_source: HashMap<PathBuf, Vec<RouteUniverseEntry>>,
+    ///
+    /// Issue #958: each entry carries its optional `paths()` params
+    /// provenance (see [`DevRouteEntry`]).
+    routes_by_source: HashMap<PathBuf, Vec<DevRouteEntry>>,
     /// URL patterns for `prerender = false` pages (issue #367 /
     /// Gap 1). Empty when every page in the project SSGs. The dev
     /// server reads this list (via [`DevRenderSession::ssr_patterns`])
@@ -1299,6 +1323,52 @@ struct DevRenderInner {
     /// update it without `&mut self`.
     #[cfg(feature = "embed_v8")]
     last_successful_skip_key: Mutex<Option<[u8; 32]>>,
+
+    /// Frontmatter gate cache for content-edit narrowing (issue #958,
+    /// fallback G4): SHA-256 of the canonical JSON of each collection
+    /// file's parsed frontmatter, keyed by the file's absolute path
+    /// exactly as the watcher delivers it. Seeded at boot
+    /// ([`seed_frontmatter_hashes`]) and updated on every narrowing-
+    /// candidate Content tick. A missing or differing entry means the
+    /// frontmatter may feed cross-page props (sidebar titles, prev/next
+    /// labels) — no narrowing that tick.
+    #[cfg(feature = "embed_v8")]
+    fm_hashes: Mutex<HashMap<PathBuf, [u8; 32]>>,
+}
+
+/// Per-source route filter for one narrowed tick (issue #958): which of a
+/// source's expanded routes [`DevRenderSession::render_one`] should fan
+/// out to this invocation.
+#[cfg_attr(not(feature = "embed_v8"), allow(dead_code))]
+#[derive(Debug)]
+enum RouteFilter {
+    /// Render every entry of the source — today's full behaviour.
+    All,
+    /// Render only the entries whose `output_path` is in the set.
+    Only(HashSet<PathBuf>),
+}
+
+impl RouteFilter {
+    fn allows(&self, output_path: &Path) -> bool {
+        match self {
+            RouteFilter::All => true,
+            RouteFilter::Only(set) => set.contains(output_path),
+        }
+    }
+}
+
+/// The whole tick's narrowing decision, computed once per render-callback
+/// invocation by [`compute_tick_narrowing`] (issue #958).
+#[cfg_attr(not(feature = "embed_v8"), allow(dead_code))]
+#[derive(Debug)]
+enum TickNarrowing {
+    /// No narrowing — every selected page renders its full fan-out.
+    Off,
+    /// Per-source filters. The map contains ONLY narrowed sources; a
+    /// source absent from the map renders in full ([`RouteFilter::All`]) —
+    /// that absence IS the always-rendered set (statics, single-entry
+    /// sources, aggregate dynamic consumers that fell back via S1/S2).
+    PerSource(HashMap<PathBuf, RouteFilter>),
 }
 
 #[cfg(feature = "embed_v8")]
@@ -1348,7 +1418,19 @@ impl DevRenderSession {
     /// its `paths()` resolved to (issue #502/#507). Returns an empty Vec
     /// when the source path is unknown to the renderer (dynamic route
     /// deferred to SSR, or a page never seen by the router scan).
-    fn render_one(&self, page: &PageId, dist_dir: &Path) -> Result<Vec<RenderedPage>> {
+    ///
+    /// `filter` (issue #958) narrows the fan-out to a subset of the
+    /// source's entries on a narrowed content-edit tick; pass
+    /// [`RouteFilter::All`] for the full fan-out. Filtering happens on
+    /// the per-tick clone, strictly BEFORE the render loop — the shared
+    /// tables are never mutated and `render_one_with`'s synthetic
+    /// output-path `PageId` keying (#507 Guardrail 1) is untouched.
+    fn render_one(
+        &self,
+        page: &PageId,
+        dist_dir: &Path,
+        filter: &RouteFilter,
+    ) -> Result<Vec<RenderedPage>> {
         // Read the (possibly watch-ADD-rebuilt, #659) route table. Clone
         // the entries out so the lock is released before the V8 render —
         // the reload path takes the write lock, and `render_one` may run
@@ -1361,7 +1443,7 @@ impl DevRenderSession {
             .routes_by_source
             .get(page.path())
         {
-            Some(es) => es.clone(),
+            Some(es) => Self::filter_entries(es, filter),
             None => return Ok(Vec::new()),
         };
         let mut lock = self.inner.renderer.lock().unwrap_or_else(|p| {
@@ -1378,6 +1460,18 @@ impl DevRenderSession {
         Self::render_one_with(page, &entries, |entry| {
             render_one(state, entry, dist_dir, &project_root).map_err(anyhow::Error::from)
         })
+    }
+
+    /// Apply a tick's per-source [`RouteFilter`] to a source's entries,
+    /// cloning out the [`RouteUniverseEntry`] payloads that survive
+    /// (issue #958). Extracted from [`Self::render_one`] so the narrowing
+    /// seam is testable without a live V8 renderer.
+    fn filter_entries(entries: &[DevRouteEntry], filter: &RouteFilter) -> Vec<RouteUniverseEntry> {
+        entries
+            .iter()
+            .filter(|de| filter.allows(&de.entry.output_path))
+            .map(|de| de.entry.clone())
+            .collect()
     }
 
     /// Fan-out loop: for each `RouteUniverseEntry` in `entries`, call
@@ -1735,11 +1829,11 @@ impl DevRenderSession {
             let old_live: std::collections::HashSet<std::path::PathBuf> = old
                 .routes_by_source
                 .values()
-                .flat_map(|entries| entries.iter().map(|e| e.output_path.clone()))
+                .flat_map(|entries| entries.iter().map(|e| e.entry.output_path.clone()))
                 .collect();
             let new_live: std::collections::HashSet<std::path::PathBuf> = new_routes_by_source
                 .values()
-                .flat_map(|entries| entries.iter().map(|e| e.output_path.clone()))
+                .flat_map(|entries| entries.iter().map(|e| e.entry.output_path.clone()))
                 .collect();
 
             let vanished: Vec<std::path::PathBuf> = old_live
@@ -1979,7 +2073,10 @@ fn compute_bundle_skip_key(
 /// `(routes_by_source, ssr_routes)` — the pair [`build_dev_route_tables`]
 /// produces and [`DevRouteTables`] stores.
 #[cfg(feature = "embed_v8")]
-type BuiltRouteTables = (HashMap<PathBuf, Vec<RouteUniverseEntry>>, Vec<RouteUniverseEntry>);
+type BuiltRouteTables = (
+    HashMap<PathBuf, Vec<DevRouteEntry>>,
+    Vec<RouteUniverseEntry>,
+);
 
 /// Build the dev session's source→route + SSR route tables from the router
 /// scan + the live V8 host (issue #659 — extracted from `boot_dev_renderer`
@@ -2003,7 +2100,7 @@ fn build_dev_route_tables(
     // tracks pages by their source path). Each value is a Vec so a dynamic
     // SSG source can hold its N `paths()`-expanded entries (#502/#507);
     // static routes contribute a single-element vec.
-    let mut routes_by_source: HashMap<PathBuf, Vec<RouteUniverseEntry>> = HashMap::new();
+    let mut routes_by_source: HashMap<PathBuf, Vec<DevRouteEntry>> = HashMap::new();
     let mut ssr_routes: Vec<RouteUniverseEntry> = Vec::new();
     for route in router.routes() {
         if let Some(entry) = plan
@@ -2017,10 +2114,15 @@ fn build_dev_route_tables(
             if crate::render_pipeline::is_ssr_route(&prerender_map, &route.template()) {
                 ssr_routes.push(entry.clone());
             } else {
+                // Static routes carry no `paths()` provenance (#958) —
+                // their sources always render in full (fallback S1).
                 routes_by_source
                     .entry(route.source_path.clone())
                     .or_default()
-                    .push(entry.clone());
+                    .push(DevRouteEntry {
+                        entry: entry.clone(),
+                        params: None,
+                    });
             }
         }
     }
@@ -2140,24 +2242,48 @@ fn build_dev_route_tables(
         // File every resolved concrete-URL entry under its dynamic source's
         // `PageId`. A single `[slug].tsx` source thus accumulates N entries,
         // which `render_one` fans out into N `RenderedPage`s per tick.
-        for entry in static_expansion
-            .resolved
-            .into_iter()
-            .chain(runtime_expansion.resolved)
-        {
-            if let Some(source) = template_to_source.get(&entry.route_key) {
-                routes_by_source
-                    .entry(source.clone())
-                    .or_default()
-                    .push(entry);
-            } else {
-                // Should not happen: every resolved entry's route_key came
-                // from one of the ssg_deferred routes. Warn rather than drop
-                // silently if the invariant is ever violated.
+        //
+        // Issue #958 — retain each URL's `paths()` params provenance by
+        // zipping `resolved` with the parallel-ordered
+        // `resolved_with_params` (documented invariant of
+        // `DynamicExpansion`; both are built together in
+        // `push_resolved_paths`). A length mismatch means the provenance
+        // cannot be trusted: warn and file `params: None` for that whole
+        // expansion, which downstream forces the affected sources to
+        // always render in full (fallback S1) — degraded performance,
+        // never under-rendering.
+        for expansion in [static_expansion, runtime_expansion] {
+            let params_aligned = expansion.resolved.len() == expansion.resolved_with_params.len();
+            if !params_aligned {
                 crate::output::warn(format!(
-                    "resolved dynamic URL {} has no matching source route ({}); skipping",
-                    entry.url_path, entry.route_key
+                    "dynamic route expansion: resolved/params length mismatch \
+                     ({} vs {}); content-edit narrowing disabled for the \
+                     affected source(s)",
+                    expansion.resolved.len(),
+                    expansion.resolved_with_params.len(),
                 ));
+            }
+            let mut params_iter = expansion.resolved_with_params.into_iter();
+            for entry in expansion.resolved {
+                let params = if params_aligned {
+                    params_iter.next().map(|p| p.params)
+                } else {
+                    None
+                };
+                if let Some(source) = template_to_source.get(&entry.route_key) {
+                    routes_by_source
+                        .entry(source.clone())
+                        .or_default()
+                        .push(DevRouteEntry { entry, params });
+                } else {
+                    // Should not happen: every resolved entry's route_key came
+                    // from one of the ssg_deferred routes. Warn rather than drop
+                    // silently if the invariant is ever violated.
+                    crate::output::warn(format!(
+                        "resolved dynamic URL {} has no matching source route ({}); skipping",
+                        entry.url_path, entry.route_key
+                    ));
+                }
             }
         }
     }
@@ -2268,6 +2394,12 @@ fn boot_dev_renderer(
     let (routes_by_source, ssr_routes) =
         build_dev_route_tables(&router, &plan, project_root, &renderer)?;
 
+    // Issue #958 — seed the frontmatter gate cache so the FIRST body-only
+    // edit of a pre-existing collection file can already narrow (G4 only
+    // fires for genuinely missing/changed frontmatter). ~1 read + parse +
+    // hash per collection file; trivial against the bundle step above.
+    let fm_hashes = seed_frontmatter_hashes(project_root, cfg);
+
     Ok(DevRenderSession {
         inner: Arc::new(DevRenderInner {
             routes: std::sync::RwLock::new(DevRouteTables {
@@ -2279,8 +2411,66 @@ fn boot_dev_renderer(
             rebuild_inputs,
             // No successful refresh yet — first tick always runs fully.
             last_successful_skip_key: Mutex::new(None),
+            fm_hashes: Mutex::new(fm_hashes),
         }),
     })
+}
+
+/// SHA-256 over the canonical JSON of a file's parsed frontmatter
+/// (issue #958, fallback-G4 gate). `serde_json`'s default BTreeMap-backed
+/// objects serialize with sorted keys, so the string is canonical: a YAML
+/// reformat that parses to the same value hashes identically and does not
+/// trip the gate. `None` when the file is unreadable or unparseable.
+#[cfg(feature = "embed_v8")]
+fn frontmatter_hash(path: &Path) -> Option<[u8; 32]> {
+    let source = std::fs::read_to_string(path).ok()?;
+    let uf = zfb_content::frontmatter::extract(path, &source).ok()?;
+    let json = serde_json::to_string(&uf.value).ok()?;
+    let mut hasher = Sha256::new();
+    hasher.update(json.as_bytes());
+    Some(hasher.finalize().into())
+}
+
+/// Boot-seed the frontmatter gate cache (issue #958): hash every
+/// configured collection file's frontmatter, keyed by absolute path.
+/// Membership routes through `derive_slug_for_file` so the seeded set is
+/// exactly the walker's. Unreadable / unparseable files (and collections
+/// with uncompilable filter globs) are simply not seeded — their first
+/// edit falls back to a full render (G4) and seeds the hash then.
+#[cfg(feature = "embed_v8")]
+fn seed_frontmatter_hashes(
+    project_root: &Path,
+    cfg: &config::Config,
+) -> HashMap<PathBuf, [u8; 32]> {
+    let mut hashes: HashMap<PathBuf, [u8; 32]> = HashMap::new();
+    for collection in &cfg.collections {
+        let root = project_root.join(normalize_relative(&collection.path));
+        let filter = match zfb_content::collection::CollectionFilter::new(
+            collection.include.as_deref(),
+            collection.exclude.as_deref(),
+            collection.id_strip_suffix.as_deref(),
+        ) {
+            Ok(f) => f,
+            Err(_) => continue,
+        };
+        for entry in walkdir::WalkDir::new(&root)
+            .follow_links(false)
+            .into_iter()
+            .flatten()
+        {
+            if !entry.file_type().is_file() {
+                continue;
+            }
+            let path = entry.path();
+            if zfb_content::collection::derive_slug_for_file(&root, path, &filter).is_none() {
+                continue;
+            }
+            if let Some(hash) = frontmatter_hash(path) {
+                hashes.insert(path.to_path_buf(), hash);
+            }
+        }
+    }
+    hashes
 }
 
 /// Per-route HTML output directory for the dev pipeline (issue #534).
@@ -2302,13 +2492,221 @@ fn dev_html_root_for(project_root: &Path) -> PathBuf {
     project_root.join(".zfb-build").join("dev-pages")
 }
 
+/// `true` when one of the edited entry's slug candidates appears among a
+/// route's resolved params (issue #958, spec §4). ANY-param semantics:
+/// scalars match by value, catchall arrays match by their `/`-join (an
+/// empty catchall joins to `""`, matching the bare-root-index candidate);
+/// a locale scalar never blocks a slug-array match. Exact byte equality —
+/// no case folding, no percent-decoding.
+#[cfg(feature = "embed_v8")]
+fn params_match(
+    p: &crate::render_pipeline::ResolvedRouteParams,
+    candidates: &std::collections::BTreeSet<String>,
+) -> bool {
+    p.scalars.values().any(|v| candidates.contains(v))
+        || p.arrays.values().any(|a| candidates.contains(&a.join("/")))
+}
+
+/// Compute the tick's narrowing decision from the plan's content-
+/// narrowing hint (issue #958, spec §4). Runs once per render-callback
+/// invocation. Every failure mode degrades to [`TickNarrowing::Off`] —
+/// i.e. today's full fan-out — never to silent under-rendering:
+///
+/// - G2: a changed file outside every configured collection (or failing
+///   its include/exclude globs, or an uncompilable filter glob),
+/// - G3: file read / frontmatter parse error,
+/// - G4: frontmatter hash missing or changed (frontmatter feeds
+///   cross-page props — titles in sidebars/prev-next — so a frontmatter
+///   delta re-renders the full selected set). The new hash is ALWAYS
+///   stored, including on the Off path, so the next body-only edit
+///   narrows.
+///
+/// Per-source fallbacks (source simply absent from the returned map ⇒
+/// [`RouteFilter::All`]):
+///
+/// - S1: any entry lacks params provenance (static routes; zip-length
+///   mismatch at table build time),
+/// - S2: zero entries matched the candidate set (aggregate dynamic
+///   consumers — tags/pagination — whose params are not slug-shaped).
+#[cfg(feature = "embed_v8")]
+fn compute_tick_narrowing(
+    session: &DevRenderSession,
+    hint: Option<&zfb_build::ContentNarrowing>,
+) -> TickNarrowing {
+    use std::collections::BTreeSet;
+
+    let Some(hint) = hint else {
+        return TickNarrowing::Off;
+    };
+    if hint.changed_content.is_empty() {
+        return TickNarrowing::Off;
+    }
+    let inner = &session.inner;
+
+    // Compile each collection's (root, filter) pair once for the tick. A
+    // bad glob means membership cannot be evaluated reliably — fall back.
+    let mut compiled: Vec<(PathBuf, zfb_content::collection::CollectionFilter)> =
+        Vec::with_capacity(inner.rebuild_inputs.cfg.collections.len());
+    for collection in &inner.rebuild_inputs.cfg.collections {
+        match zfb_content::collection::CollectionFilter::new(
+            collection.include.as_deref(),
+            collection.exclude.as_deref(),
+            collection.id_strip_suffix.as_deref(),
+        ) {
+            Ok(filter) => compiled.push((
+                inner
+                    .project_root
+                    .join(normalize_relative(&collection.path)),
+                filter,
+            )),
+            Err(err) => {
+                tracing::warn!(
+                    site = "compute_tick_narrowing",
+                    error = %err,
+                    "collection filter failed to compile; narrowing disabled for tick"
+                );
+                return TickNarrowing::Off;
+            }
+        }
+    }
+
+    let mut off = false;
+    let mut candidates: BTreeSet<String> = BTreeSet::new();
+    {
+        let mut fm_hashes = inner.fm_hashes.lock().unwrap_or_else(|p| p.into_inner());
+        for file in &hint.changed_content {
+            // Step 1 — collection resolution. A file may belong to
+            // multiple collections; candidates are unioned. Zero
+            // memberships ⇒ G2 (whole tick falls back), but keep
+            // processing the other files so their gate hashes update.
+            let slugs: Vec<String> = compiled
+                .iter()
+                .filter_map(|(root, filter)| {
+                    zfb_content::collection::derive_slug_for_file(root, file, filter)
+                })
+                .collect();
+            if slugs.is_empty() {
+                off = true; // G2
+                continue;
+            }
+
+            // Step 2 — frontmatter gate (G3/G4).
+            let fm_value = match std::fs::read_to_string(file)
+                .map_err(anyhow::Error::from)
+                .and_then(|source| {
+                    zfb_content::frontmatter::extract(file, &source)
+                        .map(|uf| uf.value)
+                        .map_err(anyhow::Error::from)
+                }) {
+                Ok(value) => value,
+                Err(_) => {
+                    // G3 — and the stored hash no longer describes the
+                    // file: drop it so the edit that FIXES the parse
+                    // error re-seeds via the G4 miss path.
+                    off = true;
+                    fm_hashes.remove(file);
+                    continue;
+                }
+            };
+            let hash: [u8; 32] = match serde_json::to_string(&fm_value) {
+                Ok(json) => {
+                    let mut hasher = Sha256::new();
+                    hasher.update(json.as_bytes());
+                    hasher.finalize().into()
+                }
+                Err(_) => {
+                    off = true;
+                    fm_hashes.remove(file);
+                    continue;
+                }
+            };
+            // Store-then-compare: the new hash must land even when the
+            // gate trips (G4), so the NEXT body-only edit narrows.
+            let prev = fm_hashes.insert(file.clone(), hash);
+            if prev != Some(hash) {
+                off = true; // G4 — missing or changed frontmatter.
+                continue;
+            }
+
+            // Step 3 — slug candidate set.
+            for slug in slugs {
+                if slug == "index" {
+                    candidates.insert(String::new());
+                }
+                if let Some(stripped) = slug.strip_suffix("/index") {
+                    candidates.insert(stripped.to_string());
+                }
+                candidates.insert(slug);
+            }
+            // Frontmatter `slug:` override candidate (Docusaurus-style):
+            // verbatim AND with one leading `/` stripped.
+            if let Some(fm_slug) = fm_value.get("slug").and_then(|v| v.as_str()) {
+                if let Some(stripped) = fm_slug.strip_prefix('/') {
+                    candidates.insert(stripped.to_string());
+                }
+                candidates.insert(fm_slug.to_string());
+            }
+        }
+    }
+    if off || candidates.is_empty() {
+        return TickNarrowing::Off;
+    }
+
+    // Steps 4+5 — per-source selection against the POST-refresh route
+    // tables (the reloader ran before the render callback, so params are
+    // fresh). Only narrowed sources enter the map; everything else — the
+    // always-rendered set — renders in full by absence.
+    let tables = inner.routes.read().unwrap_or_else(|p| p.into_inner());
+    let mut per_source: HashMap<PathBuf, RouteFilter> = HashMap::new();
+    for (source, entries) in &tables.routes_by_source {
+        if entries.iter().any(|de| de.params.is_none()) {
+            continue; // S1
+        }
+        let matched: HashSet<PathBuf> = entries
+            .iter()
+            .filter(|de| {
+                de.params
+                    .as_ref()
+                    .is_some_and(|p| params_match(p, &candidates))
+            })
+            .map(|de| de.entry.output_path.clone())
+            .collect();
+        if matched.is_empty() {
+            continue; // S2
+        }
+        per_source.insert(source.clone(), RouteFilter::Only(matched));
+    }
+    if per_source.is_empty() {
+        return TickNarrowing::Off;
+    }
+    tracing::debug!(
+        narrowed_sources = per_source.len(),
+        "content-edit narrowing active for tick (issue #958)"
+    );
+    TickNarrowing::PerSource(per_source)
+}
+
 /// Build the [`PageRenderer`] callback that the orchestrator hands to
 /// [`DevAssetPipeline`].
 fn make_render_callback(session: DevRenderSession, dist_dir: PathBuf) -> PageRenderer {
-    Arc::new(move |pages: &[PageId]| {
+    Arc::new(move |pages: &[PageId], narrowing| {
+        // Issue #958 — one narrowing decision per tick; per-page filters
+        // fall out of the per-source map. The V8-off path has no
+        // collection configs to match against, so it never narrows.
+        #[cfg(feature = "embed_v8")]
+        let tick_narrowing = compute_tick_narrowing(&session, narrowing);
+        #[cfg(not(feature = "embed_v8"))]
+        let tick_narrowing = {
+            let _ = narrowing;
+            TickNarrowing::Off
+        };
         let mut out = Vec::with_capacity(pages.len());
         for page in pages {
-            match session.render_one(page, &dist_dir) {
+            let filter = match &tick_narrowing {
+                TickNarrowing::Off => &RouteFilter::All,
+                TickNarrowing::PerSource(map) => map.get(page.path()).unwrap_or(&RouteFilter::All),
+            };
+            match session.render_one(page, &dist_dir, filter) {
                 Ok(rendered) => {
                     // A static route yields one page; a dynamic SSG route
                     // yields one page per `paths()`-resolved URL (#502/#507).
@@ -2575,12 +2973,43 @@ mod tests {
     // `resolve_host` / `resolve_addr` live in `crate::commands::resolve` (shared
     // with `preview`); their precedence and binding tests live there too.
 
+    /// Wrap bare [`RouteUniverseEntry`]s in provenance-free
+    /// [`DevRouteEntry`]s (issue #958) for tests that don't exercise
+    /// narrowing.
+    fn no_params(entries: Vec<RouteUniverseEntry>) -> Vec<DevRouteEntry> {
+        entries
+            .into_iter()
+            .map(|entry| DevRouteEntry {
+                entry,
+                params: None,
+            })
+            .collect()
+    }
+
     /// Build a stub [`DevRenderInner`] for the route-plumbing seam tests
     /// (no live V8 host). The discovery (#659) `rebuild_inputs` are filled
     /// with defaults — these tests never call `discover_created`.
     #[cfg(feature = "embed_v8")]
     fn stub_dev_inner(
-        routes_by_source: HashMap<PathBuf, Vec<RouteUniverseEntry>>,
+        routes_by_source: HashMap<PathBuf, Vec<DevRouteEntry>>,
+        ssr_routes: Vec<RouteUniverseEntry>,
+    ) -> DevRenderInner {
+        stub_dev_inner_at(
+            PathBuf::new(),
+            config::Config::default(),
+            routes_by_source,
+            ssr_routes,
+        )
+    }
+
+    /// [`stub_dev_inner`] with an explicit project root + config, for the
+    /// content-narrowing tests (issue #958) that need real collection
+    /// files on disk.
+    #[cfg(feature = "embed_v8")]
+    fn stub_dev_inner_at(
+        project_root: PathBuf,
+        cfg: config::Config,
+        routes_by_source: HashMap<PathBuf, Vec<DevRouteEntry>>,
         ssr_routes: Vec<RouteUniverseEntry>,
     ) -> DevRenderInner {
         DevRenderInner {
@@ -2589,14 +3018,15 @@ mod tests {
                 ssr_routes,
             }),
             renderer: Arc::new(Mutex::new(None)),
-            project_root: PathBuf::new(),
+            project_root,
             rebuild_inputs: DevRebuildInputs {
-                cfg: config::Config::default(),
+                cfg,
                 v8_plugin_hooks: zfb_render::PluginRegistryHooks::default(),
                 plugin_alias_entries: Vec::new(),
                 plugin_virtual_modules: Vec::new(),
             },
             last_successful_skip_key: Mutex::new(None),
+            fm_hashes: Mutex::new(HashMap::new()),
         }
     }
 
@@ -2604,7 +3034,7 @@ mod tests {
     /// field exists when `embed_v8` is disabled.
     #[cfg(not(feature = "embed_v8"))]
     fn stub_dev_inner(
-        routes_by_source: HashMap<PathBuf, Vec<RouteUniverseEntry>>,
+        routes_by_source: HashMap<PathBuf, Vec<DevRouteEntry>>,
         ssr_routes: Vec<RouteUniverseEntry>,
     ) -> DevRenderInner {
         DevRenderInner {
@@ -2747,7 +3177,7 @@ mod tests {
         let cb = make_render_callback(session, PathBuf::from("/tmp/dist"));
         // A source path not present in routes_by_source is still dropped.
         let pages = vec![PageId::new(PathBuf::from("pages/index.tsx"))];
-        let out = cb(&pages).unwrap();
+        let out = cb(&pages, None).unwrap();
         assert!(out.is_empty());
     }
 
@@ -2836,24 +3266,501 @@ mod tests {
     /// watcher must keep going.
     #[test]
     fn render_callback_keeps_watcher_alive_on_render_error() {
-        let mut routes: HashMap<PathBuf, Vec<RouteUniverseEntry>> = HashMap::new();
+        let mut routes: HashMap<PathBuf, Vec<DevRouteEntry>> = HashMap::new();
         routes.insert(
             PathBuf::from("pages/index.tsx"),
-            vec![RouteUniverseEntry {
+            no_params(vec![RouteUniverseEntry {
                 url_path: "/".into(),
                 output_path: PathBuf::from("index.html"),
                 route_key: "/".into(),
                 static_html: false,
                 source_path: None,
-            }],
+            }]),
         );
         let session = DevRenderSession {
             inner: Arc::new(stub_dev_inner(routes, Vec::new())),
         };
         let cb = make_render_callback(session, PathBuf::from("/tmp/dist"));
         let pages = vec![PageId::new(PathBuf::from("pages/index.tsx"))];
-        let out = cb(&pages).unwrap();
+        let out = cb(&pages, None).unwrap();
         assert!(out.is_empty(), "errors must yield empty list, not panic");
+    }
+
+    /// Content-edit narrowing seam tests (issue #958, locked-spec §11).
+    ///
+    /// These drive `compute_tick_narrowing` + `filter_entries` — the two
+    /// seams a narrowed tick traverses before the (untouched)
+    /// `render_one_with` fan-out — against real collection files in a
+    /// tempdir, exactly as the dev render callback composes them.
+    #[cfg(feature = "embed_v8")]
+    mod narrowing {
+        use super::*;
+        use crate::render_pipeline::ResolvedRouteParams;
+        use std::collections::BTreeMap;
+
+        fn route_entry(url: &str, out: &str, key: &str) -> RouteUniverseEntry {
+            RouteUniverseEntry {
+                url_path: url.into(),
+                output_path: PathBuf::from(out),
+                route_key: key.into(),
+                static_html: false,
+                source_path: None,
+            }
+        }
+
+        fn scalar_params(pairs: &[(&str, &str)]) -> ResolvedRouteParams {
+            ResolvedRouteParams {
+                scalars: pairs
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect(),
+                arrays: BTreeMap::new(),
+            }
+        }
+
+        fn array_params(key: &str, parts: &[&str]) -> ResolvedRouteParams {
+            ResolvedRouteParams {
+                scalars: BTreeMap::new(),
+                arrays: BTreeMap::from([(
+                    key.to_string(),
+                    parts.iter().map(|s| s.to_string()).collect(),
+                )]),
+            }
+        }
+
+        fn with_params(entry: RouteUniverseEntry, params: ResolvedRouteParams) -> DevRouteEntry {
+            DevRouteEntry {
+                entry,
+                params: Some(params),
+            }
+        }
+
+        /// Project scaffold: tempdir root + one `blog` collection under
+        /// `content/blog` with the given `(relative name, frontmatter)`
+        /// entry files.
+        fn scaffold(files: &[(&str, &str)]) -> (tempfile::TempDir, config::Config) {
+            let tmp = tempfile::tempdir().unwrap();
+            for (name, fm) in files {
+                write_entry(tmp.path(), name, fm, "body");
+            }
+            let cfg = config::Config {
+                collections: vec![config::CollectionDef {
+                    name: "blog".into(),
+                    path: PathBuf::from("content/blog"),
+                    schema: None,
+                    include: None,
+                    exclude: None,
+                    id_strip_suffix: None,
+                }],
+                ..config::Config::default()
+            };
+            (tmp, cfg)
+        }
+
+        fn write_entry(project_root: &Path, name: &str, fm: &str, body: &str) -> PathBuf {
+            let path = project_root.join("content/blog").join(name);
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(&path, format!("---\n{fm}\n---\n\n{body}\n")).unwrap();
+            path
+        }
+
+        /// Stub session with boot-seeded frontmatter hashes, like
+        /// `boot_dev_renderer` produces.
+        fn session_at(
+            tmp: &tempfile::TempDir,
+            cfg: config::Config,
+            routes: HashMap<PathBuf, Vec<DevRouteEntry>>,
+        ) -> DevRenderSession {
+            let seeded = seed_frontmatter_hashes(tmp.path(), &cfg);
+            let inner = stub_dev_inner_at(tmp.path().to_path_buf(), cfg, routes, Vec::new());
+            *inner.fm_hashes.lock().unwrap() = seeded;
+            DevRenderSession {
+                inner: Arc::new(inner),
+            }
+        }
+
+        fn hint_for(paths: &[PathBuf]) -> zfb_build::ContentNarrowing {
+            zfb_build::ContentNarrowing {
+                changed_content: paths.to_vec(),
+            }
+        }
+
+        /// Run the narrowed filter for `source` against the session's
+        /// tables and return the surviving output paths — the set
+        /// `render_one` would fan out (its `render_one_with` loop is
+        /// byte-identical pre- and post-#958).
+        fn surviving_outputs(
+            session: &DevRenderSession,
+            narrowing: &TickNarrowing,
+            source: &Path,
+        ) -> Vec<PathBuf> {
+            let filter = match narrowing {
+                TickNarrowing::Off => &RouteFilter::All,
+                TickNarrowing::PerSource(map) => map.get(source).unwrap_or(&RouteFilter::All),
+            };
+            let tables = session.inner.routes.read().unwrap();
+            DevRenderSession::filter_entries(&tables.routes_by_source[source], filter)
+                .into_iter()
+                .map(|e| e.output_path)
+                .collect()
+        }
+
+        /// Epic acceptance test 1: a body edit of entry A renders A's
+        /// route plus the static (always-rendered) source — NOT sibling
+        /// B's route.
+        #[test]
+        fn narrowed_content_edit_renders_only_matching_routes_plus_statics() {
+            let (tmp, cfg) = scaffold(&[("a.mdx", "title: A"), ("b.mdx", "title: B")]);
+            let dynamic_source = PathBuf::from("pages/blog/[slug].tsx");
+            let static_source = PathBuf::from("pages/index.tsx");
+            let mut routes = HashMap::new();
+            routes.insert(
+                dynamic_source.clone(),
+                vec![
+                    with_params(
+                        route_entry("/blog/a", "blog/a/index.html", "/blog/:slug"),
+                        scalar_params(&[("slug", "a")]),
+                    ),
+                    with_params(
+                        route_entry("/blog/b", "blog/b/index.html", "/blog/:slug"),
+                        scalar_params(&[("slug", "b")]),
+                    ),
+                ],
+            );
+            routes.insert(
+                static_source.clone(),
+                no_params(vec![route_entry("/", "index.html", "/")]),
+            );
+            let session = session_at(&tmp, cfg, routes);
+
+            // Body-only edit of A (frontmatter byte-identical).
+            let edited = write_entry(tmp.path(), "a.mdx", "title: A", "updated body");
+
+            let narrowing = compute_tick_narrowing(&session, Some(&hint_for(&[edited])));
+            assert!(
+                matches!(narrowing, TickNarrowing::PerSource(_)),
+                "a seeded body-only edit must narrow; got {narrowing:?}"
+            );
+
+            assert_eq!(
+                surviving_outputs(&session, &narrowing, &dynamic_source),
+                vec![PathBuf::from("blog/a/index.html")],
+                "dynamic source must render exactly the edited entry's route"
+            );
+            assert_eq!(
+                surviving_outputs(&session, &narrowing, &static_source),
+                vec![PathBuf::from("index.html")],
+                "the static source must stay in the render set in full (S1)"
+            );
+            if let TickNarrowing::PerSource(map) = &narrowing {
+                assert!(
+                    !map.contains_key(&static_source),
+                    "always-rendered sources are expressed by ABSENCE from the map"
+                );
+            }
+        }
+
+        /// Epic acceptance test 2 / S2: a dynamic source whose params are
+        /// not slug-shaped (tag pages) never matches the edited entry's
+        /// candidates and must fall back to its FULL fan-out — that is
+        /// the aggregate-page freshness mechanism.
+        #[test]
+        fn zero_match_dynamic_source_falls_back_to_full_fanout() {
+            let (tmp, cfg) = scaffold(&[("a.mdx", "title: A")]);
+            let blog_source = PathBuf::from("pages/blog/[slug].tsx");
+            let tags_source = PathBuf::from("pages/tags/[tag].tsx");
+            let mut routes = HashMap::new();
+            routes.insert(
+                blog_source.clone(),
+                vec![with_params(
+                    route_entry("/blog/a", "blog/a/index.html", "/blog/:slug"),
+                    scalar_params(&[("slug", "a")]),
+                )],
+            );
+            routes.insert(
+                tags_source.clone(),
+                vec![
+                    with_params(
+                        route_entry("/tags/rust", "tags/rust/index.html", "/tags/:tag"),
+                        scalar_params(&[("tag", "rust")]),
+                    ),
+                    with_params(
+                        route_entry("/tags/cli", "tags/cli/index.html", "/tags/:tag"),
+                        scalar_params(&[("tag", "cli")]),
+                    ),
+                ],
+            );
+            let session = session_at(&tmp, cfg, routes);
+
+            let edited = write_entry(tmp.path(), "a.mdx", "title: A", "updated");
+            let narrowing = compute_tick_narrowing(&session, Some(&hint_for(&[edited])));
+
+            let mut tag_outputs = surviving_outputs(&session, &narrowing, &tags_source);
+            tag_outputs.sort();
+            assert_eq!(
+                tag_outputs,
+                vec![
+                    PathBuf::from("tags/cli/index.html"),
+                    PathBuf::from("tags/rust/index.html"),
+                ],
+                "zero-match source must keep its full fan-out (S2)"
+            );
+            // The slug-shaped source still narrows on the same tick.
+            assert_eq!(
+                surviving_outputs(&session, &narrowing, &blog_source),
+                vec![PathBuf::from("blog/a/index.html")],
+            );
+        }
+
+        /// S1: a source where ANY entry lacks params provenance (zip-
+        /// length mismatch at table-build time files `params: None`)
+        /// must render in full even when another entry would match.
+        #[test]
+        fn missing_params_provenance_forces_source_full_fanout() {
+            let (tmp, cfg) = scaffold(&[("a.mdx", "title: A")]);
+            let source = PathBuf::from("pages/blog/[slug].tsx");
+            let mut routes = HashMap::new();
+            routes.insert(
+                source.clone(),
+                vec![
+                    with_params(
+                        route_entry("/blog/a", "blog/a/index.html", "/blog/:slug"),
+                        scalar_params(&[("slug", "a")]),
+                    ),
+                    DevRouteEntry {
+                        entry: route_entry("/blog/b", "blog/b/index.html", "/blog/:slug"),
+                        params: None,
+                    },
+                ],
+            );
+            let session = session_at(&tmp, cfg, routes);
+
+            let edited = write_entry(tmp.path(), "a.mdx", "title: A", "updated");
+            let narrowing = compute_tick_narrowing(&session, Some(&hint_for(&[edited])));
+
+            let mut outputs = surviving_outputs(&session, &narrowing, &source);
+            outputs.sort();
+            assert_eq!(
+                outputs,
+                vec![
+                    PathBuf::from("blog/a/index.html"),
+                    PathBuf::from("blog/b/index.html"),
+                ],
+                "missing provenance on any entry must force the source's full fan-out (S1)"
+            );
+        }
+
+        /// G4, changed direction: a frontmatter delta disables narrowing
+        /// for the tick (frontmatter feeds cross-page props) — but the
+        /// new hash is stored on the Off path, so the NEXT body-only
+        /// edit narrows.
+        #[test]
+        fn frontmatter_change_disables_narrowing_for_tick() {
+            let (tmp, cfg) = scaffold(&[("a.mdx", "title: A")]);
+            let source = PathBuf::from("pages/blog/[slug].tsx");
+            let mut routes = HashMap::new();
+            routes.insert(
+                source.clone(),
+                vec![with_params(
+                    route_entry("/blog/a", "blog/a/index.html", "/blog/:slug"),
+                    scalar_params(&[("slug", "a")]),
+                )],
+            );
+            let session = session_at(&tmp, cfg, routes);
+
+            let edited = write_entry(tmp.path(), "a.mdx", "title: A (renamed)", "body");
+            let first =
+                compute_tick_narrowing(&session, Some(&hint_for(std::slice::from_ref(&edited))));
+            assert!(
+                matches!(first, TickNarrowing::Off),
+                "a frontmatter change must disable narrowing for the tick (G4); got {first:?}"
+            );
+
+            // Same file, body-only follow-up: the hash stored on the Off
+            // path makes this tick narrow.
+            let edited = write_entry(tmp.path(), "a.mdx", "title: A (renamed)", "body v2");
+            let second = compute_tick_narrowing(&session, Some(&hint_for(&[edited])));
+            assert!(
+                matches!(second, TickNarrowing::PerSource(_)),
+                "the hash must be stored on the Off path so the next body edit narrows"
+            );
+        }
+
+        /// G4, missing direction: a file with no seeded hash (boot
+        /// seeding failed / session-created file) renders in full on its
+        /// first edit and narrows from the second on.
+        #[test]
+        fn first_edit_without_seeded_hash_renders_full_then_narrows() {
+            let (tmp, cfg) = scaffold(&[]);
+            let source = PathBuf::from("pages/blog/[slug].tsx");
+            let mut routes = HashMap::new();
+            routes.insert(
+                source.clone(),
+                vec![with_params(
+                    route_entry("/blog/new", "blog/new/index.html", "/blog/:slug"),
+                    scalar_params(&[("slug", "new")]),
+                )],
+            );
+            // Session seeded BEFORE the file exists — like a file created
+            // mid-session through the discovery path.
+            let session = session_at(&tmp, cfg, routes);
+            let created = write_entry(tmp.path(), "new.mdx", "title: New", "body");
+
+            let first =
+                compute_tick_narrowing(&session, Some(&hint_for(std::slice::from_ref(&created))));
+            assert!(
+                matches!(first, TickNarrowing::Off),
+                "first edit without a seeded hash must render in full (G4); got {first:?}"
+            );
+
+            let created = write_entry(tmp.path(), "new.mdx", "title: New", "body v2");
+            let second = compute_tick_narrowing(&session, Some(&hint_for(&[created])));
+            assert!(
+                matches!(second, TickNarrowing::PerSource(_)),
+                "second (body-only) edit must narrow once the hash is seeded"
+            );
+        }
+
+        /// Spec §10: `x/index.mdx` must match catchall params `["x"]`
+        /// via the `/index`-stripped candidate, and a root `index.mdx`
+        /// must match the bare root-index `[]` (joins to `""`).
+        #[test]
+        fn index_entry_slug_variants_match_catchall_params() {
+            let (tmp, cfg) = scaffold(&[("x/index.mdx", "title: X"), ("index.mdx", "title: Root")]);
+            let source = PathBuf::from("pages/docs/[[...slug]].tsx");
+            let mut routes = HashMap::new();
+            routes.insert(
+                source.clone(),
+                vec![
+                    with_params(
+                        route_entry("/docs/x", "docs/x/index.html", "/docs/:slug{.+}?"),
+                        array_params("slug", &["x"]),
+                    ),
+                    with_params(
+                        route_entry("/docs", "docs/index.html", "/docs/:slug{.+}?"),
+                        array_params("slug", &[]),
+                    ),
+                ],
+            );
+            let session = session_at(&tmp, cfg, routes);
+
+            let edited = write_entry(tmp.path(), "x/index.mdx", "title: X", "v2");
+            let narrowing = compute_tick_narrowing(&session, Some(&hint_for(&[edited])));
+            assert_eq!(
+                surviving_outputs(&session, &narrowing, &source),
+                vec![PathBuf::from("docs/x/index.html")],
+                "x/index.mdx must match the [\"x\"] catchall route"
+            );
+
+            let edited = write_entry(tmp.path(), "index.mdx", "title: Root", "v2");
+            let narrowing = compute_tick_narrowing(&session, Some(&hint_for(&[edited])));
+            assert_eq!(
+                surviving_outputs(&session, &narrowing, &source),
+                vec![PathBuf::from("docs/index.html")],
+                "root index.mdx must match the empty-catchall route"
+            );
+        }
+
+        /// Spec §10: `idStripSuffix` applies inside the slug derivation,
+        /// so `post.en.mdx` (suffix `.en`) matches params slug `post`.
+        #[test]
+        fn id_strip_suffix_slug_matches_params() {
+            let (tmp, mut cfg) = scaffold(&[("post.en.mdx", "title: Post")]);
+            cfg.collections[0].id_strip_suffix = Some(".en".into());
+            let source = PathBuf::from("pages/blog/[slug].tsx");
+            let mut routes = HashMap::new();
+            routes.insert(
+                source.clone(),
+                vec![
+                    with_params(
+                        route_entry("/blog/post", "blog/post/index.html", "/blog/:slug"),
+                        scalar_params(&[("slug", "post")]),
+                    ),
+                    with_params(
+                        route_entry("/blog/other", "blog/other/index.html", "/blog/:slug"),
+                        scalar_params(&[("slug", "other")]),
+                    ),
+                ],
+            );
+            let session = session_at(&tmp, cfg, routes);
+
+            let edited = write_entry(tmp.path(), "post.en.mdx", "title: Post", "v2");
+            let narrowing = compute_tick_narrowing(&session, Some(&hint_for(&[edited])));
+            assert_eq!(
+                surviving_outputs(&session, &narrowing, &source),
+                vec![PathBuf::from("blog/post/index.html")],
+                "the idStripSuffix-stripped slug must match the route params"
+            );
+        }
+
+        /// Spec §4 step 3: a frontmatter `slug:` override contributes a
+        /// candidate (verbatim + leading-`/`-stripped), so a body edit of
+        /// a file whose route URL comes from frontmatter still narrows.
+        #[test]
+        fn frontmatter_slug_override_body_edit_narrows_via_fm_candidate() {
+            let (tmp, cfg) = scaffold(&[("weird-file-name.mdx", "title: C\nslug: /custom/path")]);
+            let source = PathBuf::from("pages/docs/[[...slug]].tsx");
+            let mut routes = HashMap::new();
+            routes.insert(
+                source.clone(),
+                vec![
+                    with_params(
+                        route_entry(
+                            "/docs/custom/path",
+                            "docs/custom/path/index.html",
+                            "/docs/:slug{.+}?",
+                        ),
+                        array_params("slug", &["custom", "path"]),
+                    ),
+                    with_params(
+                        route_entry("/docs/other", "docs/other/index.html", "/docs/:slug{.+}?"),
+                        array_params("slug", &["other"]),
+                    ),
+                ],
+            );
+            let session = session_at(&tmp, cfg, routes);
+
+            let edited = write_entry(
+                tmp.path(),
+                "weird-file-name.mdx",
+                "title: C\nslug: /custom/path",
+                "v2",
+            );
+            let narrowing = compute_tick_narrowing(&session, Some(&hint_for(&[edited])));
+            assert_eq!(
+                surviving_outputs(&session, &narrowing, &source),
+                vec![PathBuf::from("docs/custom/path/index.html")],
+                "the frontmatter slug candidate must match the override route"
+            );
+        }
+
+        /// G2: a Content-classified file outside every configured
+        /// collection (e.g. a bare `content/`-segment file with no
+        /// matching collection) must disable narrowing for the tick.
+        #[test]
+        fn file_outside_every_collection_disables_narrowing() {
+            let (tmp, cfg) = scaffold(&[("a.mdx", "title: A")]);
+            let source = PathBuf::from("pages/blog/[slug].tsx");
+            let mut routes = HashMap::new();
+            routes.insert(
+                source.clone(),
+                vec![with_params(
+                    route_entry("/blog/a", "blog/a/index.html", "/blog/:slug"),
+                    scalar_params(&[("slug", "a")]),
+                )],
+            );
+            let session = session_at(&tmp, cfg, routes);
+
+            let outside = tmp.path().join("content/notes/x.md");
+            std::fs::create_dir_all(outside.parent().unwrap()).unwrap();
+            std::fs::write(&outside, "---\ntitle: X\n---\n\nbody\n").unwrap();
+
+            let narrowing = compute_tick_narrowing(&session, Some(&hint_for(&[outside])));
+            assert!(
+                matches!(narrowing, TickNarrowing::Off),
+                "a file outside every collection must fall back to full fan-out (G2)"
+            );
+        }
     }
 
     /// Deep-review regression (PR #376): `Route::template()` emits

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -1226,7 +1226,7 @@ struct DevRenderSession {
 /// The provenance is what lets a content edit narrow a dynamic source's
 /// render fan-out to the routes whose params match the edited entry's
 /// slug candidates — see [`compute_tick_narrowing`].
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 struct DevRouteEntry {
     entry: RouteUniverseEntry,
     /// Per-URL params retained from `DynamicExpansion::resolved_with_params`
@@ -1520,15 +1520,15 @@ impl DevRenderSession {
             // prune (DevAssetPipeline.last_output_path) was designed around a
             // *stable source id* whose output_path can flip across ticks (e.g.
             // sitemap.xml → sitemap.rss); output-path keying makes such a flip
-            // produce two distinct keys, so the old artifact would orphan in
-            // dist/. Still unreachable after #659 (which added live table
-            // rebuilding in `discover_created`): that function's diff gate
-            // (lines ~1289-1301) only re-renders sources whose entry COUNT
-            // changed (`prev.len() != entries.len()`), so an output_path flip
-            // on a stable-count source is never re-rendered/pruned and the
-            // orphan path is never triggered. If entry-count-stable output_path
-            // flips must be handled, restore source-path keying for static
-            // routes (or key dynamic entries on (source_path, output_path)).
+            // produce two distinct keys, so that per-page prune mechanism can
+            // never fire for it. Since #958 strengthened `diff_route_tables`
+            // to full entry-set comparison, a stable-count output_path flip IS
+            // re-rendered — but the old artifact is deleted by the GLOBAL
+            // vanished-output diff (#804: the old path drops out of the live
+            // route set and `route_vanished` prunes it from disk + cache), so
+            // no orphan accumulates. If that global diff is ever weakened,
+            // restore source-path keying for static routes (or key dynamic
+            // entries on (source_path, output_path)).
             out.push(RenderedPage {
                 page: PageId::new(entry.output_path.clone()),
                 output_path,
@@ -1804,44 +1804,13 @@ impl DevRenderSession {
             build_dev_route_tables(&router, &plan, project_root, &self.inner.renderer)
                 .context("dev refresh: route-table rebuild failed")?;
 
-        // 4. Diff against the frozen table to find:
-        //    (a) which source pages gained/changed entries, and
-        //    (b) which output paths vanished globally (were live before
-        //        but are absent from every source in the new table).
-        //    The global diff is critical: if route A loses /x while route B
-        //    simultaneously gains /x, /x must NOT be considered vanished.
+        // 4. Diff against the frozen table — see [`diff_route_tables`]
+        //    for the exact semantics (issue #958: the `changed` set is
+        //    the G5 narrowing gate, so it compares full entry SETS, not
+        //    just counts).
         let (changed, vanished_output_paths) = {
             let old = self.inner.routes.read().unwrap_or_else(|p| p.into_inner());
-
-            let changed: Vec<PageId> = new_routes_by_source
-                .iter()
-                .filter(|(src, entries)| {
-                    old.routes_by_source
-                        .get(*src)
-                        .map(|prev| prev.len() != entries.len())
-                        .unwrap_or(true)
-                })
-                .map(|(src, _)| PageId::new(src.clone()))
-                .collect();
-
-            // Collect the globally-live output_path sets for old and new.
-            // Use HashSet for O(1) membership checks.
-            let old_live: std::collections::HashSet<std::path::PathBuf> = old
-                .routes_by_source
-                .values()
-                .flat_map(|entries| entries.iter().map(|e| e.entry.output_path.clone()))
-                .collect();
-            let new_live: std::collections::HashSet<std::path::PathBuf> = new_routes_by_source
-                .values()
-                .flat_map(|entries| entries.iter().map(|e| e.entry.output_path.clone()))
-                .collect();
-
-            let vanished: Vec<std::path::PathBuf> = old_live
-                .difference(&new_live)
-                .cloned()
-                .collect();
-
-            (changed, vanished)
+            diff_route_tables(&old.routes_by_source, &new_routes_by_source)
         };
         {
             let mut tables = self.inner.routes.write().unwrap_or_else(|p| p.into_inner());
@@ -1878,12 +1847,57 @@ enum BundleRefresh {
     Skipped,
     /// Full refresh completed (host swap + route-table rebuild).
     Refreshed {
-        /// Source [`PageId`]s whose route set changed.
+        /// Source [`PageId`]s whose route-entry set changed (see
+        /// [`diff_route_tables`]).
         changed: Vec<PageId>,
         /// Relative output paths (under dist) that vanished from the
         /// global live route set.
         vanished: Vec<std::path::PathBuf>,
     },
+}
+
+/// Diff a freshly-rebuilt `routes_by_source` map against the frozen one:
+///
+/// - `changed`: sources whose route-entry SET changed — new sources, and
+///   sources whose entries differ in any way (URL, output path, params).
+///   NOT a count-only comparison: issue #958's narrowing gate (fallback
+///   G5) rides on this set, and a `paths()` refresh can replace routes
+///   without changing their count (e.g. a two-page URL swap), which a
+///   count diff reports as unchanged — a narrowed render would then skip
+///   the brand-new route (silent under-render; review finding on #958).
+///   The full-set comparison also feeds the watch-ADD discovery path,
+///   where firing more often only re-renders more (safe direction).
+/// - `vanished`: output paths that were live before but are absent from
+///   every source in the new table. The diff is GLOBAL on purpose: if
+///   route A loses /x while route B simultaneously gains /x, /x must NOT
+///   be considered vanished (#727 two-page swap).
+#[cfg(feature = "embed_v8")]
+fn diff_route_tables(
+    old: &HashMap<PathBuf, Vec<DevRouteEntry>>,
+    new: &HashMap<PathBuf, Vec<DevRouteEntry>>,
+) -> (Vec<PageId>, Vec<std::path::PathBuf>) {
+    let changed: Vec<PageId> = new
+        .iter()
+        .filter(|(src, entries)| old.get(*src).map(|prev| prev != *entries).unwrap_or(true))
+        .map(|(src, _)| PageId::new(src.clone()))
+        .collect();
+
+    // Collect the globally-live output_path sets for old and new. Use
+    // HashSet for O(1) membership checks.
+    let old_live: HashSet<&PathBuf> = old
+        .values()
+        .flat_map(|entries| entries.iter().map(|e| &e.entry.output_path))
+        .collect();
+    let new_live: HashSet<&PathBuf> = new
+        .values()
+        .flat_map(|entries| entries.iter().map(|e| &e.entry.output_path))
+        .collect();
+    let vanished: Vec<std::path::PathBuf> = old_live
+        .difference(&new_live)
+        .map(|p| (*p).clone())
+        .collect();
+
+    (changed, vanished)
 }
 
 impl Drop for DevRenderInner {
@@ -3731,6 +3745,79 @@ mod tests {
                 surviving_outputs(&session, &narrowing, &source),
                 vec![PathBuf::from("docs/custom/path/index.html")],
                 "the frontmatter slug candidate must match the override route"
+            );
+        }
+
+        /// Review finding on #958 (G5 gate integrity): the refresh diff's
+        /// `changed` set must compare full route-entry SETS, not entry
+        /// counts — a `paths()` refresh that replaces a route with a new
+        /// URL at the same cardinality must mark the source changed, or
+        /// a narrowed tick could skip the brand-new route.
+        #[test]
+        fn diff_route_tables_flags_same_count_route_replacement() {
+            let source = PathBuf::from("pages/blog/[slug].tsx");
+            let old_entries = vec![with_params(
+                route_entry("/blog/x", "blog/x/index.html", "/blog/:slug"),
+                scalar_params(&[("slug", "x")]),
+            )];
+            let new_entries = vec![with_params(
+                route_entry("/blog/y", "blog/y/index.html", "/blog/:slug"),
+                scalar_params(&[("slug", "y")]),
+            )];
+            let old = HashMap::from([(source.clone(), old_entries)]);
+            let new = HashMap::from([(source.clone(), new_entries)]);
+
+            let (changed, vanished) = diff_route_tables(&old, &new);
+            assert_eq!(
+                changed,
+                vec![PageId::new(source)],
+                "a same-count URL replacement must mark the source changed (G5)"
+            );
+            assert_eq!(
+                vanished,
+                vec![PathBuf::from("blog/x/index.html")],
+                "the replaced output path globally vanished"
+            );
+        }
+
+        /// `diff_route_tables` reports identical tables as unchanged, and
+        /// the vanished diff stays GLOBAL: a route moving between sources
+        /// (#727 two-page swap) flags both sources changed but vanishes
+        /// nothing.
+        #[test]
+        fn diff_route_tables_identity_and_cross_source_swap() {
+            let src_a = PathBuf::from("pages/a/[slug].tsx");
+            let src_b = PathBuf::from("pages/b/[slug].tsx");
+            let entry_x = with_params(
+                route_entry("/x", "x/index.html", "/a/:slug"),
+                scalar_params(&[("slug", "x")]),
+            );
+            let entry_y = with_params(
+                route_entry("/y", "y/index.html", "/b/:slug"),
+                scalar_params(&[("slug", "y")]),
+            );
+
+            let old = HashMap::from([
+                (src_a.clone(), vec![entry_x.clone()]),
+                (src_b.clone(), vec![entry_y.clone()]),
+            ]);
+
+            // Identity: nothing changed, nothing vanished.
+            let (changed, vanished) = diff_route_tables(&old, &old.clone());
+            assert!(changed.is_empty(), "identical tables must diff empty");
+            assert!(vanished.is_empty());
+
+            // Swap: A now serves /y, B now serves /x.
+            let new = HashMap::from([
+                (src_a.clone(), vec![entry_y]),
+                (src_b.clone(), vec![entry_x]),
+            ]);
+            let (mut changed, vanished) = diff_route_tables(&old, &new);
+            changed.sort_by(|a, b| a.path().cmp(b.path()));
+            assert_eq!(changed, vec![PageId::new(src_a), PageId::new(src_b)]);
+            assert!(
+                vanished.is_empty(),
+                "globally-live paths swapped between sources must not vanish"
             );
         }
 

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -79,8 +79,8 @@ use zfb_build::renderer::{
 };
 use zfb_build::{
     BuildContext, BuildOrchestrator, BuildOutcome, CssRunner, DevAssetPipeline, DiscoveryOutcome,
-    IslandsBundleInfo, IslandsRunner, OrchestratorConfig, PageRenderer, RelDistPath, RenderedPage,
-    RendererReloader,
+    IslandsBundleInfo, IslandsRunner, OrchestratorConfig, PageRenderer, RefreshOutcome,
+    RelDistPath, RenderedPage, RendererReloader,
 };
 use zfb_graph::persist::{load_from_disk, save_to_disk, ManifestDigest};
 use zfb_graph::{DependencyGraph, PageDeps, PageId};
@@ -784,9 +784,17 @@ pub async fn run(args: &DevArgs) -> Result<()> {
         // the renderer is disabled (no SSR in this project).
         let ssr_handle_for_reload = ssr_route_set.clone();
         Arc::new(move || {
-            let (changed, vanished_rel) = session
+            let (changed, vanished_rel) = match session
                 .refresh_bundle_and_routes()
-                .context("edit-tick bundle refresh failed")?;
+                .context("edit-tick bundle refresh failed")?
+            {
+                // Phase-B skip (issue #940): the live host, route tables,
+                // and SSR route set were all left untouched — report
+                // `Skipped` so DevAssetPipeline bypasses the render
+                // fan-out for the tick (issue #956).
+                BundleRefresh::Skipped => return Ok(RefreshOutcome::Skipped),
+                BundleRefresh::Refreshed { changed, vanished } => (changed, vanished),
+            };
             if !changed.is_empty() {
                 tracing::debug!(
                     count = changed.len(),
@@ -811,7 +819,9 @@ pub async fn run(args: &DevArgs) -> Result<()> {
                     "edit-tick refresh found globally-vanished routes"
                 );
             }
-            Ok(vanished_abs)
+            Ok(RefreshOutcome::Refreshed {
+                vanished: vanished_abs,
+            })
         }) as RendererReloader
     });
 
@@ -1277,11 +1287,12 @@ struct DevRenderInner {
 
     /// Skip key from the last SUCCESSFUL `refresh_bundle_and_routes` call
     /// (issue #940 — Phase B). Hashes bundle bytes + the router scan's
-    /// sorted source paths + route templates so a no-op tick (identical
-    /// bundle, identical route universe) skips V8 host boot + swap and
-    /// the `paths()` re-expansion. Stored only after ALL of: host boot,
-    /// swap, AND route-table rebuild succeed — a failed refresh must NOT
-    /// poison this field so the next byte-identical tick can retry.
+    /// sorted source paths + route templates + static `pages/**.html`
+    /// bodies (issue #956) so a no-op tick (identical bundle, identical
+    /// route universe) skips V8 host boot + swap and the `paths()`
+    /// re-expansion. Stored only after ALL of: host boot, swap, AND
+    /// route-table rebuild succeed — a failed refresh must NOT poison
+    /// this field so the next byte-identical tick can retry.
     ///
     /// `None` on first tick (cold start) — forces a full refresh.
     /// Wrapped in a `Mutex` so `&self.refresh_bundle_and_routes` can
@@ -1515,6 +1526,11 @@ impl DevRenderSession {
     /// that vanished from the global live route set. The caller is
     /// responsible for joining the relative paths with the appropriate dist
     /// root before propagating them (issue #804 P2).
+    ///
+    /// A Phase-B skip during discovery is folded back into the empty
+    /// change/vanish tuple here (pre-#956 behaviour): the discovery hook
+    /// still reports `renderer_reloaded = true`, so the tick behaves as a
+    /// completed refresh (issue #940 Inv 3).
     #[cfg(feature = "embed_v8")]
     fn discover_created(
         &self,
@@ -1523,7 +1539,10 @@ impl DevRenderSession {
         if created.is_empty() {
             return Ok((Vec::new(), Vec::new()));
         }
-        self.refresh_bundle_and_routes()
+        match self.refresh_bundle_and_routes()? {
+            BundleRefresh::Skipped => Ok((Vec::new(), Vec::new())),
+            BundleRefresh::Refreshed { changed, vanished } => Ok((changed, vanished)),
+        }
     }
 
     /// Re-bundle the SSR worker, swap in a freshly-started embedded V8
@@ -1564,10 +1583,12 @@ impl DevRenderSession {
     ///    change a dynamic route's `paths()` output surface without a
     ///    restart.
     ///
-    /// Returns `(changed_sources, vanished_output_paths)` where:
-    /// - `changed_sources`: source [`PageId`]s whose route set changed
+    /// Returns [`BundleRefresh::Skipped`] when the Phase-B check (issue
+    /// #940) proved nothing observable changed, otherwise
+    /// [`BundleRefresh::Refreshed`] with:
+    /// - `changed`: source [`PageId`]s whose route set changed
     ///   (empty for a plain content edit).
-    /// - `vanished_output_paths`: relative output paths (under dist) that
+    /// - `vanished`: relative output paths (under dist) that
     ///   existed in the old live route set but are absent from the new one,
     ///   globally across all sources. Used by the caller to prune stale
     ///   HTML files and invalidate PageCache entries (issue #804).
@@ -1575,7 +1596,7 @@ impl DevRenderSession {
     /// `embed_v8`-gated like `boot_dev_renderer` — the host start +
     /// `paths()` runtime eval need the embedded V8 host.
     #[cfg(feature = "embed_v8")]
-    fn refresh_bundle_and_routes(&self) -> Result<(Vec<PageId>, Vec<std::path::PathBuf>)> {
+    fn refresh_bundle_and_routes(&self) -> Result<BundleRefresh> {
         let project_root = &self.inner.project_root;
         let inputs = &self.inner.rebuild_inputs;
 
@@ -1602,14 +1623,18 @@ impl DevRenderSession {
         // Phase B (issue #940) — skip key check.
         //
         // Compute a digest over bundle bytes + the router-scan signature
-        // (sorted source paths + route templates). If the new key matches
-        // the previous SUCCESSFUL tick's key, nothing observable changed:
+        // (sorted source paths + route templates) + static pages/**.html
+        // bodies (issue #956 gate (a)). If the new key matches the previous
+        // SUCCESSFUL tick's key, nothing observable changed:
         // - bundle bytes ≡ snapshot unchanged ≡ V8 host would observe
         //   identical globals,
-        // - router signature unchanged ≡ pages/ universe identical.
-        // Return early with empty (changed, vanished) — the caller treats
-        // this as a completed refresh (Inv 3: renderer_reloaded=true via
-        // the DiscoveryOutcome path above us).
+        // - router signature unchanged ≡ pages/ universe identical,
+        // - static-HTML bodies unchanged ≡ verbatim-copied routes identical.
+        // Return `Skipped` — the discovery caller treats this as a
+        // completed refresh (Inv 3: renderer_reloaded=true via the
+        // DiscoveryOutcome path above us), while the per-tick reloader
+        // propagates it so DevAssetPipeline bypasses the render fan-out
+        // (issue #956).
         //
         // Key is stored only AFTER the full success path below (host swap +
         // route rebuild). A failed refresh — e.g. host start error — must
@@ -1622,10 +1647,10 @@ impl DevRenderSession {
                 "bundle skip: byte-identical bundle + unchanged route universe; \
                  skipping V8 host boot and paths() re-expansion"
             );
-            // Early return — behaves as a completed refresh with empty
-            // change/vanish sets (Inv 3).  The skip key is already
-            // stored from the last successful tick; no update needed.
-            return Ok((Vec::new(), Vec::new()));
+            // Early return — the live host and route tables were left
+            // untouched. The skip key is already stored from the last
+            // successful tick; no update needed.
+            return Ok(BundleRefresh::Skipped);
         }
 
         // 2. Start a NEW embedded V8 host against the rebuilt bundle,
@@ -1740,8 +1765,31 @@ impl DevRenderSession {
         // `None`-clears-the-key rationale.
         self.inner.commit_skip_key(new_skip_key);
 
-        Ok((changed, vanished_output_paths))
+        Ok(BundleRefresh::Refreshed {
+            changed,
+            vanished: vanished_output_paths,
+        })
     }
+}
+
+/// Result of one [`DevRenderSession::refresh_bundle_and_routes`] call —
+/// the dev session's internal counterpart of
+/// [`zfb_build::RefreshOutcome`] (issue #956), carrying the extra
+/// `changed` source set the discovery path needs.
+#[cfg(feature = "embed_v8")]
+enum BundleRefresh {
+    /// Phase-B skip (issue #940): byte-identical bundle + unchanged route
+    /// universe (including static `pages/**.html` bodies). The live V8
+    /// host and route tables were left untouched.
+    Skipped,
+    /// Full refresh completed (host swap + route-table rebuild).
+    Refreshed {
+        /// Source [`PageId`]s whose route set changed.
+        changed: Vec<PageId>,
+        /// Relative output paths (under dist) that vanished from the
+        /// global live route set.
+        vanished: Vec<std::path::PathBuf>,
+    },
 }
 
 impl Drop for DevRenderInner {
@@ -1832,9 +1880,17 @@ fn assemble_and_bundle_dev(
 ///    (e.g. a `.tsx` page added with no JS-visible impact on the snapshot),
 ///    satisfying Inv 2 (§3 of the roadmap, issue #935).
 ///
-/// Returns `None` if the bundle file cannot be read — the caller treats
-/// that as a forced full refresh (safe direction: false-invalidate, never
-/// false-reuse).
+/// 3. **Static `pages/**.html` bodies** (issue #956 gate (a)) — routes
+///    with `static_html = true` bypass the JS bundle entirely: the
+///    renderer copies the source file from disk at render time
+///    (`zfb-build/src/renderer.rs`), so neither the bundle bytes nor the
+///    route signature reflect an edit to such a file's CONTENT. Hashing
+///    the bodies here keeps a static-HTML edit from being swallowed by
+///    the skip.
+///
+/// Returns `None` if the bundle file or any static-HTML source cannot be
+/// read — the caller treats that as a forced full refresh (safe
+/// direction: false-invalidate, never false-reuse).
 #[cfg(feature = "embed_v8")]
 fn compute_bundle_skip_key(
     bundler_out: &BundlerOutput,
@@ -1882,6 +1938,38 @@ fn compute_bundle_skip_key(
         hasher.update(src.as_bytes());
         hasher.update(b"=");
         hasher.update(tpl.as_bytes());
+        hasher.update(b"\n");
+    }
+
+    // Part 3: static pages/**.html bodies (issue #956 gate (a)). Sorted by
+    // source_path for a deterministic order; the paths come straight from
+    // the router's WalkDir over `<project_root>/pages`, so reading them
+    // here sees exactly the files the renderer would copy at render time.
+    let mut static_html_routes: Vec<&zfb_router::Route> =
+        routes.iter().filter(|r| r.static_html).collect();
+    static_html_routes.sort_unstable_by(|a, b| a.source_path.cmp(&b.source_path));
+    hasher.update(b"static-html:");
+    hasher.update((static_html_routes.len() as u64).to_le_bytes());
+    hasher.update(b":");
+    for route in static_html_routes {
+        let body = match std::fs::read(&route.source_path) {
+            Ok(b) => b,
+            Err(err) => {
+                tracing::warn!(
+                    site = "compute_bundle_skip_key",
+                    path = %route.source_path.display(),
+                    error = %err,
+                    "could not read static .html page for skip-key; \
+                     will perform full refresh"
+                );
+                return None;
+            }
+        };
+        hasher.update(route.source_path.to_string_lossy().as_bytes());
+        hasher.update(b"=");
+        hasher.update((body.len() as u64).to_le_bytes());
+        hasher.update(b":");
+        hasher.update(&body);
         hasher.update(b"\n");
     }
 
@@ -3295,6 +3383,88 @@ mod tests {
             !inner.should_skip_refresh(Some(key_k)),
             "committing None must clear the stored key so a later tick \
              with the old key cannot skip against the wrong host state"
+        );
+    }
+
+    // ── Static pages/**.html skip-key coverage (issue #956 gate (a)) ────────
+    //
+    // Static `.html` page routes bypass the JS bundle entirely (the
+    // renderer copies the source body from disk at render time), so their
+    // CONTENT is invisible to bundle bytes and to the route signature.
+    // `compute_bundle_skip_key` must fold their bodies into the key.
+
+    /// Build a `static_html` route pointing at `src`.
+    #[cfg(feature = "embed_v8")]
+    fn make_static_html_route(src: PathBuf) -> zfb_router::Route {
+        zfb_router::Route {
+            source_path: src,
+            segments: vec![zfb_router::Segment::Static("about".into())],
+            kind: zfb_router::RouteKind::Static,
+            specificity: 100,
+            output_extension: None,
+            static_html: true,
+        }
+    }
+
+    /// Editing a static `.html` page's bytes must change the skip key even
+    /// when bundle bytes and the route signature are identical — otherwise
+    /// the edit would be silently swallowed by the Phase-B skip.
+    #[cfg(feature = "embed_v8")]
+    #[test]
+    fn bundle_skip_key_changes_on_static_html_edit() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = make_bundler_out(write_temp_bundle(&dir, b"identical-bundle"));
+
+        let html_path = dir.path().join("about.html");
+        std::fs::write(&html_path, "<h1>v1</h1>").unwrap();
+        let routes = vec![make_static_html_route(html_path.clone())];
+
+        let k1 = compute_bundle_skip_key(&out, &routes);
+        // Edit ONLY the static html body — same path, same route
+        // signature, same bundle bytes.
+        std::fs::write(&html_path, "<h1>v2</h1>").unwrap();
+        let k2 = compute_bundle_skip_key(&out, &routes);
+
+        assert!(k1.is_some());
+        assert!(k2.is_some());
+        assert_ne!(
+            k1, k2,
+            "a static pages/*.html content edit must defeat the skip \
+             even when bundle bytes and route signature are unchanged"
+        );
+    }
+
+    /// Unchanged static `.html` bodies keep the key stable — the skip
+    /// still fires for genuine no-op ticks on projects with static pages.
+    #[cfg(feature = "embed_v8")]
+    #[test]
+    fn bundle_skip_key_stable_when_static_html_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = make_bundler_out(write_temp_bundle(&dir, b"identical-bundle"));
+
+        let html_path = dir.path().join("about.html");
+        std::fs::write(&html_path, "<h1>same</h1>").unwrap();
+        let routes = vec![make_static_html_route(html_path)];
+
+        let k1 = compute_bundle_skip_key(&out, &routes);
+        let k2 = compute_bundle_skip_key(&out, &routes);
+        assert!(k1.is_some());
+        assert_eq!(k1, k2, "identical static html bodies → identical keys");
+    }
+
+    /// An unreadable static `.html` source forces `None` (full refresh) —
+    /// the safe direction, mirroring the unreadable-bundle case.
+    #[cfg(feature = "embed_v8")]
+    #[test]
+    fn bundle_skip_key_returns_none_for_unreadable_static_html() {
+        let dir = tempfile::tempdir().unwrap();
+        let out = make_bundler_out(write_temp_bundle(&dir, b"bundle"));
+
+        let routes = vec![make_static_html_route(dir.path().join("missing.html"))];
+        let key = compute_bundle_skip_key(&out, &routes);
+        assert!(
+            key.is_none(),
+            "an unreadable static html source must force a full refresh"
         );
     }
 }


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/950

---

## Summary

Implements epic #950 (superseding #948 and #947) — two tracks:

**Track A — production BuildContext arming (#948 scope).** The three context-aware markdown feature plugins (transclude, imageDimensions, linkValidation) were inert in production: nothing threaded `BuildContext` roots into real builds. Now:

- `PipelineSpec` gains `build_context_roots`; `pipeline_spec_from_config` arms it (gated on a filesystem-dependent feature being enabled, so unarmed projects keep byte-identical fingerprints and the #942 ReadRecorder always co-occurs with roots) (#952)
- The bundler drains `take_markdown_diagnostics()` at all three compile sites and routes by severity after all walks: Info/Warning → stderr, Error → bail listing every finding. Intentional divergence from #948's wording: transclude failures are Error severity (the include node is dropped) and fail the build; imageDimensions stays warning-only (#953)
- linkValidation made safe to arm: URL-space hrefs (ResolveLinks rewrites) are skipped via a new `ParsedLink::UrlSpace`; cross-file fragment checks degrade to existence-only without a registry entry (kills the `./other.md#frag` false positive); same-file anchors validate via a per-compile-local `HeadingRegistry` seeded from `collect_headings` (#954, spec locked by decision task #951)
- Confirmed end-to-end on the dogfood docs site: zero validator false positives, snapshot↔bundler content_hash parity holds, imageDimensions injects width/height (#955; genuine docs content breakage filed as #964)

**Track B — dev render narrowing (#947 scope).** A single MDX edit re-rendered every paths()-expanded route (~228 pages, ~2.9s) and no-op ticks still rendered (~2.4s). Now:

- `RendererReloader` returns an explicit `RefreshOutcome { Skipped, Refreshed { vanished } }`; Phase-B-skipped ticks bypass the render fan-out entirely; static `pages/**.html` bodies join the skip key so HTML edits still defeat the skip (#956)
- Content edits carry a `ContentNarrowing` hint from plan to renderer: per-URL params provenance is retained in the dev route tables, the changed entry is matched by slug candidates, and only its routes + non-narrowable sources render — with mandatory full-fan-out fallbacks (G1–G6 tick-wide, S1–S2 per-source) so narrowing only ever subtracts (#958, spec locked by decision task #957)
- Bonus root-cause fix: inotify `Access` events were classified as `Modified`, causing ~9 ticks/sec background churn on Linux (pre-existing on main; surfaced by the B4 measurement) — only `Access(Close(Write))` now maps to `Modified` (`cf8407a`)
- Post-review fix: markdown-diagnostic errors and broken-link errors now both report before a single combined bail (`abc5401`)

## Measured impact (docs workload, 228 pages — #959 report on #950)

| Metric | Before | After |
|---|---:|---:|
| Edit tick total (median) | ~3750ms | **1026ms** (−73%) |
| Pages rendered per edit | ~228 | **5** (−98%) |
| No-op tick render | 2414ms | **skipped** |
| Background churn | ~9 ticks/sec | **0** |

## Notes for reviewers

- A4's commit (`eab5490`) and A3's fmt commit carry deterministic rustfmt reflow of `zfb-content`/`zfb-md-extras` beyond their logical changes — semantically inert; the logical changes are described in each commit message.
- Deferred follow-ups: #960 (build-scoped heading registry for cross-file anchors), #961 (render-on-request in dev), #963 (flaky color-test race), #964 (docs content link breakage).

## Topic branches

All six topic branches were merged into this base locally and deleted (commits: #952 `72116b6`, #956 `e16b1c5`, #954 `eab5490`, #953 `a973652`+`5715db8`, #958 `8903d50`+`f4a1eca`+`c8c929d`, #959 `cf8407a`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)