### PR TITLE
issue-roundup: fmt gate, islands default-alias fix, refresh-floor cuts

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# One-off cargo fmt --all reformat (style only, no logic changes)
+8c0b14a2714abb83b4d0c46e3123a06cef4dc8cf

--- a/.github/workflows/health.yml
+++ b/.github/workflows/health.yml
@@ -82,7 +82,14 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable (2026-03-27)
         with:
-          components: clippy
+          components: clippy, rustfmt
+
+      # Fmt gate (issue #988): near-free fail-fast check before the expensive
+      # rust-cache restore + V8 build. Note: cargo fmt --check on the stable
+      # toolchain can change behaviour on a future toolchain bump — accepted
+      # cost; same posture as `clippy -D warnings` (a future stable rustfmt
+      # can change defaults and turn CI red with zero code changes).
+      - run: cargo fmt --all --check
 
       # Cache compiled Rust artifacts across runs. The cache key encodes the
       # OS, Rust toolchain, and a hash of every Cargo.toml/Cargo.lock in the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5543,6 +5543,7 @@ dependencies = [
  "indicatif",
  "libc",
  "local-ip-address",
+ "lol_html",
  "owo-colors",
  "oxc_resolver",
  "reqwest",

--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -844,6 +844,23 @@ pub const ESBUILD_LOADER_ARGS: &[&str] = &[
 /// kept a private duplicate that has been removed in favour of this one.
 pub const DEFAULT_ESBUILD_SLOT: &str = "crates/zfb/binaries/esbuild/esbuild";
 
+/// `ZFB_DEV_TIMING` gate for the per-call [`bundle`] phase-split line
+/// (issue #993 Step 0 — extends the #991 instrumentation INSIDE the
+/// bundler). Same env var and truthy parser as the dev-tick timing in
+/// `crates/zfb/src/commands/dev.rs::dev_timing_enabled` so one flag turns
+/// on the whole timing story. Unset/empty/unrecognized → off, and every
+/// `Instant::now()` in [`bundle`] is behind the flag (zero hot-path cost).
+fn bundler_timing_enabled() -> bool {
+    std::env::var("ZFB_DEV_TIMING")
+        .ok()
+        .as_deref()
+        .map(|raw| {
+            let t = raw.trim();
+            t.eq_ignore_ascii_case("1") || t.eq_ignore_ascii_case("true")
+        })
+        .unwrap_or(false)
+}
+
 /// Bundle the user's source tree into a single ESM file.
 ///
 /// See the module-level documentation for the full pipeline.
@@ -952,7 +969,21 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
         project_root: &input.project_root,
     };
 
+    // `ZFB_DEV_TIMING=1` — per-call phase split (issue #993 Step 0):
+    // `materialise` (tempdir alloc + every materialise walk + diagnostics
+    // gates + css rewrite + entry/shim/tsconfig writes), `esbuild` (the
+    // subprocess), `post` (manifest assembly after the subprocess), and
+    // `teardown` (the shadow TempDir's recursive delete, timed via an
+    // explicit drop). One stderr line per successful call; error paths
+    // print nothing (the failed tick is reported by the caller anyway).
+    let timing_enabled = bundler_timing_enabled();
+
     // 2. Materialise the shadow tree.
+    let materialise_start = if timing_enabled {
+        Some(std::time::Instant::now())
+    } else {
+        None
+    };
     let work = tempfile::Builder::new()
         .prefix("zfb-bundler-")
         .tempdir()
@@ -1522,8 +1553,14 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
         },
     )
     .context("bundler: failed writing entry.mjs")?;
+    let materialise_ms = materialise_start.map(|t| t.elapsed().as_millis());
 
     // 6. Resolve and run esbuild (or the mock).
+    let esbuild_start = if timing_enabled {
+        Some(std::time::Instant::now())
+    } else {
+        None
+    };
     fs::create_dir_all(&outdir)
         .with_context(|| format!("bundler: failed to create outdir {}", outdir.display()))?;
     // Bundle filename — `bundle_basename` lets callers run two bundle()
@@ -1542,7 +1579,13 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
     } else {
         run_esbuild(&input, shadow, &bundle_path)?;
     }
+    let esbuild_ms = esbuild_start.map(|t| t.elapsed().as_millis());
 
+    let post_start = if timing_enabled {
+        Some(std::time::Instant::now())
+    } else {
+        None
+    };
     let manifest = BundleManifest {
         framework: adapter.name().to_string(),
         jsx_import_source: adapter.jsx_import_source().to_string(),
@@ -1554,6 +1597,28 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
             .to_string(),
         routes,
     };
+    let post_ms = post_start.map(|t| t.elapsed().as_millis());
+
+    // Teardown — the shadow TempDir's recursive delete. Dropped explicitly
+    // here (instead of implicitly at scope exit) so the unlink storm is
+    // measurable; behavior is identical (this is already the last use).
+    let teardown_start = if timing_enabled {
+        Some(std::time::Instant::now())
+    } else {
+        None
+    };
+    drop(work);
+    let teardown_ms = teardown_start.map(|t| t.elapsed().as_millis());
+
+    if timing_enabled {
+        eprintln!(
+            "[zfb-timing] bundle(): materialise={}ms esbuild={}ms post={}ms teardown={}ms",
+            materialise_ms.unwrap_or(0),
+            esbuild_ms.unwrap_or(0),
+            post_ms.unwrap_or(0),
+            teardown_ms.unwrap_or(0),
+        );
+    }
 
     Ok(BundlerOutput {
         bundle_path,

--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -893,6 +893,14 @@ fn bundler_timing_enabled() -> bool {
 ///   A session whose last call failed wipes the shadow dir and
 ///   materialises from scratch, so a half-updated tree can never feed
 ///   esbuild.
+/// - **Path-type flips heal in place**: a source path whose kind changes
+///   between calls (directory→file or file→directory) clears the stale
+///   shadow entry at write/mkdir time — recursively for directories,
+///   invalidating every `written` hash beneath — so the session succeeds
+///   on the same call a fresh [`bundle`] would, instead of erroring into
+///   the dirty-reset. Directories are never recorded in `visited` (the
+///   prune pass stays file-based); the prune tolerates a stale file path
+///   that a live directory has replaced.
 ///
 /// `zfb build` keeps calling [`bundle`], which passes no session — the
 /// production path is byte-for-byte unchanged.
@@ -1092,6 +1100,16 @@ impl<'s> ShadowWriter<'s> {
             // was last created as a symlink): remove first so we never
             // write THROUGH a symlink (#553).
             None => {
+                // A stale DIRECTORY at this path (directory→file source
+                // mutation during the dev session) would make the write
+                // fail until the next dirty wipe — a fresh bundle() would
+                // succeed immediately. Remove it recursively and drop
+                // every `written` hash beneath it, or a later write at a
+                // descendant path could be wrongly skipped.
+                if fs::symlink_metadata(to).is_ok_and(|m| m.is_dir()) {
+                    fs::remove_dir_all(to)?;
+                    session.written.retain(|p, _| !p.starts_with(&rel));
+                }
                 let _ = fs::remove_file(to);
                 fs::write(to, bytes)?;
                 session.written.insert(rel, hash);
@@ -1125,11 +1143,47 @@ impl<'s> ShadowWriter<'s> {
                 return Ok(());
             }
         }
+        // A stale DIRECTORY at this path (directory→file source mutation
+        // during the dev session) would make the symlink creation fail
+        // until the next dirty wipe. Remove it recursively and drop every
+        // `written` hash beneath it (see the matching block in
+        // `write_inner`). `symlink_metadata` reports a symlink-to-dir as
+        // a symlink, so only real directories take this branch — links
+        // are handled by `symlink_or_copy`'s remove-first.
+        if fs::symlink_metadata(to).is_ok_and(|m| m.is_dir()) {
+            fs::remove_dir_all(to)?;
+            cell.borrow_mut()
+                .written
+                .retain(|p, _| !p.starts_with(&rel));
+        }
         // (Re-)creating the link invalidates any recorded content hash:
         // the path's provenance is now "symlink", not "bytes we wrote",
         // so a later write_if_changed must take the remove-first branch.
         cell.borrow_mut().written.remove(&rel);
         symlink_or_copy(target, to)
+    }
+
+    /// Create the directory at `to` (and any missing parents). In session
+    /// mode a stale non-directory entry at `to` — a regular file, or a
+    /// symlink (which `create_dir_all` would FOLLOW, so a symlink whose
+    /// source path became a directory would alias the live source tree
+    /// and let later child writes escape the shadow — the #553 hazard) —
+    /// left by a previous call's file→directory source mutation is
+    /// removed first and its `written` hash dropped. Directories are NOT
+    /// recorded as visited: the prune pass stays file-based, and a stale
+    /// dir is instead cleared lazily by whichever later call needs a
+    /// file (`write_inner` / `symlink_if_absent`) or dir (here) at its
+    /// path. Passthrough mode is the plain pre-#993 `create_dir_all`
+    /// (the prod shadow tempdir is fresh, so no conflict can exist).
+    fn ensure_dir(&self, to: &Path) -> std::io::Result<()> {
+        if let Some(cell) = &self.session {
+            if fs::symlink_metadata(to).is_ok_and(|m| !m.is_dir()) {
+                fs::remove_file(to)?;
+                let rel = self.rel_of(to)?;
+                cell.borrow_mut().written.remove(&rel);
+            }
+        }
+        fs::create_dir_all(to)
     }
 
     /// Delete stale shadow files (`prev_visited − visited`) — MUST run
@@ -1155,6 +1209,45 @@ impl<'s> ShadowWriter<'s> {
                 continue;
             }
             let abs = self.shadow_root.join(&rel);
+            // Path-type flips (see the safety model on [`ShadowSession`])
+            // leave stale entries the plain remove_file below would choke
+            // on; discriminate via lstat first:
+            match fs::symlink_metadata(&abs) {
+                // file→dir flip: a materialise pass replaced the stale
+                // file with a LIVE directory this call (`ensure_dir`
+                // already deleted the file). Removing the dir would prune
+                // freshly-written output — keep it, drop the bookkeeping.
+                Ok(m) if m.is_dir() => {
+                    session.written.remove(&rel);
+                    continue;
+                }
+                Ok(_) => {}
+                // Already gone: deleted with an ancestor directory
+                // (dir→file flip removes whole subtrees — NotFound), or
+                // an ancestor is now a regular file so the path can no
+                // longer be traversed (NotADirectory). Nothing stale is
+                // on disk; drop the bookkeeping.
+                Err(e)
+                    if matches!(
+                        e.kind(),
+                        std::io::ErrorKind::NotFound | std::io::ErrorKind::NotADirectory
+                    ) =>
+                {
+                    session.written.remove(&rel);
+                    continue;
+                }
+                // Any other lstat failure: a stale file we cannot verify
+                // gone would feed esbuild wrong input — hard error, same
+                // self-healing contract as the remove_file arm below.
+                Err(e) => {
+                    return Err(e).with_context(|| {
+                        format!(
+                            "shadow session: failed to stat stale shadow path {}",
+                            abs.display()
+                        )
+                    });
+                }
+            }
             match fs::remove_file(&abs) {
                 Ok(()) => {}
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
@@ -2229,7 +2322,7 @@ fn symlink_or_copy(from: &Path, to: &Path) -> std::io::Result<()> {
 /// route through `writer` (#993) so the persistent shadow session skips
 /// byte-identical rewrites and tracks the files for the prune pass.
 fn copy_dir_recursive(src: &Path, dest: &Path, writer: &ShadowWriter<'_>) -> std::io::Result<()> {
-    fs::create_dir_all(dest)?;
+    writer.ensure_dir(dest)?;
     for entry in WalkDir::new(src)
         .follow_links(true)
         .into_iter()
@@ -2243,10 +2336,10 @@ fn copy_dir_recursive(src: &Path, dest: &Path, writer: &ShadowWriter<'_>) -> std
         };
         let to = dest.join(rel);
         if entry.file_type().is_dir() {
-            fs::create_dir_all(&to)?;
+            writer.ensure_dir(&to)?;
         } else if entry.file_type().is_file() {
             if let Some(parent) = to.parent() {
-                fs::create_dir_all(parent)?;
+                writer.ensure_dir(parent)?;
             }
             writer.copy_if_changed(from, &to)?;
         }
@@ -2322,7 +2415,9 @@ fn materialise_shadow(
         return Ok(());
     }
 
-    fs::create_dir_all(dest).with_context(|| format!("create dir {}", dest.display()))?;
+    ctx.writer
+        .ensure_dir(dest)
+        .with_context(|| format!("create dir {}", dest.display()))?;
     // Routes are only collected when the caller passed a `routes` vec
     // they actually intend to fill — by convention, only the call for
     // the pages root does this. We detect "is this the pages call?" by
@@ -2399,7 +2494,9 @@ fn materialise_shadow(
         let to = dest.join(rel);
 
         if entry.file_type().is_dir() {
-            fs::create_dir_all(&to).with_context(|| format!("create dir {}", to.display()))?;
+            ctx.writer
+                .ensure_dir(&to)
+                .with_context(|| format!("create dir {}", to.display()))?;
             continue;
         }
         if !entry.file_type().is_file() {
@@ -2920,7 +3017,9 @@ fn materialise_collection(
     if !src.exists() {
         return Ok(());
     }
-    fs::create_dir_all(dest).with_context(|| format!("create dir {}", dest.display()))?;
+    ctx.writer
+        .ensure_dir(dest)
+        .with_context(|| format!("create dir {}", dest.display()))?;
 
     // Compile the include / exclude globs once per collection. The
     // shared `CollectionFilter` MUST match `CollectionConfig::*` on the
@@ -2981,7 +3080,9 @@ fn materialise_collection(
         let to = dest.join(rel);
 
         if entry.file_type().is_dir() {
-            fs::create_dir_all(&to).with_context(|| format!("create dir {}", to.display()))?;
+            ctx.writer
+                .ensure_dir(&to)
+                .with_context(|| format!("create dir {}", to.display()))?;
             continue;
         }
         if !entry.file_type().is_file() {

--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -106,6 +106,7 @@
 //! instructing the operator to either set the env var or stage the
 //! binary in the slot.
 
+use std::cell::RefCell;
 use std::collections::{BTreeMap, HashMap};
 use std::ffi::OsString;
 use std::fs;
@@ -114,6 +115,7 @@ use std::process::Command;
 
 use anyhow::{anyhow, bail, Context, Result};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::collections::HashSet;
 use walkdir::WalkDir;
 
@@ -861,10 +863,346 @@ fn bundler_timing_enabled() -> bool {
         .unwrap_or(false)
 }
 
+/// Persistent dev shadow-tree session (issue #993).
+///
+/// A plain [`bundle`] call materialises a fresh shadow tempdir, re-writes
+/// every source file into it (~hundreds of creates/writes on a docs-sized
+/// site), and recursively deletes the whole tree at scope exit — pure
+/// filesystem churn when most bytes are unchanged between dev ticks. A
+/// `ShadowSession` keeps ONE shadow tempdir alive for the whole dev
+/// process and lets [`bundle_with_session`] skip byte-identical rewrites
+/// ("compute always, write only if changed" — spec locked by #992 on the
+/// #987 epic).
+///
+/// Safety model:
+///
+/// - **No computation is ever skipped.** Every materialise walk, MDX
+///   compile (cache-hit), `import.meta.glob` expansion, CSS-modules
+///   rewrite, diagnostics drain, and link gate runs exactly as in a fresh
+///   [`bundle`]. Glob expansion and transclude output depend on *other*
+///   files, so any stat-based computation skipping would be unsound. Only
+///   the final `fs::write` of byte-identical content is elided — the
+///   shadow tree (and therefore the bundle bytes, and therefore the #940
+///   skip key) stays byte-for-byte what a fresh build would produce.
+/// - **Stale files are pruned** before esbuild runs: every path written
+///   by the previous call but not visited by this one is deleted, so a
+///   deleted/renamed/newly-excluded source can never leave a stale module
+///   in the bundle (same wrong-output hazard family as #727).
+/// - **Dirty-reset on error** (false-invalidate, never false-reuse — the
+///   #940 spirit): `dirty` is armed on entry and cleared only on success.
+///   A session whose last call failed wipes the shadow dir and
+///   materialises from scratch, so a half-updated tree can never feed
+///   esbuild.
+///
+/// `zfb build` keeps calling [`bundle`], which passes no session — the
+/// production path is byte-for-byte unchanged.
+pub struct ShadowSession {
+    /// The persistent shadow tempdir — lives as long as the session.
+    work: tempfile::TempDir,
+    /// SHA-256 of the last-written bytes per shadow-relative path. Only
+    /// real files written through [`ShadowWriter`] are recorded; symlinks
+    /// and the always-write infra files (entry.mjs / shim / tsconfig)
+    /// are not.
+    written: HashMap<PathBuf, [u8; 32]>,
+    /// Shadow-relative paths visited by the previous call's materialise
+    /// passes — the prune baseline.
+    prev_visited: HashSet<PathBuf>,
+    /// `true` while a call is in flight or after a failed call; cleared
+    /// only when a call returns `Ok`.
+    dirty: bool,
+    /// `copy_mode` of the last call. A mode flip invalidates the whole
+    /// tree — symlink-mode and copy-mode materialise the same source
+    /// differently, so reusing across the flip would mix the two.
+    copy_mode: Option<bool>,
+}
+
+impl ShadowSession {
+    /// Allocate the persistent shadow tempdir for a dev session.
+    pub fn new() -> Result<Self> {
+        let work = tempfile::Builder::new()
+            .prefix("zfb-shadow-session-")
+            .tempdir()
+            .context("shadow session: failed to allocate persistent shadow tempdir")?;
+        Ok(Self {
+            work,
+            written: HashMap::new(),
+            prev_visited: HashSet::new(),
+            dirty: false,
+            copy_mode: None,
+        })
+    }
+
+    /// Root of the persistent shadow tree. Exposed for tests that assert
+    /// on the materialised/pruned file set.
+    pub fn shadow_root(&self) -> &Path {
+        self.work.path()
+    }
+}
+
+/// Remove every entry inside `dir` without removing `dir` itself.
+/// Symlinked children (e.g. the `node_modules` link) are removed as
+/// links, never followed into.
+fn wipe_dir_contents(dir: &Path) -> Result<()> {
+    let entries = fs::read_dir(dir).with_context(|| {
+        format!(
+            "shadow session: failed reading shadow dir {}",
+            dir.display()
+        )
+    })?;
+    for entry in entries {
+        let entry = entry.with_context(|| {
+            format!(
+                "shadow session: failed walking shadow dir {}",
+                dir.display()
+            )
+        })?;
+        let ft = entry.file_type().with_context(|| {
+            format!(
+                "shadow session: failed to stat shadow entry {}",
+                entry.path().display()
+            )
+        })?;
+        let result = if ft.is_dir() {
+            fs::remove_dir_all(entry.path())
+        } else {
+            // Files AND symlinks (symlink_metadata-based file_type reports
+            // a symlink-to-dir as symlink, not dir — remove_file is right).
+            fs::remove_file(entry.path())
+        };
+        result.with_context(|| {
+            format!(
+                "shadow session: failed to wipe shadow entry {}",
+                entry.path().display()
+            )
+        })?;
+    }
+    Ok(())
+}
+
+/// Conditional-write seam threaded through [`MaterialiseCtx`] to every
+/// materialise call (issue #993).
+///
+/// In passthrough mode (`session: None` — prod builds and sessionless
+/// callers) each method performs exactly the pre-#993 filesystem
+/// operation. In session mode it skips byte-identical rewrites, records
+/// each visited shadow-relative path for the prune pass, and maintains
+/// the session's `written` hash map.
+struct ShadowWriter<'s> {
+    shadow_root: PathBuf,
+    /// `None` → passthrough. `Some` wraps the borrowed session in a
+    /// `RefCell` so the `&MaterialiseCtx` plumbing (shared refs) can
+    /// still mutate the bookkeeping — all single-threaded within one
+    /// bundle call.
+    session: Option<RefCell<&'s mut ShadowSession>>,
+    /// Shadow-relative paths visited by THIS call (session mode only).
+    visited: RefCell<HashSet<PathBuf>>,
+}
+
+impl<'s> ShadowWriter<'s> {
+    /// Build the writer; in session mode also performs the dirty /
+    /// copy-mode-flip wipe and arms the dirty flag for this call.
+    fn new(
+        shadow_root: PathBuf,
+        session: Option<&'s mut ShadowSession>,
+        copy_mode: bool,
+    ) -> Result<Self> {
+        let session = match session {
+            Some(s) => {
+                if s.dirty || s.copy_mode != Some(copy_mode) {
+                    // Previous call failed mid-flight (or the symlink/copy
+                    // materialise mode flipped): the tree may be
+                    // half-updated, so it must never feed esbuild —
+                    // rebuild it from scratch this call.
+                    wipe_dir_contents(s.work.path())?;
+                    s.written.clear();
+                    s.prev_visited.clear();
+                }
+                s.copy_mode = Some(copy_mode);
+                // Armed for the whole call; cleared by `mark_clean()` only
+                // after esbuild succeeded. An early `?` return anywhere in
+                // `bundle_with_session` leaves it set, forcing the wipe
+                // above on the next call.
+                s.dirty = true;
+                Some(RefCell::new(s))
+            }
+            None => None,
+        };
+        Ok(Self {
+            shadow_root,
+            session,
+            visited: RefCell::new(HashSet::new()),
+        })
+    }
+
+    fn rel_of(&self, to: &Path) -> std::io::Result<PathBuf> {
+        to.strip_prefix(&self.shadow_root)
+            .map(|p| p.to_path_buf())
+            .map_err(|_| {
+                std::io::Error::other(format!(
+                    "shadow writer: {} is not under shadow root {}",
+                    to.display(),
+                    self.shadow_root.display()
+                ))
+            })
+    }
+
+    /// Write `bytes` at `to`, skipping the write when the session already
+    /// wrote identical bytes there. Records the path as visited.
+    fn write_if_changed(&self, to: &Path, bytes: &[u8]) -> std::io::Result<()> {
+        self.write_inner(to, bytes, true)
+    }
+
+    /// Variant for the in-place `.module.css` rewrite, which walks the
+    /// whole (possibly stale) shadow tree: it must NOT mark paths
+    /// visited — marking a stale file visited would shield it from the
+    /// prune. Legitimate `.module.css` files were already visited by
+    /// their materialise pass this call.
+    fn write_if_changed_no_visit(&self, to: &Path, bytes: &[u8]) -> std::io::Result<()> {
+        self.write_inner(to, bytes, false)
+    }
+
+    fn write_inner(&self, to: &Path, bytes: &[u8], mark_visited: bool) -> std::io::Result<()> {
+        let Some(cell) = &self.session else {
+            // Passthrough — pre-#993 semantics. The remove-first protects
+            // against writing THROUGH a pre-existing symlink into the
+            // user's source tree (#553); for the plain-write sites it is
+            // a no-op ENOENT unlink (the prod shadow tempdir is fresh).
+            let _ = fs::remove_file(to);
+            return fs::write(to, bytes);
+        };
+        let rel = self.rel_of(to)?;
+        if mark_visited {
+            self.visited.borrow_mut().insert(rel.clone());
+        }
+        let mut hasher = Sha256::new();
+        hasher.update(bytes);
+        let hash: [u8; 32] = hasher.finalize().into();
+        let mut session = cell.borrow_mut();
+        match session.written.get(&rel) {
+            // Identical bytes already on disk — the whole point: skip.
+            Some(prev) if *prev == hash => Ok(()),
+            // We wrote a (different) regular file here last time — plain
+            // overwrite is safe.
+            Some(_) => {
+                fs::write(to, bytes)?;
+                session.written.insert(rel, hash);
+                Ok(())
+            }
+            // Unknown provenance (first write at this path, or the path
+            // was last created as a symlink): remove first so we never
+            // write THROUGH a symlink (#553).
+            None => {
+                let _ = fs::remove_file(to);
+                fs::write(to, bytes)?;
+                session.written.insert(rel, hash);
+                Ok(())
+            }
+        }
+    }
+
+    /// Copy `from` to `to` through the write-if-changed logic (reads are
+    /// cheap relative to writes — the dev snapshot walk already reads
+    /// every content file each tick).
+    fn copy_if_changed(&self, from: &Path, to: &Path) -> std::io::Result<()> {
+        if self.session.is_none() {
+            let _ = fs::remove_file(to);
+            return fs::copy(from, to).map(|_| ());
+        }
+        let bytes = fs::read(from)?;
+        self.write_if_changed(to, &bytes)
+    }
+
+    /// Symlink `target` at `to`, re-creating only when the link is
+    /// missing or points elsewhere. Records the path as visited.
+    fn symlink_if_absent(&self, target: &Path, to: &Path) -> std::io::Result<()> {
+        let Some(cell) = &self.session else {
+            return symlink_or_copy(target, to);
+        };
+        let rel = self.rel_of(to)?;
+        self.visited.borrow_mut().insert(rel.clone());
+        if let Ok(existing) = fs::read_link(to) {
+            if existing == target {
+                return Ok(());
+            }
+        }
+        // (Re-)creating the link invalidates any recorded content hash:
+        // the path's provenance is now "symlink", not "bytes we wrote",
+        // so a later write_if_changed must take the remove-first branch.
+        cell.borrow_mut().written.remove(&rel);
+        symlink_or_copy(target, to)
+    }
+
+    /// Delete stale shadow files (`prev_visited − visited`) — MUST run
+    /// before esbuild so the bundle can never include a module a fresh
+    /// build would not (#727 hazard family). Also commits this call's
+    /// visited set as the next call's prune baseline.
+    fn prune_stale(&self) -> Result<()> {
+        let Some(cell) = &self.session else {
+            return Ok(());
+        };
+        let mut session = cell.borrow_mut();
+        let visited = std::mem::take(&mut *self.visited.borrow_mut());
+        let stale: Vec<PathBuf> = session.prev_visited.difference(&visited).cloned().collect();
+        for rel in stale {
+            // Never prune the node_modules link (defense in depth — the
+            // link bypasses the writer entirely, so it can never appear
+            // in `prev_visited`; keep the guard in case that changes).
+            if rel
+                .components()
+                .next()
+                .is_some_and(|c| c.as_os_str() == "node_modules")
+            {
+                continue;
+            }
+            let abs = self.shadow_root.join(&rel);
+            match fs::remove_file(&abs) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                // Any other failure is a hard error: a stale file we
+                // could not remove would feed esbuild wrong input. The
+                // error propagates, dirty stays armed, and the next call
+                // wipes the tree (self-healing).
+                Err(e) => {
+                    return Err(e).with_context(|| {
+                        format!(
+                            "shadow session: failed pruning stale shadow file {}",
+                            abs.display()
+                        )
+                    });
+                }
+            }
+            session.written.remove(&rel);
+        }
+        session.prev_visited = visited;
+        Ok(())
+    }
+
+    /// Success epilogue — the shadow tree now exactly matches this call's
+    /// inputs, so the next call may trust `written` / `prev_visited`.
+    fn mark_clean(&self) {
+        if let Some(cell) = &self.session {
+            cell.borrow_mut().dirty = false;
+        }
+    }
+}
+
 /// Bundle the user's source tree into a single ESM file.
 ///
-/// See the module-level documentation for the full pipeline.
+/// See the module-level documentation for the full pipeline. Production
+/// path: materialises a fresh shadow tempdir per call (no session) —
+/// byte-for-byte the pre-#993 behaviour.
 pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
+    bundle_with_session(input, None)
+}
+
+/// [`bundle`] with an optional persistent dev [`ShadowSession`]
+/// (issue #993). `None` is the production path; `Some` reuses the
+/// session's shadow tree across calls, skipping byte-identical rewrites
+/// and pruning stale files. See [`ShadowSession`] for the safety model.
+pub fn bundle_with_session(
+    input: BundlerInput,
+    session: Option<&mut ShadowSession>,
+) -> Result<BundlerOutput> {
     // 1. Resolve & validate.
     let resolver = PathResolver::new(&input.project_root);
     let pages_dir = resolver.resolve(&input.pages_dir);
@@ -958,16 +1296,7 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
     // `None` otherwise) — the bundler owns that knob, so a caller-set
     // value on `input.pipeline_spec` can never desync from the route
     // spec (zfb#917).
-    let mat_ctx = MaterialiseCtx {
-        pipeline_spec: {
-            let mut spec = input.pipeline_spec.clone();
-            spec.resolve_source_map = resolve_source_map;
-            spec
-        },
-        copy_mode,
-        bundle_exclude: &bundle_exclude,
-        project_root: &input.project_root,
-    };
+    // (constructed below, after the shadow root and writer exist)
 
     // `ZFB_DEV_TIMING=1` — per-call phase split (issue #993 Step 0):
     // `materialise` (tempdir alloc + every materialise walk + diagnostics
@@ -979,16 +1308,41 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
     let timing_enabled = bundler_timing_enabled();
 
     // 2. Materialise the shadow tree.
+    //
+    // Sessionless (prod): a fresh tempdir per call, recursively deleted at
+    // the end (`owned_work`). Session mode (#993): reuse the session's
+    // persistent tempdir; `ShadowWriter::new` handles the dirty-wipe and
+    // arms the dirty flag.
     let materialise_start = if timing_enabled {
         Some(std::time::Instant::now())
     } else {
         None
     };
-    let work = tempfile::Builder::new()
-        .prefix("zfb-bundler-")
-        .tempdir()
-        .context("bundler: failed to allocate shadow tempdir")?;
-    let shadow = work.path();
+    let (owned_work, shadow) = match &session {
+        Some(s) => (None, s.work.path().to_path_buf()),
+        None => {
+            let work = tempfile::Builder::new()
+                .prefix("zfb-bundler-")
+                .tempdir()
+                .context("bundler: failed to allocate shadow tempdir")?;
+            let path = work.path().to_path_buf();
+            (Some(work), path)
+        }
+    };
+    let shadow: &Path = &shadow;
+    let writer = ShadowWriter::new(shadow.to_path_buf(), session, copy_mode)?;
+
+    let mat_ctx = MaterialiseCtx {
+        pipeline_spec: {
+            let mut spec = input.pipeline_spec.clone();
+            spec.resolve_source_map = resolve_source_map;
+            spec
+        },
+        copy_mode,
+        bundle_exclude: &bundle_exclude,
+        project_root: &input.project_root,
+        writer: &writer,
+    };
 
     let shadow_pages = shadow.join("pages");
     let shadow_content = shadow.join("content");
@@ -1223,13 +1577,29 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
     if let Some(ref nm_dir) = input.node_modules_dir {
         let shadow_nm = shadow.join("node_modules");
         #[cfg(unix)]
-        std::os::unix::fs::symlink(nm_dir, &shadow_nm).with_context(|| {
-            format!(
-                "bundler: failed to symlink node_modules {} → {}",
-                nm_dir.display(),
-                shadow_nm.display()
-            )
-        })?;
+        {
+            // Session mode (#993) reuses the persistent shadow across
+            // calls, so the link usually already exists — re-creating it
+            // unconditionally would fail with AlreadyExists. Recreate only
+            // when missing or pointing elsewhere. (Sessionless path: the
+            // tempdir is fresh, read_link fails, behaviour is identical
+            // to the previous unconditional symlink.) The link bypasses
+            // the ShadowWriter bookkeeping entirely — the prune pass can
+            // never see it, and guards against it anyway.
+            let already_correct = fs::read_link(&shadow_nm)
+                .map(|t| &t == nm_dir)
+                .unwrap_or(false);
+            if !already_correct {
+                let _ = fs::remove_file(&shadow_nm);
+                std::os::unix::fs::symlink(nm_dir, &shadow_nm).with_context(|| {
+                    format!(
+                        "bundler: failed to symlink node_modules {} → {}",
+                        nm_dir.display(),
+                        shadow_nm.display()
+                    )
+                })?;
+            }
+        }
         #[cfg(not(unix))]
         {
             // On Windows, attempt a directory junction.
@@ -1456,8 +1826,13 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
     //     `import styles from "./x.module.css"; styles.foo` resolve to
     //     the scoped class string at bundle time. See the module-level
     //     `ESBUILD_LOADER_ARGS` doc and `BundlerInput::css_module_class_maps`.
-    rewrite_css_modules_in_shadow(shadow, &input.project_root, &input.css_module_class_maps)
-        .context("bundler: failed rewriting CSS Modules in shadow tree")?;
+    rewrite_css_modules_in_shadow(
+        shadow,
+        &input.project_root,
+        &input.css_module_class_maps,
+        &writer,
+    )
+    .context("bundler: failed rewriting CSS Modules in shadow tree")?;
 
     // 2f. Project-root `mdx-components.tsx` global override map (#616).
     //     A root-level FILE is not materialised by any pass above, so copy
@@ -1468,13 +1843,18 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
     //     without the convention.
     let mdx_components_import_spec: Option<String> = match input.mdx_components_file.as_ref() {
         Some(src) => Some(
-            materialise_mdx_components_file(src, shadow)
+            materialise_mdx_components_file(src, shadow, &writer)
                 .context("bundler: failed materialising mdx-components.tsx into shadow")?,
         ),
         None => None,
     };
 
     // 3. Hydration shim.
+    //
+    // Always-write infra file: written unconditionally every call (like
+    // the tsconfig and entry.mjs below), so it bypasses the #993
+    // ShadowWriter — never recorded as visited, therefore never eligible
+    // for the prune pass, which only deletes previously-visited paths.
     let shim_path = shadow.join(SHADOW_HYDRATE_FILENAME);
     fs::write(&shim_path, adapter.hydrate_shim_source()).with_context(|| {
         format!(
@@ -1553,6 +1933,17 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
         },
     )
     .context("bundler: failed writing entry.mjs")?;
+
+    // 5b. Prune stale shadow files (#993 — session mode only, no-op
+    //     otherwise). MUST run before esbuild: a deleted/renamed/newly-
+    //     excluded source's compiled artifact would otherwise stay in the
+    //     persistent tree and esbuild would bundle a module a fresh build
+    //     would not (the #727 wrong-output hazard family). Runs after ALL
+    //     materialise passes so the visited set is complete; the
+    //     `.zfb-virtual-*.mjs` NamedTempFiles are created inside
+    //     `run_esbuild` AFTER this pass and self-delete — they never
+    //     interact with the prune.
+    writer.prune_stale()?;
     let materialise_ms = materialise_start.map(|t| t.elapsed().as_millis());
 
     // 6. Resolve and run esbuild (or the mock).
@@ -1599,15 +1990,21 @@ pub fn bundle(input: BundlerInput) -> Result<BundlerOutput> {
     };
     let post_ms = post_start.map(|t| t.elapsed().as_millis());
 
+    // The whole call succeeded — the session's shadow tree exactly matches
+    // this call's inputs, so the next call may reuse it (dirty cleared).
+    writer.mark_clean();
+
     // Teardown — the shadow TempDir's recursive delete. Dropped explicitly
     // here (instead of implicitly at scope exit) so the unlink storm is
     // measurable; behavior is identical (this is already the last use).
+    // Session mode: `owned_work` is `None` (the persistent tree outlives
+    // the call), so teardown is ~0ms by construction.
     let teardown_start = if timing_enabled {
         Some(std::time::Instant::now())
     } else {
         None
     };
-    drop(work);
+    drop(owned_work);
     let teardown_ms = teardown_start.map(|t| t.elapsed().as_millis());
 
     if timing_enabled {
@@ -1759,9 +2156,18 @@ fn enumerate_extra_top_level_dirs(project_root: &Path, known_skip_list: &[&str])
 ///
 /// Returns the shadow-relative import specifier (always
 /// `./mdx-components.tsx`) that the synthetic `entry.mjs` imports.
-fn materialise_mdx_components_file(src: &Path, shadow: &Path) -> Result<String> {
+fn materialise_mdx_components_file(
+    src: &Path,
+    shadow: &Path,
+    writer: &ShadowWriter<'_>,
+) -> Result<String> {
     let dst = shadow.join(MDX_COMPONENTS_FILENAME);
-    fs::copy(src, &dst).with_context(|| {
+    // Routed through the #993 writer (NOT an always-write infra file):
+    // the override file is user-deletable, so it must take part in the
+    // visited/prune bookkeeping — a deleted mdx-components.tsx must
+    // vanish from the persistent shadow, else an explicit user import of
+    // it would resolve in dev but fail in a fresh build.
+    writer.copy_if_changed(src, &dst).with_context(|| {
         format!(
             "bundler: failed copying mdx-components file {} → {}",
             src.display(),
@@ -1821,8 +2227,10 @@ fn symlink_or_copy(from: &Path, to: &Path) -> std::io::Result<()> {
 ///
 /// Uses `follow_links(true)` so the subtree's own contents (including any
 /// nested symlinks) are dereferenced and written as real files. Infra dirs
-/// are pruned with the same predicate the top-level walks use.
-fn copy_dir_recursive(src: &Path, dest: &Path) -> std::io::Result<()> {
+/// are pruned with the same predicate the top-level walks use. Copies
+/// route through `writer` (#993) so the persistent shadow session skips
+/// byte-identical rewrites and tracks the files for the prune pass.
+fn copy_dir_recursive(src: &Path, dest: &Path, writer: &ShadowWriter<'_>) -> std::io::Result<()> {
     fs::create_dir_all(dest)?;
     for entry in WalkDir::new(src)
         .follow_links(true)
@@ -1842,8 +2250,7 @@ fn copy_dir_recursive(src: &Path, dest: &Path) -> std::io::Result<()> {
             if let Some(parent) = to.parent() {
                 fs::create_dir_all(parent)?;
             }
-            let _ = fs::remove_file(&to);
-            fs::copy(from, &to)?;
+            writer.copy_if_changed(from, &to)?;
         }
     }
     Ok(())
@@ -1859,8 +2266,9 @@ fn copy_dir_recursive(src: &Path, dest: &Path) -> std::io::Result<()> {
 ///
 /// Lifetime `'a` is the lifetime of the references borrowed from the
 /// [`bundle`] stack frame (i.e. `&BundlerInput` fields and the
-/// `bundle_exclude` local).
-struct MaterialiseCtx<'a> {
+/// `bundle_exclude` / `writer` locals); `'s` is the [`ShadowSession`]
+/// borrow inside the writer (invariant, so it cannot be folded into `'a`).
+struct MaterialiseCtx<'a, 's> {
     /// Effective pipeline knob set shared by all MDX compile calls —
     /// `input.pipeline_spec` with `resolve_source_map` rewritten from
     /// `input.resolve_markdown_links` (see [`bundle`]). Both walkers
@@ -1880,6 +2288,11 @@ struct MaterialiseCtx<'a> {
     /// Project root — used by `materialise_shadow` for the `bundle.exclude`
     /// relativisation step.
     project_root: &'a Path,
+    /// Conditional-write seam (#993): passthrough for prod, write-if-
+    /// changed + visited bookkeeping for the persistent dev shadow
+    /// session. Every shadow write in the materialise passes routes
+    /// through this.
+    writer: &'a ShadowWriter<'s>,
 }
 
 /// Recursively copy `src` into `dest`, transforming `.mdx` files via
@@ -1897,7 +2310,7 @@ fn materialise_shadow(
     src: &Path,
     dest: &Path,
     routes: &mut Vec<RouteEntry>,
-    ctx: &MaterialiseCtx<'_>,
+    ctx: &MaterialiseCtx<'_, '_>,
     broken_links_out: &mut Vec<(String, String)>,
     markdown_diagnostics_out: &mut Vec<MarkdownDiagnostic>,
     cross_file_links_out: &mut Vec<CrossFileLinkCandidate>,
@@ -2004,7 +2417,7 @@ fn materialise_shadow(
             // Explicitly copy the symlinked subtree as real files in that
             // mode. Low-frequency, but a hole otherwise.
             if ctx.copy_mode && entry.path_is_symlink() && from.is_dir() {
-                copy_dir_recursive(from, &to).with_context(|| {
+                copy_dir_recursive(from, &to, ctx.writer).with_context(|| {
                     format!(
                         "bundler: failed copying symlinked subdir {} -> {} under copy_mode",
                         from.display(),
@@ -2102,7 +2515,8 @@ fn materialise_shadow(
             // build-wide after ALL walks complete (gate 2c-anchor).
             cross_file_links_out.extend(pipeline.take_cross_file_link_candidates());
             file_headings_out.extend(pipeline.take_file_headings());
-            fs::write(&to, compiled.jsx_source.as_bytes())
+            ctx.writer
+                .write_if_changed(&to, compiled.jsx_source.as_bytes())
                 .with_context(|| format!("write compiled mdx to {}", to.display()))?;
         } else if is_md && is_pages_dir {
             // .md page: compile via the MDX pipeline then wrap in a minimal
@@ -2175,14 +2589,16 @@ fn materialise_shadow(
                 .parent()
                 .map(|p| p.join(&body_filename))
                 .unwrap_or_else(|| PathBuf::from(&body_filename));
-            fs::write(&body_shadow_path, compiled.jsx_source.as_bytes())
+            ctx.writer
+                .write_if_changed(&body_shadow_path, compiled.jsx_source.as_bytes())
                 .with_context(|| format!("write md body to {}", body_shadow_path.display()))?;
             // Shell module at the original `.md` shadow path.
             // Prefix the body import with "./" so esbuild resolves it as a
             // relative path (bare names are interpreted as package specifiers).
             let body_import = format!("./{body_filename}");
             let shell = render_md_page_shell(&frontmatter_value, &slug_fallback, &body_import);
-            fs::write(&to, shell.as_bytes())
+            ctx.writer
+                .write_if_changed(&to, shell.as_bytes())
                 .with_context(|| format!("write md page shell to {}", to.display()))?;
         } else {
             // Non-MDX source: copy/symlink, expanding eager
@@ -2191,7 +2607,7 @@ fn materialise_shadow(
             // threaded into the glob expansion (#665's `is_excluded` seam) so
             // an excluded file is never emitted as a static import — which
             // would otherwise make esbuild error on the generated import.
-            materialise_source_file(from, &to, &is_excluded, ctx.copy_mode)?;
+            materialise_source_file(from, &to, &is_excluded, ctx.copy_mode, ctx.writer)?;
         }
 
         // Routes only collected from the pages root.
@@ -2355,6 +2771,7 @@ fn rewrite_css_modules_in_shadow(
     shadow: &Path,
     project_root: &Path,
     class_maps: &HashMap<PathBuf, HashMap<String, String>>,
+    writer: &ShadowWriter<'_>,
 ) -> Result<()> {
     // FIX #553: use `entry.path().is_file()` instead of
     // `entry.file_type().is_file()` so .module.css symlinks materialised
@@ -2396,26 +2813,26 @@ fn rewrite_css_modules_in_shadow(
         let names = class_maps.get(&original);
         let js = render_css_module_js(names);
 
-        // FIX #553 (critical): replace the symlink in the shadow before
-        // writing, so we never write THROUGH the symlink and corrupt
-        // the user's source file in the project root. Mirrors the same
-        // pattern used by symlink_or_copy (bundler.rs:1385).
+        // FIX #553 (critical): never write THROUGH the symlink (that
+        // would corrupt the user's source file in the project root).
+        // `write_if_changed*` preserves this contract in both modes:
+        // passthrough removes the entry first unconditionally; session
+        // mode removes it whenever the path's last recorded provenance
+        // is not "bytes we wrote" (a fresh symlink drops the record).
         //
-        // The error is intentionally discarded with `let _ =`, NOT
-        // `?`: when the shadow entry is a regular file (no symlink to
-        // remove) or NotFound (already gone), the subsequent
-        // `fs::write` will succeed and overwrite cleanly. A real
-        // permission or filesystem failure will surface immediately on
-        // the `fs::write` call below with a useful error context. Do
-        // not "helpfully" change this to `?` — it would convert
-        // benign NotFound cases into spurious build failures.
-        let _ = fs::remove_file(path);
-        fs::write(path, js.as_bytes()).with_context(|| {
-            format!(
-                "bundler: failed writing CSS Modules JS shim to {}",
-                path.display()
-            )
-        })?;
+        // `_no_visit` variant (#993): this walk visits the WHOLE shadow
+        // tree, including files whose source was deleted this tick —
+        // marking those visited would shield them from the prune pass.
+        // Legit `.module.css` files were already marked visited by their
+        // materialise pass.
+        writer
+            .write_if_changed_no_visit(path, js.as_bytes())
+            .with_context(|| {
+                format!(
+                    "bundler: failed writing CSS Modules JS shim to {}",
+                    path.display()
+                )
+            })?;
     }
     Ok(())
 }
@@ -2493,7 +2910,7 @@ fn materialise_collection(
     dest: &Path,
     collection_name: &str,
     imports: &mut Vec<ContentImport>,
-    ctx: &MaterialiseCtx<'_>,
+    ctx: &MaterialiseCtx<'_, '_>,
     include: Option<&[String]>,
     exclude: Option<&[String]>,
     id_strip_suffix: Option<&str>,
@@ -2574,7 +2991,7 @@ fn materialise_collection(
             // stays mirrored in the shadow (see the matching block in
             // `materialise_shadow`).
             if ctx.copy_mode && entry.path_is_symlink() && from.is_dir() {
-                copy_dir_recursive(from, &to).with_context(|| {
+                copy_dir_recursive(from, &to, ctx.writer).with_context(|| {
                     format!(
                         "bundler: failed copying symlinked subdir {} -> {} under copy_mode",
                         from.display(),
@@ -2683,7 +3100,8 @@ fn materialise_collection(
             // Drain cross-file anchor-check side channels (#980).
             cross_file_links_out.extend(pipeline.take_cross_file_link_candidates());
             file_headings_out.extend(pipeline.take_file_headings());
-            fs::write(&to, compiled.jsx_source.as_bytes())
+            ctx.writer
+                .write_if_changed(&to, compiled.jsx_source.as_bytes())
                 .with_context(|| format!("write compiled mdx to {}", to.display()))?;
 
             // Defensive skip — see [`jsx_likely_breaks_downstream_parser`].
@@ -2729,7 +3147,7 @@ fn materialise_collection(
         } else {
             // Non-MDX source in a content collection: same eager
             // `import.meta.glob(...)` expansion as the page/component pass.
-            materialise_source_file(from, &to, &|_| false, ctx.copy_mode)?;
+            materialise_source_file(from, &to, &|_| false, ctx.copy_mode, ctx.writer)?;
         }
     }
     Ok(())
@@ -3050,6 +3468,7 @@ fn materialise_source_file(
     to: &Path,
     is_excluded: &dyn Fn(&Path) -> bool,
     copy_mode: bool,
+    writer: &ShadowWriter<'_>,
 ) -> Result<()> {
     let is_js_like = matches!(
         from.extension().and_then(|s| s.to_str()),
@@ -3064,10 +3483,14 @@ fn materialise_source_file(
                 let file_dir = from.parent().unwrap_or_else(|| Path::new("."));
                 let expanded = expand_import_meta_glob(&source, file_dir, is_excluded)
                     .with_context(|| format!("expand import.meta.glob in {}", from.display()))?;
-                // Remove any pre-existing entry (e.g. a stale symlink from a
-                // prior persistent-shadow pass) before writing the real file.
-                let _ = fs::remove_file(to);
-                fs::write(to, expanded.as_bytes())
+                // The expansion is recomputed from the LIVE project tree on
+                // every call (glob output depends on *other* files), so the
+                // #993 write-if-changed skip is sound: a glob-matched file
+                // appearing/vanishing changes `expanded` and forces the
+                // write. The writer's remove-first handles a pre-existing
+                // stale symlink at `to`.
+                writer
+                    .write_if_changed(to, expanded.as_bytes())
                     .with_context(|| format!("write expanded source to {}", to.display()))?;
                 return Ok(());
             }
@@ -3077,12 +3500,12 @@ fn materialise_source_file(
         // Force a real copy so esbuild (running WITHOUT --preserve-symlinks)
         // reads this file — and any in-shadow transform it relatively imports
         // — from the shadow tree, not the canonicalised original.
-        let _ = fs::remove_file(to);
-        fs::copy(from, to)
-            .map(|_| ())
+        writer
+            .copy_if_changed(from, to)
             .with_context(|| format!("copy (copy_mode) {} -> {}", from.display(), to.display()))
     } else {
-        symlink_or_copy(from, to)
+        writer
+            .symlink_if_absent(from, to)
             .with_context(|| format!("symlink_or_copy {} -> {}", from.display(), to.display()))
     }
 }
@@ -4567,7 +4990,13 @@ mod tests {
         let mut maps = HashMap::new();
         maps.insert(project_root.join("components/card.module.css"), names);
 
-        rewrite_css_modules_in_shadow(shadow_root, project_root, &maps).unwrap();
+        rewrite_css_modules_in_shadow(
+            shadow_root,
+            project_root,
+            &maps,
+            leaked_passthrough_writer(),
+        )
+        .unwrap();
 
         let mapped = fs::read_to_string(shadow_root.join("components/card.module.css")).unwrap();
         assert!(mapped.contains("sc0_card"), "mapped module: {mapped}");
@@ -5159,7 +5588,8 @@ mod tests {
         let shadow = tempfile::tempdir().unwrap();
         let shadow_root = shadow.path();
 
-        let spec = materialise_mdx_components_file(&src, shadow_root).unwrap();
+        let spec = materialise_mdx_components_file(&src, shadow_root, leaked_passthrough_writer())
+            .unwrap();
         assert_eq!(spec, "./mdx-components.tsx");
 
         // A real copy lands in the shadow root (so esbuild resolves its
@@ -7505,13 +7935,30 @@ mod tests {
     fn default_mat_ctx<'a>(
         project_root: &'a Path,
         exclude: &'a BundleExcludeMatcher,
-    ) -> MaterialiseCtx<'a> {
+    ) -> MaterialiseCtx<'a, 'static> {
         MaterialiseCtx {
             pipeline_spec: zfb_content::PipelineSpec::default(),
             copy_mode: false,
             bundle_exclude: exclude,
             project_root,
+            writer: leaked_passthrough_writer(),
         }
+    }
+
+    /// Sessionless `ShadowWriter` for test call sites — passthrough mode
+    /// performs exactly the pre-#993 fs operations. Leaked (`Box::leak`)
+    /// so `default_mat_ctx` can hand out a `'static` borrow without
+    /// changing its many call sites; the struct is a few words, leaked
+    /// once per test call.
+    fn leaked_passthrough_writer() -> &'static ShadowWriter<'static> {
+        Box::leak(Box::new(
+            ShadowWriter::new(
+                PathBuf::from("/nonexistent-passthrough-shadow"),
+                None,
+                false,
+            )
+            .expect("passthrough writer construction is infallible"),
+        ))
     }
 
     /// Create a tempdir, write `(rel, body)` files (creating parent dirs),

--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -1286,18 +1286,6 @@ pub fn bundle_with_session(
     // knob. An invalid glob is a hard, clearly-named build error.
     let bundle_exclude = BundleExcludeMatcher::new(&input.bundle_exclude)?;
 
-    // Build the shared materialisation context from the fields of `input`
-    // that are invariant across every materialise_shadow / materialise_collection
-    // call in this bundle() invocation.
-    //
-    // The effective `PipelineSpec` is the input spec with its
-    // `resolve_source_map` knob ALWAYS rewritten from the derivation
-    // above (`Some(map)` when `resolve_markdown_links` is configured,
-    // `None` otherwise) — the bundler owns that knob, so a caller-set
-    // value on `input.pipeline_spec` can never desync from the route
-    // spec (zfb#917).
-    // (constructed below, after the shadow root and writer exist)
-
     // `ZFB_DEV_TIMING=1` — per-call phase split (issue #993 Step 0):
     // `materialise` (tempdir alloc + every materialise walk + diagnostics
     // gates + css rewrite + entry/shim/tsconfig writes), `esbuild` (the
@@ -1332,6 +1320,16 @@ pub fn bundle_with_session(
     let shadow: &Path = &shadow;
     let writer = ShadowWriter::new(shadow.to_path_buf(), session, copy_mode)?;
 
+    // Build the shared materialisation context from the fields of `input`
+    // that are invariant across every materialise_shadow / materialise_collection
+    // call in this bundle invocation.
+    //
+    // The effective `PipelineSpec` is the input spec with its
+    // `resolve_source_map` knob ALWAYS rewritten from the derivation
+    // above (`Some(map)` when `resolve_markdown_links` is configured,
+    // `None` otherwise) — the bundler owns that knob, so a caller-set
+    // value on `input.pipeline_spec` can never desync from the route
+    // spec (zfb#917).
     let mat_ctx = MaterialiseCtx {
         pipeline_spec: {
             let mut spec = input.pipeline_spec.clone();

--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -1178,8 +1178,11 @@ impl<'s> ShadowWriter<'s> {
     fn ensure_dir(&self, to: &Path) -> std::io::Result<()> {
         if let Some(cell) = &self.session {
             if fs::symlink_metadata(to).is_ok_and(|m| !m.is_dir()) {
-                fs::remove_file(to)?;
+                // Validate the path is shadow-relative BEFORE the
+                // destructive removal (rel_of rejects out-of-shadow
+                // paths — none exist today, but never delete first).
                 let rel = self.rel_of(to)?;
+                fs::remove_file(to)?;
                 cell.borrow_mut().written.remove(&rel);
             }
         }

--- a/crates/zfb-build/src/lib.rs
+++ b/crates/zfb-build/src/lib.rs
@@ -67,9 +67,9 @@ pub use adapter::{
 };
 pub use atomic::{atomic_write, atomic_write_string, validate_output_path};
 pub use bundler::{
-    bundle, resolve_esbuild_binary_with_env, BundleManifest, BundleMode, BundlerInput,
-    BundlerOutput, ContentCollectionSpec, OnBrokenLinks, ResolveMarkdownLinksRoute,
-    ResolveMarkdownLinksSpec, RouteEntry, DEFAULT_ESBUILD_SLOT,
+    bundle, bundle_with_session, resolve_esbuild_binary_with_env, BundleManifest, BundleMode,
+    BundlerInput, BundlerOutput, ContentCollectionSpec, OnBrokenLinks, ResolveMarkdownLinksRoute,
+    ResolveMarkdownLinksSpec, RouteEntry, ShadowSession, DEFAULT_ESBUILD_SLOT,
 };
 pub use head_inject::{
     css_link_tag, inject_prod_head_assets, island_module_script_tag, needs_html5_doctype,

--- a/crates/zfb-build/tests/bundler_shadow_session.rs
+++ b/crates/zfb-build/tests/bundler_shadow_session.rs
@@ -342,6 +342,188 @@ fn shadow_session_dirty_resets_after_error() {
     );
 }
 
+/// Path-type-flip regression (#987 review): a source path whose kind
+/// changes between two `bundle_with_session` calls (directory→file and
+/// file→directory) must succeed on the SAME call a fresh `bundle()`
+/// would — not error into the dirty-reset — and stay byte-identical to
+/// fresh. The widgets round-trip also pins `written`-hash invalidation:
+/// w1.ts is recreated with its ORIGINAL bytes, so a stale surviving hash
+/// would wrongly skip the re-write and drop the module from the bundle.
+#[test]
+fn shadow_session_survives_path_type_flips() {
+    let Some(esbuild) = locate_esbuild() else {
+        eprintln!(
+            "[shadow_session_survives_path_type_flips] no esbuild binary; \
+             set ZFB_ESBUILD_BIN, stage the slot, or install esbuild on PATH. Skipping."
+        );
+        return;
+    };
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write_fixture(root);
+    // Extensionless page-tree file that will flip into a directory later.
+    fs::write(root.join("pages/sub"), "placeholder, not a module\n").unwrap();
+
+    let mut session = ShadowSession::new().unwrap();
+
+    let mut assert_equal_bytes = |step: &str| {
+        let session_out = bundle_with_session(
+            make_input(root, Some(&esbuild), "dist-session"),
+            Some(&mut session),
+        )
+        .unwrap_or_else(|e| panic!("session bundle failed at step `{step}`: {e:#}"));
+        let fresh_out = bundle(make_input(root, Some(&esbuild), "dist-fresh"))
+            .unwrap_or_else(|e| panic!("fresh bundle failed at step `{step}`: {e:#}"));
+        let session_bytes = fs::read(&session_out.bundle_path).unwrap();
+        let fresh_bytes = fs::read(&fresh_out.bundle_path).unwrap();
+        assert_eq!(
+            session_bytes, fresh_bytes,
+            "session vs fresh bundle bytes diverged at step `{step}`"
+        );
+        session_bytes
+    };
+
+    assert_equal_bytes("baseline");
+
+    // directory→file: the glob-matched widgets DIR becomes a plain file
+    // at the same path. The stale shadow dir (with w1.ts inside) must be
+    // cleared at write time, and the prune must tolerate the now-gone
+    // w1.ts child whose ancestor is a file.
+    fs::remove_dir_all(root.join("components/widgets")).unwrap();
+    fs::write(root.join("components/widgets"), "not a directory anymore\n").unwrap();
+    let bytes = assert_equal_bytes("widgets dir→file");
+    assert!(
+        !String::from_utf8_lossy(&bytes).contains("w1"),
+        "bundle must drop the glob-matched widget after its dir became a file"
+    );
+
+    // file→directory (restore): w1.ts comes back with its ORIGINAL
+    // bytes. ensure_dir must clear the stale file, and the invalidated
+    // `written` hash must force a real re-write (a stale hash would skip
+    // it and leave the module missing).
+    fs::remove_file(root.join("components/widgets")).unwrap();
+    fs::create_dir_all(root.join("components/widgets")).unwrap();
+    fs::write(
+        root.join("components/widgets/w1.ts"),
+        "export const name = \"w1\";\n",
+    )
+    .unwrap();
+    let bytes = assert_equal_bytes("widgets file→dir restore");
+    assert!(
+        String::from_utf8_lossy(&bytes).contains("w1"),
+        "restored glob-matched widget must re-enter the bundle"
+    );
+
+    // file→directory on the pages tree: the flip produces a NEW route,
+    // so the change is observable in the bundle bytes.
+    fs::remove_file(root.join("pages/sub")).unwrap();
+    fs::create_dir_all(root.join("pages/sub")).unwrap();
+    fs::write(
+        root.join("pages/sub/index.tsx"),
+        "export default function Sub() { return <p>sub-route-page</p>; }\n",
+    )
+    .unwrap();
+    let bytes = assert_equal_bytes("pages/sub file→dir");
+    assert!(
+        String::from_utf8_lossy(&bytes).contains("sub-route-page"),
+        "page added via the file→dir flip must be bundled"
+    );
+
+    // directory→file back: the route must vanish again.
+    fs::remove_dir_all(root.join("pages/sub")).unwrap();
+    fs::write(root.join("pages/sub"), "placeholder again\n").unwrap();
+    let bytes = assert_equal_bytes("pages/sub dir→file");
+    assert!(
+        !String::from_utf8_lossy(&bytes).contains("sub-route-page"),
+        "page removed via the dir→file flip must leave the bundle"
+    );
+}
+
+/// Esbuild-free companion to the flip test above (mirrors the prune
+/// test's `mock_subprocess_output` pattern): asserts the SHADOW TREE
+/// shape directly across directory→file / file→directory mutations, for
+/// both the pages walk and a content-collection walk.
+#[test]
+fn shadow_session_path_type_flips_update_shadow_tree() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write_fixture(root);
+    fs::write(root.join("content/posts/media"), "extensionless asset\n").unwrap();
+
+    let mock_input = || BundlerInput {
+        mock_subprocess_output: Some("export default {};".to_string()),
+        ..make_input(root, None, "dist-session")
+    };
+    let mut session = ShadowSession::new().unwrap();
+    bundle_with_session(mock_input(), Some(&mut session)).unwrap();
+
+    let shadow = session.shadow_root().to_path_buf();
+    let widgets = shadow.join("components/widgets");
+    let w1 = shadow.join("components/widgets/w1.ts");
+    let media = shadow.join("content/posts/media");
+    // symlink_metadata (not `exists()`) so symlink-mode materialisation
+    // is asserted identically to copy-mode.
+    assert!(fs::symlink_metadata(&widgets).unwrap().is_dir());
+    assert!(fs::symlink_metadata(&w1).is_ok(), "w1.ts materialised");
+    assert!(
+        !fs::symlink_metadata(&media).unwrap().is_dir(),
+        "collection asset materialised as a file/symlink"
+    );
+
+    // directory→file (pages-family walk) + file→directory (collection
+    // walk), in the same tick.
+    fs::remove_dir_all(root.join("components/widgets")).unwrap();
+    fs::write(root.join("components/widgets"), "not a directory anymore\n").unwrap();
+    fs::remove_file(root.join("content/posts/media")).unwrap();
+    fs::create_dir_all(root.join("content/posts/media")).unwrap();
+    fs::write(root.join("content/posts/media/pic.txt"), "inner asset\n").unwrap();
+    bundle_with_session(mock_input(), Some(&mut session))
+        .expect("path-type flips must not fail the session call");
+
+    assert!(
+        !fs::symlink_metadata(&widgets).unwrap().is_dir(),
+        "stale shadow dir must be replaced by the new file"
+    );
+    assert!(
+        fs::symlink_metadata(&w1).is_err(),
+        "subtree of the replaced dir must be gone"
+    );
+    assert!(
+        fs::symlink_metadata(&media).unwrap().is_dir(),
+        "stale shadow file must be replaced by the new dir"
+    );
+    assert!(
+        fs::symlink_metadata(media.join("pic.txt")).is_ok(),
+        "child of the new dir materialised"
+    );
+
+    // Flip both back; the session must keep succeeding and converge to
+    // the original shape, with w1.ts re-written despite identical bytes
+    // (its `written` hash was invalidated with the deleted dir).
+    fs::remove_file(root.join("components/widgets")).unwrap();
+    fs::create_dir_all(root.join("components/widgets")).unwrap();
+    fs::write(
+        root.join("components/widgets/w1.ts"),
+        "export const name = \"w1\";\n",
+    )
+    .unwrap();
+    fs::remove_dir_all(root.join("content/posts/media")).unwrap();
+    fs::write(root.join("content/posts/media"), "extensionless asset\n").unwrap();
+    bundle_with_session(mock_input(), Some(&mut session))
+        .expect("reverse path-type flips must not fail the session call");
+
+    assert!(fs::symlink_metadata(&widgets).unwrap().is_dir());
+    assert!(
+        fs::symlink_metadata(&w1).is_ok(),
+        "w1.ts must be re-materialised after the round-trip"
+    );
+    assert!(!fs::symlink_metadata(&media).unwrap().is_dir());
+    assert!(
+        fs::symlink_metadata(media.join("pic.txt")).is_err(),
+        "child of the removed dir must be gone"
+    );
+}
+
 /// Spec test 4 (#993): diagnostics must be replayed on EVERY call,
 /// including a call where no input changed — the zfb#905 compile cache
 /// stores and replays them, and the session must never skip the

--- a/crates/zfb-build/tests/bundler_shadow_session.rs
+++ b/crates/zfb-build/tests/bundler_shadow_session.rs
@@ -1,0 +1,387 @@
+//! Persistent dev shadow-tree session tests (issue #993).
+//!
+//! The lever's load-bearing safety property is **byte-determinism**: a
+//! `bundle_with_session` call on a persistent session must produce
+//! bundle bytes identical to a fresh `bundle()` over the same tree, for
+//! every mutation class a dev loop can produce (the #940 skip key hashes
+//! these bytes, so any divergence would corrupt skip decisions). The
+//! equivalence test drives the same project through content edits,
+//! file adds/deletes, page adds/deletes, and a glob-set change, checking
+//! session-vs-fresh byte equality at every step.
+//!
+//! The remaining tests pin the session bookkeeping itself: stale-file
+//! pruning (#727 hazard family), dirty-reset on error (false-invalidate,
+//! never false-reuse — the #940 spirit), and diagnostics replay on
+//! unchanged ticks (the "no computation skipping" property).
+//!
+//! ## Esbuild gating
+//!
+//! The byte-equivalence and dirty-reset tests need a real esbuild binary
+//! and self-skip when none is available (`ZFB_ESBUILD_BIN` → workspace
+//! slot → pnpm store → PATH), matching the other bundler integration
+//! tests. The prune and diagnostics-replay tests run everywhere via
+//! `mock_subprocess_output`.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use zfb_build::{
+    bundle, bundle_with_session, BundleMode, BundlerInput, ContentCollectionSpec, OnBrokenLinks,
+    ResolveMarkdownLinksRoute, ResolveMarkdownLinksSpec, ShadowSession,
+};
+use zfb_render::adapters::Framework;
+use zfb_test_utils::locate_esbuild;
+
+/// Write the base fixture project: pages (a css-module consumer, an
+/// `import.meta.glob` consumer, an `.md` page), a content collection,
+/// components (css module + glob-matched widgets), and a layout stub.
+fn write_fixture(root: &Path) {
+    for d in ["pages", "content/posts", "components/widgets", "layouts"] {
+        fs::create_dir_all(root.join(d)).unwrap();
+    }
+    fs::write(
+        root.join("layouts/default.tsx"),
+        "export default function L({ children }) { return children; }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("pages/index.tsx"),
+        r#"import styles from "../components/card.module.css";
+export default function Index() {
+  return <div class={styles.card}>home</div>;
+}
+"#,
+    )
+    .unwrap();
+    // The glob consumer lives in components/ because the expander only
+    // supports same-or-sub-directory patterns (no `../`).
+    fs::write(
+        root.join("components/gallery.tsx"),
+        r#"const widgets = import.meta.glob("./widgets/*.ts", { eager: true });
+export function Gallery() {
+  return <pre>{Object.keys(widgets).join(",")}</pre>;
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("pages/glob.tsx"),
+        r#"import { Gallery } from "../components/gallery";
+export default function Glob() {
+  return <Gallery />;
+}
+"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("pages/about.md"),
+        "---\ntitle: About\n---\n\n# About\n\nplain md page body.\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("components/card.module.css"),
+        ".card { color: red; }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("components/widgets/w1.ts"),
+        "export const name = \"w1\";\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("content/posts/first.mdx"),
+        "# First post\n\nSome *markdown* body.\n",
+    )
+    .unwrap();
+}
+
+/// BundlerInput for the fixture. `outdir_name` keeps the session and
+/// fresh outputs separate so they never clobber each other.
+fn make_input(root: &Path, esbuild: Option<&Path>, outdir_name: &str) -> BundlerInput {
+    let mut css_names = std::collections::HashMap::new();
+    css_names.insert("card".to_string(), "card_scoped1".to_string());
+    let mut css_maps = std::collections::HashMap::new();
+    css_maps.insert(root.join("components/card.module.css"), css_names);
+
+    BundlerInput {
+        external: vec![
+            "preact".into(),
+            "preact-render-to-string".into(),
+            "@takazudo/zfb-runtime".into(),
+        ],
+        esbuild_binary: esbuild.map(|p| p.to_path_buf()),
+        content_collections: vec![ContentCollectionSpec::new(
+            "posts",
+            PathBuf::from("content/posts"),
+        )],
+        css_module_class_maps: css_maps,
+        ..BundlerInput::for_project(
+            root.to_path_buf(),
+            Framework::Preact,
+            BundleMode::Development,
+            root.join(outdir_name),
+            None,
+        )
+    }
+}
+
+/// Spec test 1 (#993): for every dev mutation class, the session bundle's
+/// bytes must equal a fresh `bundle()`'s bytes over the same tree.
+#[test]
+fn shadow_session_bundle_bytes_match_fresh_bundle() {
+    let Some(esbuild) = locate_esbuild() else {
+        eprintln!(
+            "[shadow_session_bundle_bytes_match_fresh_bundle] no esbuild binary; \
+             set ZFB_ESBUILD_BIN, stage the slot, or install esbuild on PATH. Skipping."
+        );
+        return;
+    };
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write_fixture(root);
+
+    let mut session = ShadowSession::new().unwrap();
+
+    let mut assert_equal_bytes = |step: &str| {
+        let session_out = bundle_with_session(
+            make_input(root, Some(&esbuild), "dist-session"),
+            Some(&mut session),
+        )
+        .unwrap_or_else(|e| panic!("session bundle failed at step `{step}`: {e:#}"));
+        let fresh_out = bundle(make_input(root, Some(&esbuild), "dist-fresh"))
+            .unwrap_or_else(|e| panic!("fresh bundle failed at step `{step}`: {e:#}"));
+        let session_bytes = fs::read(&session_out.bundle_path).unwrap();
+        let fresh_bytes = fs::read(&fresh_out.bundle_path).unwrap();
+        assert_eq!(
+            session_bytes, fresh_bytes,
+            "session vs fresh bundle bytes diverged at step `{step}`"
+        );
+        session_bytes
+    };
+
+    // Baseline.
+    assert_equal_bytes("baseline");
+
+    // Content body edit.
+    fs::write(
+        root.join("content/posts/first.mdx"),
+        "# First post\n\nSome *markdown* body.\n\nEdited paragraph.\n",
+    )
+    .unwrap();
+    assert_equal_bytes("content body edit");
+
+    // Content file added.
+    fs::write(
+        root.join("content/posts/second.mdx"),
+        "# Second post\n\nAnother body.\n",
+    )
+    .unwrap();
+    assert_equal_bytes("content file added");
+
+    // Content file deleted.
+    fs::remove_file(root.join("content/posts/second.mdx")).unwrap();
+    assert_equal_bytes("content file deleted");
+
+    // Page .tsx added.
+    fs::write(
+        root.join("pages/extra.tsx"),
+        "export default function Extra() { return <p>extra</p>; }\n",
+    )
+    .unwrap();
+    assert_equal_bytes("page tsx added");
+
+    // Page .tsx deleted.
+    fs::remove_file(root.join("pages/extra.tsx")).unwrap();
+    assert_equal_bytes("page tsx deleted");
+
+    // Glob-matched file added — must change pages/glob.tsx's expanded
+    // import list even though glob.tsx itself is untouched (the expansion
+    // is recomputed from the live tree every call; #993's "no computation
+    // skipping" property).
+    fs::write(
+        root.join("components/widgets/w2.ts"),
+        "export const name = \"w2\";\n",
+    )
+    .unwrap();
+    let bytes = assert_equal_bytes("glob-matched file added");
+    let text = String::from_utf8_lossy(&bytes);
+    assert!(
+        text.contains("w2"),
+        "bundle must include the newly glob-matched widget module"
+    );
+
+    // No-op tick — nothing changed since the previous step.
+    assert_equal_bytes("no-op tick");
+}
+
+/// Spec test 2 (#993): a deleted source's compiled shadow artifacts (incl.
+/// an `.md` page's `_zfb_md_body_*` sibling) must be pruned from the
+/// persistent shadow before esbuild would run.
+#[test]
+fn shadow_session_prunes_deleted_sources() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write_fixture(root);
+
+    let mut session = ShadowSession::new().unwrap();
+    let input = BundlerInput {
+        mock_subprocess_output: Some("export default {};".to_string()),
+        ..make_input(root, None, "dist-session")
+    };
+    bundle_with_session(input, Some(&mut session)).unwrap();
+
+    let shadow = session.shadow_root().to_path_buf();
+    let compiled_mdx = shadow.join("content/posts/first.mdx");
+    let md_shell = shadow.join("pages/about.md");
+    let md_body = shadow.join("pages/_zfb_md_body_about.jsx");
+    assert!(
+        compiled_mdx.exists(),
+        "compiled collection mdx materialised"
+    );
+    assert!(md_shell.exists(), "md page shell materialised");
+    assert!(md_body.exists(), "md page body sibling materialised");
+
+    fs::remove_file(root.join("content/posts/first.mdx")).unwrap();
+    fs::remove_file(root.join("pages/about.md")).unwrap();
+
+    let input = BundlerInput {
+        mock_subprocess_output: Some("export default {};".to_string()),
+        ..make_input(root, None, "dist-session")
+    };
+    bundle_with_session(input, Some(&mut session)).unwrap();
+
+    assert!(
+        !compiled_mdx.exists(),
+        "deleted collection source's compiled shadow file must be pruned"
+    );
+    assert!(
+        !md_shell.exists(),
+        "deleted md page's shell module must be pruned"
+    );
+    assert!(
+        !md_body.exists(),
+        "deleted md page's _zfb_md_body_* sibling must be pruned"
+    );
+    // Surviving sources stay materialised.
+    assert!(
+        shadow.join("pages/index.tsx").exists(),
+        "untouched page must survive the prune"
+    );
+}
+
+/// Spec test 3 (#993): a failed call leaves the session dirty; the next
+/// call must rebuild the shadow from scratch and succeed with bytes
+/// identical to a fresh bundle.
+#[test]
+fn shadow_session_dirty_resets_after_error() {
+    let Some(esbuild) = locate_esbuild() else {
+        eprintln!(
+            "[shadow_session_dirty_resets_after_error] no esbuild binary; \
+             set ZFB_ESBUILD_BIN, stage the slot, or install esbuild on PATH. Skipping."
+        );
+        return;
+    };
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write_fixture(root);
+
+    let broken_links_input = |outdir: &str| BundlerInput {
+        resolve_markdown_links: Some(ResolveMarkdownLinksSpec {
+            routes: vec![ResolveMarkdownLinksRoute {
+                docs_dir: PathBuf::from("content/posts"),
+                route_prefix: "/posts/".to_string(),
+            }],
+            on_broken_links: OnBrokenLinks::Error,
+        }),
+        ..make_input(root, Some(&esbuild), outdir)
+    };
+
+    let mut session = ShadowSession::new().unwrap();
+
+    // Induce a bundle error AFTER the materialise walks populated the
+    // shadow (the broken-links gate runs post-walk), so the session is
+    // left with a half-trusted tree.
+    fs::write(
+        root.join("content/posts/first.mdx"),
+        "# First post\n\n[bad](./missing.mdx)\n",
+    )
+    .unwrap();
+    let err = bundle_with_session(broken_links_input("dist-session"), Some(&mut session))
+        .expect_err("broken link with on_broken_links=Error must fail the bundle");
+    assert!(
+        format!("{err:#}").contains("missing.mdx"),
+        "error must report the broken link: {err:#}"
+    );
+
+    // Plant a foreign file in the persistent shadow. The next call starts
+    // from a dirty session, so it must wipe the tree — observable as this
+    // file vanishing.
+    let foreign = session
+        .shadow_root()
+        .join("zz-foreign-from-failed-tick.txt");
+    fs::write(&foreign, "leftover").unwrap();
+
+    // Fix the link; the next call must full-rebuild and succeed.
+    fs::write(
+        root.join("content/posts/first.mdx"),
+        "# First post\n\nfixed body.\n",
+    )
+    .unwrap();
+    let session_out = bundle_with_session(broken_links_input("dist-session"), Some(&mut session))
+        .expect("call after a failed tick must rebuild from scratch and succeed");
+    assert!(
+        !foreign.exists(),
+        "dirty session must wipe the shadow before reusing it"
+    );
+
+    let fresh_out = bundle(broken_links_input("dist-fresh")).expect("fresh bundle");
+    assert_eq!(
+        fs::read(&session_out.bundle_path).unwrap(),
+        fs::read(&fresh_out.bundle_path).unwrap(),
+        "post-recovery session bundle must be byte-identical to a fresh bundle"
+    );
+}
+
+/// Spec test 4 (#993): diagnostics must be replayed on EVERY call,
+/// including a call where no input changed — the zfb#905 compile cache
+/// stores and replays them, and the session must never skip the
+/// computation that drains them (the "no computation skipping" property).
+#[test]
+fn shadow_session_replays_diagnostics_on_unchanged_tick() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    write_fixture(root);
+    fs::write(
+        root.join("content/posts/first.mdx"),
+        "# First post\n\n[bad](./missing.mdx)\n",
+    )
+    .unwrap();
+
+    let broken_links_input = || BundlerInput {
+        mock_subprocess_output: Some("export default {};".to_string()),
+        resolve_markdown_links: Some(ResolveMarkdownLinksSpec {
+            routes: vec![ResolveMarkdownLinksRoute {
+                docs_dir: PathBuf::from("content/posts"),
+                route_prefix: "/posts/".to_string(),
+            }],
+            on_broken_links: OnBrokenLinks::Error,
+        }),
+        ..make_input(root, None, "dist-session")
+    };
+
+    let mut session = ShadowSession::new().unwrap();
+
+    let err1 = bundle_with_session(broken_links_input(), Some(&mut session))
+        .expect_err("first call must surface the broken link");
+    assert!(format!("{err1:#}").contains("missing.mdx"));
+
+    // Nothing changed — the second call compiles via the zfb#905 cache
+    // hit, which must REPLAY the stored broken-link diagnostic rather
+    // than silently succeed.
+    let err2 = bundle_with_session(broken_links_input(), Some(&mut session))
+        .expect_err("unchanged tick must replay the broken-link diagnostic");
+    assert!(
+        format!("{err2:#}").contains("missing.mdx"),
+        "replayed diagnostics must match the original: {err2:#}"
+    );
+}

--- a/crates/zfb-css/src/modules.rs
+++ b/crates/zfb-css/src/modules.rs
@@ -18,8 +18,8 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use lightningcss::css_modules::{Config as LcssConfig, Pattern};
-use zfb_types::path_to_posix_string;
 use lightningcss::stylesheet::{ParserOptions, PrinterOptions, StyleSheet};
+use zfb_types::path_to_posix_string;
 
 /// Configuration for [`CssModulesProcessor`].
 #[derive(Debug, Clone, Default)]

--- a/crates/zfb-graph/src/lib.rs
+++ b/crates/zfb-graph/src/lib.rs
@@ -1111,10 +1111,14 @@ mod tests {
         // CSS consumers are not added to the source-rebuild set.
         assert!(!affected.contains(&pid("/pages/a.tsx")));
         // Reverse index is drained.
-        assert!(g.pages_using_css_module(&p("/styles/h.module.css")).is_empty());
+        assert!(g
+            .pages_using_css_module(&p("/styles/h.module.css"))
+            .is_empty());
         // The module path is removed from the page's asset record, but the
         // page record itself survives — the page was not deleted.
-        let rec = g.assets_for_page(&pid("/pages/a.tsx")).expect("page record should still exist");
+        let rec = g
+            .assets_for_page(&pid("/pages/a.tsx"))
+            .expect("page record should still exist");
         assert!(!rec.css_modules.contains(&p("/styles/h.module.css")));
     }
 

--- a/crates/zfb-islands/src/bundler.rs
+++ b/crates/zfb-islands/src/bundler.rs
@@ -72,10 +72,14 @@ pub struct Island {
     /// `"default"` for `export default function Foo()` and is mangled by
     /// esbuild minification at runtime).
     ///
-    /// Resolution rules in the scanner (issue #149):
+    /// Resolution rules in the scanner (issues #149, #984):
     ///
     /// - `export default function Foo()` / `export default class Foo` →
     ///   `marker_name = "Foo"` (the identifier name), NOT `"default"`.
+    /// - `export { Foo as default }` / `export { Foo as "default" }` →
+    ///   `marker_name = "Foo"` (the local identifier), NOT `"default"`.
+    ///   This is the alias form tsup/esbuild emits when compiling
+    ///   `export default function Foo()`.
     /// - `export function Foo()` / `export class Foo` /
     ///   `export const Foo = ...` → `marker_name = "Foo"`.
     /// - When the body of an exported function calls

--- a/crates/zfb-islands/src/scanner.rs
+++ b/crates/zfb-islands/src/scanner.rs
@@ -1797,10 +1797,18 @@ fn exported_island_records(module: &Module) -> Vec<IslandRecord> {
                             // `n.orig` — that's what the body-marker
                             // table is keyed on.
                             let local = module_export_name(&n.orig);
-                            let marker = body_markers
-                                .get(&local)
-                                .cloned()
-                                .unwrap_or_else(|| name.clone());
+                            let marker = body_markers.get(&local).cloned().unwrap_or_else(|| {
+                                // `export { Foo as default }` — the exported alias
+                                // is "default" but the SSR side uses
+                                // `displayName ?? name`, which resolves to the
+                                // local identifier ("Foo").  Fall back to `local`
+                                // so the manifest key matches the runtime marker.
+                                if name == "default" {
+                                    local.clone()
+                                } else {
+                                    name.clone()
+                                }
+                            });
                             out.push(IslandRecord {
                                 component_name: name,
                                 marker_name: marker,
@@ -5037,6 +5045,147 @@ mod tests {
         assert_eq!(islands.len(), 1);
         assert_eq!(islands[0].component_name, "default");
         assert_eq!(islands[0].marker_name, "default");
+    }
+
+    // --- export { Foo as default } alias form (#984) --------------------
+
+    #[test]
+    fn marker_name_for_export_alias_as_default_uses_local_identifier() {
+        // Issue #984: tsup/esbuild compiles `export default function Foo()`
+        // to `function Foo() {...}; export { Foo as default }`.
+        // component_name must be "default" (the public export name) but
+        // marker_name must be "Foo" (the local identifier that the SSR side
+        // writes via `displayName ?? name`).
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import SidebarToggle from "../components/sidebar-toggle";
+                export default function Home() { return <SidebarToggle/>; }
+                "#,
+            )
+            .with_file(
+                root().join("components/sidebar-toggle.tsx"),
+                r#""use client";
+                function SidebarToggle() { return null; }
+                export { SidebarToggle as default };
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert_eq!(islands.len(), 1);
+        assert_eq!(islands[0].component_name, "default");
+        assert_eq!(
+            islands[0].marker_name, "SidebarToggle",
+            "issue #984: marker_name must use the local identifier, not the alias"
+        );
+    }
+
+    #[test]
+    fn marker_name_for_export_string_literal_default_alias_uses_local_identifier() {
+        // String-literal alias form: `export { Foo as "default" }` —
+        // semantically identical to `export { Foo as default }`.
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import Counter from "../components/counter";
+                export default function Home() { return <Counter/>; }
+                "#,
+            )
+            .with_file(
+                root().join("components/counter.tsx"),
+                r#""use client";
+                function Counter() { return null; }
+                export { Counter as "default" };
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert_eq!(islands.len(), 1);
+        assert_eq!(islands[0].component_name, "default");
+        assert_eq!(
+            islands[0].marker_name, "Counter",
+            "issue #984: string-literal 'default' alias must use the local identifier"
+        );
+    }
+
+    #[test]
+    fn marker_name_for_mixed_named_and_default_alias_export() {
+        // `export { Foo, Foo as default }` — a module that exports the same
+        // function under both its own name and as the default.  The scanner
+        // emits two IslandRecords (component_name "Foo" and "default"), both
+        // with marker_name "Foo".  Manifest::from_islands keys on marker_name
+        // and keeps same-source duplicates silently (no collision), so the
+        // manifest ends up with a single "Foo" entry.
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import Foo, { Foo as FooNamed } from "../components/foo";
+                export default function Home() { return <Foo/>; }
+                "#,
+            )
+            .with_file(
+                root().join("components/foo.tsx"),
+                r#""use client";
+                function Foo() { return null; }
+                export { Foo, Foo as default };
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        // Both the named and the default export are emitted as separate
+        // IslandRecords (different component_name), but both share
+        // marker_name = "Foo".
+        assert!(
+            islands
+                .iter()
+                .any(|i| i.component_name == "Foo" && i.marker_name == "Foo"),
+            "named export Foo must be emitted with marker_name Foo; got {islands:?}"
+        );
+        assert!(
+            islands
+                .iter()
+                .any(|i| i.component_name == "default" && i.marker_name == "Foo"),
+            "default alias must be emitted with marker_name Foo; got {islands:?}"
+        );
+    }
+
+    #[test]
+    fn marker_name_for_reexport_alias_as_default_defers_to_source_module() {
+        // `export { Foo as default } from './x'` — a re-export from another
+        // module.  collect_import_specifiers DFS-follows './x' and if it
+        // carries "use client" it self-registers there.  The re-export
+        // specifier in the barrel also produces an IslandRecord
+        // (component_name "default", marker_name "Foo") pointing at the
+        // barrel's path, not the source module's path; the manifest will have
+        // two entries (barrel and source) both keyed on "Foo" — the one from
+        // the actual "use client" source wins via insertion order.
+        // This test documents the resulting behavior rather than asserting a
+        // precise number of records; the key invariant is that at least one
+        // island with marker_name "Foo" is emitted.
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("pages/home.tsx"),
+                r#"import Foo from "../components/index";
+                export default function Home() { return <Foo/>; }
+                "#,
+            )
+            .with_file(
+                root().join("components/index.tsx"),
+                r#"export { Foo as default } from "./foo";
+                "#,
+            )
+            .with_file(
+                root().join("components/foo.tsx"),
+                r#""use client";
+                export function Foo() { return null; }
+                "#,
+            );
+
+        let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
+        assert!(
+            islands.iter().any(|i| i.marker_name == "Foo"),
+            "at least one island with marker_name 'Foo' must be emitted; got {islands:?}"
+        );
     }
 
     #[test]

--- a/crates/zfb-md-ast/src/directives.rs
+++ b/crates/zfb-md-ast/src/directives.rs
@@ -104,7 +104,11 @@ impl ValidatedAttrValue {
             | ValidatedAttrValue::Enum(s)
             | ValidatedAttrValue::Number(s) => s.as_str(),
             ValidatedAttrValue::Boolean(b) => {
-                if *b { "true" } else { "false" }
+                if *b {
+                    "true"
+                } else {
+                    "false"
+                }
             }
         }
     }
@@ -279,24 +283,22 @@ impl DirectiveDef {
                         });
                     }
                 }
-                Some(val) => {
-                    match coerce_value(&schema.ty, val) {
-                        Ok(v) => {
-                            validated.insert(schema.name.clone(), v);
-                        }
-                        Err(msg) => {
-                            errors.push(DirectiveDiagnostic {
-                                message: format!(
-                                    "directive `{}`: attr `{}` value `{val}` is not valid \
-                                     for type {:?}: {msg}",
-                                    self.name, schema.name, schema.ty,
-                                ),
-                                line: None,
-                                column: None,
-                            });
-                        }
+                Some(val) => match coerce_value(&schema.ty, val) {
+                    Ok(v) => {
+                        validated.insert(schema.name.clone(), v);
                     }
-                }
+                    Err(msg) => {
+                        errors.push(DirectiveDiagnostic {
+                            message: format!(
+                                "directive `{}`: attr `{}` value `{val}` is not valid \
+                                     for type {:?}: {msg}",
+                                self.name, schema.name, schema.ty,
+                            ),
+                            line: None,
+                            column: None,
+                        });
+                    }
+                },
             }
         }
 
@@ -323,15 +325,11 @@ fn coerce_value(ty: &AttrType, raw: &str) -> Result<ValidatedAttrValue, String> 
                 ))
             }
         }
-        AttrType::Boolean => {
-            match raw.to_lowercase().as_str() {
-                "true" | "" => Ok(ValidatedAttrValue::Boolean(true)),
-                "false" => Ok(ValidatedAttrValue::Boolean(false)),
-                _ => Err(format!(
-                    "expected `true` or `false`, got `{raw}`"
-                )),
-            }
-        }
+        AttrType::Boolean => match raw.to_lowercase().as_str() {
+            "true" | "" => Ok(ValidatedAttrValue::Boolean(true)),
+            "false" => Ok(ValidatedAttrValue::Boolean(false)),
+            _ => Err(format!("expected `true` or `false`, got `{raw}`")),
+        },
         AttrType::Number => {
             if raw.parse::<f64>().is_ok() {
                 Ok(ValidatedAttrValue::Number(raw.to_string()))

--- a/crates/zfb-md-ast/src/features_config.rs
+++ b/crates/zfb-md-ast/src/features_config.rs
@@ -286,7 +286,9 @@ pub fn feature_enabled(toggle: &Option<FeatureToggle>) -> bool {
 /// accepts the rich `TocConfig` shape via [`HeadingMarkerTocFeature`].
 #[must_use]
 pub fn heading_marker_toc_enabled(toggle: &Option<HeadingMarkerTocFeature>) -> bool {
-    toggle.as_ref().is_some_and(HeadingMarkerTocFeature::is_enabled)
+    toggle
+        .as_ref()
+        .is_some_and(HeadingMarkerTocFeature::is_enabled)
 }
 
 /// Options for the `readingTime` feature.
@@ -655,7 +657,10 @@ mod tests {
         let json = serde_json::json!({ "headingIds": { "strategy": "flat" } });
         let cfg: MarkdownFeaturesConfig =
             serde_json::from_value(json).expect("headingIds flat deserialises");
-        assert_eq!(heading_id_strategy(&cfg.heading_ids), HeadingIdStrategy::Flat);
+        assert_eq!(
+            heading_id_strategy(&cfg.heading_ids),
+            HeadingIdStrategy::Flat
+        );
     }
 
     // `headingIds: {}` and an absent key both resolve to Flat.
@@ -664,7 +669,10 @@ mod tests {
         let json = serde_json::json!({ "headingIds": {} });
         let cfg: MarkdownFeaturesConfig =
             serde_json::from_value(json).expect("empty headingIds deserialises");
-        assert_eq!(heading_id_strategy(&cfg.heading_ids), HeadingIdStrategy::Flat);
+        assert_eq!(
+            heading_id_strategy(&cfg.heading_ids),
+            HeadingIdStrategy::Flat
+        );
         assert_eq!(heading_id_strategy(&None), HeadingIdStrategy::Flat);
     }
 

--- a/crates/zfb-md-ast/src/heading_registry.rs
+++ b/crates/zfb-md-ast/src/heading_registry.rs
@@ -118,6 +118,8 @@ mod tests {
     #[test]
     fn query_unknown_path_returns_none() {
         let reg = HeadingRegistry::new();
-        assert!(reg.get(std::path::Path::new("/does/not/exist.md")).is_none());
+        assert!(reg
+            .get(std::path::Path::new("/does/not/exist.md"))
+            .is_none());
     }
 }

--- a/crates/zfb-plugin-resolver/src/lib.rs
+++ b/crates/zfb-plugin-resolver/src/lib.rs
@@ -275,7 +275,11 @@ pub fn read_tsconfig_paths(tsconfig_dir: &Path) -> Option<TsConfigPaths> {
         paths_anchor: Option<PathBuf>,
     }
 
-    fn walk(file: &Path, depth: usize, mut state: WalkState) -> Option<(PathBuf, Vec<TsPathAlias>)> {
+    fn walk(
+        file: &Path,
+        depth: usize,
+        mut state: WalkState,
+    ) -> Option<(PathBuf, Vec<TsPathAlias>)> {
         if depth > 8 {
             return None;
         }
@@ -385,9 +389,7 @@ pub fn read_tsconfig_paths(tsconfig_dir: &Path) -> Option<TsConfigPaths> {
 /// using [`resolve_tsconfig_path_target`].  Already-absolute targets are
 /// returned unchanged.  Missing file / parse errors / absent paths all
 /// return an empty map.
-pub fn read_tsconfig_paths_into_map(
-    project_root: &Path,
-) -> BTreeMap<String, Vec<String>> {
+pub fn read_tsconfig_paths_into_map(project_root: &Path) -> BTreeMap<String, Vec<String>> {
     let Some(parsed) = read_tsconfig_paths(project_root) else {
         return BTreeMap::new();
     };
@@ -673,7 +675,10 @@ mod tests {
         ];
         merge_into_tsconfig_paths(&mut paths, &entries);
         assert_eq!(paths.len(), 2);
-        assert_eq!(paths.get("@/foo").unwrap(), &vec!["/abs/foo.tsx".to_string()]);
+        assert_eq!(
+            paths.get("@/foo").unwrap(),
+            &vec!["/abs/foo.tsx".to_string()]
+        );
         assert_eq!(
             paths.get("virtual:meta").unwrap(),
             &vec!["/tmp/v.mjs".to_string()]
@@ -722,7 +727,10 @@ mod tests {
     /// slashes.
     #[test]
     fn to_posix_replaces_backslashes() {
-        assert_eq!(path_to_posix_string(Path::new("/abs/foo.tsx")), "/abs/foo.tsx");
+        assert_eq!(
+            path_to_posix_string(Path::new("/abs/foo.tsx")),
+            "/abs/foo.tsx"
+        );
         // Simulate a Windows-style path string. On Unix `Path` does not
         // recognize `\` as a separator, but `to_string_lossy()` still
         // returns the literal characters, which our replace then maps
@@ -958,8 +966,7 @@ mod tests {
     fn strip_tsconfig_jsonc_trailing_comma_pass_is_string_aware() {
         let input = r#"{ "a": "x, }", "b": "y" }"#;
         let cleaned = strip_tsconfig_jsonc(input);
-        let v: serde_json::Value =
-            serde_json::from_str(&cleaned).expect("must still parse");
+        let v: serde_json::Value = serde_json::from_str(&cleaned).expect("must still parse");
         assert_eq!(v["a"], "x, }", "comma inside string must survive");
     }
 

--- a/crates/zfb-render/src/adapters/preact.rs
+++ b/crates/zfb-render/src/adapters/preact.rs
@@ -81,8 +81,8 @@ impl Adapter for PreactAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use async_trait::async_trait;
     use crate::render_host::ModuleHandle;
+    use async_trait::async_trait;
     use serde_json::Value as JsonValue;
 
     /// In-memory `RenderHost` that records every module evaluation it

--- a/crates/zfb-render/src/adapters/react.rs
+++ b/crates/zfb-render/src/adapters/react.rs
@@ -100,8 +100,8 @@ impl Adapter for ReactAdapter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use async_trait::async_trait;
     use crate::render_host::ModuleHandle;
+    use async_trait::async_trait;
     use serde_json::Value as JsonValue;
 
     /// In-memory `RenderHost` that records every module evaluation it

--- a/crates/zfb-render/src/config_eval/runtime.rs
+++ b/crates/zfb-render/src/config_eval/runtime.rs
@@ -9,10 +9,9 @@
 use std::rc::Rc;
 
 use deno_core::{
-    v8, JsRuntime, ModuleLoadOptions, ModuleLoadReferrer, ModuleLoadResponse, ModuleLoader,
-    ModuleSource, ModuleSourceCode, ModuleSpecifier, ModuleType, PollEventLoopOptions,
-    ResolutionKind, RuntimeOptions,
-    error::ModuleLoaderError,
+    error::ModuleLoaderError, v8, JsRuntime, ModuleLoadOptions, ModuleLoadReferrer,
+    ModuleLoadResponse, ModuleLoader, ModuleSource, ModuleSourceCode, ModuleSpecifier, ModuleType,
+    PollEventLoopOptions, ResolutionKind, RuntimeOptions,
 };
 
 use super::{ConfigEvalError, NO_BARE_IMPORTS_ERROR};
@@ -36,9 +35,7 @@ pub(super) const MAIN_SPECIFIER: &str = "file:///zfb-config-eval/main.mjs";
 /// - The module source throws at top level
 /// - The `default` export is not a plain object
 /// - The source contains non-main-module imports
-pub async fn evaluate_config_bundle(
-    js_source: &str,
-) -> Result<serde_json::Value, ConfigEvalError> {
+pub async fn evaluate_config_bundle(js_source: &str) -> Result<serde_json::Value, ConfigEvalError> {
     let main_spec =
         ModuleSpecifier::parse(MAIN_SPECIFIER).expect("MAIN_SPECIFIER is a valid URL; qed");
     let loader = Rc::new(ConfigModuleLoader::new(MAIN_SPECIFIER, js_source));
@@ -60,7 +57,9 @@ pub async fn evaluate_config_bundle(
             "zfb:config_eval_polyfills",
             crate::embedded_v8::extensions::WEB_POLYFILLS_SRC,
         )
-        .map_err(|e| ConfigEvalError::Evaluation(format!("config-eval polyfill init failed: {e}")))?;
+        .map_err(|e| {
+            ConfigEvalError::Evaluation(format!("config-eval polyfill init failed: {e}"))
+        })?;
 
     evaluate_in_runtime(runtime, main_spec).await
 }
@@ -70,17 +69,14 @@ async fn evaluate_in_runtime(
     main_spec: ModuleSpecifier,
 ) -> Result<serde_json::Value, ConfigEvalError> {
     // Load + evaluate the main module.
-    let module_id = runtime
-        .load_main_es_module(&main_spec)
-        .await
-        .map_err(|e| {
-            let msg = e.to_string();
-            if msg.contains(NO_BARE_IMPORTS_ERROR) {
-                ConfigEvalError::BareImportRejected(msg)
-            } else {
-                ConfigEvalError::ModuleLoad(msg)
-            }
-        })?;
+    let module_id = runtime.load_main_es_module(&main_spec).await.map_err(|e| {
+        let msg = e.to_string();
+        if msg.contains(NO_BARE_IMPORTS_ERROR) {
+            ConfigEvalError::BareImportRejected(msg)
+        } else {
+            ConfigEvalError::ModuleLoad(msg)
+        }
+    })?;
 
     let evaluate = runtime.mod_evaluate(module_id);
     runtime
@@ -168,14 +164,16 @@ async fn evaluate_in_runtime(
             "JSON.stringify returned a non-string value (unexpected)".into(),
         ));
     }
-    let json_str: v8::Local<v8::String> = result.try_into().map_err(|_| {
-        ConfigEvalError::Evaluation("JSON.stringify result is not a String".into())
-    })?;
+    let json_str: v8::Local<v8::String> = result
+        .try_into()
+        .map_err(|_| ConfigEvalError::Evaluation("JSON.stringify result is not a String".into()))?;
     let json_rust = json_str.to_rust_string_lossy(tc);
 
     // Parse the JSON string back into a serde_json::Value.
     serde_json::from_str::<serde_json::Value>(&json_rust).map_err(|e| {
-        ConfigEvalError::Evaluation(format!("serde_json parsing of stringify result failed: {e}"))
+        ConfigEvalError::Evaluation(format!(
+            "serde_json parsing of stringify result failed: {e}"
+        ))
     })
 }
 

--- a/crates/zfb-render/src/embedded_v8/mod.rs
+++ b/crates/zfb-render/src/embedded_v8/mod.rs
@@ -218,14 +218,10 @@ impl EmbeddedV8RenderHost {
     fn bootstrap_host_shim(&mut self) -> Result<()> {
         self.runtime
             .execute_script("zfb:web_polyfills", extensions::WEB_POLYFILLS_SRC)
-            .map_err(|e| {
-                RenderError::Runtime(format!("web polyfills init failed: {e}"))
-            })?;
+            .map_err(|e| RenderError::Runtime(format!("web polyfills init failed: {e}")))?;
         self.runtime
             .execute_script("zfb:browser_event", extensions::BROWSER_EVENT_SRC)
-            .map_err(|e| {
-                RenderError::Runtime(format!("browser-event globals init failed: {e}"))
-            })?;
+            .map_err(|e| RenderError::Runtime(format!("browser-event globals init failed: {e}")))?;
         self.runtime
             .execute_script("zfb:host_shim", extensions::HOST_GLOBALS_SHIM_SRC)
             .map_err(|e| RenderError::Runtime(format!("host shim init failed: {e}")))?;
@@ -277,9 +273,9 @@ impl EmbeddedV8RenderHost {
         let set_bundle_fn = zfb_obj
             .get(scope, set_bundle_key.into())
             .ok_or_else(|| RenderError::Runtime("__zfb.setBundle missing".into()))?;
-        let set_bundle_fn: v8::Local<v8::Function> = set_bundle_fn.try_into().map_err(|_| {
-            RenderError::Runtime("__zfb.setBundle is not a function".into())
-        })?;
+        let set_bundle_fn: v8::Local<v8::Function> = set_bundle_fn
+            .try_into()
+            .map_err(|_| RenderError::Runtime("__zfb.setBundle is not a function".into()))?;
         let recv: v8::Local<v8::Value> = zfb_obj.into();
         // Build a TryCatch via the macro so the scope plumbing is
         // correct — see v8 crate's `tc_scope!` for the pinned-ref
@@ -310,10 +306,7 @@ impl EmbeddedV8RenderHost {
     /// `execute_module` MUST have been called for at least one bundle
     /// before this is called; otherwise the host returns a `Runtime`
     /// error.
-    pub async fn dispatch_fetch(
-        &mut self,
-        request: HttpRequestLike,
-    ) -> Result<HttpResponseLike> {
+    pub async fn dispatch_fetch(&mut self, request: HttpRequestLike) -> Result<HttpResponseLike> {
         if !*self.bundle_installed.borrow() {
             let base = "embedded V8 host: dispatch_fetch called before any bundle was loaded \
                  (call execute_module() first)";
@@ -337,10 +330,7 @@ impl EmbeddedV8RenderHost {
         let resolve_future = self.runtime.resolve(promise);
         let resolved = self
             .runtime
-            .with_event_loop_promise(
-                Box::pin(resolve_future),
-                PollEventLoopOptions::default(),
-            )
+            .with_event_loop_promise(Box::pin(resolve_future), PollEventLoopOptions::default())
             .await
             .map_err(|e| RenderError::Runtime(format_js_error(&e)))?;
         // Pull the resolved JS object back out as a Rust struct.
@@ -367,10 +357,7 @@ impl EmbeddedV8RenderHost {
     /// Invoke `__zfb.dispatch(...)` for `request` and return the
     /// resulting v8 Promise as a `Global<Value>`. The caller is
     /// responsible for awaiting / resolving it.
-    fn invoke_dispatch_js(
-        &mut self,
-        request: &HttpRequestLike,
-    ) -> Result<v8::Global<v8::Value>> {
+    fn invoke_dispatch_js(&mut self, request: &HttpRequestLike) -> Result<v8::Global<v8::Value>> {
         // We construct the call as a small JS expression rather than
         // wrestling with v8::Function::call from Rust — `serde_v8`'s
         // round trip on the input arguments is brittle when the body
@@ -452,10 +439,7 @@ impl EmbeddedV8RenderHost {
 
     /// Lookup `(handle, module_id)` for an already-registered module.
     fn module_id_for(&self, handle: &ModuleHandle) -> Option<ModuleId> {
-        self.handles
-            .borrow()
-            .get(&handle.name)
-            .map(|(_, id)| *id)
+        self.handles.borrow().get(&handle.name).map(|(_, id)| *id)
     }
 }
 
@@ -558,15 +542,15 @@ impl RenderHost for EmbeddedV8RenderHost {
             let local_ns: v8::Local<v8::Object> = v8::Local::new(scope, namespace);
             let key = v8::String::new(scope, "default")
                 .ok_or_else(|| RenderError::Runtime("v8 string alloc failed".into()))?;
-            let default_val = local_ns.get(scope, key.into()).ok_or_else(|| {
-                RenderError::MissingDefaultExport(handle.name.clone())
-            })?;
+            let default_val = local_ns
+                .get(scope, key.into())
+                .ok_or_else(|| RenderError::MissingDefaultExport(handle.name.clone()))?;
             if !default_val.is_function() {
                 return Err(RenderError::MissingDefaultExport(handle.name.clone()));
             }
-            let func: v8::Local<v8::Function> = default_val.try_into().map_err(|_| {
-                RenderError::MissingDefaultExport(handle.name.clone())
-            })?;
+            let func: v8::Local<v8::Function> = default_val
+                .try_into()
+                .map_err(|_| RenderError::MissingDefaultExport(handle.name.clone()))?;
             // Marshal `props` from JSON to a v8 Value via serde_v8.
             let props_v8 = serde_v8::to_v8(scope, props).map_err(|e| {
                 RenderError::Runtime(format!("encoding props for default() failed: {e}"))
@@ -581,9 +565,8 @@ impl RenderHost for EmbeddedV8RenderHost {
                     .unwrap_or_else(|| "<no exception>".to_string());
                 return Err(RenderError::Runtime(msg));
             }
-            let result = result.ok_or_else(|| {
-                RenderError::Runtime("default() returned no value".into())
-            })?;
+            let result =
+                result.ok_or_else(|| RenderError::Runtime("default() returned no value".into()))?;
             v8::Global::new(tc, result)
         };
         // If the result was a Promise, await it; else short-circuit.
@@ -592,10 +575,7 @@ impl RenderHost for EmbeddedV8RenderHost {
         let resolve_future = self.runtime.resolve(promise);
         let resolved = self
             .runtime
-            .with_event_loop_promise(
-                Box::pin(resolve_future),
-                PollEventLoopOptions::default(),
-            )
+            .with_event_loop_promise(Box::pin(resolve_future), PollEventLoopOptions::default())
             .await
             .map_err(|e| RenderError::Runtime(format_js_error(&e)))?;
         deno_core::scope!(scope, &mut self.runtime);
@@ -640,10 +620,7 @@ impl RenderHost for EmbeddedV8RenderHost {
 // `to_rust_string_lossy(&Isolate)` works on a `Local<v8::String>`;
 // we accept `&Isolate` here so the caller can pass either the
 // isolate or anything that derefs to it.
-fn local_to_string_if_string(
-    isolate: &v8::Isolate,
-    local: v8::Local<v8::Value>,
-) -> Option<String> {
+fn local_to_string_if_string(isolate: &v8::Isolate, local: v8::Local<v8::Value>) -> Option<String> {
     if local.is_string() {
         let s: v8::Local<v8::String> = local.try_into().ok()?;
         Some(s.to_rust_string_lossy(isolate))

--- a/crates/zfb-render/src/embedded_v8/module_loader.rs
+++ b/crates/zfb-render/src/embedded_v8/module_loader.rs
@@ -348,12 +348,12 @@ impl ModuleLoader for BundleModuleLoader {
                     let path = match module_specifier.to_file_path() {
                         Ok(p) => p,
                         Err(_) => {
-                            return ModuleLoadResponse::Sync(Err(
-                                ModuleLoaderError::generic(format!(
+                            return ModuleLoadResponse::Sync(Err(ModuleLoaderError::generic(
+                                format!(
                                     "embedded V8 host: alias-rooted target `{spec_str}` \
                                      is not a valid file:// URL"
-                                )),
-                            ));
+                                ),
+                            )));
                         }
                     };
                     // v1 limitation: the V8 host does not transpile
@@ -362,27 +362,27 @@ impl ModuleLoader for BundleModuleLoader {
                     // error on the user's source.
                     if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
                         if matches!(ext, "ts" | "tsx" | "mts" | "cts") {
-                            return ModuleLoadResponse::Sync(Err(
-                                ModuleLoaderError::generic(format!(
+                            return ModuleLoadResponse::Sync(Err(ModuleLoaderError::generic(
+                                format!(
                                     "embedded V8 host: alias target `{}` (plugin `{plugin_name}`) \
                                      has a TypeScript extension, but the V8 host only accepts \
                                      pre-compiled ESM JavaScript. Point the alias at a `.js` \
                                      file or have your bundler pre-process the target.",
                                     path.display()
-                                )),
-                            ));
+                                ),
+                            )));
                         }
                     }
                     let src = match std::fs::read_to_string(&path) {
                         Ok(s) => s,
                         Err(e) => {
-                            return ModuleLoadResponse::Sync(Err(
-                                ModuleLoaderError::generic(format!(
+                            return ModuleLoadResponse::Sync(Err(ModuleLoaderError::generic(
+                                format!(
                                     "embedded V8 host: alias-rooted file `{}` (under plugin \
                                      `{plugin_name}`'s alias) could not be read: {e}",
                                     path.display()
-                                )),
-                            ));
+                                ),
+                            )));
                         }
                     };
                     return ok_js(module_specifier, &src);

--- a/crates/zfb-render/src/meta.rs
+++ b/crates/zfb-render/src/meta.rs
@@ -247,10 +247,7 @@ pub fn derive_output_extension(
 /// The known-extension table is intentionally small and only covers
 /// the cases we care about for static-site builds. Adding entries is
 /// a non-breaking change.
-pub fn derive_content_type(
-    extension: &str,
-    frontmatter_content_type: Option<&str>,
-) -> String {
+pub fn derive_content_type(extension: &str, frontmatter_content_type: Option<&str>) -> String {
     if let Some(ct) = frontmatter_content_type {
         return ct.to_string();
     }
@@ -638,8 +635,7 @@ mod tests {
 
         let page = root.join("pages/blog/[slug].tsx");
         let candidates = vec![blog.clone(), default];
-        let resolved =
-            resolve_meta(PageMeta::default(), &page, root, &candidates).unwrap();
+        let resolved = resolve_meta(PageMeta::default(), &page, root, &candidates).unwrap();
         assert_eq!(resolved.layout_path.as_deref(), Some(blog.as_path()));
     }
 
@@ -653,8 +649,7 @@ mod tests {
 
         let page = root.join("pages/blog/[slug].tsx");
         let candidates = vec![blog, default.clone()];
-        let resolved =
-            resolve_meta(PageMeta::default(), &page, root, &candidates).unwrap();
+        let resolved = resolve_meta(PageMeta::default(), &page, root, &candidates).unwrap();
         assert_eq!(resolved.layout_path.as_deref(), Some(default.as_path()));
     }
 
@@ -667,8 +662,7 @@ mod tests {
 
         let page = root.join("pages/about.tsx");
         let candidates = vec![default.clone()];
-        let resolved =
-            resolve_meta(PageMeta::default(), &page, root, &candidates).unwrap();
+        let resolved = resolve_meta(PageMeta::default(), &page, root, &candidates).unwrap();
         assert_eq!(resolved.layout_path.as_deref(), Some(default.as_path()));
     }
 
@@ -701,28 +695,19 @@ mod tests {
     #[test]
     fn derive_extension_frontmatter_beats_route() {
         // Frontmatter wins over filename convention.
-        assert_eq!(
-            derive_output_extension(Some("rss"), Some("xml")),
-            "rss",
-        );
+        assert_eq!(derive_output_extension(Some("rss"), Some("xml")), "rss",);
     }
 
     #[test]
     fn derive_extension_falls_through_to_route() {
         // No frontmatter override → use the filename convention.
-        assert_eq!(
-            derive_output_extension(None, Some("xml")),
-            "xml",
-        );
+        assert_eq!(derive_output_extension(None, Some("xml")), "xml",);
     }
 
     #[test]
     fn derive_extension_default_html() {
         // Neither override nor convention → html default.
-        assert_eq!(
-            derive_output_extension(None, None),
-            "html",
-        );
+        assert_eq!(derive_output_extension(None, None), "html",);
     }
 
     #[test]
@@ -736,11 +721,17 @@ mod tests {
 
     #[test]
     fn derive_content_type_extension_defaults() {
-        assert_eq!(derive_content_type("html", None), "text/html; charset=utf-8");
+        assert_eq!(
+            derive_content_type("html", None),
+            "text/html; charset=utf-8"
+        );
         assert_eq!(derive_content_type("xml", None), "application/xml");
         assert_eq!(derive_content_type("rss", None), "application/rss+xml");
         assert_eq!(derive_content_type("json", None), "application/json");
-        assert_eq!(derive_content_type("txt", None), "text/plain; charset=utf-8");
+        assert_eq!(
+            derive_content_type("txt", None),
+            "text/plain; charset=utf-8"
+        );
     }
 
     #[test]
@@ -767,7 +758,10 @@ mod tests {
         )
         .unwrap();
         assert_eq!(resolved.extension.as_deref(), Some("rss"));
-        assert_eq!(resolved.content_type.as_deref(), Some("application/rss+xml"));
+        assert_eq!(
+            resolved.content_type.as_deref(),
+            Some("application/rss+xml")
+        );
     }
 
     #[test]

--- a/crates/zfb-render/src/paths.rs
+++ b/crates/zfb-render/src/paths.rs
@@ -692,7 +692,10 @@ mod tests {
         assert!(msg.contains("got []"), "got: {msg}");
         match err {
             PathsError::MissingParam { provided, .. } => {
-                assert!(provided.is_empty(), "expected empty provided, got {provided:?}");
+                assert!(
+                    provided.is_empty(),
+                    "expected empty provided, got {provided:?}"
+                );
             }
             other => unreachable!("expected MissingParam, got {other:?}"),
         }
@@ -920,11 +923,13 @@ mod tests {
             { "params": { "slug": [] }, "props": { "title": "Docs home" } }
         ]);
 
-        let out =
-            resolve_paths(&mut cache, "docs/[[...slug]].tsx", &segs, &export).unwrap();
+        let out = resolve_paths(&mut cache, "docs/[[...slug]].tsx", &segs, &export).unwrap();
 
         assert_eq!(out.len(), 1);
-        assert_eq!(out[0].url, "/docs", "zero segments must map to the bare URL");
+        assert_eq!(
+            out[0].url, "/docs",
+            "zero segments must map to the bare URL"
+        );
         assert_eq!(out[0].params.get("slug").unwrap(), "");
         assert_eq!(out[0].props, json!({ "title": "Docs home" }));
     }
@@ -939,8 +944,7 @@ mod tests {
             { "params": { "slug": "c/d" } }
         ]);
 
-        let out =
-            resolve_paths(&mut cache, "docs/[[...slug]].tsx", &segs, &export).unwrap();
+        let out = resolve_paths(&mut cache, "docs/[[...slug]].tsx", &segs, &export).unwrap();
 
         let urls: Vec<&str> = out.iter().map(|r| r.url.as_str()).collect();
         assert_eq!(urls, vec!["/docs", "/docs/a/b", "/docs/c/d"]);
@@ -963,8 +967,7 @@ mod tests {
         let segs = route_docs_optional_catchall();
         let export = json!([{ "params": { "slug": "" } }]);
 
-        let err =
-            resolve_paths(&mut cache, "docs/[[...slug]].tsx", &segs, &export).unwrap_err();
+        let err = resolve_paths(&mut cache, "docs/[[...slug]].tsx", &segs, &export).unwrap_err();
         assert!(matches!(err, PathsError::InvalidParamType { .. }));
         assert!(
             err.to_string().contains("[]"),
@@ -978,8 +981,7 @@ mod tests {
         let segs = route_docs_optional_catchall();
         let export = json!([{ "params": { "slug": "/" } }]);
 
-        let err =
-            resolve_paths(&mut cache, "docs/[[...slug]].tsx", &segs, &export).unwrap_err();
+        let err = resolve_paths(&mut cache, "docs/[[...slug]].tsx", &segs, &export).unwrap_err();
         assert!(matches!(err, PathsError::InvalidParamType { .. }));
     }
 
@@ -989,8 +991,7 @@ mod tests {
         let segs = route_docs_optional_catchall();
         let export = json!([{ "params": { "slug": [""] } }]);
 
-        let err =
-            resolve_paths(&mut cache, "docs/[[...slug]].tsx", &segs, &export).unwrap_err();
+        let err = resolve_paths(&mut cache, "docs/[[...slug]].tsx", &segs, &export).unwrap_err();
         assert!(matches!(err, PathsError::InvalidParamType { .. }));
     }
 
@@ -1002,8 +1003,7 @@ mod tests {
         let segs = route_docs_optional_catchall();
         let export = json!([{ "params": {} }]);
 
-        let err =
-            resolve_paths(&mut cache, "docs/[[...slug]].tsx", &segs, &export).unwrap_err();
+        let err = resolve_paths(&mut cache, "docs/[[...slug]].tsx", &segs, &export).unwrap_err();
         assert!(matches!(err, PathsError::MissingParam { .. }));
     }
 
@@ -1016,8 +1016,7 @@ mod tests {
             { "params": { "slug": [] } }
         ]);
 
-        let err =
-            resolve_paths(&mut cache, "docs/[[...slug]].tsx", &segs, &export).unwrap_err();
+        let err = resolve_paths(&mut cache, "docs/[[...slug]].tsx", &segs, &export).unwrap_err();
         assert!(matches!(err, PathsError::AmbiguousResolution { .. }));
     }
 

--- a/crates/zfb-render/src/paths_extract.rs
+++ b/crates/zfb-render/src/paths_extract.rs
@@ -92,10 +92,7 @@ pub enum PathsExtractError {
 /// surfaced as [`PathsExtractError::Parse`] rather than panics.
 pub fn extract_paths(source: &str, file_name: &str) -> Result<PathsExtraction, PathsExtractError> {
     let cm: Lrc<SourceMap> = Default::default();
-    let fm = cm.new_source_file(
-        FileName::Real(file_name.into()).into(),
-        source.to_string(),
-    );
+    let fm = cm.new_source_file(FileName::Real(file_name.into()).into(), source.to_string());
 
     let lexer = Lexer::new(
         Syntax::Typescript(TsSyntax {
@@ -130,9 +127,7 @@ pub fn extract_paths(source: &str, file_name: &str) -> Result<PathsExtraction, P
         match &export_decl.decl {
             // export function paths() { return [...] }
             Decl::Fn(fn_decl) if fn_decl.ident.sym.as_ref() == "paths" => {
-                return Ok(extract_from_block_stmt(
-                    fn_decl.function.body.as_ref(),
-                ));
+                return Ok(extract_from_block_stmt(fn_decl.function.body.as_ref()));
             }
             // export const paths = <init>;
             Decl::Var(var_decl) if matches!(var_decl.kind, VarDeclKind::Const) => {
@@ -289,8 +284,7 @@ fn expr_to_json(expr: &Expr) -> Result<JsonValue, String> {
         Expr::Tpl(tpl) => {
             if !tpl.exprs.is_empty() {
                 return Err(
-                    "template strings with substitutions are not statically resolvable"
-                        .to_string(),
+                    "template strings with substitutions are not statically resolvable".to_string(),
                 );
             }
             Ok(JsonValue::String(tpl_quasi_to_string(tpl)))
@@ -303,9 +297,8 @@ fn expr_to_json(expr: &Expr) -> Result<JsonValue, String> {
                     } else {
                         n.value
                     };
-                    number_to_json(value).ok_or_else(|| {
-                        "non-finite number is not representable in JSON".to_string()
-                    })
+                    number_to_json(value)
+                        .ok_or_else(|| "non-finite number is not representable in JSON".to_string())
                 }
                 _ => Err("unary operator only allowed in front of a numeric literal".to_string()),
             },
@@ -341,7 +334,7 @@ fn object_to_json(obj: &ObjectLit) -> Result<JsonValue, String> {
                 }
                 Prop::Shorthand(_) => {
                     return Err(
-                        "shorthand property references a variable, not a literal".to_string(),
+                        "shorthand property references a variable, not a literal".to_string()
                     );
                 }
                 Prop::Method(_) => {
@@ -453,7 +446,10 @@ fn expr_kind(expr: &Expr) -> &'static str {
         Expr::MetaProp(_) => "meta-property",
         Expr::Await(_) => "`await` expression",
         Expr::Paren(_) => "parenthesized expression",
-        Expr::JSXElement(_) | Expr::JSXFragment(_) | Expr::JSXEmpty(_) | Expr::JSXMember(_)
+        Expr::JSXElement(_)
+        | Expr::JSXFragment(_)
+        | Expr::JSXEmpty(_)
+        | Expr::JSXMember(_)
         | Expr::JSXNamespacedName(_) => "JSX expression",
         _ => "expression",
     }
@@ -625,10 +621,7 @@ mod tests {
         "#;
         match extract_ok(src) {
             PathsExtraction::NonLiteral { reason } => {
-                assert!(
-                    !reason.is_empty(),
-                    "non-literal reason should not be empty",
-                );
+                assert!(!reason.is_empty(), "non-literal reason should not be empty",);
             }
             other => unreachable!("expected NonLiteral, got {other:?}"),
         }
@@ -691,7 +684,10 @@ mod tests {
         "#;
         // The `if` is a non-return statement — extraction bails before
         // it gets to count returns. Either way: NonLiteral.
-        assert!(matches!(extract_ok(src), PathsExtraction::NonLiteral { .. }));
+        assert!(matches!(
+            extract_ok(src),
+            PathsExtraction::NonLiteral { .. }
+        ));
     }
 
     #[test]
@@ -755,10 +751,7 @@ mod tests {
         "#;
         match extract_ok(src) {
             PathsExtraction::Literal(v) => {
-                assert_eq!(
-                    v,
-                    json!([{ "params": { "slug": ["a", "b", "c"] } }]),
-                );
+                assert_eq!(v, json!([{ "params": { "slug": ["a", "b", "c"] } }]),);
             }
             other => unreachable!("expected Literal, got {other:?}"),
         }

--- a/crates/zfb-render/src/render.rs
+++ b/crates/zfb-render/src/render.rs
@@ -87,7 +87,13 @@ impl<H: RenderHost> Renderer<H> {
         strip_md_ext: bool,
         gfm_constructs: zfb_content::ResolvedGfmConstructs,
     ) -> Self {
-        Self::with_strip_md_ext_and_gfm_and_cjk(host, jsx_runtime, strip_md_ext, gfm_constructs, true)
+        Self::with_strip_md_ext_and_gfm_and_cjk(
+            host,
+            jsx_runtime,
+            strip_md_ext,
+            gfm_constructs,
+            true,
+        )
     }
 
     /// Constructor: forwards `strip_md_ext`, GFM constructs, and

--- a/crates/zfb-render/src/sourcemap.rs
+++ b/crates/zfb-render/src/sourcemap.rs
@@ -172,12 +172,20 @@ fn replay_line(line: &str, state: &mut State) {
             continue;
         }
         let mut bytes = segment.as_bytes();
-        let Some(delta) = decode_vlq(&mut bytes) else { return; };
+        let Some(delta) = decode_vlq(&mut bytes) else {
+            return;
+        };
         state.gen_col = state.gen_col.saturating_add(delta);
         if !bytes.is_empty() {
-            let Some(d1) = decode_vlq(&mut bytes) else { return; };
-            let Some(d2) = decode_vlq(&mut bytes) else { return; };
-            let Some(d3) = decode_vlq(&mut bytes) else { return; };
+            let Some(d1) = decode_vlq(&mut bytes) else {
+                return;
+            };
+            let Some(d2) = decode_vlq(&mut bytes) else {
+                return;
+            };
+            let Some(d3) = decode_vlq(&mut bytes) else {
+                return;
+            };
             state.src_idx = state.src_idx.saturating_add(d1);
             state.src_line = state.src_line.saturating_add(d2);
             state.src_col = state.src_col.saturating_add(d3);

--- a/crates/zfb-render/tests/config_eval.rs
+++ b/crates/zfb-render/tests/config_eval.rs
@@ -18,7 +18,7 @@
 
 #![cfg(feature = "embed_v8")]
 
-use zfb_render::{ConfigEvalError, ThreadedConfigEvaluator, config_eval};
+use zfb_render::{config_eval, ConfigEvalError, ThreadedConfigEvaluator};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -153,8 +153,8 @@ async fn test_g_bare_specifier_import_rejected() {
 #[test]
 fn test_thread_pinned_two_sequential_calls() {
     // First call.
-    let val1 = ThreadedConfigEvaluator::eval_bundle(r#"export default { call: 1 };"#)
-        .expect("first call");
+    let val1 =
+        ThreadedConfigEvaluator::eval_bundle(r#"export default { call: 1 };"#).expect("first call");
     assert_eq!(val1, serde_json::json!({ "call": 1 }));
 
     // Second call — fresh isolate, fresh thread.
@@ -192,7 +192,10 @@ async fn test_spawn_blocking_does_not_starve_tokio_workers() {
     );
 
     // The V8 eval also completes successfully.
-    let val = eval_handle.await.expect("spawn_blocking join").expect("eval");
+    let val = eval_handle
+        .await
+        .expect("spawn_blocking join")
+        .expect("eval");
     assert_eq!(val, serde_json::json!({ "ok": true }));
 }
 
@@ -204,35 +207,33 @@ async fn test_spawn_blocking_does_not_starve_tokio_workers() {
 /// esbuild emits `new URL(...)` calls to resolve module specifiers.
 #[tokio::test]
 async fn test_h_url_pathname_accessible() {
-    let val = eval(
-        r#"export default { p: new URL("https://example.com/path?q=1").pathname };"#,
-    )
-    .await
-    .expect("URL should be defined in config-eval isolate");
+    let val = eval(r#"export default { p: new URL("https://example.com/path?q=1").pathname };"#)
+        .await
+        .expect("URL should be defined in config-eval isolate");
     assert_eq!(val, serde_json::json!({ "p": "/path" }));
 }
 
 /// `typeof URL` must be `"function"` and `TextEncoder().encode("hi").length` must be `2`.
 #[tokio::test]
 async fn test_h_url_and_text_encoder_types() {
-    let val = eval(
-        r#"export default { t: typeof URL, encLen: new TextEncoder().encode("hi").length };"#,
-    )
-    .await
-    .expect("URL and TextEncoder should be defined");
+    let val =
+        eval(r#"export default { t: typeof URL, encLen: new TextEncoder().encode("hi").length };"#)
+            .await
+            .expect("URL and TextEncoder should be defined");
     assert_eq!(val["t"], "function", "typeof URL should be 'function'");
-    assert_eq!(val["encLen"], 2, "TextEncoder().encode('hi').length should be 2");
+    assert_eq!(
+        val["encLen"], 2,
+        "TextEncoder().encode('hi').length should be 2"
+    );
 }
 
 /// `typeof process` and `typeof Buffer` must both be `"undefined"` — the
 /// no-Node-globals contract must not be broken by the polyfill bootstrap.
 #[tokio::test]
 async fn test_h_no_node_globals_contract_intact() {
-    let val = eval(
-        r#"export default { proc: typeof process, buf: typeof Buffer };"#,
-    )
-    .await
-    .expect("should succeed — no Node globals present");
+    let val = eval(r#"export default { proc: typeof process, buf: typeof Buffer };"#)
+        .await
+        .expect("should succeed — no Node globals present");
     assert_eq!(
         val["proc"], "undefined",
         "typeof process must be 'undefined' in config-eval isolate"
@@ -250,13 +251,11 @@ async fn test_h_no_node_globals_contract_intact() {
 #[tokio::test]
 async fn test_v8_double_init_safety() {
     // Boot the render host (initialises V8 platform).
-    let _render_host = zfb_render::EmbeddedV8RenderHost::new()
-        .expect("render host boot");
+    let _render_host = zfb_render::EmbeddedV8RenderHost::new().expect("render host boot");
 
     // Now evaluate a config bundle — uses a separate JsRuntime but the same
     // V8 platform. Should not double-init or crash.
-    let val =
-        ThreadedConfigEvaluator::eval_bundle(r#"export default { platform: "shared" };"#)
-            .expect("config eval after render host init");
+    let val = ThreadedConfigEvaluator::eval_bundle(r#"export default { platform: "shared" };"#)
+        .expect("config eval after render host init");
     assert_eq!(val, serde_json::json!({ "platform": "shared" }));
 }

--- a/crates/zfb-render/tests/embedded_v8_browser_event.rs
+++ b/crates/zfb-render/tests/embedded_v8_browser_event.rs
@@ -71,7 +71,10 @@ async fn module_top_level_extends_event_loads() {
         .expect("dispatch");
     assert_eq!(resp.status, 200);
     let body = resp.body_utf8().expect("utf-8 body");
-    assert!(body.contains(r#""type":"zfb:before-preparation""#), "body={body}");
+    assert!(
+        body.contains(r#""type":"zfb:before-preparation""#),
+        "body={body}"
+    );
     assert!(body.contains(r#""cancelable":true"#), "body={body}");
     assert!(body.contains(r#""defaultPrevented":false"#), "body={body}");
     assert!(body.contains(r#""payload":{"ok":true}"#), "body={body}");

--- a/crates/zfb-render/tests/embedded_v8_node_stubs.rs
+++ b/crates/zfb-render/tests/embedded_v8_node_stubs.rs
@@ -42,15 +42,11 @@ async fn assert_import_resolves(specifier: &str, named_import: &str) {
     );
     host.execute_module("bundle.mjs", &bundle)
         .await
-        .unwrap_or_else(|e| {
-            panic!("bundle importing {specifier} failed to load: {e}")
-        });
+        .unwrap_or_else(|e| panic!("bundle importing {specifier} failed to load: {e}"));
     let resp = host
         .dispatch_fetch(HttpRequestLike::get("http://zfb.local/"))
         .await
-        .unwrap_or_else(|e| {
-            panic!("dispatch after importing {specifier} failed: {e}")
-        });
+        .unwrap_or_else(|e| panic!("dispatch after importing {specifier} failed: {e}"));
     assert_eq!(resp.status, 200);
     assert_eq!(resp.body_utf8(), Some("loaded"));
 }
@@ -77,16 +73,12 @@ async fn assert_call_throws(specifier: &str, member_call: &str) {
     );
     host.execute_module("bundle.mjs", &bundle)
         .await
-        .unwrap_or_else(|e| {
-            panic!("bundle importing {specifier} failed to load: {e}")
-        });
+        .unwrap_or_else(|e| panic!("bundle importing {specifier} failed to load: {e}"));
     let err = match host
         .dispatch_fetch(HttpRequestLike::get("http://zfb.local/"))
         .await
     {
-        Ok(_) => panic!(
-            "expected dispatch to throw for {specifier}, but it returned a response"
-        ),
+        Ok(_) => panic!("expected dispatch to throw for {specifier}, but it returned a response"),
         Err(e) => e,
     };
     let msg = err.to_string();
@@ -120,11 +112,7 @@ async fn node_url_resolves_and_throws_on_call() {
     // `node:url` is the deprecated Node namespace; the global
     // `URL` from the polyfill is unaffected (covered separately
     // in `embedded_v8_smoke.rs::handles_hono_shape_router`).
-    assert_call_throws(
-        "node:url",
-        "nodeStub.fileURLToPath('file:///a')",
-    )
-    .await;
+    assert_call_throws("node:url", "nodeStub.fileURLToPath('file:///a')").await;
 }
 
 #[tokio::test]

--- a/crates/zfb-render/tests/embedded_v8_plugin_resolver.rs
+++ b/crates/zfb-render/tests/embedded_v8_plugin_resolver.rs
@@ -66,8 +66,7 @@ async fn alias_hit_resolves_to_aliased_file() {
     let mut hooks = PluginRegistryHooks::new();
     hooks.add_alias("@my/lib", lib_path.clone(), "test-plugin");
 
-    let loader =
-        BundleModuleLoader::new().with_plugin_hooks(hooks);
+    let loader = BundleModuleLoader::new().with_plugin_hooks(hooks);
     let mut host = EmbeddedV8RenderHost::with_loader(loader).expect("host boot");
 
     let bundle = bundle_importing("@my/lib", "greeting");
@@ -173,11 +172,7 @@ async fn alias_transitively_loads_sibling_files() {
     // sibling-directory disk-read support, the transitive import
     // would fail with "no in-memory source".
     let dir = TempDir::new().expect("tempdir");
-    let _helper = write_temp_file(
-        &dir,
-        "helper.js",
-        r#"export const help = "from helper";"#,
-    );
+    let _helper = write_temp_file(&dir, "helper.js", r#"export const help = "from helper";"#);
     let lib_path = write_temp_file(
         &dir,
         "lib.js",

--- a/crates/zfb-render/tests/embedded_v8_real_bundle_smoke.rs
+++ b/crates/zfb-render/tests/embedded_v8_real_bundle_smoke.rs
@@ -66,12 +66,8 @@ async fn real_bundle_dispatches_representative_request_set() {
             path.display()
         );
     }
-    let source = std::fs::read_to_string(&path).unwrap_or_else(|e| {
-        panic!(
-            "failed to read bundle at `{}`: {e}",
-            path.display()
-        )
-    });
+    let source = std::fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read bundle at `{}`: {e}", path.display()));
     let mut host = EmbeddedV8RenderHost::new().expect("host boot");
     host.execute_module("bundle.mjs", &source)
         .await

--- a/crates/zfb-render/tests/integration_routing_rendering.rs
+++ b/crates/zfb-render/tests/integration_routing_rendering.rs
@@ -51,8 +51,7 @@ fn pages_dir() -> PathBuf {
 
 #[test]
 fn router_discovers_all_required_routes() {
-    let routes = scan_pages(&pages_dir())
-        .unwrap_or_else(|e| panic!("scan_pages failed: {e}"));
+    let routes = scan_pages(&pages_dir()).unwrap_or_else(|e| panic!("scan_pages failed: {e}"));
     let templates: Vec<String> = routes.iter().map(|r| r.template()).collect();
     for required in [
         "/",
@@ -73,8 +72,7 @@ fn router_discovers_all_required_routes() {
 
 #[test]
 fn router_classifies_route_kinds_correctly() {
-    let routes = scan_pages(&pages_dir())
-        .unwrap_or_else(|e| panic!("scan_pages failed: {e}"));
+    let routes = scan_pages(&pages_dir()).unwrap_or_else(|e| panic!("scan_pages failed: {e}"));
 
     let kind_of = |template: &str| -> RouteKind {
         routes

--- a/crates/zfb-router/src/scan.rs
+++ b/crates/zfb-router/src/scan.rs
@@ -75,7 +75,10 @@ pub fn scan_pages(pages_dir: &Path) -> Result<Vec<Route>, RouterError> {
 
     let mut routes: Vec<Route> = Vec::new();
 
-    for entry in WalkDir::new(pages_dir).follow_links(false).sort_by_file_name() {
+    for entry in WalkDir::new(pages_dir)
+        .follow_links(false)
+        .sort_by_file_name()
+    {
         let entry = entry.map_err(|e| RouterError::Io {
             path: e
                 .path()
@@ -154,9 +157,7 @@ pub fn scan_pages(pages_dir: &Path) -> Result<Vec<Route>, RouterError> {
         // pure .md or .html file cannot carry). Skip them with a loud
         // warning so authors notice rather than shipping a green build
         // that silently produces no pages.
-        if matches!(ext, Some("md") | Some("html"))
-            && !matches!(route.kind, RouteKind::Static)
-        {
+        if matches!(ext, Some("md") | Some("html")) && !matches!(route.kind, RouteKind::Static) {
             tracing::warn!(
                 path = %rel.display(),
                 kind = ?route.kind,
@@ -255,10 +256,7 @@ fn parse_route(source: &Path, rel: &Path) -> Result<Route, RouterError> {
     let total = raw_segments.len();
     for (i, raw) in raw_segments.iter().enumerate() {
         let parsed = parse_segment(source, raw)?;
-        if matches!(
-            &parsed,
-            Segment::Catchall(_) | Segment::OptionalCatchall(_)
-        ) && i != total - 1
+        if matches!(&parsed, Segment::Catchall(_) | Segment::OptionalCatchall(_)) && i != total - 1
         {
             return Err(RouterError::CatchallNotLast {
                 path: source.to_path_buf(),
@@ -869,8 +867,7 @@ mod tests {
         // first-match would send `/docs` to the less-specific `/[id]`.
         let routes = scan_tree(&["[id].tsx", "docs/[[...slug]].tsx"]).expect("scan");
         assert!(
-            template_index(&routes, "/docs/:slug{.+}?")
-                < template_index(&routes, "/:id"),
+            template_index(&routes, "/docs/:slug{.+}?") < template_index(&routes, "/:id"),
             "optional catchall /docs/[[...slug]] must sort before /[id]: {:?}",
             routes.iter().map(Route::template).collect::<Vec<_>>(),
         );
@@ -885,8 +882,7 @@ mod tests {
         // static-vs-dynamic at index 0 — so it must sort FIRST.
         let routes = scan_tree(&["[lang]/[slug].tsx", "docs/[[...slug]].tsx"]).expect("scan");
         assert!(
-            template_index(&routes, "/docs/:slug{.+}?")
-                < template_index(&routes, "/:lang/:slug"),
+            template_index(&routes, "/docs/:slug{.+}?") < template_index(&routes, "/:lang/:slug"),
             "optional catchall /docs/[[...slug]] must sort before /[lang]/[slug]: {:?}",
             routes.iter().map(Route::template).collect::<Vec<_>>(),
         );
@@ -998,8 +994,7 @@ mod tests {
     #[test]
     fn nested_dynamic_siblings_with_different_param_names_conflict() {
         // Mixed static + dynamic shape: `/docs/:*/edit` shared by both.
-        let err =
-            scan_tree(&["docs/[a]/edit.tsx", "docs/[b]/edit.tsx"]).unwrap_err();
+        let err = scan_tree(&["docs/[a]/edit.tsx", "docs/[b]/edit.tsx"]).unwrap_err();
         assert!(matches!(err, RouterError::AmbiguousShape { .. }));
     }
 
@@ -1077,10 +1072,7 @@ mod tests {
         assert_eq!(r.template(), "/sitemap.xml");
         assert_eq!(r.output_extension.as_deref(), Some("xml"));
         assert_eq!(r.kind, RouteKind::Static);
-        assert_eq!(
-            r.output_filename(None),
-            PathBuf::from("sitemap.xml"),
-        );
+        assert_eq!(r.output_filename(None), PathBuf::from("sitemap.xml"),);
     }
 
     #[test]
@@ -1090,10 +1082,7 @@ mod tests {
         let r = route_from("api.v2.json.tsx");
         assert_eq!(r.template(), "/api.v2.json");
         assert_eq!(r.output_extension.as_deref(), Some("json"));
-        assert_eq!(
-            r.output_filename(None),
-            PathBuf::from("api.v2.json"),
-        );
+        assert_eq!(r.output_filename(None), PathBuf::from("api.v2.json"),);
     }
 
     #[test]
@@ -1101,10 +1090,7 @@ mod tests {
         // `pages/sitemap.xml.tsx` with frontmatter `extension: "rss"`
         // should write to `sitemap.rss`.
         let r = route_from("sitemap.xml.tsx");
-        assert_eq!(
-            r.output_filename(Some("rss")),
-            PathBuf::from("sitemap.rss"),
-        );
+        assert_eq!(r.output_filename(Some("rss")), PathBuf::from("sitemap.rss"),);
     }
 
     #[test]
@@ -1112,7 +1098,10 @@ mod tests {
         // No filename extension and no frontmatter override → standard
         // `<path>/index.html` layout.
         let about = route_from("about.tsx");
-        assert_eq!(about.output_filename(None), PathBuf::from("about/index.html"));
+        assert_eq!(
+            about.output_filename(None),
+            PathBuf::from("about/index.html")
+        );
 
         let root = route_from("index.tsx");
         assert_eq!(root.output_filename(None), PathBuf::from("index.html"));
@@ -1161,10 +1150,7 @@ mod tests {
         // literally named `blog`. It should write to `blog/index.xml`.
         let r = route_from("blog/index.xml.tsx");
         assert_eq!(r.output_extension.as_deref(), Some("xml"));
-        assert_eq!(
-            r.output_filename(None),
-            PathBuf::from("blog/index.xml"),
-        );
+        assert_eq!(r.output_filename(None), PathBuf::from("blog/index.xml"),);
     }
 
     // ---- error-page convention (Sub 107) ------------------------------------
@@ -1194,20 +1180,14 @@ mod tests {
         // `pages/foo/404.tsx` is a regular page: `foo/404/index.html`.
         let r = route_from("foo/404.tsx");
         assert_eq!(r.template(), "/foo/404");
-        assert_eq!(
-            r.output_filename(None),
-            PathBuf::from("foo/404/index.html"),
-        );
+        assert_eq!(r.output_filename(None), PathBuf::from("foo/404/index.html"),);
     }
 
     #[test]
     fn about_still_uses_directory_index() {
         // Non-error pages are unaffected.
         let r = route_from("about.tsx");
-        assert_eq!(
-            r.output_filename(None),
-            PathBuf::from("about/index.html"),
-        );
+        assert_eq!(r.output_filename(None), PathBuf::from("about/index.html"),);
     }
 
     // ---- .md page sources (Sub 406) ----------------------------------------
@@ -1391,7 +1371,10 @@ mod tests {
         let pages = tmp.path();
         fs::write(pages.join("notes.txt"), "hello").unwrap();
         let routes = scan_pages(pages).expect("scan");
-        assert!(routes.is_empty(), "unknown extension file should be skipped");
+        assert!(
+            routes.is_empty(),
+            "unknown extension file should be skipped"
+        );
         assert!(
             logs_contain("unrecognised extension"),
             "expected a warning about the unrecognised extension"

--- a/crates/zfb-router/tests/scan_routes.rs
+++ b/crates/zfb-router/tests/scan_routes.rs
@@ -132,7 +132,10 @@ fn dynamic_param_name_preserved() {
         .expect("/blog/:slug");
     assert_eq!(
         blog_slug.segments,
-        vec![Segment::Static("blog".into()), Segment::Dynamic("slug".into())],
+        vec![
+            Segment::Static("blog".into()),
+            Segment::Dynamic("slug".into())
+        ],
     );
 
     let pagination = router
@@ -156,7 +159,10 @@ fn dynamic_param_name_preserved() {
         .expect("/docs/:slug{.+}");
     assert_eq!(
         docs.segments,
-        vec![Segment::Static("docs".into()), Segment::Catchall("slug".into())],
+        vec![
+            Segment::Static("docs".into()),
+            Segment::Catchall("slug".into())
+        ],
     );
 }
 
@@ -238,10 +244,7 @@ fn ambiguous_routes_are_rejected() {
 
 #[test]
 fn missing_pages_dir_is_an_error() {
-    let err = Router::scan(Path::new(
-        "/this/path/should/not/exist/zfb-router/test",
-    ))
-    .unwrap_err();
+    let err = Router::scan(Path::new("/this/path/should/not/exist/zfb-router/test")).unwrap_err();
     assert!(matches!(err, RouterError::PagesDirMissing(_)));
 }
 

--- a/crates/zfb-server/src/assets_containment.rs
+++ b/crates/zfb-server/src/assets_containment.rs
@@ -294,9 +294,7 @@ mod tests {
     /// Build a `ContainedAssetsService` backed by a tempdir, run `setup`
     /// inside it, and return `(service, tempdir)`.  The `tempdir` is
     /// returned so the caller keeps it alive for the test duration.
-    fn make_service(
-        setup: impl FnOnce(&Path),
-    ) -> (ContainedAssetsService, tempfile::TempDir) {
+    fn make_service(setup: impl FnOnce(&Path)) -> (ContainedAssetsService, tempfile::TempDir) {
         let dir = tempfile::tempdir().expect("tempdir");
         setup(dir.path());
         let svc = ContainedAssetsService::new(dir.path().to_path_buf());
@@ -305,12 +303,7 @@ mod tests {
 
     async fn status_for(svc: ContainedAssetsService, path: &str) -> StatusCode {
         let resp = svc
-            .oneshot(
-                Request::builder()
-                    .uri(path)
-                    .body(Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(Request::builder().uri(path).body(Body::empty()).unwrap())
             .await
             .unwrap();
         resp.status()
@@ -414,8 +407,7 @@ mod tests {
         // Either is acceptable here — we just confirm the wrapper doesn't
         // block range requests.
         assert!(
-            resp.status() == StatusCode::PARTIAL_CONTENT
-                || resp.status() == StatusCode::OK,
+            resp.status() == StatusCode::PARTIAL_CONTENT || resp.status() == StatusCode::OK,
             "range request must not be blocked by the containment wrapper (got {:?})",
             resp.status()
         );
@@ -436,11 +428,7 @@ mod tests {
 
         let (svc, _assets) = make_service(|assets| {
             // Symlink inside assets pointing to a file outside the dir.
-            symlink(
-                outside.path().join("secret.txt"),
-                assets.join("evil.txt"),
-            )
-            .unwrap();
+            symlink(outside.path().join("secret.txt"), assets.join("evil.txt")).unwrap();
         });
 
         let status = status_for(svc, "/evil.txt").await;

--- a/crates/zfb-server/src/embed.rs
+++ b/crates/zfb-server/src/embed.rs
@@ -70,10 +70,8 @@ use axum::response::IntoResponse;
 /// Default bind address for an embedded server: `127.0.0.1:0` so the
 /// OS picks an ephemeral port. The actual port is readable from
 /// [`ServerHandle::addr`] once the server is running.
-const DEFAULT_BIND: SocketAddr = SocketAddr::new(
-    std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
-    0,
-);
+const DEFAULT_BIND: SocketAddr =
+    SocketAddr::new(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST), 0);
 
 /// Server flavour. Controls which dev-flavoured surfaces the server
 /// exposes (live-reload script injection, `/__zfb/*` SSE endpoint,
@@ -99,7 +97,6 @@ pub enum ServerMode {
     /// per-request Tauri context, SSR handlers, etc.
     Embed,
 }
-
 
 /// A built, ready-to-serve embedded server. Construct via
 /// [`Server::builder`]; consume via [`Server::serve`] (async) or
@@ -171,8 +168,7 @@ impl Server {
     /// the thread fails to boot (bind error, runtime error).
     pub fn serve_in_thread(self) -> anyhow::Result<ServerHandle> {
         let bind = self.bind;
-        let (boot_tx, boot_rx) =
-            mpsc::sync_channel::<anyhow::Result<SocketAddr>>(0);
+        let (boot_tx, boot_rx) = mpsc::sync_channel::<anyhow::Result<SocketAddr>>(0);
         let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
 
         let thread_handle = thread::Builder::new()
@@ -251,11 +247,7 @@ impl Server {
     /// Internal: serve on the supplied listener. Replicates the logic
     /// of [`crate::serve_with_listener`] but threads the
     /// request-extension layer that the embed builder accumulated.
-    async fn serve_with_listener<S>(
-        self,
-        listener: TcpListener,
-        shutdown: S,
-    ) -> anyhow::Result<()>
+    async fn serve_with_listener<S>(self, listener: TcpListener, shutdown: S) -> anyhow::Result<()>
     where
         S: Future<Output = ()> + Send + 'static,
     {
@@ -272,12 +264,8 @@ impl Server {
         // a non-loopback bind enforces the built-in allowlist
         // (localhost forms + the bound IP); the default loopback bind
         // disables validation entirely.
-        let host_validation = crate::host_validation::HostValidation::for_bind(
-            actual.ip(),
-            None,
-            &[],
-            self.mode,
-        );
+        let host_validation =
+            crate::host_validation::HostValidation::for_bind(actual.ip(), None, &[], self.mode);
         let state = AppState {
             mode: self.mode,
             pages: self.pages,
@@ -472,14 +460,12 @@ impl ServerBuilder {
     ///   parse (JSON only in this milestone; `.ts` is not yet loadable
     ///   from this crate).
     pub fn build(self) -> anyhow::Result<Server> {
-        let config_path = self
-            .config_path
-            .ok_or_else(|| {
-                anyhow!(
-                    "ServerBuilder::build: missing project source — call \
+        let config_path = self.config_path.ok_or_else(|| {
+            anyhow!(
+                "ServerBuilder::build: missing project source — call \
                      `.config_path(...)` before `.build()`"
-                )
-            })?;
+            )
+        })?;
 
         let (project_root, dist_root, public_root, base, trailing_slash) =
             load_embed_config(&config_path)?;
@@ -511,7 +497,6 @@ impl ServerBuilder {
             request_extensions: self.request_extensions,
         })
     }
-
 }
 
 /// Runtime handle for a server started by [`Server::serve_in_thread`].
@@ -676,9 +661,7 @@ fn load_embed_config(
         .parent()
         .map(|p| p.to_path_buf())
         .unwrap_or_else(|| PathBuf::from("."));
-    let project_root = project_root
-        .canonicalize()
-        .unwrap_or(project_root);
+    let project_root = project_root.canonicalize().unwrap_or(project_root);
 
     let dist_root = if cfg.out_dir.is_absolute() {
         cfg.out_dir
@@ -746,7 +729,10 @@ mod tests {
         let (project_root, dist_root, public_root, base, trailing_slash) =
             load_embed_config(&json_path).unwrap();
         // Canonicalised project root must point at the config's parent.
-        let expected_root = tmp.path().canonicalize().unwrap_or_else(|_| tmp.path().to_path_buf());
+        let expected_root = tmp
+            .path()
+            .canonicalize()
+            .unwrap_or_else(|_| tmp.path().to_path_buf());
         assert_eq!(project_root, expected_root);
         assert_eq!(dist_root, project_root.join("build"));
         assert_eq!(public_root, project_root.join("static"));

--- a/crates/zfb-server/src/embed_handlers.rs
+++ b/crates/zfb-server/src/embed_handlers.rs
@@ -118,9 +118,8 @@ pub type EmbedHandlerFuture = Pin<Box<dyn Future<Output = Response> + Send>>;
 /// `Fn(Request, RouteParams) -> Future<Output = Response>` because the
 /// public builder method takes an `async fn` (or async closure) and we
 /// box the resulting future once at registration time.
-pub type EmbedHandlerFn = Arc<
-    dyn Fn(Request<Body>, RouteParams) -> EmbedHandlerFuture + Send + Sync + 'static,
->;
+pub type EmbedHandlerFn =
+    Arc<dyn Fn(Request<Body>, RouteParams) -> EmbedHandlerFuture + Send + Sync + 'static>;
 
 /// One registered handler — pattern plus the boxed dispatch closure.
 #[derive(Clone)]
@@ -286,8 +285,7 @@ mod tests {
     use axum::http::StatusCode;
 
     fn matched(pattern: &str, url: &str) -> RouteParams {
-        pattern_matches(pattern, url)
-            .unwrap_or_else(|| panic!("expected {pattern} to match {url}"))
+        pattern_matches(pattern, url).unwrap_or_else(|| panic!("expected {pattern} to match {url}"))
     }
 
     #[test]
@@ -324,7 +322,10 @@ mod tests {
 
     #[test]
     fn mixed_pattern_captures_multiple_params() {
-        let params = matched("/projects/:proj/refs/*rest", "/projects/zfb/refs/heads/main");
+        let params = matched(
+            "/projects/:proj/refs/*rest",
+            "/projects/zfb/refs/heads/main",
+        );
         assert_eq!(params.get("proj"), Some("zfb"));
         assert_eq!(params.get("rest"), Some("heads/main"));
     }
@@ -345,13 +346,11 @@ mod tests {
 
     #[tokio::test]
     async fn erased_handler_forwards_request_and_params() {
-        let handler = erase_handler(
-            |req: Request<Body>, params: RouteParams| async move {
-                let path = req.uri().path().to_string();
-                let id = params.get("id").unwrap_or("none").to_string();
-                (StatusCode::OK, format!("{path}|{id}"))
-            },
-        );
+        let handler = erase_handler(|req: Request<Body>, params: RouteParams| async move {
+            let path = req.uri().path().to_string();
+            let id = params.get("id").unwrap_or("none").to_string();
+            (StatusCode::OK, format!("{path}|{id}"))
+        });
         let req = Request::builder()
             .uri("/users/42")
             .body(Body::empty())
@@ -367,12 +366,8 @@ mod tests {
 
     #[tokio::test]
     async fn handler_set_dispatches_first_match() {
-        let h1 = erase_handler(|_req, _params: RouteParams| async {
-            (StatusCode::OK, "first")
-        });
-        let h2 = erase_handler(|_req, _params: RouteParams| async {
-            (StatusCode::OK, "second")
-        });
+        let h1 = erase_handler(|_req, _params: RouteParams| async { (StatusCode::OK, "first") });
+        let h2 = erase_handler(|_req, _params: RouteParams| async { (StatusCode::OK, "second") });
         let set = EmbedHandlerSet::new(vec![
             EmbedHandler {
                 pattern: "/foo".into(),
@@ -384,10 +379,7 @@ mod tests {
             },
         ]);
         let (handler, _params) = set.find_match("/foo").expect("hit");
-        let req = Request::builder()
-            .uri("/foo")
-            .body(Body::empty())
-            .unwrap();
+        let req = Request::builder().uri("/foo").body(Body::empty()).unwrap();
         let resp = handler(req, RouteParams::new()).await;
         let body = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();
         assert_eq!(&body[..], b"first");

--- a/crates/zfb-server/src/host_validation.rs
+++ b/crates/zfb-server/src/host_validation.rs
@@ -198,10 +198,7 @@ impl HostValidation {
         let Some((_, rest)) = trimmed.split_once("://") else {
             return false;
         };
-        let authority = rest
-            .split(['/', '?', '#'])
-            .next()
-            .unwrap_or(rest);
+        let authority = rest.split(['/', '?', '#']).next().unwrap_or(rest);
         self.host_allowed(authority)
     }
 }
@@ -226,9 +223,9 @@ fn host_without_port(raw: &str) -> Option<String> {
         // Accepting `[::1]evil.test` would hand the trailing garbage a free
         // pass through the always-allowed IP-literal rule.
         let after = &rest[end + 1..];
-        let valid_port = after.strip_prefix(':').is_some_and(|p| {
-            !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit())
-        });
+        let valid_port = after
+            .strip_prefix(':')
+            .is_some_and(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()));
         if !(after.is_empty() || valid_port) {
             return None;
         }
@@ -500,12 +497,7 @@ mod tests {
 
     #[test]
     fn bound_host_and_bind_ip_are_always_allowed() {
-        let v = HostValidation::for_bind(
-            LAN_IP,
-            Some("mydev.local"),
-            &[],
-            ServerMode::Dev,
-        );
+        let v = HostValidation::for_bind(LAN_IP, Some("mydev.local"), &[], ServerMode::Dev);
         assert!(v.is_enforced());
         assert!(v.host_allowed("192.168.1.5:3000"));
         assert!(v.host_allowed("mydev.local:3000"));
@@ -612,12 +604,8 @@ mod tests {
 
     #[tokio::test]
     async fn layer_passes_allowed_host_through() {
-        let v = HostValidation::for_bind(
-            ANY_IP,
-            None,
-            &["allowed.test".to_string()],
-            ServerMode::Dev,
-        );
+        let v =
+            HostValidation::for_bind(ANY_IP, None, &["allowed.test".to_string()], ServerMode::Dev);
         let router = apply_host_validation_layer(test_router(), v);
         let (status, body) = status_for(router, Some("allowed.test:3000")).await;
         assert_eq!(status, StatusCode::OK);
@@ -634,8 +622,7 @@ mod tests {
 
     #[tokio::test]
     async fn layer_is_noop_when_not_enforced() {
-        let router =
-            apply_host_validation_layer(test_router(), HostValidation::disabled());
+        let router = apply_host_validation_layer(test_router(), HostValidation::disabled());
         let (status, _) = status_for(router, Some("evil.test")).await;
         assert_eq!(status, StatusCode::OK);
     }

--- a/crates/zfb-server/src/lib.rs
+++ b/crates/zfb-server/src/lib.rs
@@ -45,8 +45,8 @@ pub mod assets_containment;
 pub mod embed;
 pub mod embed_handlers;
 pub mod host_validation;
-pub mod injected_routes;
 pub mod inject;
+pub mod injected_routes;
 pub mod livereload;
 pub mod middleware;
 pub mod plugin_middleware;
@@ -103,7 +103,6 @@ pub use embed_handlers::{
 pub use host_validation::{apply_host_validation_layer, HostValidation};
 pub use inject::{inject_livereload, inject_livereload_into_tree, LIVERELOAD_TAG};
 pub use injected_routes::{pattern_matches, InjectedRouteSet};
-pub use zfb_build::InjectedRoute;
 pub use livereload::{outcome_to_events, IslandsBundleInfo, ReloadEvent, ReloadTx};
 pub use plugin_middleware::{
     path_matches_prefix, DevMiddlewareDispatcher, DevMiddlewareSet, PluginDispatchError,
@@ -118,6 +117,7 @@ pub use ssr::{
     SsrDispatchError, SsrDispatcher, SsrRequest, SsrResponse, SsrRouteRecord, SsrRouteSet,
     SsrRoutesHandle,
 };
+pub use zfb_build::InjectedRoute;
 
 /// Options for [`serve`].
 ///

--- a/crates/zfb-server/src/middleware.rs
+++ b/crates/zfb-server/src/middleware.rs
@@ -37,8 +37,7 @@ use axum::Router;
 /// Type-erased "insert a clone of the captured value into the
 /// request's extensions map" closure. One closure per
 /// `.with_request_extension(value)` call.
-pub(crate) type RequestExtensionInjector =
-    Arc<dyn Fn(&mut Extensions) + Send + Sync + 'static>;
+pub(crate) type RequestExtensionInjector = Arc<dyn Fn(&mut Extensions) + Send + Sync + 'static>;
 
 /// Build a single [`RequestExtensionInjector`] that clones `value` into
 /// each incoming request's extensions. `T: Clone + Send + Sync +
@@ -114,10 +113,7 @@ mod tests {
     /// must all reach the handler.
     #[tokio::test]
     async fn injects_multiple_types_into_request_extensions() {
-        let injectors = vec![
-            make_injector(CtxA("hello")),
-            make_injector(CtxB(42)),
-        ];
+        let injectors = vec![make_injector(CtxA("hello")), make_injector(CtxB(42))];
 
         let router: Router = Router::new().route(
             "/",
@@ -130,12 +126,7 @@ mod tests {
         let router = apply_request_extension_layer(router, injectors);
 
         let resp = router
-            .oneshot(
-                HttpRequest::builder()
-                    .uri("/")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(HttpRequest::builder().uri("/").body(Body::empty()).unwrap())
             .await
             .unwrap();
         let body = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();
@@ -157,12 +148,7 @@ mod tests {
         let router = apply_request_extension_layer(router, Vec::new());
 
         let resp = router
-            .oneshot(
-                HttpRequest::builder()
-                    .uri("/")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(HttpRequest::builder().uri("/").body(Body::empty()).unwrap())
             .await
             .unwrap();
         let body = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();

--- a/crates/zfb-server/src/plugin_middleware.rs
+++ b/crates/zfb-server/src/plugin_middleware.rs
@@ -130,7 +130,8 @@ impl DevMiddlewareSet {
         let mut best: Option<&PluginRegistration> = None;
         for reg in self.registrations.iter() {
             if path_matches_prefix(url_path, &reg.path)
-                && best.map(|b| b.path.len() < reg.path.len()).unwrap_or(true) {
+                && best.map(|b| b.path.len() < reg.path.len()).unwrap_or(true)
+            {
                 best = Some(reg);
             }
         }

--- a/crates/zfb-server/src/routes.rs
+++ b/crates/zfb-server/src/routes.rs
@@ -85,13 +85,13 @@ use tower_http::trace::TraceLayer;
 use zfb_types::escape_html;
 
 use crate::assets_containment::ContainedAssetsService;
+use crate::embed_handlers::EmbedHandlerSet;
 use crate::inject::inject_livereload_with_prefix;
 use crate::livereload::{sse_response, ReloadTx};
 use crate::plugin_middleware::{
     DevMiddlewareSet, PluginDispatchOutcome, PluginRegistration, PluginRequest,
     PluginResponseEncoding,
 };
-use crate::embed_handlers::EmbedHandlerSet;
 use crate::ssr::{SsrRequest, SsrRouteSet};
 
 /// HTML body returned when a page is not in the cache.
@@ -869,10 +869,8 @@ async fn serve_page(
     // lock — the lock is released before any I/O so the writer (per-tick
     // reload) is never blocked by in-flight requests.
     if let Some(handle) = state.ssr_routes.as_ref() {
-        let set_snapshot: Option<crate::ssr::SsrRouteSet> = handle
-            .read()
-            .unwrap_or_else(|p| p.into_inner())
-            .clone();
+        let set_snapshot: Option<crate::ssr::SsrRouteSet> =
+            handle.read().unwrap_or_else(|p| p.into_inner()).clone();
         if let Some(set) = set_snapshot {
             let path_only = format!("/{trimmed}");
             if set.find_match(&path_only).is_some() {
@@ -1276,7 +1274,9 @@ async fn dispatch_plugin(
                                 "plugin `{}` returned an invalid base64 body: {}",
                                 reg.plugin, e
                             );
-                            return PluginDispatchAttempt::Errored(plugin_error_response(&msg, mode));
+                            return PluginDispatchAttempt::Errored(plugin_error_response(
+                                &msg, mode,
+                            ));
                         }
                     }
                 }
@@ -1305,17 +1305,20 @@ async fn dispatch_plugin(
             builder = builder.header(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
             match builder.body(axum::body::Body::from(body_bytes)) {
                 Ok(resp) => PluginDispatchAttempt::Responded(resp),
-                Err(e) => PluginDispatchAttempt::Errored(plugin_error_response(&format!(
-                    "failed to build response from plugin `{}`: {e}",
-                    reg.plugin,
-                ), mode)),
+                Err(e) => PluginDispatchAttempt::Errored(plugin_error_response(
+                    &format!("failed to build response from plugin `{}`: {e}", reg.plugin,),
+                    mode,
+                )),
             }
         }
         Ok(PluginDispatchOutcome::Passthrough) => PluginDispatchAttempt::Passthrough,
-        Err(err) => PluginDispatchAttempt::Errored(plugin_error_response(&format!(
-            "plugin `{}` dev-middleware failed: {}",
-            err.plugin, err.message,
-        ), mode)),
+        Err(err) => PluginDispatchAttempt::Errored(plugin_error_response(
+            &format!(
+                "plugin `{}` dev-middleware failed: {}",
+                err.plugin, err.message,
+            ),
+            mode,
+        )),
     }
 }
 
@@ -1377,8 +1380,7 @@ async fn dispatch_ssr(
         .map(|(_, v)| v.clone())
         .unwrap_or_else(|| "text/html; charset=utf-8".to_string());
     let is_html = content_type.to_ascii_lowercase().starts_with("text/html");
-    let status =
-        StatusCode::from_u16(resp.status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+    let status = StatusCode::from_u16(resp.status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
     let mut out = page_response_bytes(
         status,
         resp.body,
@@ -1459,8 +1461,8 @@ async fn dispatch_embed_handler(
     // [`crate::middleware::apply_request_extension_layer`] are
     // forwarded verbatim so the handler can read host-supplied values
     // via `req.extensions().get::<T>()`.
-    let stripped = strip_prefix_from_full_uri(uri, base_prefix)
-        .unwrap_or_else(|| uri.path().to_string());
+    let stripped =
+        strip_prefix_from_full_uri(uri, base_prefix).unwrap_or_else(|| uri.path().to_string());
 
     let mut builder = Request::builder().method(method.clone()).uri(&stripped);
     for (name, value) in headers.iter() {
@@ -1469,9 +1471,10 @@ async fn dispatch_embed_handler(
     let mut req = match builder.body(Body::from(body)) {
         Ok(r) => r,
         Err(e) => {
-            return embed_handler_error_response(&format!(
-                "failed to rebuild request for embed handler: {e}"
-            ), mode);
+            return embed_handler_error_response(
+                &format!("failed to rebuild request for embed handler: {e}"),
+                mode,
+            );
         }
     };
     *req.extensions_mut() = extensions.clone();
@@ -1734,18 +1737,14 @@ pub(crate) fn page_response_bytes(
     // treated as absent (the bin crate seeds the handle with `None`
     // when no `"use client"` islands exist).
     let islands_script_url = if is_dev && inject_reload {
-        islands_bundle_url
-            .map(str::trim)
-            .filter(|u| !u.is_empty())
+        islands_bundle_url.map(str::trim).filter(|u| !u.is_empty())
     } else {
         None
     };
     // Issue #494 / #498: dev-mode injection of the CSS `<link>` tag.
     // Same gate as islands — Dev mode only, HTML responses only.
     let css_link_url = if is_dev && inject_reload {
-        css_bundle_url
-            .map(str::trim)
-            .filter(|u| !u.is_empty())
+        css_bundle_url.map(str::trim).filter(|u| !u.is_empty())
     } else {
         None
     };
@@ -2397,10 +2396,7 @@ mod tests {
         // HTML must include <head></head> so inject_prod_head_assets has an anchor.
         state
             .pages
-            .insert(
-                "/",
-                "<html><head></head><body><p>hello</p></body></html>",
-            )
+            .insert("/", "<html><head></head><body><p>hello</p></body></html>")
             .await;
         let router = test_router(state);
 
@@ -2423,10 +2419,7 @@ mod tests {
         let state = test_state();
         state
             .pages
-            .insert(
-                "/",
-                "<html><head></head><body><p>hello</p></body></html>",
-            )
+            .insert("/", "<html><head></head><body><p>hello</p></body></html>")
             .await;
         let router = test_router(state);
 
@@ -2465,10 +2458,7 @@ mod tests {
         };
         state
             .pages
-            .insert(
-                "/",
-                "<html><head></head><body><p>hello</p></body></html>",
-            )
+            .insert("/", "<html><head></head><body><p>hello</p></body></html>")
             .await;
         let router = test_router(state);
 
@@ -2512,10 +2502,7 @@ mod tests {
         };
         state
             .pages
-            .insert(
-                "/",
-                "<html><head></head><body><p>hello</p></body></html>",
-            )
+            .insert("/", "<html><head></head><body><p>hello</p></body></html>")
             .await;
         let router = test_router(state);
 
@@ -2562,8 +2549,7 @@ mod tests {
             &self,
             _id: &str,
             request: PluginRequest,
-        ) -> Result<PluginDispatchOutcome, crate::plugin_middleware::PluginDispatchError>
-        {
+        ) -> Result<PluginDispatchOutcome, crate::plugin_middleware::PluginDispatchError> {
             *self.last.lock().await = Some(request);
             Ok(self.outcome.clone())
         }
@@ -2580,10 +2566,7 @@ mod tests {
         })
     }
 
-    fn state_with_dispatcher(
-        dispatcher: Arc<RecordingDispatcher>,
-        path: &str,
-    ) -> AppState {
+    fn state_with_dispatcher(dispatcher: Arc<RecordingDispatcher>, path: &str) -> AppState {
         let (tx, _rx) = broadcast::channel::<ReloadEvent>(16);
         let set = DevMiddlewareSet {
             registrations: Arc::new(vec![PluginRegistration {
@@ -2942,7 +2925,10 @@ mod tests {
             .and_then(|h| h.to_str().ok())
             .unwrap_or_default()
             .to_string();
-        assert_eq!(location, "/foo/", "expected redirect to /foo/, got {location}");
+        assert_eq!(
+            location, "/foo/",
+            "expected redirect to /foo/, got {location}"
+        );
     }
 
     #[tokio::test]
@@ -2954,12 +2940,7 @@ mod tests {
         let router = test_router_with_base(state);
 
         let resp = router
-            .oneshot(
-                Request::builder()
-                    .uri("/?x=1")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(Request::builder().uri("/?x=1").body(Body::empty()).unwrap())
             .await
             .unwrap();
 
@@ -3132,12 +3113,7 @@ mod tests {
         let router = test_router_with_base(state);
 
         let resp = router
-            .oneshot(
-                Request::builder()
-                    .uri("/foo/")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(Request::builder().uri("/foo/").body(Body::empty()).unwrap())
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
@@ -3349,7 +3325,11 @@ mod tests {
         let dist = tempfile::tempdir().expect("dist dir");
         std::fs::write(dist.path().join("real.html"), b"<h1>real</h1>").unwrap();
         // Symlink inside dist pointing at another file inside dist.
-        symlink(dist.path().join("real.html"), dist.path().join("alias.html")).unwrap();
+        symlink(
+            dist.path().join("real.html"),
+            dist.path().join("alias.html"),
+        )
+        .unwrap();
 
         let result = read_from_dist(dist.path(), "alias.html").await;
         assert_eq!(
@@ -3732,9 +3712,7 @@ mod tests {
             StatusCode::OK,
             "HEAD request for existing asset must return 200"
         );
-        let body_bytes = axum::body::to_bytes(resp.into_body(), 1024)
-            .await
-            .unwrap();
+        let body_bytes = axum::body::to_bytes(resp.into_body(), 1024).await.unwrap();
         assert!(
             body_bytes.is_empty(),
             "HEAD response body must be empty (got {} bytes)",

--- a/crates/zfb-server/tests/combined_gap_integration.rs
+++ b/crates/zfb-server/tests/combined_gap_integration.rs
@@ -64,8 +64,7 @@ impl SsrDispatcher for FileSsrDispatcher {
             headers,
             // Wrap in minimal HTML so the livereload injection logic is
             // exercised the same way a real page would be.
-            body: format!("<html><body>{content}</body></html>")
-                .into_bytes(),
+            body: format!("<html><body>{content}</body></html>").into_bytes(),
         })
     }
 }
@@ -197,7 +196,11 @@ async fn gap1_ssr_and_gap2_watcher_work_together() {
         .send()
         .await
         .expect("GET /page v2");
-    assert_eq!(resp2.status().as_u16(), 200, "expected 200 for /page after edit");
+    assert_eq!(
+        resp2.status().as_u16(),
+        200,
+        "expected 200 for /page after edit"
+    );
     let body2 = resp2.text().await.expect("read body v2");
     assert!(
         body2.contains("v2 content"),

--- a/crates/zfb-server/tests/embed_lifecycle_smoke.rs
+++ b/crates/zfb-server/tests/embed_lifecycle_smoke.rs
@@ -111,10 +111,7 @@ fn serve_in_thread_lifecycle_round_trip() {
     );
     // The `/__zfb/reload` SSE endpoint must also not be mounted.
     let (sse_status, _sse_body) = rt.block_on(probe(addr, "/__zfb/reload"));
-    assert_eq!(
-        sse_status, 404,
-        "Embed mode must not mount /__zfb/reload",
-    );
+    assert_eq!(sse_status, 404, "Embed mode must not mount /__zfb/reload",);
 
     // Idempotent shutdown — first call signals, second is a no-op.
     handle.shutdown().expect("first shutdown");

--- a/crates/zfb-server/tests/embed_ssr_smoke.rs
+++ b/crates/zfb-server/tests/embed_ssr_smoke.rs
@@ -174,11 +174,9 @@ async fn rust_handler_wins_over_ssr_for_overlapping_pattern() {
 
     let handlers = EmbedHandlerSet::new(vec![EmbedHandler {
         pattern: "/dynamic".into(),
-        handler: erase_handler_for_test(
-            |req: Request<Body>, _params: RouteParams| async move {
-                (StatusCode::OK, format!("rust-handler|{}", req.uri().path()))
-            },
-        ),
+        handler: erase_handler_for_test(|req: Request<Body>, _params: RouteParams| async move {
+            (StatusCode::OK, format!("rust-handler|{}", req.uri().path()))
+        }),
     }]);
 
     let (addr, server, _tmp) = boot(handlers, ssr_set).await;
@@ -259,10 +257,7 @@ async fn plugin_dev_middleware_wins_over_rust_handler() {
         body: b"ssr".to_vec(),
     };
     let ssr_dispatcher = Arc::new(CountingSsrDispatcher::new(canned_ssr));
-    let ssr_set = SsrRouteSet::new(
-        Vec::new(),
-        ssr_dispatcher.clone() as Arc<dyn SsrDispatcher>,
-    );
+    let ssr_set = SsrRouteSet::new(Vec::new(), ssr_dispatcher.clone() as Arc<dyn SsrDispatcher>);
 
     let rust_handler_calls = Arc::new(AtomicU32::new(0));
     let counter = Arc::clone(&rust_handler_calls);
@@ -283,12 +278,10 @@ async fn plugin_dev_middleware_wins_over_rust_handler() {
             handler_id: "h1".into(),
             plugin: "test".into(),
         }]),
-        dispatcher: Arc::new(AlwaysRespondingPluginDispatcher)
-            as Arc<dyn DevMiddlewareDispatcher>,
+        dispatcher: Arc::new(AlwaysRespondingPluginDispatcher) as Arc<dyn DevMiddlewareDispatcher>,
     };
 
-    let (addr, server, _tmp) =
-        boot_with_plugins(handlers, ssr_set, Some(plugin_set)).await;
+    let (addr, server, _tmp) = boot_with_plugins(handlers, ssr_set, Some(plugin_set)).await;
 
     let client = reqwest::Client::builder().build().unwrap();
     let resp = client

--- a/crates/zfb-server/tests/host_validation_integration.rs
+++ b/crates/zfb-server/tests/host_validation_integration.rs
@@ -33,8 +33,8 @@ use tokio::net::TcpListener;
 use tokio::sync::broadcast;
 use zfb_server::livereload::ReloadEvent;
 use zfb_server::{
-    serve_with_listener, DevMiddlewareDispatcher, DevMiddlewareSet, PageCache,
-    PluginDispatchError, PluginDispatchOutcome, PluginRegistration, PluginRequest, PluginResponse,
+    serve_with_listener, DevMiddlewareDispatcher, DevMiddlewareSet, PageCache, PluginDispatchError,
+    PluginDispatchOutcome, PluginRegistration, PluginRequest, PluginResponse,
     PluginResponseEncoding, ServeOpts, SsrDispatchError, SsrDispatcher, SsrRequest, SsrResponse,
     SsrRouteRecord, SsrRouteSet, SsrRoutesHandle,
 };
@@ -279,7 +279,9 @@ async fn enforced_bind_protects_base_prefixed_router_too() {
         ..Default::default()
     })
     .await;
-    pages.insert("/", "<html><body>docs home</body></html>").await;
+    pages
+        .insert("/", "<html><body>docs home</body></html>")
+        .await;
 
     // Disallowed Host under the prefix → 403.
     let resp = client()
@@ -333,7 +335,11 @@ async fn cross_origin_post_to_ssr_route_is_rejected_without_dispatch() {
         .await
         .unwrap();
     assert_eq!(resp.status().as_u16(), 403);
-    assert_eq!(dispatcher.count(), 0, "dispatcher must not run on a rejected request");
+    assert_eq!(
+        dispatcher.count(),
+        0,
+        "dispatcher must not run on a rejected request"
+    );
 
     // Allowed-origin POST (port differs — only the host matters) → dispatched.
     let resp = client()
@@ -389,7 +395,11 @@ async fn cross_origin_post_to_plugin_route_is_rejected_without_dispatch() {
         .await
         .unwrap();
     assert_eq!(resp.status().as_u16(), 403);
-    assert_eq!(dispatcher.count(), 0, "plugin must not run on a rejected request");
+    assert_eq!(
+        dispatcher.count(),
+        0,
+        "plugin must not run on a rejected request"
+    );
 
     let resp = client()
         .post(local_url(addr, "/api/echo"))

--- a/crates/zfb-server/tests/integration.rs
+++ b/crates/zfb-server/tests/integration.rs
@@ -171,7 +171,11 @@ async fn asset_route_serves_static_files() {
 async fn public_files_serve_at_site_root() {
     let h = Harness::start().await;
     let resp = reqwest::get(h.url("/favicon.ico")).await.unwrap();
-    assert_eq!(resp.status(), 200, "public file should be reachable at root");
+    assert_eq!(
+        resp.status(),
+        200,
+        "public file should be reachable at root"
+    );
     let body = resp.bytes().await.unwrap();
     assert_eq!(body.as_ref(), b"\x00FAVICON\x00");
 }
@@ -202,9 +206,7 @@ async fn page_cache_wins_over_public_file() {
     // Stage a "page" at /robots.txt in the cache while a same-named
     // file exists in public/ (we add one via the harness's tempdir).
     std::fs::write(h.public_root().join("robots.txt"), b"FROM PUBLIC").unwrap();
-    h.pages
-        .insert("/robots.txt", "FROM PAGE CACHE")
-        .await;
+    h.pages.insert("/robots.txt", "FROM PAGE CACHE").await;
 
     let resp = reqwest::get(h.url("/robots.txt")).await.unwrap();
     assert_eq!(resp.status(), 200);
@@ -569,11 +571,7 @@ async fn islands_chunks_served_from_assets_dir() {
     let chunk_js = b"export function LazyComponent() {}";
 
     std::fs::write(dist_root.join("assets/islands.js"), islands_js).unwrap();
-    std::fs::write(
-        dist_root.join("assets/islands-chunk-TESTHASH.js"),
-        chunk_js,
-    )
-    .unwrap();
+    std::fs::write(dist_root.join("assets/islands-chunk-TESTHASH.js"), chunk_js).unwrap();
 
     // The entry must be served.
     let resp = reqwest::get(h.url("/assets/islands.js")).await.unwrap();
@@ -613,7 +611,11 @@ async fn stale_chunk_pruned_after_rebundle() {
     let resp = reqwest::get(h.url(&format!("/assets/{gen1_chunk}")))
         .await
         .unwrap();
-    assert_eq!(resp.status(), 200, "gen-1 chunk must be served before rebundle");
+    assert_eq!(
+        resp.status(),
+        200,
+        "gen-1 chunk must be served before rebundle"
+    );
 
     // Simulate a rebundle: delete the old chunk, write the new one.
     std::fs::remove_file(assets_dir.join(gen1_chunk)).unwrap();

--- a/crates/zfb-server/tests/islands_head_injection.rs
+++ b/crates/zfb-server/tests/islands_head_injection.rs
@@ -107,8 +107,7 @@ const ISLANDS_URL: &str = "/assets/islands.js";
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn dev_mode_injects_islands_script_into_head_when_url_seeded() {
-    let handle: zfb_server::IslandsBundleUrl =
-        Arc::new(RwLock::new(Some(ISLANDS_URL.to_string())));
+    let handle: zfb_server::IslandsBundleUrl = Arc::new(RwLock::new(Some(ISLANDS_URL.to_string())));
     let h = Harness::start(zfb_server::ServerMode::Dev, Some(handle)).await;
 
     h.pages
@@ -211,8 +210,7 @@ async fn preview_mode_never_injects_islands_script_even_with_seeded_url() {
     // `/assets/islands.js` URL into production HTML would defeat the
     // prod pipeline's content-hash rewrite (which only matches its own
     // stable forms; an in-flight injection here would not).
-    let handle: zfb_server::IslandsBundleUrl =
-        Arc::new(RwLock::new(Some(ISLANDS_URL.to_string())));
+    let handle: zfb_server::IslandsBundleUrl = Arc::new(RwLock::new(Some(ISLANDS_URL.to_string())));
     let h = Harness::start(zfb_server::ServerMode::Preview, Some(handle)).await;
 
     h.pages
@@ -245,8 +243,7 @@ async fn clearing_the_shared_handle_stops_head_injection_on_next_request() {
     // server MUST stop injecting on the next request — otherwise the
     // previously-emitted bundle URL keeps appearing in HTML, leaving
     // stale hydration code referenced after the bundle is gone.
-    let handle: zfb_server::IslandsBundleUrl =
-        Arc::new(RwLock::new(Some(ISLANDS_URL.to_string())));
+    let handle: zfb_server::IslandsBundleUrl = Arc::new(RwLock::new(Some(ISLANDS_URL.to_string())));
     let h = Harness::start(zfb_server::ServerMode::Dev, Some(Arc::clone(&handle))).await;
 
     h.pages
@@ -286,8 +283,7 @@ async fn dev_mode_double_request_is_idempotent_on_head_injection() {
     // — the splicer is also called every time. Idempotency at the
     // splicer means the served body for two back-to-back requests
     // contains EXACTLY ONE islands `<script>` tag, not two.
-    let handle: zfb_server::IslandsBundleUrl =
-        Arc::new(RwLock::new(Some(ISLANDS_URL.to_string())));
+    let handle: zfb_server::IslandsBundleUrl = Arc::new(RwLock::new(Some(ISLANDS_URL.to_string())));
     let h = Harness::start(zfb_server::ServerMode::Dev, Some(handle)).await;
 
     h.pages

--- a/crates/zfb-server/tests/plugin_middleware_integration.rs
+++ b/crates/zfb-server/tests/plugin_middleware_integration.rs
@@ -13,16 +13,16 @@
 
 use std::collections::HashMap;
 use std::net::SocketAddr;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use tokio::net::TcpListener;
 use tokio::sync::broadcast;
 use zfb_server::livereload::ReloadEvent;
 use zfb_server::{
-    serve_with_listener, DevMiddlewareDispatcher, DevMiddlewareSet, PageCache,
-    PluginDispatchError, PluginDispatchOutcome, PluginRegistration, PluginRequest, PluginResponse,
+    serve_with_listener, DevMiddlewareDispatcher, DevMiddlewareSet, PageCache, PluginDispatchError,
+    PluginDispatchOutcome, PluginRegistration, PluginRequest, PluginResponse,
     PluginResponseEncoding, ServeOpts,
 };
 
@@ -88,7 +88,12 @@ impl DevMiddlewareDispatcher for CountingDispatcher {
 async fn boot_with_dispatcher(
     dispatcher: Arc<CountingDispatcher>,
     registrations: Vec<PluginRegistration>,
-) -> (SocketAddr, PageCache, tokio::task::JoinHandle<anyhow::Result<()>>, tempfile::TempDir) {
+) -> (
+    SocketAddr,
+    PageCache,
+    tokio::task::JoinHandle<anyhow::Result<()>>,
+    tempfile::TempDir,
+) {
     let tmp = tempfile::tempdir().unwrap();
     let dist_root = tmp.path().join("dist");
     let public_root = tmp.path().join("public");
@@ -97,7 +102,9 @@ async fn boot_with_dispatcher(
 
     let pages = PageCache::new();
     let (tx, _rx) = broadcast::channel::<ReloadEvent>(8);
-    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0))).await.unwrap();
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .unwrap();
     let addr = listener.local_addr().unwrap();
 
     let plugin_set = DevMiddlewareSet {
@@ -143,13 +150,20 @@ async fn dev_middleware_handles_registered_path() {
     )
     .await;
 
-    let resp = reqwest::get(format!("http://{addr}/api/echo?x=1")).await.unwrap();
+    let resp = reqwest::get(format!("http://{addr}/api/echo?x=1"))
+        .await
+        .unwrap();
     assert_eq!(resp.status(), 200);
     assert_eq!(
-        resp.headers().get("x-zfb-plugin").and_then(|h| h.to_str().ok()),
+        resp.headers()
+            .get("x-zfb-plugin")
+            .and_then(|h| h.to_str().ok()),
         Some("ok"),
     );
-    let ct = resp.headers().get("content-type").and_then(|h| h.to_str().ok());
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .and_then(|h| h.to_str().ok());
     assert_eq!(ct, Some("application/json"));
     let body = resp.text().await.unwrap();
     assert!(body.contains("/api/echo?x=1"), "body: {body}");
@@ -200,7 +214,9 @@ async fn dev_middleware_unregistered_path_skips_dispatch() {
 
     // No registered prefix matches `/different` — the dispatcher must
     // never be called, and the server returns the dev-mode 404.
-    let resp = reqwest::get(format!("http://{addr}/different")).await.unwrap();
+    let resp = reqwest::get(format!("http://{addr}/different"))
+        .await
+        .unwrap();
     assert_eq!(resp.status(), 404);
     assert_eq!(dispatcher.invocations.load(Ordering::SeqCst), 0);
 
@@ -271,7 +287,11 @@ async fn dev_middleware_handles_put_and_delete() {
     .await;
 
     let client = reqwest::Client::new();
-    for method in [reqwest::Method::PUT, reqwest::Method::DELETE, reqwest::Method::PATCH] {
+    for method in [
+        reqwest::Method::PUT,
+        reqwest::Method::DELETE,
+        reqwest::Method::PATCH,
+    ] {
         let resp = client
             .request(method.clone(), format!("http://{addr}/api/echo"))
             .send()
@@ -384,7 +404,11 @@ impl DevMiddlewareDispatcher for AlwaysFailingDispatcher {
 
 async fn boot_with_failing_dispatcher(
     mode: zfb_server::ServerMode,
-) -> (SocketAddr, tokio::task::JoinHandle<anyhow::Result<()>>, tempfile::TempDir) {
+) -> (
+    SocketAddr,
+    tokio::task::JoinHandle<anyhow::Result<()>>,
+    tempfile::TempDir,
+) {
     let tmp = tempfile::tempdir().unwrap();
     let dist_root = tmp.path().join("dist");
     let public_root = tmp.path().join("public");
@@ -392,7 +416,9 @@ async fn boot_with_failing_dispatcher(
     std::fs::create_dir_all(&public_root).unwrap();
 
     let (tx, _rx) = broadcast::channel::<ReloadEvent>(8);
-    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0))).await.unwrap();
+    let listener = TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+        .await
+        .unwrap();
     let addr = listener.local_addr().unwrap();
 
     let plugin_set = DevMiddlewareSet {
@@ -433,10 +459,11 @@ async fn boot_with_failing_dispatcher(
 /// contains the underlying error message.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn plugin_error_body_is_verbose_in_dev_mode() {
-    let (addr, server, _tmp) =
-        boot_with_failing_dispatcher(zfb_server::ServerMode::Dev).await;
+    let (addr, server, _tmp) = boot_with_failing_dispatcher(zfb_server::ServerMode::Dev).await;
 
-    let resp = reqwest::get(format!("http://{addr}/api/fail")).await.unwrap();
+    let resp = reqwest::get(format!("http://{addr}/api/fail"))
+        .await
+        .unwrap();
     assert_eq!(resp.status().as_u16(), 500);
     let body = resp.text().await.unwrap();
     assert!(
@@ -451,10 +478,11 @@ async fn plugin_error_body_is_verbose_in_dev_mode() {
 /// generic body — the plugin/internal detail must not leak to the client.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn plugin_error_body_is_generic_in_preview_mode() {
-    let (addr, server, _tmp) =
-        boot_with_failing_dispatcher(zfb_server::ServerMode::Preview).await;
+    let (addr, server, _tmp) = boot_with_failing_dispatcher(zfb_server::ServerMode::Preview).await;
 
-    let resp = reqwest::get(format!("http://{addr}/api/fail")).await.unwrap();
+    let resp = reqwest::get(format!("http://{addr}/api/fail"))
+        .await
+        .unwrap();
     assert_eq!(resp.status().as_u16(), 500);
     let body = resp.text().await.unwrap();
     assert!(

--- a/crates/zfb-server/tests/ssr_integration.rs
+++ b/crates/zfb-server/tests/ssr_integration.rs
@@ -27,8 +27,8 @@ use tokio::net::TcpListener;
 use tokio::sync::broadcast;
 use zfb_server::livereload::ReloadEvent;
 use zfb_server::{
-    serve_with_listener, DevMiddlewareDispatcher, DevMiddlewareSet, PageCache,
-    PluginDispatchError, PluginDispatchOutcome, PluginRegistration, PluginRequest, PluginResponse,
+    serve_with_listener, DevMiddlewareDispatcher, DevMiddlewareSet, PageCache, PluginDispatchError,
+    PluginDispatchOutcome, PluginRegistration, PluginRequest, PluginResponse,
     PluginResponseEncoding, ServeOpts, SsrDispatchError, SsrDispatcher, SsrRequest, SsrResponse,
     SsrRouteRecord, SsrRouteSet, SsrRoutesHandle,
 };
@@ -132,8 +132,7 @@ async fn boot_with_opts(
     let addr = listener.local_addr().unwrap();
 
     // Wrap the SsrRouteSet in the live handle (issue #807).
-    let ssr_handle: Option<SsrRoutesHandle> =
-        ssr_routes.map(|s| Arc::new(RwLock::new(Some(s))));
+    let ssr_handle: Option<SsrRoutesHandle> = ssr_routes.map(|s| Arc::new(RwLock::new(Some(s))));
 
     let opts = ServeOpts {
         project_root: tmp.path().to_path_buf(),
@@ -210,10 +209,7 @@ async fn matched_url_dispatches_through_ssr_layer() {
         .and_then(|v| v.to_str().ok())
         .unwrap_or("")
         .to_string();
-    assert!(
-        ct.starts_with("text/html"),
-        "expected text/html, got {ct}"
-    );
+    assert!(ct.starts_with("text/html"), "expected text/html, got {ct}");
     let cookie = resp
         .headers()
         .get(reqwest::header::SET_COOKIE)
@@ -293,10 +289,7 @@ async fn unmatched_url_falls_through_to_page_cache() {
         body: b"ssr".to_vec(),
     };
     let ssr_dispatcher = Arc::new(RecordingSsrDispatcher::new(canned));
-    let set = ssr_set(
-        "/dynamic",
-        ssr_dispatcher.clone() as Arc<dyn SsrDispatcher>,
-    );
+    let set = ssr_set("/dynamic", ssr_dispatcher.clone() as Arc<dyn SsrDispatcher>);
     let (addr, pages, server, _tmp) = boot(Some(set), None).await;
 
     // Static page in the cache at a DIFFERENT URL — confirm the SSR
@@ -509,8 +502,11 @@ async fn adding_ssr_route_mid_session_becomes_dispatchable() {
 
     // Boot with an empty initial route set (no SSR routes at startup).
     let empty_set = SsrRouteSet::new(vec![], dispatcher.clone() as Arc<dyn SsrDispatcher>);
-    let (addr, handle, server, _tmp, _pages) =
-        boot_with_live_handle(Some(empty_set), dispatcher.clone() as Arc<dyn SsrDispatcher>).await;
+    let (addr, handle, server, _tmp, _pages) = boot_with_live_handle(
+        Some(empty_set),
+        dispatcher.clone() as Arc<dyn SsrDispatcher>,
+    )
+    .await;
 
     let client = reqwest::Client::new();
 
@@ -575,8 +571,11 @@ async fn removing_ssr_route_mid_session_becomes_404() {
         }],
         dispatcher.clone() as Arc<dyn SsrDispatcher>,
     );
-    let (addr, handle, server, _tmp, _pages) =
-        boot_with_live_handle(Some(initial_set), dispatcher.clone() as Arc<dyn SsrDispatcher>).await;
+    let (addr, handle, server, _tmp, _pages) = boot_with_live_handle(
+        Some(initial_set),
+        dispatcher.clone() as Arc<dyn SsrDispatcher>,
+    )
+    .await;
 
     let client = reqwest::Client::new();
 
@@ -659,7 +658,11 @@ async fn ssr_route_update_does_not_break_static_pages() {
         .send()
         .await
         .unwrap();
-    assert_eq!(r2.status().as_u16(), 200, "/ssr-new must dispatch after handle update");
+    assert_eq!(
+        r2.status().as_u16(),
+        200,
+        "/ssr-new must dispatch after handle update"
+    );
 
     // Static page still serves correctly after the SSR update.
     let r3 = client
@@ -673,7 +676,10 @@ async fn ssr_route_update_does_not_break_static_pages() {
         "/static must still serve 200 after SSR handle update"
     );
     let body = r3.text().await.unwrap();
-    assert!(body.contains("static"), "static page body must be unchanged");
+    assert!(
+        body.contains("static"),
+        "static page body must be unchanged"
+    );
 
     server.abort();
 }

--- a/crates/zfb-types/src/helpers.rs
+++ b/crates/zfb-types/src/helpers.rs
@@ -160,17 +160,17 @@ mod tests {
 
     #[test]
     fn escape_html_all_specials() {
-        assert_eq!(
-            escape_html("& < > \" '"),
-            "&amp; &lt; &gt; &quot; &#39;"
-        );
+        assert_eq!(escape_html("& < > \" '"), "&amp; &lt; &gt; &quot; &#39;");
     }
 
     // ── path_to_posix_string ──────────────────────────────────────────────────
 
     #[test]
     fn path_to_posix_unix_path() {
-        assert_eq!(path_to_posix_string(Path::new("/abs/foo.tsx")), "/abs/foo.tsx");
+        assert_eq!(
+            path_to_posix_string(Path::new("/abs/foo.tsx")),
+            "/abs/foo.tsx"
+        );
     }
 
     #[test]
@@ -186,7 +186,10 @@ mod tests {
 
     #[test]
     fn path_to_posix_relative() {
-        assert_eq!(path_to_posix_string(Path::new("sub/dir/file.ts")), "sub/dir/file.ts");
+        assert_eq!(
+            path_to_posix_string(Path::new("sub/dir/file.ts")),
+            "sub/dir/file.ts"
+        );
     }
 
     // ── normalize_path_lexical ────────────────────────────────────────────────

--- a/crates/zfb-watcher/src/lib.rs
+++ b/crates/zfb-watcher/src/lib.rs
@@ -501,13 +501,19 @@ mod tests {
     #[test]
     fn classify_create_is_created() {
         use notify::event::{CreateKind, EventKind};
-        assert_eq!(classify(&EventKind::Create(CreateKind::File)), Some(ChangeKind::Created));
+        assert_eq!(
+            classify(&EventKind::Create(CreateKind::File)),
+            Some(ChangeKind::Created)
+        );
     }
 
     #[test]
     fn classify_remove_is_removed() {
         use notify::event::{EventKind, RemoveKind};
-        assert_eq!(classify(&EventKind::Remove(RemoveKind::File)), Some(ChangeKind::Removed));
+        assert_eq!(
+            classify(&EventKind::Remove(RemoveKind::File)),
+            Some(ChangeKind::Removed)
+        );
     }
 
     #[test]
@@ -666,8 +672,14 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         let file = tmp.path().join("any.txt");
         std::fs::write(&file, b"x").expect("write");
-        assert_eq!(resolve_emit_kind(&file, ChangeKind::Created), ChangeKind::Created);
-        assert_eq!(resolve_emit_kind(&file, ChangeKind::Modified), ChangeKind::Modified);
+        assert_eq!(
+            resolve_emit_kind(&file, ChangeKind::Created),
+            ChangeKind::Created
+        );
+        assert_eq!(
+            resolve_emit_kind(&file, ChangeKind::Modified),
+            ChangeKind::Modified
+        );
     }
 
     #[test]
@@ -757,9 +769,8 @@ mod tests {
         std::fs::write(&target, b"original\n").expect("seed file");
 
         let debounce = Duration::from_millis(200);
-        let (watcher, mut rx) =
-            Watcher::start_with_debounce(&root, std::iter::once("."), debounce)
-                .expect("watcher start");
+        let (watcher, mut rx) = Watcher::start_with_debounce(&root, std::iter::once("."), debounce)
+            .expect("watcher start");
 
         // Let the OS watch settle and drain the seed/create noise.
         let _ = last_kind_for(&mut rx, &target, Duration::from_millis(500)).await;
@@ -787,9 +798,8 @@ mod tests {
         std::fs::write(&target, b"original\n").expect("seed file");
 
         let debounce = Duration::from_millis(200);
-        let (watcher, mut rx) =
-            Watcher::start_with_debounce(&root, std::iter::once("."), debounce)
-                .expect("watcher start");
+        let (watcher, mut rx) = Watcher::start_with_debounce(&root, std::iter::once("."), debounce)
+            .expect("watcher start");
 
         let _ = last_kind_for(&mut rx, &target, Duration::from_millis(500)).await;
 

--- a/crates/zfb-watcher/tests/smoke.rs
+++ b/crates/zfb-watcher/tests/smoke.rs
@@ -20,8 +20,8 @@ async fn touching_file_emits_change() {
 
     // Watch `content/` (existing) and `data/` (deliberately missing — the
     // watcher must not crash on this).
-    let (_watcher, mut rx) = Watcher::start(root.path(), ["content", "data"])
-        .expect("start watcher");
+    let (_watcher, mut rx) =
+        Watcher::start(root.path(), ["content", "data"]).expect("start watcher");
 
     // Give notify a beat to register its OS-level watch before we start
     // poking the filesystem. Otherwise on slower CI machines the very
@@ -35,8 +35,7 @@ async fn touching_file_emits_change() {
     // Canonicalizing upfront also ensures the file exists before we try
     // to call canonicalize on reported paths (macOS FSEvents can report
     // the parent directory path in addition to the file path).
-    let target_canon = std::fs::canonicalize(&target)
-        .expect("canonicalize target");
+    let target_canon = std::fs::canonicalize(&target).expect("canonicalize target");
 
     // Drain events until we find one whose canonical path matches the
     // file we wrote. We loop because macOS FSEvents may fire a change for

--- a/crates/zfb/Cargo.toml
+++ b/crates/zfb/Cargo.toml
@@ -55,7 +55,12 @@ indicatif = "0.17"
 # the same rewrite to served HTML (issue #229), the pure-string pieces
 # moved to `zfb_build::link_base_rewrite` so both consumers funnel
 # through the same code. We no longer call `lol_html` directly from
-# this crate.
+# this crate for the link-rewrite path.
+#
+# Issue #990 re-introduces a direct `lol_html` usage for the read-only
+# island-marker-check pass (`commands/island_marker_check.rs`).  Same
+# workspace pin as the existing users (`zfb-build`, `zfb-islands`).
+lol_html = "2.8.1"
 owo-colors = { version = "4", features = ["supports-colors"] }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/zfb/build.rs
+++ b/crates/zfb/build.rs
@@ -571,9 +571,8 @@ fn download_binaries() -> Result<(), String> {
 fn stage_binaries_into_vendor(esbuild_slot: &Path, tailwind_slot: &Path) -> Result<(), String> {
     let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
     let bin_dir = out_dir.join("vendor").join("bin");
-    fs::create_dir_all(&bin_dir).map_err(|e| {
-        format!("failed to create vendor bin dir {}: {e}", bin_dir.display())
-    })?;
+    fs::create_dir_all(&bin_dir)
+        .map_err(|e| format!("failed to create vendor bin dir {}: {e}", bin_dir.display()))?;
 
     // Re-emit rerun triggers so a manual re-fetch of either binary refreshes
     // the embedded snapshot on the next cargo build.
@@ -612,22 +611,13 @@ fn copy_executable(src: &Path, dst: &Path) -> Result<(), String> {
             src.display()
         ));
     }
-    fs::copy(src, dst).map_err(|e| {
-        format!(
-            "failed to copy {} → {}: {e}",
-            src.display(),
-            dst.display()
-        )
-    })?;
+    fs::copy(src, dst)
+        .map_err(|e| format!("failed to copy {} → {}: {e}", src.display(), dst.display()))?;
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        fs::set_permissions(dst, fs::Permissions::from_mode(0o755)).map_err(|e| {
-            format!(
-                "failed to set executable bit on {}: {e}",
-                dst.display()
-            )
-        })?;
+        fs::set_permissions(dst, fs::Permissions::from_mode(0o755))
+            .map_err(|e| format!("failed to set executable bit on {}: {e}", dst.display()))?;
     }
     Ok(())
 }

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -434,12 +434,16 @@ trait BuildRunner {
     /// - `FakeRunner` (test-only) — returns whatever bytes the test
     ///   set up so the rewrite path can be exercised without running
     ///   Tailwind / esbuild subprocesses.
+    /// Returns both the bytes-only emitter inputs (CSS / islands / client
+    /// scripts) **and** the set of registered island marker names collected by
+    /// the islands scanner.  The marker-name set is empty when no islands were
+    /// found; callers that only need the pipeline bytes may simply ignore it.
     fn emit_prod_assets(
         &self,
         project_root: &Path,
         outdir: &Path,
         config: &Config,
-    ) -> Result<ProdAssetEmitterInputs>;
+    ) -> Result<(ProdAssetEmitterInputs, std::collections::BTreeSet<String>)>;
 }
 
 /// Opaque handle that keeps a background renderer state alive.
@@ -573,7 +577,7 @@ impl BuildRunner for DefaultRunner {
         project_root: &Path,
         outdir: &Path,
         config: &Config,
-    ) -> Result<ProdAssetEmitterInputs> {
+    ) -> Result<(ProdAssetEmitterInputs, std::collections::BTreeSet<String>)> {
         // Run `CssPipeline::build_emitter` and
         // `build_production_islands_asset` eagerly (before render) so
         // head injection knows which stable URLs are backed by
@@ -582,7 +586,7 @@ impl BuildRunner for DefaultRunner {
         // `"use client"` components, etc.).
         let css = build_default_css_payload(project_root, outdir, config)
             .context("CSS emitter (DefaultRunner) failed")?;
-        let islands = build_default_islands_payload(
+        let (islands, registered_marker_names) = build_default_islands_payload(
             project_root,
             outdir,
             config.framework,
@@ -592,11 +596,14 @@ impl BuildRunner for DefaultRunner {
         let client_scripts =
             build_default_client_scripts_payloads(project_root, outdir, config.framework)
                 .context("client-script emitters (DefaultRunner) failed")?;
-        Ok(ProdAssetEmitterInputs {
-            css,
-            islands,
-            client_scripts,
-        })
+        Ok((
+            ProdAssetEmitterInputs {
+                css,
+                islands,
+                client_scripts,
+            },
+            registered_marker_names,
+        ))
     }
 }
 
@@ -1008,12 +1015,23 @@ pub(crate) fn compute_css_module_class_maps(
 /// the stable URL (`/assets/islands.js`) which the rewrite step
 /// replaces with the hashed form; no stable `islands.js` is written
 /// to disk in production (the bundler carries bytes in memory only).
+///
+/// The second return value is the set of **registered marker names** from
+/// `islands_set` — the strings the SSR side will write into
+/// `data-zfb-island` / `data-zfb-island-skip-ssr` attributes.  The build
+/// pass uses this for the island-marker-check (#984 / #990).  It is empty
+/// (not `None`) when no islands were found or when the scanner failed, so
+/// the marker-check pass can still warn about rendered markers with zero
+/// registered islands.
 pub(crate) fn build_default_islands_payload(
     project_root: &Path,
     outdir: &Path,
     framework: crate::config::Framework,
     plugin_config: &IslandsPluginConfig,
-) -> Result<Option<AssetEmitterPayload>> {
+) -> Result<(
+    Option<AssetEmitterPayload>,
+    std::collections::BTreeSet<String>,
+)> {
     // Walk the conventional islands roots. The scanner DFS-walks
     // imports starting from each entry path, so seeding with the
     // pages dir is enough — anything reachable through a
@@ -1035,7 +1053,7 @@ pub(crate) fn build_default_islands_payload(
         }
     }
     if entries.is_empty() {
-        return Ok(None);
+        return Ok((None, std::collections::BTreeSet::new()));
     }
 
     let resolver = FsResolver::new();
@@ -1045,7 +1063,7 @@ pub(crate) fn build_default_islands_payload(
             output::warn(format!(
                 "islands scanner failed ({e}); skipping islands asset emission"
             ));
-            return Ok(None);
+            return Ok((None, std::collections::BTreeSet::new()));
         }
     };
     // Issue #289: a project may use `<ClientRouter />` without any
@@ -1083,8 +1101,14 @@ pub(crate) fn build_default_islands_payload(
                 if entries.len() == 1 { "y" } else { "ies" }
             ));
         }
-        return Ok(None);
+        return Ok((None, std::collections::BTreeSet::new()));
     }
+
+    // Collect the registered marker names now — needed by the build-time
+    // island-marker-check pass (#984 / #990) even when esbuild later decides
+    // no bundle is needed (client-router-only projects).
+    let registered_marker_names: std::collections::BTreeSet<String> =
+        islands_set.iter().map(|i| i.marker_name.clone()).collect();
 
     // Sub #212 follow-up — extend embedded-binary AND embedded-node_modules
     // extraction to the islands bundler.
@@ -1199,14 +1223,17 @@ pub(crate) fn build_default_islands_payload(
                     bytes: c.bytes,
                 })
                 .collect();
-            Ok(Some(AssetEmitterPayload {
-                bytes: asset.bytes,
-                relative_path: asset.relative_path,
-                stable_url: asset.stable_url,
-                companions,
-            }))
+            Ok((
+                Some(AssetEmitterPayload {
+                    bytes: asset.bytes,
+                    relative_path: asset.relative_path,
+                    stable_url: asset.stable_url,
+                    companions,
+                }),
+                registered_marker_names,
+            ))
         }
-        None => Ok(None),
+        None => Ok((None, registered_marker_names)),
     }
 }
 
@@ -1793,7 +1820,7 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
     //      never written would leak the unhashed `/assets/styles.css`
     //      URL into shipped HTML (the prod pipeline only rewrites
     //      stable→hashed for slots it actually emits).
-    let mut prod_asset_inputs = runner
+    let (mut prod_asset_inputs, registered_marker_names) = runner
         .emit_prod_assets(project_root, outdir, config)
         .context("production asset emitters failed")?;
     apply_asset_url_base(&mut prod_asset_inputs, config.base.as_deref());
@@ -1886,6 +1913,19 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
         config.trailing_slash,
     )
     .context("link base rewrite failed")?;
+
+    // 3.7. Island-marker check (issue #984 / #990).
+    //
+    // Walk the post-processed HTML pages and warn for every
+    // `data-zfb-island="X"` / `data-zfb-island-skip-ssr="X"` marker
+    // whose name is absent from the scanner's registry set.  Non-fatal:
+    // the build succeeds; the warning is the signal.  Runs even when
+    // `registered_marker_names` is empty (zero registered islands + a
+    // rendered marker is exactly the scenario this check targets).
+    crate::commands::island_marker_check::check_island_markers(
+        &post_processable_pages,
+        &registered_marker_names,
+    );
 
     // Surface embedded V8 host runtime logs (console output from the
     // worker) on a green build — they are often informative about
@@ -2744,15 +2784,18 @@ mod tests {
             _project_root: &Path,
             _outdir: &Path,
             _config: &Config,
-        ) -> Result<ProdAssetEmitterInputs> {
+        ) -> Result<(ProdAssetEmitterInputs, std::collections::BTreeSet<String>)> {
             // Clone the canned inputs so multiple tests can share the
             // same FakeRunner without consuming its state.
             let inputs = self.prod_asset_inputs.borrow();
-            Ok(ProdAssetEmitterInputs {
-                css: inputs.css.clone(),
-                islands: inputs.islands.clone(),
-                client_scripts: inputs.client_scripts.clone(),
-            })
+            Ok((
+                ProdAssetEmitterInputs {
+                    css: inputs.css.clone(),
+                    islands: inputs.islands.clone(),
+                    client_scripts: inputs.client_scripts.clone(),
+                },
+                std::collections::BTreeSet::new(),
+            ))
         }
     }
 
@@ -3111,8 +3154,11 @@ mod tests {
                 _project_root: &Path,
                 _outdir: &Path,
                 _config: &Config,
-            ) -> Result<ProdAssetEmitterInputs> {
-                Ok(ProdAssetEmitterInputs::default())
+            ) -> Result<(ProdAssetEmitterInputs, std::collections::BTreeSet<String>)> {
+                Ok((
+                    ProdAssetEmitterInputs::default(),
+                    std::collections::BTreeSet::new(),
+                ))
             }
         }
         let tmp = tempdir().unwrap();
@@ -4205,7 +4251,7 @@ mod tests {
         let project_root = tmp.path();
         // No pages/, so the entry walk returns empty and we never
         // reach the scanner or esbuild.
-        let payload = build_default_islands_payload(
+        let (payload, names) = build_default_islands_payload(
             project_root,
             &project_root.join("dist"),
             crate::config::Framework::Preact,
@@ -4215,6 +4261,10 @@ mod tests {
         assert!(
             payload.is_none(),
             "expected None when project has no pages/; got {payload:?}",
+        );
+        assert!(
+            names.is_empty(),
+            "expected empty names when no pages/; got {names:?}"
         );
     }
 
@@ -4232,7 +4282,7 @@ mod tests {
             "export default function Index() { return null; }\n",
         )
         .unwrap();
-        let payload = build_default_islands_payload(
+        let (payload, names) = build_default_islands_payload(
             project_root,
             &project_root.join("dist"),
             crate::config::Framework::Preact,
@@ -4242,6 +4292,10 @@ mod tests {
         assert!(
             payload.is_none(),
             "expected None when no use-client components; got {payload:?}",
+        );
+        assert!(
+            names.is_empty(),
+            "expected empty names when no islands; got {names:?}"
         );
     }
 
@@ -4273,7 +4327,7 @@ mod tests {
              export function Counter() { return null; }\n",
         )
         .unwrap();
-        let payload = build_default_islands_payload(
+        let (payload, names) = build_default_islands_payload(
             project_root,
             &project_root.join("dist"),
             crate::config::Framework::Preact,
@@ -4283,6 +4337,10 @@ mod tests {
         assert!(
             payload.is_none(),
             "expected None for a misplaced use-client directive; got {payload:?}",
+        );
+        assert!(
+            names.is_empty(),
+            "expected empty names for near-miss directive; got {names:?}"
         );
     }
 

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -434,6 +434,7 @@ trait BuildRunner {
     /// - `FakeRunner` (test-only) — returns whatever bytes the test
     ///   set up so the rewrite path can be exercised without running
     ///   Tailwind / esbuild subprocesses.
+    ///
     /// Returns both the bytes-only emitter inputs (CSS / islands / client
     /// scripts) **and** the set of registered island marker names collected by
     /// the islands scanner.  The marker-name set is empty when no islands were

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -4375,7 +4375,7 @@ mod tests {
             islands_plugin_config: IslandsPluginConfig::default(),
             v8_plugin_hooks: zfb_render::PluginRegistryHooks::default(),
         };
-        let inputs = runner
+        let (inputs, _marker_names) = runner
             .emit_prod_assets(project_root, &outdir, &cfg)
             .expect("emit_prod_assets must succeed");
         let css = inputs

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -1772,6 +1772,10 @@ fn run_build<R: BuildRunner, A: AdapterRunner>(
         content_snapshot_json,
         plugin_alias_entries,
         plugin_virtual_modules,
+        // `zfb build` keeps the per-call embedded-esbuild extraction —
+        // one extraction per build; the per-tick reuse (#994 item A) is a
+        // dev-only concern.
+        None,
     )?;
 
     // Snapshot the bundler input before consuming it so the runtime-only

--- a/crates/zfb/src/commands/bundler_input.rs
+++ b/crates/zfb/src/commands/bundler_input.rs
@@ -162,6 +162,7 @@ pub(crate) struct AssembledBundlerInput {
 /// already process-lifetime there). Ignored when an explicit
 /// `esbuild_binary` or `ZFB_ESBUILD_BIN` override is in play — the
 /// existing precedence is preserved.
+#[allow(clippy::too_many_arguments)] // 8 params: #994 item A added pre_resolved_esbuild; a struct would obscure the caller-keeps-alive contract documented above
 pub(crate) fn assemble_bundler_input(
     project_root: &Path,
     config: &Config,

--- a/crates/zfb/src/commands/bundler_input.rs
+++ b/crates/zfb/src/commands/bundler_input.rs
@@ -152,6 +152,16 @@ pub(crate) struct AssembledBundlerInput {
 /// The caller supplies the pre-fetched plugin lists
 /// (`plugin_alias_entries`, `plugin_virtual_modules`) from the plugin
 /// lifecycle setup step ([`super::plugins::run_plugin_setup`]).
+///
+/// `pre_resolved_esbuild` (#994 item A) — an already-extracted embedded
+/// esbuild binary whose backing directory the CALLER keeps alive for at
+/// least as long as the returned [`AssembledBundlerInput`] is in use.
+/// `zfb dev` extracts once at boot and passes it on every tick so the
+/// per-call tempdir extraction below is skipped; `zfb build` passes
+/// `None` and keeps the per-call extraction (one extraction per build is
+/// already process-lifetime there). Ignored when an explicit
+/// `esbuild_binary` or `ZFB_ESBUILD_BIN` override is in play — the
+/// existing precedence is preserved.
 pub(crate) fn assemble_bundler_input(
     project_root: &Path,
     config: &Config,
@@ -160,6 +170,7 @@ pub(crate) fn assemble_bundler_input(
     content_snapshot_json: Option<String>,
     plugin_alias_entries: Vec<(String, String)>,
     plugin_virtual_modules: Vec<(String, String)>,
+    pre_resolved_esbuild: Option<&Path>,
 ) -> Result<AssembledBundlerInput> {
     let mut bundler_input = BundlerInput::for_project(
         project_root.to_path_buf(),
@@ -384,20 +395,32 @@ pub(crate) fn assemble_bundler_input(
     // Skip when an explicit override is in play (input field or env var).
     let _esbuild_handle: Option<tempfile::TempDir>;
     if bundler_input.esbuild_binary.is_none() && std::env::var_os("ZFB_ESBUILD_BIN").is_none() {
-        match crate::render_pipeline::embedded_binary("esbuild") {
-            Ok((handle, path)) => {
-                bundler_input.esbuild_binary = Some(path);
-                _esbuild_handle = Some(handle);
-            }
-            Err(e) => {
-                // Non-fatal: log and let the bundler's own resolver fall
-                // through to the on-disk slot, which still produces a useful
-                // error message pointing at `crates/zfb/binaries/esbuild/`.
-                crate::output::warn(format!(
-                    "could not extract embedded esbuild ({e}); \
-                     falling back to bundler resolver"
-                ));
-                _esbuild_handle = None;
+        if let Some(path) = pre_resolved_esbuild {
+            // #994 item A — the caller already extracted the embedded
+            // esbuild binary and keeps its tempdir alive beyond this
+            // input's lifetime (process-lifetime in `zfb dev`), so the
+            // per-call extraction is skipped. No handle is stored here:
+            // the lifetime contract on `AssembledBundlerInput` is
+            // satisfied by the caller's longer-lived handle.
+            bundler_input.esbuild_binary = Some(path.to_path_buf());
+            _esbuild_handle = None;
+        } else {
+            match crate::render_pipeline::embedded_binary("esbuild") {
+                Ok((handle, path)) => {
+                    bundler_input.esbuild_binary = Some(path);
+                    _esbuild_handle = Some(handle);
+                }
+                Err(e) => {
+                    // Non-fatal: log and let the bundler's own resolver fall
+                    // through to the on-disk slot, which still produces a
+                    // useful error message pointing at
+                    // `crates/zfb/binaries/esbuild/`.
+                    crate::output::warn(format!(
+                        "could not extract embedded esbuild ({e}); \
+                         falling back to bundler resolver"
+                    ));
+                    _esbuild_handle = None;
+                }
             }
         }
     } else {

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -75,7 +75,7 @@ use anyhow::{Context, Result};
 use sha2::{Digest as _, Sha256};
 use tokio::net::TcpListener;
 use tokio::sync::broadcast;
-use zfb_build::bundler::{bundle, BundleMode, BundlerOutput};
+use zfb_build::bundler::{bundle_with_session, BundleMode, BundlerOutput, ShadowSession};
 use zfb_build::renderer::{
     render_one, shutdown, start, Backend, RendererStartInput, RendererState, RouteUniverseEntry,
 };
@@ -1384,6 +1384,19 @@ struct DevRenderInner {
     /// labels) — no narrowing that tick.
     #[cfg(feature = "embed_v8")]
     fm_hashes: Mutex<HashMap<PathBuf, [u8; 32]>>,
+
+    /// Persistent dev shadow-tree session (issue #993): the bundler
+    /// reuses one shadow tempdir across all ticks, skipping
+    /// byte-identical rewrites ("compute always, write only if
+    /// changed" — see [`zfb_build::bundler::ShadowSession`] for the
+    /// safety model). Created at boot ([`boot_dev_renderer`]) and used
+    /// for the boot bundle AND every refresh, so both go through the
+    /// identical assembly path + shadow tree (#659 parity by
+    /// construction). The lock is held only across the P1 bundle step
+    /// of [`DevRenderSession::refresh_bundle_and_routes`] — it never
+    /// overlaps the renderer mutex, so SSR latency is unaffected.
+    #[cfg(feature = "embed_v8")]
+    shadow_session: Mutex<Option<ShadowSession>>,
 }
 
 /// Per-source route filter for one narrowed tick (issue #958): which of a
@@ -1773,14 +1786,32 @@ impl DevRenderSession {
         //    construction incl. embedded esbuild extraction), bundle/esbuild
         //    (subprocess or embedded runner).
         let p1_snapshot_start = tick_start.map(|_| std::time::Instant::now());
-        let bundle_result = assemble_and_bundle_dev(
-            project_root,
-            &inputs.cfg,
-            inputs.plugin_alias_entries.clone(),
-            inputs.plugin_virtual_modules.clone(),
-            timing_enabled,
-        )
-        .context("dev refresh: re-bundle failed")?;
+        let bundle_result = {
+            // #993 — the persistent shadow session lock is scoped to the
+            // P1 bundle step only: it is released before the P2 renderer-
+            // mutex work below, so it can never overlap the renderer
+            // mutex (SSR latency unaffected). On a bundle error the `?`
+            // drops the guard and propagates above the swap — the
+            // previous renderer keeps serving and the session's dirty
+            // flag (set inside bundle_with_session) forces a from-scratch
+            // materialise next tick.
+            let mut session_guard = self.inner.shadow_session.lock().unwrap_or_else(|p| {
+                tracing::warn!(
+                    site = "refresh_bundle_and_routes",
+                    "shadow session mutex poisoned, recovered"
+                );
+                p.into_inner()
+            });
+            assemble_and_bundle_dev(
+                project_root,
+                &inputs.cfg,
+                inputs.plugin_alias_entries.clone(),
+                inputs.plugin_virtual_modules.clone(),
+                timing_enabled,
+                session_guard.as_mut(),
+            )
+            .context("dev refresh: re-bundle failed")?
+        };
         let p1_total_ms = p1_snapshot_start.map(|t| t.elapsed().as_millis());
         // Sub-phase split is reported by assemble_and_bundle_dev into the
         // BundleSubTiming fields when timing_enabled.
@@ -2104,6 +2135,11 @@ fn assemble_and_bundle_dev(
     plugin_alias_entries: Vec<(String, String)>,
     plugin_virtual_modules: Vec<(String, String)>,
     timing_enabled: bool,
+    // Persistent dev shadow-tree session (issue #993). Both the boot
+    // bundle and every refresh pass the SAME session through this seam,
+    // so boot and refresh share one assembly path AND one shadow tree —
+    // #659 configuration parity by construction.
+    shadow_session: Option<&mut ShadowSession>,
 ) -> Result<AssembledBundleResult> {
     // Embed the content snapshot so a page's `getStaticProps()` (and any
     // runtime `paths()`) sees the same collection data the production
@@ -2157,7 +2193,8 @@ fn assemble_and_bundle_dev(
     } else {
         None
     };
-    let bundler_out: BundlerOutput = bundle(bundler_input).context("bundler step failed")?;
+    let bundler_out: BundlerOutput =
+        bundle_with_session(bundler_input, shadow_session).context("bundler step failed")?;
     let bundle_ms = bnd_start.map(|t| t.elapsed().as_millis()).unwrap_or(0);
 
     let sub_timing = if timing_enabled {
@@ -2631,6 +2668,11 @@ fn boot_dev_renderer(
         plugin_virtual_modules: plugin_virtual_modules.clone(),
     };
 
+    // Persistent dev shadow-tree session (issue #993) — created once
+    // here, used for the boot bundle below, then stored on
+    // `DevRenderInner` so every refresh reuses the same shadow tree.
+    let mut shadow_session = ShadowSession::new()?;
+
     // Boot path — timing not collected here (one-shot at startup, not a
     // hot-path tick). `timing_enabled = false` so no Instant::now() overhead.
     let bundler_out: BundlerOutput = assemble_and_bundle_dev(
@@ -2639,6 +2681,7 @@ fn boot_dev_renderer(
         plugin_alias_entries,
         plugin_virtual_modules,
         false,
+        Some(&mut shadow_session),
     )?
     .output;
 
@@ -2692,6 +2735,7 @@ fn boot_dev_renderer(
             // No successful refresh yet — first tick always runs fully.
             last_successful_skip_key: Mutex::new(None),
             fm_hashes: Mutex::new(fm_hashes),
+            shadow_session: Mutex::new(Some(shadow_session)),
         }),
     })
 }
@@ -3306,6 +3350,7 @@ mod tests {
             },
             last_successful_skip_key: Mutex::new(None),
             fm_hashes: Mutex::new(HashMap::new()),
+            shadow_session: Mutex::new(None),
         }
     }
 

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -96,9 +96,8 @@ use crate::commands::resolve::{resolve_addr, resolve_host, resolve_port, resolve
 use crate::config;
 use crate::output;
 use crate::render_pipeline::{
-    build_prerender_map_cached, build_route_universe, check_runtime_installed,
-    eval_deferred_paths_via_worker, expand_dynamic_routes_cached, SourceExtractCache,
-    WorkerDispatch,
+    build_prerender_map, build_route_universe, check_runtime_installed,
+    eval_deferred_paths_via_worker, expand_dynamic_routes, WorkerDispatch,
 };
 #[cfg(feature = "embed_v8")]
 use zfb_render::paths::PathsCache;
@@ -1434,18 +1433,6 @@ struct DevRenderInner {
     /// hold time is unchanged.
     #[cfg(feature = "embed_v8")]
     paths_cache: Mutex<PathsCache>,
-
-    /// Cross-tick per-file content-hash cache (#994 item C) for the two
-    /// SWC-parse extraction passes of the route-table build: TSX
-    /// prerender frontmatter ([`build_prerender_map_cached`]) and static
-    /// `paths()` extraction. Keyed by SHA-256 of the bytes read each
-    /// tick, so any source change invalidates exactly; see
-    /// [`crate::render_pipeline::SourceExtractCache`] for the safety
-    /// notes. Seeded at boot and shared with every refresh (#659
-    /// boot/refresh parity). Locked together with `paths_cache` for the
-    /// P3 build only.
-    #[cfg(feature = "embed_v8")]
-    extract_cache: Mutex<SourceExtractCache>,
 }
 
 /// Per-source route filter for one narrowed tick (issue #958): which of a
@@ -1983,20 +1970,12 @@ impl DevRenderSession {
                 );
                 p.into_inner()
             });
-            let mut extract_cache = self.inner.extract_cache.lock().unwrap_or_else(|p| {
-                tracing::warn!(
-                    site = "refresh_bundle_and_routes",
-                    "extract cache mutex poisoned, recovered"
-                );
-                p.into_inner()
-            });
             build_dev_route_tables_timed(
                 &router,
                 &plan,
                 project_root,
                 &self.inner.renderer,
                 &mut paths_cache,
-                &mut extract_cache,
             )
             .context("dev refresh: route-table rebuild failed")?
         };
@@ -2430,16 +2409,9 @@ fn build_dev_route_tables_timed(
     project_root: &Path,
     renderer: &Arc<Mutex<Option<RendererState>>>,
     paths_cache: &mut PathsCache,
-    extract_cache: &mut SourceExtractCache,
 ) -> Result<TimedRouteTables> {
-    let (routes_by_source, ssr_routes, hits, misses) = build_dev_route_tables_inner(
-        router,
-        plan,
-        project_root,
-        renderer,
-        paths_cache,
-        extract_cache,
-    )?;
+    let (routes_by_source, ssr_routes, hits, misses) =
+        build_dev_route_tables_inner(router, plan, project_root, renderer, paths_cache)?;
     Ok((routes_by_source, ssr_routes, hits, misses))
 }
 
@@ -2456,16 +2428,9 @@ fn build_dev_route_tables(
     project_root: &Path,
     renderer: &Arc<Mutex<Option<RendererState>>>,
     paths_cache: &mut PathsCache,
-    extract_cache: &mut SourceExtractCache,
 ) -> Result<BuiltRouteTables> {
-    let (routes_by_source, ssr_routes, _hits, _misses) = build_dev_route_tables_inner(
-        router,
-        plan,
-        project_root,
-        renderer,
-        paths_cache,
-        extract_cache,
-    )?;
+    let (routes_by_source, ssr_routes, _hits, _misses) =
+        build_dev_route_tables_inner(router, plan, project_root, renderer, paths_cache)?;
     Ok((routes_by_source, ssr_routes))
 }
 
@@ -2481,18 +2446,10 @@ fn build_dev_route_tables_inner(
     project_root: &Path,
     renderer: &Arc<Mutex<Option<RendererState>>>,
     paths_cache: &mut PathsCache,
-    extract_cache: &mut SourceExtractCache,
 ) -> Result<TimedRouteTables> {
-    // #994 item C — both SWC-parse passes below (prerender frontmatter
-    // here, static `paths()` extraction in `expand_dynamic_routes_cached`)
-    // go through the per-file content-hash cache, so unchanged sources
-    // skip the parse on every tick after the first.
-    let prerender_map = build_prerender_map_cached(
-        router.routes(),
-        project_root,
-        |msg| crate::output::warn(msg),
-        Some(extract_cache),
-    );
+    let prerender_map = build_prerender_map(router.routes(), project_root, |msg| {
+        crate::output::warn(msg)
+    });
 
     // Build the source-path → entries map once. Router source paths are
     // project-relative; PageId keys on the same value (the orchestrator
@@ -2601,12 +2558,7 @@ fn build_dev_route_tables_inner(
         // Phase 1 — literal `paths()` arrays (no runtime needed).
         // A missing `paths()` export on an SSG route is a hard error here
         // too — consistent with `zfb build` (issue #520).
-        let static_expansion = expand_dynamic_routes_cached(
-            &ssg_deferred,
-            project_root,
-            paths_cache,
-            Some(extract_cache),
-        )?;
+        let static_expansion = expand_dynamic_routes(&ssg_deferred, project_root, paths_cache)?;
 
         // Phase 2 — evaluate the routes phase 1 couldn't resolve statically
         // through the running embedded V8 host. We borrow the live host out
@@ -2848,20 +2800,13 @@ fn boot_dev_renderer(
     // extracted into `build_dev_route_tables` so the watch-ADD rebuild
     // reproduces the boot tables exactly).
     //
-    // #994 items B + C — the PathsCache and the per-file extraction
-    // cache are seeded here and stored on `DevRenderInner` below, so
-    // every refresh tick reuses the entries this boot-time build
-    // populated (boot/refresh parity: both go through the same caches).
+    // #994 item B — the PathsCache is seeded here and stored on
+    // `DevRenderInner` below, so every refresh tick reuses the entries
+    // this boot-time build populated (boot/refresh parity: both go
+    // through the same cache).
     let mut paths_cache = PathsCache::new();
-    let mut extract_cache = SourceExtractCache::new();
-    let (routes_by_source, ssr_routes) = build_dev_route_tables(
-        &router,
-        &plan,
-        project_root,
-        &renderer,
-        &mut paths_cache,
-        &mut extract_cache,
-    )?;
+    let (routes_by_source, ssr_routes) =
+        build_dev_route_tables(&router, &plan, project_root, &renderer, &mut paths_cache)?;
 
     // Issue #958 — seed the frontmatter gate cache so the FIRST body-only
     // edit of a pre-existing collection file can already narrow (G4 only
@@ -2883,7 +2828,6 @@ fn boot_dev_renderer(
             fm_hashes: Mutex::new(fm_hashes),
             shadow_session: Mutex::new(Some(shadow_session)),
             paths_cache: Mutex::new(paths_cache),
-            extract_cache: Mutex::new(extract_cache),
         }),
     })
 }
@@ -3501,7 +3445,6 @@ mod tests {
             fm_hashes: Mutex::new(HashMap::new()),
             shadow_session: Mutex::new(None),
             paths_cache: Mutex::new(PathsCache::new()),
-            extract_cache: Mutex::new(SourceExtractCache::new()),
         }
     }
 
@@ -3565,26 +3508,9 @@ mod tests {
         let renderer: Arc<Mutex<Option<RendererState>>> = Arc::new(Mutex::new(None));
 
         let mut cache = PathsCache::new();
-        let mut extract_cache = SourceExtractCache::new();
-        let (tables1, ssr1, hits1, misses1) = build_dev_route_tables_timed(
-            &router,
-            &plan,
-            dir.path(),
-            &renderer,
-            &mut cache,
-            &mut extract_cache,
-        )
-        .expect("first build");
-        let extract_misses_after_first = extract_cache.miss_count();
-        assert_eq!(
-            extract_cache.hit_count(),
-            0,
-            "first build runs against a cold extract cache (#994 item C)"
-        );
-        assert!(
-            extract_misses_after_first > 0,
-            "first build must parse (and cache) at least one source"
-        );
+        let (tables1, ssr1, hits1, misses1) =
+            build_dev_route_tables_timed(&router, &plan, dir.path(), &renderer, &mut cache)
+                .expect("first build");
         assert_eq!(hits1, 0, "first build runs against a cold cache");
         assert!(misses1 > 0, "first build must record a miss");
         assert_eq!(
@@ -3595,29 +3521,14 @@ mod tests {
             "literal paths() expands to 2 entries: {tables1:?}"
         );
 
-        let (tables2, ssr2, hits2, misses2) = build_dev_route_tables_timed(
-            &router,
-            &plan,
-            dir.path(),
-            &renderer,
-            &mut cache,
-            &mut extract_cache,
-        )
-        .expect("second build");
+        let (tables2, ssr2, hits2, misses2) =
+            build_dev_route_tables_timed(&router, &plan, dir.path(), &renderer, &mut cache)
+                .expect("second build");
         assert!(
             hits2 > 0,
             "unchanged paths() JSON must hit the shared cache"
         );
         assert_eq!(misses2, 0, "second build must add no misses");
-        assert!(
-            extract_cache.hit_count() > 0,
-            "unchanged sources must hit the extract cache (#994 item C)"
-        );
-        assert_eq!(
-            extract_cache.miss_count(),
-            extract_misses_after_first,
-            "second build must add no extract-cache misses"
-        );
         assert_eq!(
             tables1, tables2,
             "cache-sharing builds must produce identical tables"

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -1333,6 +1333,26 @@ struct DevRebuildInputs {
     v8_plugin_hooks: zfb_render::PluginRegistryHooks,
     plugin_alias_entries: Vec<(String, String)>,
     plugin_virtual_modules: Vec<(String, String)>,
+    /// Process-lifetime embedded-esbuild extraction (#994 item A): the
+    /// `(TempDir, PathBuf)` pair from one boot-time
+    /// [`crate::render_pipeline::embedded_binary`] call, threaded into
+    /// `assemble_bundler_input` on every tick so the per-tick tempdir
+    /// extraction (the bulk of the measured P1 `asm` cost) is skipped.
+    /// The TempDir handle lives as long as the dev session — i.e. it
+    /// outlives every `bundle()` call, trivially satisfying the
+    /// [`crate::commands::bundler_input::AssembledBundlerInput`]
+    /// lifetime contract. `None` when boot-time extraction failed
+    /// (non-fatal: warn + per-tick fallback) or when `ZFB_ESBUILD_BIN`
+    /// overrides the embedded binary.
+    esbuild: Option<(tempfile::TempDir, PathBuf)>,
+}
+
+#[cfg(feature = "embed_v8")]
+impl DevRebuildInputs {
+    /// Path of the boot-time extracted esbuild binary (#994 item A), if any.
+    fn esbuild_path(&self) -> Option<&Path> {
+        self.esbuild.as_ref().map(|(_, path)| path.as_path())
+    }
 }
 
 struct DevRenderInner {
@@ -1809,6 +1829,7 @@ impl DevRenderSession {
                 inputs.plugin_virtual_modules.clone(),
                 timing_enabled,
                 session_guard.as_mut(),
+                inputs.esbuild_path(),
             )
             .context("dev refresh: re-bundle failed")?
         };
@@ -2117,9 +2138,12 @@ struct AssembledBundleResult {
 /// — extracted from `boot_dev_renderer` so the watch-ADD re-bundle reuses
 /// the EXACT same configuration the boot bundle used; any drift here would
 /// make a newly-added page render differently in dev than it did at boot).
-/// The embedded node_modules / esbuild tempdir handles live only for the
+/// The embedded node_modules tempdir handle lives only for the
 /// synchronous `bundle()` call (which writes `bundle_path` to disk), so
-/// scoping them to this function is correct.
+/// scoping it to this function is correct. The esbuild binary is the
+/// boot-time process-lifetime extraction passed via `pre_resolved_esbuild`
+/// (#994 item A); the per-call extraction only runs as a fallback when
+/// that is `None`.
 ///
 /// `recompute snapshot` is implicit: `build_content_snapshot_json` re-reads
 /// the content collections from disk on every call, so a re-bundle here
@@ -2140,6 +2164,10 @@ fn assemble_and_bundle_dev(
     // so boot and refresh share one assembly path AND one shadow tree —
     // #659 configuration parity by construction.
     shadow_session: Option<&mut ShadowSession>,
+    // Boot-time extracted embedded esbuild binary (#994 item A) — see
+    // [`DevRebuildInputs::esbuild`]. Both boot and refresh pass the same
+    // path so every tick skips the per-call tempdir extraction.
+    pre_resolved_esbuild: Option<&Path>,
 ) -> Result<AssembledBundleResult> {
     // Embed the content snapshot so a page's `getStaticProps()` (and any
     // runtime `paths()`) sees the same collection data the production
@@ -2185,6 +2213,7 @@ fn assemble_and_bundle_dev(
         content_snapshot_json,
         plugin_alias_entries,
         plugin_virtual_modules,
+        pre_resolved_esbuild,
     )?;
     let assemble_ms = asm_start.map(|t| t.elapsed().as_millis()).unwrap_or(0);
 
@@ -2666,6 +2695,28 @@ fn boot_dev_renderer(
         v8_plugin_hooks: v8_plugin_hooks.clone(),
         plugin_alias_entries: plugin_alias_entries.clone(),
         plugin_virtual_modules: plugin_virtual_modules.clone(),
+        // #994 item A — extract the embedded esbuild binary ONCE here;
+        // the handle lives on `DevRebuildInputs` for the whole dev
+        // session, so every tick's `assemble_bundler_input` skips its
+        // per-call tempdir extraction. Skipped when `ZFB_ESBUILD_BIN`
+        // overrides the embedded binary (the assemble-side skip
+        // condition would ignore the path anyway). Extraction failure
+        // is non-fatal, matching the assemble-side handling: warn and
+        // fall back to the per-tick extraction by passing `None`.
+        esbuild: if std::env::var_os("ZFB_ESBUILD_BIN").is_none() {
+            match crate::render_pipeline::embedded_binary("esbuild") {
+                Ok(pair) => Some(pair),
+                Err(e) => {
+                    crate::output::warn(format!(
+                        "could not extract embedded esbuild at dev boot ({e}); \
+                         falling back to per-tick extraction"
+                    ));
+                    None
+                }
+            }
+        } else {
+            None
+        },
     };
 
     // Persistent dev shadow-tree session (issue #993) — created once
@@ -2682,6 +2733,7 @@ fn boot_dev_renderer(
         plugin_virtual_modules,
         false,
         Some(&mut shadow_session),
+        rebuild_inputs.esbuild_path(),
     )?
     .output;
 
@@ -3347,6 +3399,7 @@ mod tests {
                 v8_plugin_hooks: zfb_render::PluginRegistryHooks::default(),
                 plugin_alias_entries: Vec::new(),
                 plugin_virtual_modules: Vec::new(),
+                esbuild: None,
             },
             last_successful_skip_key: Mutex::new(None),
             fm_hashes: Mutex::new(HashMap::new()),

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -96,8 +96,9 @@ use crate::commands::resolve::{resolve_addr, resolve_host, resolve_port, resolve
 use crate::config;
 use crate::output;
 use crate::render_pipeline::{
-    build_prerender_map, build_route_universe, check_runtime_installed,
-    eval_deferred_paths_via_worker, expand_dynamic_routes, WorkerDispatch,
+    build_prerender_map_cached, build_route_universe, check_runtime_installed,
+    eval_deferred_paths_via_worker, expand_dynamic_routes_cached, SourceExtractCache,
+    WorkerDispatch,
 };
 #[cfg(feature = "embed_v8")]
 use zfb_render::paths::PathsCache;
@@ -1433,6 +1434,18 @@ struct DevRenderInner {
     /// hold time is unchanged.
     #[cfg(feature = "embed_v8")]
     paths_cache: Mutex<PathsCache>,
+
+    /// Cross-tick per-file content-hash cache (#994 item C) for the two
+    /// SWC-parse extraction passes of the route-table build: TSX
+    /// prerender frontmatter ([`build_prerender_map`]) and static
+    /// `paths()` extraction. Keyed by SHA-256 of the bytes read each
+    /// tick, so any source change invalidates exactly; see
+    /// [`crate::render_pipeline::SourceExtractCache`] for the safety
+    /// notes. Seeded at boot and shared with every refresh (#659
+    /// boot/refresh parity). Locked together with `paths_cache` for the
+    /// P3 build only.
+    #[cfg(feature = "embed_v8")]
+    extract_cache: Mutex<SourceExtractCache>,
 }
 
 /// Per-source route filter for one narrowed tick (issue #958): which of a
@@ -1970,12 +1983,20 @@ impl DevRenderSession {
                 );
                 p.into_inner()
             });
+            let mut extract_cache = self.inner.extract_cache.lock().unwrap_or_else(|p| {
+                tracing::warn!(
+                    site = "refresh_bundle_and_routes",
+                    "extract cache mutex poisoned, recovered"
+                );
+                p.into_inner()
+            });
             build_dev_route_tables_timed(
                 &router,
                 &plan,
                 project_root,
                 &self.inner.renderer,
                 &mut paths_cache,
+                &mut extract_cache,
             )
             .context("dev refresh: route-table rebuild failed")?
         };
@@ -2409,9 +2430,16 @@ fn build_dev_route_tables_timed(
     project_root: &Path,
     renderer: &Arc<Mutex<Option<RendererState>>>,
     paths_cache: &mut PathsCache,
+    extract_cache: &mut SourceExtractCache,
 ) -> Result<TimedRouteTables> {
-    let (routes_by_source, ssr_routes, hits, misses) =
-        build_dev_route_tables_inner(router, plan, project_root, renderer, paths_cache)?;
+    let (routes_by_source, ssr_routes, hits, misses) = build_dev_route_tables_inner(
+        router,
+        plan,
+        project_root,
+        renderer,
+        paths_cache,
+        extract_cache,
+    )?;
     Ok((routes_by_source, ssr_routes, hits, misses))
 }
 
@@ -2428,9 +2456,16 @@ fn build_dev_route_tables(
     project_root: &Path,
     renderer: &Arc<Mutex<Option<RendererState>>>,
     paths_cache: &mut PathsCache,
+    extract_cache: &mut SourceExtractCache,
 ) -> Result<BuiltRouteTables> {
-    let (routes_by_source, ssr_routes, _hits, _misses) =
-        build_dev_route_tables_inner(router, plan, project_root, renderer, paths_cache)?;
+    let (routes_by_source, ssr_routes, _hits, _misses) = build_dev_route_tables_inner(
+        router,
+        plan,
+        project_root,
+        renderer,
+        paths_cache,
+        extract_cache,
+    )?;
     Ok((routes_by_source, ssr_routes))
 }
 
@@ -2446,10 +2481,18 @@ fn build_dev_route_tables_inner(
     project_root: &Path,
     renderer: &Arc<Mutex<Option<RendererState>>>,
     paths_cache: &mut PathsCache,
+    extract_cache: &mut SourceExtractCache,
 ) -> Result<TimedRouteTables> {
-    let prerender_map = build_prerender_map(router.routes(), project_root, |msg| {
-        crate::output::warn(msg)
-    });
+    // #994 item C — both SWC-parse passes below (prerender frontmatter
+    // here, static `paths()` extraction in `expand_dynamic_routes_cached`)
+    // go through the per-file content-hash cache, so unchanged sources
+    // skip the parse on every tick after the first.
+    let prerender_map = build_prerender_map_cached(
+        router.routes(),
+        project_root,
+        |msg| crate::output::warn(msg),
+        Some(extract_cache),
+    );
 
     // Build the source-path → entries map once. Router source paths are
     // project-relative; PageId keys on the same value (the orchestrator
@@ -2558,7 +2601,12 @@ fn build_dev_route_tables_inner(
         // Phase 1 — literal `paths()` arrays (no runtime needed).
         // A missing `paths()` export on an SSG route is a hard error here
         // too — consistent with `zfb build` (issue #520).
-        let static_expansion = expand_dynamic_routes(&ssg_deferred, project_root, paths_cache)?;
+        let static_expansion = expand_dynamic_routes_cached(
+            &ssg_deferred,
+            project_root,
+            paths_cache,
+            Some(extract_cache),
+        )?;
 
         // Phase 2 — evaluate the routes phase 1 couldn't resolve statically
         // through the running embedded V8 host. We borrow the live host out
@@ -2800,13 +2848,20 @@ fn boot_dev_renderer(
     // extracted into `build_dev_route_tables` so the watch-ADD rebuild
     // reproduces the boot tables exactly).
     //
-    // #994 item B — the PathsCache is seeded here and stored on
-    // `DevRenderInner` below, so every refresh tick reuses the entries
-    // this boot-time build populated (boot/refresh parity: both go
-    // through the same cache).
+    // #994 items B + C — the PathsCache and the per-file extraction
+    // cache are seeded here and stored on `DevRenderInner` below, so
+    // every refresh tick reuses the entries this boot-time build
+    // populated (boot/refresh parity: both go through the same caches).
     let mut paths_cache = PathsCache::new();
-    let (routes_by_source, ssr_routes) =
-        build_dev_route_tables(&router, &plan, project_root, &renderer, &mut paths_cache)?;
+    let mut extract_cache = SourceExtractCache::new();
+    let (routes_by_source, ssr_routes) = build_dev_route_tables(
+        &router,
+        &plan,
+        project_root,
+        &renderer,
+        &mut paths_cache,
+        &mut extract_cache,
+    )?;
 
     // Issue #958 — seed the frontmatter gate cache so the FIRST body-only
     // edit of a pre-existing collection file can already narrow (G4 only
@@ -2828,6 +2883,7 @@ fn boot_dev_renderer(
             fm_hashes: Mutex::new(fm_hashes),
             shadow_session: Mutex::new(Some(shadow_session)),
             paths_cache: Mutex::new(paths_cache),
+            extract_cache: Mutex::new(extract_cache),
         }),
     })
 }
@@ -3445,6 +3501,7 @@ mod tests {
             fm_hashes: Mutex::new(HashMap::new()),
             shadow_session: Mutex::new(None),
             paths_cache: Mutex::new(PathsCache::new()),
+            extract_cache: Mutex::new(SourceExtractCache::new()),
         }
     }
 
@@ -3508,9 +3565,26 @@ mod tests {
         let renderer: Arc<Mutex<Option<RendererState>>> = Arc::new(Mutex::new(None));
 
         let mut cache = PathsCache::new();
-        let (tables1, ssr1, hits1, misses1) =
-            build_dev_route_tables_timed(&router, &plan, dir.path(), &renderer, &mut cache)
-                .expect("first build");
+        let mut extract_cache = SourceExtractCache::new();
+        let (tables1, ssr1, hits1, misses1) = build_dev_route_tables_timed(
+            &router,
+            &plan,
+            dir.path(),
+            &renderer,
+            &mut cache,
+            &mut extract_cache,
+        )
+        .expect("first build");
+        let extract_misses_after_first = extract_cache.miss_count();
+        assert_eq!(
+            extract_cache.hit_count(),
+            0,
+            "first build runs against a cold extract cache (#994 item C)"
+        );
+        assert!(
+            extract_misses_after_first > 0,
+            "first build must parse (and cache) at least one source"
+        );
         assert_eq!(hits1, 0, "first build runs against a cold cache");
         assert!(misses1 > 0, "first build must record a miss");
         assert_eq!(
@@ -3521,14 +3595,29 @@ mod tests {
             "literal paths() expands to 2 entries: {tables1:?}"
         );
 
-        let (tables2, ssr2, hits2, misses2) =
-            build_dev_route_tables_timed(&router, &plan, dir.path(), &renderer, &mut cache)
-                .expect("second build");
+        let (tables2, ssr2, hits2, misses2) = build_dev_route_tables_timed(
+            &router,
+            &plan,
+            dir.path(),
+            &renderer,
+            &mut cache,
+            &mut extract_cache,
+        )
+        .expect("second build");
         assert!(
             hits2 > 0,
             "unchanged paths() JSON must hit the shared cache"
         );
         assert_eq!(misses2, 0, "second build must add no misses");
+        assert!(
+            extract_cache.hit_count() > 0,
+            "unchanged sources must hit the extract cache (#994 item C)"
+        );
+        assert_eq!(
+            extract_cache.miss_count(),
+            extract_misses_after_first,
+            "second build must add no extract-cache misses"
+        );
         assert_eq!(
             tables1, tables2,
             "cache-sharing builds must produce identical tables"

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -1417,6 +1417,22 @@ struct DevRenderInner {
     /// overlaps the renderer mutex, so SSR latency is unaffected.
     #[cfg(feature = "embed_v8")]
     shadow_session: Mutex<Option<ShadowSession>>,
+
+    /// Cross-tick [`PathsCache`] (#994 item B): seeded at boot and
+    /// passed into every route-table build, so a `paths()` JSON output
+    /// identical to a previous tick's skips the Rust-side
+    /// validate/URL-build in `resolve_paths`. NOTE the corrected scope
+    /// (#992): the cache lookup happens AFTER the V8 `/__paths__/`
+    /// dispatch — the key includes the hash of the dispatch RESULT — so
+    /// persistence does NOT skip the per-tick V8 evals; the saving is
+    /// the ~1–5 ms Rust tail only. Sound by construction: a changed
+    /// `paths()` output can never hit a stale entry (key = template +
+    /// JSON hash) and stale entries are inert. The lock is scoped to
+    /// the P3 route-table build; the renderer lock for phase-2 eval is
+    /// taken inside the build exactly as before, so renderer-mutex
+    /// hold time is unchanged.
+    #[cfg(feature = "embed_v8")]
+    paths_cache: Mutex<PathsCache>,
 }
 
 /// Per-source route filter for one narrowed tick (issue #958): which of a
@@ -1938,16 +1954,31 @@ impl DevRenderSession {
         self.inner.commit_skip_key(None);
 
         // P3 — route-table rebuild (re-expands `paths()` through the new
-        //      V8 host) with paths()-expansion sub-timing and PathsCache
-        //      hit/miss counts. The cache is constructed fresh each call
-        //      (dev.rs:2250), so 100% miss is expected here — instrumented
-        //      to measure; fix deferred (#991).
+        //      V8 host) with paths()-expansion sub-timing and this tick's
+        //      PathsCache hit/miss deltas. The cache persists across
+        //      ticks (#994 item B) — note the lookup happens AFTER the
+        //      V8 dispatch (keyed on its result), so hits save only the
+        //      Rust-side validate/URL-build, not the V8 evals.
         // 3. Rebuild the route tables through the reloaded host (re-expands
         //    `paths()`, so the dynamic source now resolves the new URL).
         let p3_start = tick_start.map(|_| std::time::Instant::now());
-        let (new_routes_by_source, new_ssr_routes, p3_cache_hits, p3_cache_misses) =
-            build_dev_route_tables_timed(&router, &plan, project_root, &self.inner.renderer)
-                .context("dev refresh: route-table rebuild failed")?;
+        let (new_routes_by_source, new_ssr_routes, p3_cache_hits, p3_cache_misses) = {
+            let mut paths_cache = self.inner.paths_cache.lock().unwrap_or_else(|p| {
+                tracing::warn!(
+                    site = "refresh_bundle_and_routes",
+                    "paths cache mutex poisoned, recovered"
+                );
+                p.into_inner()
+            });
+            build_dev_route_tables_timed(
+                &router,
+                &plan,
+                project_root,
+                &self.inner.renderer,
+                &mut paths_cache,
+            )
+            .context("dev refresh: route-table rebuild failed")?
+        };
         let p3_ms = p3_start.map(|t| t.elapsed().as_millis());
 
         // P4 — diff + RwLock table swap + skip-key commit.
@@ -2368,20 +2399,19 @@ type TimedRouteTables = (
 );
 
 /// Timed variant of [`build_dev_route_tables`]: returns the same tables plus
-/// the [`PathsCache`] hit and miss counters for P3 diagnostics (issue #991).
-///
-/// Note: the cache is constructed fresh on every call (see line below), so
-/// 100% miss is expected — this is instrumented here to confirm and to
-/// provide the data needed for the cache-reuse decision (deferred).
+/// the [`PathsCache`] hit and miss DELTAS for this call, for P3 diagnostics
+/// (issue #991). The cache persists across ticks (#994 item B) and its
+/// counters are cumulative, so the inner build reports per-call deltas.
 #[cfg(feature = "embed_v8")]
 fn build_dev_route_tables_timed(
     router: &zfb_router::Router,
     plan: &crate::render_pipeline::RouteUniversePlan,
     project_root: &Path,
     renderer: &Arc<Mutex<Option<RendererState>>>,
+    paths_cache: &mut PathsCache,
 ) -> Result<TimedRouteTables> {
     let (routes_by_source, ssr_routes, hits, misses) =
-        build_dev_route_tables_inner(router, plan, project_root, renderer)?;
+        build_dev_route_tables_inner(router, plan, project_root, renderer, paths_cache)?;
     Ok((routes_by_source, ssr_routes, hits, misses))
 }
 
@@ -2397,23 +2427,25 @@ fn build_dev_route_tables(
     plan: &crate::render_pipeline::RouteUniversePlan,
     project_root: &Path,
     renderer: &Arc<Mutex<Option<RendererState>>>,
+    paths_cache: &mut PathsCache,
 ) -> Result<BuiltRouteTables> {
     let (routes_by_source, ssr_routes, _hits, _misses) =
-        build_dev_route_tables_inner(router, plan, project_root, renderer)?;
+        build_dev_route_tables_inner(router, plan, project_root, renderer, paths_cache)?;
     Ok((routes_by_source, ssr_routes))
 }
 
 /// Inner implementation shared by [`build_dev_route_tables`] and
-/// [`build_dev_route_tables_timed`]. Returns the route tables plus the
-/// PathsCache hit/miss counts (issue #991 — cache is fresh-constructed per
-/// call, so 100% miss is expected; see the comment at the PathsCache::new()
-/// call below).
+/// [`build_dev_route_tables_timed`]. Returns the route tables plus this
+/// call's PathsCache hit/miss deltas (#991 instrumentation; the cache is
+/// caller-owned and persists across ticks per #994 item B, so the
+/// cumulative counters are differenced here).
 #[cfg(feature = "embed_v8")]
 fn build_dev_route_tables_inner(
     router: &zfb_router::Router,
     plan: &crate::render_pipeline::RouteUniversePlan,
     project_root: &Path,
     renderer: &Arc<Mutex<Option<RendererState>>>,
+    paths_cache: &mut PathsCache,
 ) -> Result<TimedRouteTables> {
     let prerender_map = build_prerender_map(router.routes(), project_root, |msg| {
         crate::output::warn(msg)
@@ -2503,13 +2535,13 @@ fn build_dev_route_tables_inner(
         .filter(|d| !crate::render_pipeline::is_ssr_route(&prerender_map, &d.template))
         .cloned()
         .collect();
-    // PathsCache hit/miss counters — issue #991 instrumentation.
-    // The cache is constructed fresh here on every call (not shared across
-    // ticks), so 100% miss is expected; these counts confirm that and feed
-    // the ZFB_DEV_TIMING P3 line. Deferred: caching across ticks is not
-    // done here.
-    let mut paths_cache_hits: u64 = 0;
-    let mut paths_cache_misses: u64 = 0;
+    // PathsCache hit/miss DELTAS for this call — issue #991
+    // instrumentation. The cache is caller-owned and persists across
+    // ticks (#994 item B), so its cumulative counters are snapshotted
+    // here and differenced at the end to feed the ZFB_DEV_TIMING P3
+    // line.
+    let hits_before = paths_cache.hit_count();
+    let misses_before = paths_cache.miss_count();
 
     if !ssg_deferred.is_empty() {
         // Map each route template back to its source path so the resolved
@@ -2523,13 +2555,10 @@ fn build_dev_route_tables_inner(
             .map(|d| (d.template.clone(), d.source_path.clone()))
             .collect();
 
-        let mut paths_cache = PathsCache::new();
-
         // Phase 1 — literal `paths()` arrays (no runtime needed).
         // A missing `paths()` export on an SSG route is a hard error here
         // too — consistent with `zfb build` (issue #520).
-        let static_expansion =
-            expand_dynamic_routes(&ssg_deferred, project_root, &mut paths_cache)?;
+        let static_expansion = expand_dynamic_routes(&ssg_deferred, project_root, paths_cache)?;
 
         // Phase 2 — evaluate the routes phase 1 couldn't resolve statically
         // through the running embedded V8 host. We borrow the live host out
@@ -2537,7 +2566,15 @@ fn build_dev_route_tables_inner(
         // RendererState>>>` the SSG render callback and the SSR adapter
         // share) and dispatch via `WorkerDispatch::EmbeddedV8`, exactly like
         // `commands/build.rs::eval_deferred_paths`.
-        let runtime_expansion = {
+        //
+        // The renderer mutex is only taken when phase 1 left anything to
+        // evaluate (#994 item B): when every `paths()` resolved
+        // statically there is nothing to dispatch, so borrowing the live
+        // host would be a pointless lock (and previously made an
+        // all-literal project hard-require a started renderer here).
+        let runtime_expansion = if static_expansion.deferred.is_empty() {
+            crate::render_pipeline::DynamicExpansion::default()
+        } else {
             let mut lock = renderer.lock().unwrap_or_else(|p| {
                 tracing::warn!(
                     site = "boot_dev_renderer.paths",
@@ -2558,14 +2595,10 @@ fn build_dev_route_tables_inner(
             eval_deferred_paths_via_worker(
                 &static_expansion.deferred,
                 &mut dispatch,
-                &mut paths_cache,
+                paths_cache,
                 None,
             )
         };
-
-        // Capture PathsCache stats before consuming the cache (issue #991).
-        paths_cache_hits = paths_cache.hit_count();
-        paths_cache_misses = paths_cache.miss_count();
 
         // Surface routes that still couldn't be expanded (after both phases)
         // as warnings so the user knows why a `[slug]` route didn't appear —
@@ -2630,8 +2663,8 @@ fn build_dev_route_tables_inner(
     Ok((
         routes_by_source,
         ssr_routes,
-        paths_cache_hits,
-        paths_cache_misses,
+        paths_cache.hit_count() - hits_before,
+        paths_cache.miss_count() - misses_before,
     ))
 }
 
@@ -2766,8 +2799,14 @@ fn boot_dev_renderer(
     // Build the route tables from the router scan + the live host (#659:
     // extracted into `build_dev_route_tables` so the watch-ADD rebuild
     // reproduces the boot tables exactly).
+    //
+    // #994 item B — the PathsCache is seeded here and stored on
+    // `DevRenderInner` below, so every refresh tick reuses the entries
+    // this boot-time build populated (boot/refresh parity: both go
+    // through the same cache).
+    let mut paths_cache = PathsCache::new();
     let (routes_by_source, ssr_routes) =
-        build_dev_route_tables(&router, &plan, project_root, &renderer)?;
+        build_dev_route_tables(&router, &plan, project_root, &renderer, &mut paths_cache)?;
 
     // Issue #958 — seed the frontmatter gate cache so the FIRST body-only
     // edit of a pre-existing collection file can already narrow (G4 only
@@ -2788,6 +2827,7 @@ fn boot_dev_renderer(
             last_successful_skip_key: Mutex::new(None),
             fm_hashes: Mutex::new(fm_hashes),
             shadow_session: Mutex::new(Some(shadow_session)),
+            paths_cache: Mutex::new(paths_cache),
         }),
     })
 }
@@ -3404,6 +3444,7 @@ mod tests {
             last_successful_skip_key: Mutex::new(None),
             fm_hashes: Mutex::new(HashMap::new()),
             shadow_session: Mutex::new(None),
+            paths_cache: Mutex::new(PathsCache::new()),
         }
     }
 
@@ -3428,6 +3469,71 @@ mod tests {
     fn default_watch_roots_includes_zfb_config_json() {
         assert!(DEFAULT_WATCH_ROOTS.contains(&"zfb.config.json"));
         assert!(DEFAULT_WATCH_ROOTS.contains(&"zfb.config.ts"));
+    }
+
+    /// #994 item B — the PathsCache is caller-owned and persists across
+    /// route-table builds: a second build sharing the cache with
+    /// unchanged `paths()` JSON reports cache hits (delta counters) and
+    /// produces identical tables.
+    #[test]
+    #[cfg(feature = "embed_v8")]
+    fn build_dev_route_tables_shares_paths_cache_across_calls() {
+        let dir = tempfile::tempdir().unwrap();
+        let pages = dir.path().join("pages");
+        std::fs::create_dir_all(pages.join("blog")).unwrap();
+        std::fs::write(
+            pages.join("index.tsx"),
+            "export default function Home() { return null; }",
+        )
+        .unwrap();
+        std::fs::write(
+            pages.join("blog").join("[slug].tsx"),
+            r#"
+            export function paths() {
+                return [
+                    { params: { slug: "hello" } },
+                    { params: { slug: "world" } },
+                ];
+            }
+            export default function P() { return null; }
+            "#,
+        )
+        .unwrap();
+
+        let router = zfb_router::Router::scan(&pages).unwrap();
+        let plan = build_route_universe(router.routes());
+        // No live V8 host: the literal `paths()` resolves in phase 1, so
+        // the renderer mutex is never borrowed (see the phase-2 gate in
+        // `build_dev_route_tables_inner`).
+        let renderer: Arc<Mutex<Option<RendererState>>> = Arc::new(Mutex::new(None));
+
+        let mut cache = PathsCache::new();
+        let (tables1, ssr1, hits1, misses1) =
+            build_dev_route_tables_timed(&router, &plan, dir.path(), &renderer, &mut cache)
+                .expect("first build");
+        assert_eq!(hits1, 0, "first build runs against a cold cache");
+        assert!(misses1 > 0, "first build must record a miss");
+        assert_eq!(
+            tables1
+                .get(&pages.join("blog").join("[slug].tsx"))
+                .map(Vec::len),
+            Some(2),
+            "literal paths() expands to 2 entries: {tables1:?}"
+        );
+
+        let (tables2, ssr2, hits2, misses2) =
+            build_dev_route_tables_timed(&router, &plan, dir.path(), &renderer, &mut cache)
+                .expect("second build");
+        assert!(
+            hits2 > 0,
+            "unchanged paths() JSON must hit the shared cache"
+        );
+        assert_eq!(misses2, 0, "second build must add no misses");
+        assert_eq!(
+            tables1, tables2,
+            "cache-sharing builds must produce identical tables"
+        );
+        assert_eq!(ssr1, ssr2);
     }
 
     fn cfg_with_collections(paths: &[&str]) -> config::Config {

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -467,7 +467,7 @@ pub async fn run(args: &DevArgs) -> Result<()> {
         cfg.framework,
         &islands_plugin_config,
     ) {
-        Ok(Some(payload)) => {
+        Ok((Some(payload), _marker_names)) => {
             // Write the stable `islands.js` bytes to disk so the dev
             // server's `ServeDir` can handle `GET /assets/islands.js`.
             // The bundler no longer writes to disk itself — the caller
@@ -514,7 +514,7 @@ pub async fn run(args: &DevArgs) -> Result<()> {
                 }
             }
         }
-        Ok(None) => {
+        Ok((None, _marker_names)) => {
             // No `"use client"` islands in the project. Leave the handle
             // at `None` so the server skips head injection entirely.
         }
@@ -535,7 +535,10 @@ pub async fn run(args: &DevArgs) -> Result<()> {
         let url_handle = Arc::clone(&islands_bundle_url_handle);
         let chunk_names = Arc::clone(&live_chunk_filenames);
         Some(Arc::new(move || -> Result<Option<IslandsBundleInfo>> {
-            let payload = crate::commands::build::build_default_islands_payload(
+            // Marker names are only needed by the production build pass; dev
+            // mode already surfaces unknown-marker warnings in the browser
+            // console via the runtime.ts warn path.
+            let (payload, _marker_names) = crate::commands::build::build_default_islands_payload(
                 &project_root,
                 &dist_root_for_islands,
                 framework,

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -1437,7 +1437,7 @@ struct DevRenderInner {
 
     /// Cross-tick per-file content-hash cache (#994 item C) for the two
     /// SWC-parse extraction passes of the route-table build: TSX
-    /// prerender frontmatter ([`build_prerender_map`]) and static
+    /// prerender frontmatter ([`build_prerender_map_cached`]) and static
     /// `paths()` extraction. Keyed by SHA-256 of the bytes read each
     /// tick, so any source change invalidates exactly; see
     /// [`crate::render_pipeline::SourceExtractCache`] for the safety

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -1744,26 +1744,52 @@ impl DevRenderSession {
         let project_root = &self.inner.project_root;
         let inputs = &self.inner.rebuild_inputs;
 
+        // `ZFB_DEV_TIMING=1` — per-tick phase timing (issue #991).
+        // Checked once here; all Instant::now() calls inside are skipped
+        // when the flag is unset (zero overhead on the hot path).
+        let timing_enabled = dev_timing_enabled();
+        let tick_start = if timing_enabled {
+            Some(std::time::Instant::now())
+        } else {
+            None
+        };
+
+        // P0 — router re-scan + route-universe plan.
+        let p0_start = tick_start.map(|_| std::time::Instant::now());
+        let pages_dir = project_root.join("pages");
         // Re-scan the router. `Router::scan` is unchanged by adding a
         // CONTENT file (the dynamic `[slug].tsx` source is the same), but
         // re-running it is cheap and keeps boot and rebuild symmetrical —
         // and it correctly picks up a brand-new `.tsx`/`.md` page placed
         // directly under `pages/` too.
-        let pages_dir = project_root.join("pages");
         let router = zfb_router::Router::scan(&pages_dir).map_err(anyhow::Error::from)?;
         let plan = build_route_universe(router.routes());
+        let p0_ms = p0_start.map(|t| t.elapsed().as_millis());
 
-        // 1. Re-bundle with a fresh content snapshot (reads every
+        // P1 — re-bundle with a fresh content snapshot (reads every
         //    configured collection from disk, so created AND edited
         //    entries are in the snapshot).
-        let bundler_out = assemble_and_bundle_dev(
+        //    Sub-phases: snapshot (content walk), assemble (BundlerInput
+        //    construction incl. embedded esbuild extraction), bundle/esbuild
+        //    (subprocess or embedded runner).
+        let p1_snapshot_start = tick_start.map(|_| std::time::Instant::now());
+        let bundle_result = assemble_and_bundle_dev(
             project_root,
             &inputs.cfg,
             inputs.plugin_alias_entries.clone(),
             inputs.plugin_virtual_modules.clone(),
+            timing_enabled,
         )
         .context("dev refresh: re-bundle failed")?;
+        let p1_total_ms = p1_snapshot_start.map(|t| t.elapsed().as_millis());
+        // Sub-phase split is reported by assemble_and_bundle_dev into the
+        // BundleSubTiming fields when timing_enabled.
+        let p1_snapshot_ms = bundle_result.sub_timing.as_ref().map(|t| t.snapshot_ms);
+        let p1_assemble_ms = bundle_result.sub_timing.as_ref().map(|t| t.assemble_ms);
+        let p1_bundle_ms = bundle_result.sub_timing.as_ref().map(|t| t.bundle_ms);
+        let bundler_out = bundle_result.output;
 
+        // P1b — skip-key compute (SHA-256 over bundle + router + static HTML).
         // Phase B (issue #940) — skip key check.
         //
         // Compute a digest over bundle bytes + the router-scan signature
@@ -1784,7 +1810,9 @@ impl DevRenderSession {
         // route rebuild). A failed refresh — e.g. host start error — must
         // NOT update last_successful_skip_key so the next byte-identical
         // tick retries in full (Correctness Req 1, issue #940).
+        let p1b_start = tick_start.map(|_| std::time::Instant::now());
         let new_skip_key = compute_bundle_skip_key(&bundler_out, router.routes());
+        let p1b_ms = p1b_start.map(|t| t.elapsed().as_millis());
         if self.inner.should_skip_refresh(new_skip_key) {
             tracing::debug!(
                 site = "refresh_bundle_and_routes",
@@ -1797,44 +1825,53 @@ impl DevRenderSession {
             return Ok(BundleRefresh::Skipped);
         }
 
+        // P2 — V8 host boot, mutex swap, old-host shutdown (three separate
+        //      sub-timers: boot vs eval vs teardown; split matters for the
+        //      host-reuse decision).
         // 2. Start a NEW embedded V8 host against the rebuilt bundle,
         //    swap it into the existing mutex (the render callback + SSR
         //    adapter share this exact Arc), and shut the old host down
         //    only after the swap — a host-start failure must leave the
         //    previous renderer serving (see the method docs).
-        {
-            let started = start(RendererStartInput {
-                bundle_path: bundler_out.bundle_path.clone(),
-                sourcemap_path: bundler_out.sourcemap_path.clone(),
-                backend: Backend::EmbeddedV8 {
-                    host_factory: crate::v8_host_adapter::make_v8_host_factory_with_hooks(
-                        inputs.v8_plugin_hooks.clone(),
-                    ),
-                },
-                request_timeout: None,
-            })
-            .map_err(anyhow::Error::from)
-            .context("dev refresh: renderer start failed (previous renderer kept serving)")?;
-            let previous = {
-                let mut lock = self.inner.renderer.lock().unwrap_or_else(|p| {
-                    tracing::warn!(
-                        site = "refresh_bundle_and_routes",
-                        "renderer mutex poisoned, recovered"
-                    );
-                    p.into_inner()
-                });
-                lock.replace(started)
-            };
-            if let Some(prev) = previous {
-                if let Err(err) = shutdown(prev) {
-                    tracing::warn!(
-                        site = "refresh_bundle_and_routes",
-                        error = %err,
-                        "old renderer shutdown failed; continuing with new host"
-                    );
-                }
+        let p2_boot_start = tick_start.map(|_| std::time::Instant::now());
+        let started = start(RendererStartInput {
+            bundle_path: bundler_out.bundle_path.clone(),
+            sourcemap_path: bundler_out.sourcemap_path.clone(),
+            backend: Backend::EmbeddedV8 {
+                host_factory: crate::v8_host_adapter::make_v8_host_factory_with_hooks(
+                    inputs.v8_plugin_hooks.clone(),
+                ),
+            },
+            request_timeout: None,
+        })
+        .map_err(anyhow::Error::from)
+        .context("dev refresh: renderer start failed (previous renderer kept serving)")?;
+        let p2_boot_ms = p2_boot_start.map(|t| t.elapsed().as_millis());
+
+        let p2_swap_start = tick_start.map(|_| std::time::Instant::now());
+        let previous = {
+            let mut lock = self.inner.renderer.lock().unwrap_or_else(|p| {
+                tracing::warn!(
+                    site = "refresh_bundle_and_routes",
+                    "renderer mutex poisoned, recovered"
+                );
+                p.into_inner()
+            });
+            lock.replace(started)
+        };
+        let p2_swap_ms = p2_swap_start.map(|t| t.elapsed().as_millis());
+
+        let p2_shutdown_start = tick_start.map(|_| std::time::Instant::now());
+        if let Some(prev) = previous {
+            if let Err(err) = shutdown(prev) {
+                tracing::warn!(
+                    site = "refresh_bundle_and_routes",
+                    error = %err,
+                    "old renderer shutdown failed; continuing with new host"
+                );
             }
         }
+        let p2_shutdown_ms = p2_shutdown_start.map(|t| t.elapsed().as_millis());
 
         // Phase B (issue #940, review fix) — the live renderer just
         // diverged from whatever the stored skip key described. Invalidate
@@ -1848,16 +1885,25 @@ impl DevRenderSession {
         // touched, so the old key still describes it).
         self.inner.commit_skip_key(None);
 
+        // P3 — route-table rebuild (re-expands `paths()` through the new
+        //      V8 host) with paths()-expansion sub-timing and PathsCache
+        //      hit/miss counts. The cache is constructed fresh each call
+        //      (dev.rs:2250), so 100% miss is expected here — instrumented
+        //      to measure; fix deferred (#991).
         // 3. Rebuild the route tables through the reloaded host (re-expands
         //    `paths()`, so the dynamic source now resolves the new URL).
-        let (new_routes_by_source, new_ssr_routes) =
-            build_dev_route_tables(&router, &plan, project_root, &self.inner.renderer)
+        let p3_start = tick_start.map(|_| std::time::Instant::now());
+        let (new_routes_by_source, new_ssr_routes, p3_cache_hits, p3_cache_misses) =
+            build_dev_route_tables_timed(&router, &plan, project_root, &self.inner.renderer)
                 .context("dev refresh: route-table rebuild failed")?;
+        let p3_ms = p3_start.map(|t| t.elapsed().as_millis());
 
+        // P4 — diff + RwLock table swap + skip-key commit.
         // 4. Diff against the frozen table — see [`diff_route_tables`]
         //    for the exact semantics (issue #958: the `changed` set is
         //    the G5 narrowing gate, so it compares full entry SETS, not
         //    just counts).
+        let p4_start = tick_start.map(|_| std::time::Instant::now());
         let (changed, vanished_output_paths) = {
             let old = self.inner.routes.read().unwrap_or_else(|p| p.into_inner());
             diff_route_tables(&old.routes_by_source, &new_routes_by_source)
@@ -1867,6 +1913,7 @@ impl DevRenderSession {
             tables.routes_by_source = new_routes_by_source;
             tables.ssr_routes = new_ssr_routes;
         }
+        let p4_ms = p4_start.map(|t| t.elapsed().as_millis());
 
         // Phase B (issue #940) — commit-after-success.
         //
@@ -1877,6 +1924,30 @@ impl DevRenderSession {
         // fully (Correctness Req 1). See `commit_skip_key` for the
         // `None`-clears-the-key rationale.
         self.inner.commit_skip_key(new_skip_key);
+
+        // Print one stderr line per tick when ZFB_DEV_TIMING=1.
+        if let Some(tick_elapsed) = tick_start.map(|t| t.elapsed().as_millis()) {
+            let p0 = p0_ms.unwrap_or(0);
+            let p1 = p1_total_ms.unwrap_or(0);
+            let p1_snap = p1_snapshot_ms.unwrap_or(0);
+            let p1_asm = p1_assemble_ms.unwrap_or(0);
+            let p1_bnd = p1_bundle_ms.unwrap_or(0);
+            let p1b = p1b_ms.unwrap_or(0);
+            let p2b = p2_boot_ms.unwrap_or(0);
+            let p2s = p2_swap_ms.unwrap_or(0);
+            let p2d = p2_shutdown_ms.unwrap_or(0);
+            let p3 = p3_ms.unwrap_or(0);
+            let p4 = p4_ms.unwrap_or(0);
+            eprintln!(
+                "[zfb-timing] tick={tick_elapsed}ms \
+                 P0(router)={p0}ms \
+                 P1(bundle)={p1}ms[snap={p1_snap}ms,asm={p1_asm}ms,esbuild={p1_bnd}ms] \
+                 P1b(skip-key)={p1b}ms \
+                 P2(host)[boot={p2b}ms,swap={p2s}ms,shutdown={p2d}ms] \
+                 P3(routes)={p3}ms[cache-hits={p3_cache_hits},miss={p3_cache_misses}] \
+                 P4(diff+swap)={p4}ms"
+            );
+        }
 
         Ok(BundleRefresh::Refreshed {
             changed,
@@ -1964,25 +2035,76 @@ impl Drop for DevRenderInner {
     }
 }
 
+// ---------------------------------------------------------------------------
+// ZFB_DEV_TIMING — per-tick phase timing (issue #991)
+// ---------------------------------------------------------------------------
+
+/// Read `ZFB_DEV_TIMING` and decide whether to emit per-tick timing lines.
+/// Truthy values: `1`, `true` (case-insensitive). Everything else — including
+/// unset, empty, and unrecognized values — is off, so the hot path has zero
+/// overhead.
+#[cfg(feature = "embed_v8")]
+fn dev_timing_enabled() -> bool {
+    std::env::var("ZFB_DEV_TIMING")
+        .ok()
+        .as_deref()
+        .map(|raw| {
+            let t = raw.trim();
+            t.eq_ignore_ascii_case("1") || t.eq_ignore_ascii_case("true")
+        })
+        .unwrap_or(false)
+}
+
+/// Per-P1-sub-phase wall-clock durations collected inside
+/// [`assemble_and_bundle_dev`] when `ZFB_DEV_TIMING=1`. Only populated when
+/// `timing_enabled` is `true`; the caller always has `Some(...)` in that
+/// case.
+#[cfg(feature = "embed_v8")]
+struct BundleSubTiming {
+    /// `build_content_snapshot_json` — full content-collection walk.
+    snapshot_ms: u128,
+    /// `assemble_bundler_input` — BundlerInput construction incl. embedded
+    /// esbuild/node_modules tempdir extraction.
+    assemble_ms: u128,
+    /// `bundle()` — esbuild subprocess / embedded runner.
+    bundle_ms: u128,
+}
+
+/// Return value of [`assemble_and_bundle_dev`].
+///
+/// Wraps the `BundlerOutput` with an optional timing record that is `Some`
+/// when `ZFB_DEV_TIMING=1` and `None` otherwise (zero allocation on the hot
+/// path).
+#[cfg(feature = "embed_v8")]
+struct AssembledBundleResult {
+    output: BundlerOutput,
+    sub_timing: Option<BundleSubTiming>,
+}
+
 /// Assemble the dev-mode bundler input and run the bundler, returning the
-/// fresh [`BundlerOutput`] (issue #659 — extracted from `boot_dev_renderer`
-/// so the watch-ADD re-bundle reuses the EXACT same configuration the boot
-/// bundle used; any drift here would make a newly-added page render
-/// differently in dev than it did at boot). The embedded node_modules /
-/// esbuild tempdir handles live only for the synchronous `bundle()` call
-/// (which writes `bundle_path` to disk), so scoping them to this function
-/// is correct.
+/// fresh [`BundlerOutput`] wrapped in [`AssembledBundleResult`] (issue #659
+/// — extracted from `boot_dev_renderer` so the watch-ADD re-bundle reuses
+/// the EXACT same configuration the boot bundle used; any drift here would
+/// make a newly-added page render differently in dev than it did at boot).
+/// The embedded node_modules / esbuild tempdir handles live only for the
+/// synchronous `bundle()` call (which writes `bundle_path` to disk), so
+/// scoping them to this function is correct.
 ///
 /// `recompute snapshot` is implicit: `build_content_snapshot_json` re-reads
 /// the content collections from disk on every call, so a re-bundle here
 /// picks up a content file created after boot.
+///
+/// `timing_enabled` — when `true`, record sub-phase wall-clock durations
+/// into the returned [`BundleSubTiming`]. When `false`, no `Instant::now()`
+/// calls are made (zero overhead on the hot path).
 #[cfg(feature = "embed_v8")]
 fn assemble_and_bundle_dev(
     project_root: &Path,
     cfg: &config::Config,
     plugin_alias_entries: Vec<(String, String)>,
     plugin_virtual_modules: Vec<(String, String)>,
-) -> Result<BundlerOutput> {
+    timing_enabled: bool,
+) -> Result<AssembledBundleResult> {
     // Embed the content snapshot so a page's `getStaticProps()` (and any
     // runtime `paths()`) sees the same collection data the production
     // build does. The published `zfb/content` `getCollection(...)` reads
@@ -1996,14 +2118,25 @@ fn assemble_and_bundle_dev(
     // build stay byte-identical (returns `None` when no collections are
     // declared, matching the previous behaviour for collection-less
     // projects).
+    let snap_start = if timing_enabled {
+        Some(std::time::Instant::now())
+    } else {
+        None
+    };
     let content_snapshot_json =
         crate::commands::build::build_content_snapshot_json(project_root, cfg);
+    let snapshot_ms = snap_start.map(|t| t.elapsed().as_millis()).unwrap_or(0);
 
     // The full ~25-field BundlerInput assembly is shared with `zfb build`
     // via `commands::bundler_input::assemble_bundler_input`. The two
     // per-command differences passed here:
     //   • BundleMode::Development  (build uses Production)
     //   • CssModuleFailMode::WarnAndEmpty  (build uses HardFail)
+    let asm_start = if timing_enabled {
+        Some(std::time::Instant::now())
+    } else {
+        None
+    };
     let crate::commands::bundler_input::AssembledBundlerInput {
         bundler_input,
         _node_modules_handle: _embedded_nm_handle,
@@ -2017,9 +2150,29 @@ fn assemble_and_bundle_dev(
         plugin_alias_entries,
         plugin_virtual_modules,
     )?;
+    let assemble_ms = asm_start.map(|t| t.elapsed().as_millis()).unwrap_or(0);
 
+    let bnd_start = if timing_enabled {
+        Some(std::time::Instant::now())
+    } else {
+        None
+    };
     let bundler_out: BundlerOutput = bundle(bundler_input).context("bundler step failed")?;
-    Ok(bundler_out)
+    let bundle_ms = bnd_start.map(|t| t.elapsed().as_millis()).unwrap_or(0);
+
+    let sub_timing = if timing_enabled {
+        Some(BundleSubTiming {
+            snapshot_ms,
+            assemble_ms,
+            bundle_ms,
+        })
+    } else {
+        None
+    };
+    Ok(AssembledBundleResult {
+        output: bundler_out,
+        sub_timing,
+    })
 }
 
 /// Compute the Phase-B skip key for a single dev refresh tick (issue #940).
@@ -2137,6 +2290,35 @@ type BuiltRouteTables = (
     Vec<RouteUniverseEntry>,
 );
 
+/// `(routes_by_source, ssr_routes, paths_cache_hits, paths_cache_misses)` —
+/// the 4-tuple [`build_dev_route_tables_timed`] returns with PathsCache stats
+/// exposed for ZFB_DEV_TIMING instrumentation (issue #991).
+#[cfg(feature = "embed_v8")]
+type TimedRouteTables = (
+    HashMap<PathBuf, Vec<DevRouteEntry>>,
+    Vec<RouteUniverseEntry>,
+    u64,
+    u64,
+);
+
+/// Timed variant of [`build_dev_route_tables`]: returns the same tables plus
+/// the [`PathsCache`] hit and miss counters for P3 diagnostics (issue #991).
+///
+/// Note: the cache is constructed fresh on every call (see line below), so
+/// 100% miss is expected — this is instrumented here to confirm and to
+/// provide the data needed for the cache-reuse decision (deferred).
+#[cfg(feature = "embed_v8")]
+fn build_dev_route_tables_timed(
+    router: &zfb_router::Router,
+    plan: &crate::render_pipeline::RouteUniversePlan,
+    project_root: &Path,
+    renderer: &Arc<Mutex<Option<RendererState>>>,
+) -> Result<TimedRouteTables> {
+    let (routes_by_source, ssr_routes, hits, misses) =
+        build_dev_route_tables_inner(router, plan, project_root, renderer)?;
+    Ok((routes_by_source, ssr_routes, hits, misses))
+}
+
 /// Build the dev session's source→route + SSR route tables from the router
 /// scan + the live V8 host (issue #659 — extracted from `boot_dev_renderer`
 /// so boot and the watch-ADD rebuild produce byte-identical tables). The
@@ -2150,6 +2332,23 @@ fn build_dev_route_tables(
     project_root: &Path,
     renderer: &Arc<Mutex<Option<RendererState>>>,
 ) -> Result<BuiltRouteTables> {
+    let (routes_by_source, ssr_routes, _hits, _misses) =
+        build_dev_route_tables_inner(router, plan, project_root, renderer)?;
+    Ok((routes_by_source, ssr_routes))
+}
+
+/// Inner implementation shared by [`build_dev_route_tables`] and
+/// [`build_dev_route_tables_timed`]. Returns the route tables plus the
+/// PathsCache hit/miss counts (issue #991 — cache is fresh-constructed per
+/// call, so 100% miss is expected; see the comment at the PathsCache::new()
+/// call below).
+#[cfg(feature = "embed_v8")]
+fn build_dev_route_tables_inner(
+    router: &zfb_router::Router,
+    plan: &crate::render_pipeline::RouteUniversePlan,
+    project_root: &Path,
+    renderer: &Arc<Mutex<Option<RendererState>>>,
+) -> Result<TimedRouteTables> {
     let prerender_map = build_prerender_map(router.routes(), project_root, |msg| {
         crate::output::warn(msg)
     });
@@ -2238,6 +2437,14 @@ fn build_dev_route_tables(
         .filter(|d| !crate::render_pipeline::is_ssr_route(&prerender_map, &d.template))
         .cloned()
         .collect();
+    // PathsCache hit/miss counters — issue #991 instrumentation.
+    // The cache is constructed fresh here on every call (not shared across
+    // ticks), so 100% miss is expected; these counts confirm that and feed
+    // the ZFB_DEV_TIMING P3 line. Deferred: caching across ticks is not
+    // done here.
+    let mut paths_cache_hits: u64 = 0;
+    let mut paths_cache_misses: u64 = 0;
+
     if !ssg_deferred.is_empty() {
         // Map each route template back to its source path so the resolved
         // (concrete-URL) entries — whose `source_path` is `None` and whose
@@ -2289,6 +2496,10 @@ fn build_dev_route_tables(
                 None,
             )
         };
+
+        // Capture PathsCache stats before consuming the cache (issue #991).
+        paths_cache_hits = paths_cache.hit_count();
+        paths_cache_misses = paths_cache.miss_count();
 
         // Surface routes that still couldn't be expanded (after both phases)
         // as warnings so the user knows why a `[slug]` route didn't appear —
@@ -2350,7 +2561,12 @@ fn build_dev_route_tables(
         }
     }
 
-    Ok((routes_by_source, ssr_routes))
+    Ok((
+        routes_by_source,
+        ssr_routes,
+        paths_cache_hits,
+        paths_cache_misses,
+    ))
 }
 
 /// Bring up the renderer and the route map for the dev session.
@@ -2415,12 +2631,16 @@ fn boot_dev_renderer(
         plugin_virtual_modules: plugin_virtual_modules.clone(),
     };
 
+    // Boot path — timing not collected here (one-shot at startup, not a
+    // hot-path tick). `timing_enabled = false` so no Instant::now() overhead.
     let bundler_out: BundlerOutput = assemble_and_bundle_dev(
         project_root,
         cfg,
         plugin_alias_entries,
         plugin_virtual_modules,
-    )?;
+        false,
+    )?
+    .output;
 
     let state = start(RendererStartInput {
         bundle_path: bundler_out.bundle_path.clone(),

--- a/crates/zfb/src/commands/island_marker_check.rs
+++ b/crates/zfb/src/commands/island_marker_check.rs
@@ -1,0 +1,366 @@
+//! Issue #984 / #990: build-time warning when a rendered
+//! `data-zfb-island="X"` / `data-zfb-island-skip-ssr="X"` marker has no
+//! matching entry in the islands registry.
+//!
+//! ## Why this is non-fatal
+//!
+//! A missing registry entry turns the island into a dead-island at runtime
+//! (the hydration manifests skips it), which is a silent UX failure rather
+//! than a build-time crash.  The same non-fatal posture as the #122 / #822
+//! scanner warnings is appropriate here: warn loudly, never block shipping.
+//!
+//! ## Why production only
+//!
+//! The dev bundle already surfaces this in the browser console via
+//! `packages/zfb/src/runtime.ts:475-485` (`NODE_ENV=development` warn path).
+//! This build pass closes the gap for production builds, where no runtime
+//! warning fires.
+//!
+//! ## Known coverage gaps
+//!
+//! - **SSR-only routes** (`prerender = false`) are not rendered to disk by the
+//!   SSG pass and therefore never reach this check.  An SSR route with an
+//!   unregistered island will silently ship the dead-island to the runtime.
+//! - **`.html`-source verbatim pages** (the `static_html` flag) bypass the
+//!   renderer entirely; their HTML is copied as-is and is not in
+//!   `post_processable_pages`, so this pass never sees them.
+//!
+//! ## Selector vs substring
+//!
+//! This pass uses `lol_html`'s CSS attribute selector (`[data-zfb-island]`,
+//! `[data-zfb-island-skip-ssr]`) rather than a substring scan.  This mirrors
+//! the approach taken in `crates/zfb-islands/src/hydration.rs:471-478` and
+//! avoids false-positive matches inside `<pre>` / `<code>` / Markdown-rendered
+//! code blocks that contain the literal attribute string.  See the hazard note
+//! at `crates/zfb-islands/src/hydration.rs:239-243`.
+
+use std::borrow::Cow;
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+
+use lol_html::html_content::Element;
+use lol_html::{ElementContentHandlers, RewriteStrSettings, Selector};
+
+use crate::output;
+
+/// Walk `pages` (the SSG post-processable HTML files) and emit one
+/// `output::warn` per unknown marker name — a name that appears in a
+/// `data-zfb-island` or `data-zfb-island-skip-ssr` attribute but is absent
+/// from `registered_names`.
+///
+/// The check is non-fatal: no `Result` is returned.  The caller must not
+/// treat a non-empty warning set as a build error.
+///
+/// Runs even when `registered_names` is empty (the "zero registered islands
+/// but at least one rendered marker" scenario is exactly the #984 case).
+pub fn check_island_markers(pages: &[PathBuf], registered_names: &BTreeSet<String>) {
+    // Collect (marker_name → first path that contained it, count of pages).
+    let mut unknown: BTreeMap<String, (PathBuf, usize)> = BTreeMap::new();
+
+    for page in pages {
+        if !is_html_path(page) {
+            continue;
+        }
+        let bytes = match std::fs::read(page) {
+            Ok(b) => b,
+            Err(_) => continue, // best-effort; read failure is non-fatal here
+        };
+        // Fast pre-filter: skip pages that do not mention the attribute at all.
+        // `contains` on bytes avoids a UTF-8 conversion for the cold path.
+        if !bytes
+            .windows(b"data-zfb-island".len())
+            .any(|w| w == b"data-zfb-island")
+        {
+            continue;
+        }
+        let html = match std::str::from_utf8(&bytes) {
+            Ok(s) => s,
+            Err(_) => continue, // binary-ish file with .html extension — skip
+        };
+        let names = collect_marker_names_in_page(html);
+        for name in names {
+            if !registered_names.contains(&name) {
+                unknown
+                    .entry(name)
+                    .and_modify(|(_, count)| *count += 1)
+                    .or_insert_with(|| (page.clone(), 1));
+            }
+        }
+    }
+
+    for (name, (first_page, extra_count)) in unknown {
+        let location = if extra_count > 1 {
+            format!(
+                "{} (+{} more page{})",
+                first_page.display(),
+                extra_count - 1,
+                if extra_count - 1 == 1 { "" } else { "s" },
+            )
+        } else {
+            first_page.display().to_string()
+        };
+
+        if name == "Anonymous" {
+            // "Anonymous" is the captureComponentName fallback
+            // (packages/zfb/src/island.ts:71) — it means the SSR side could
+            // not recover a component name at render time.  The usual
+            // export-shape hint would mislead here because the problem is not
+            // an unrecognised export shape but a missing displayName /
+            // function identifier on the component.
+            output::warn(format!(
+                "island marker \"Anonymous\" found in {location} has no matching registry entry. \
+                 This usually means the island component is an anonymous function or arrow \
+                 expression with no `displayName`. Add a named function or set \
+                 `Component.displayName` so the SSR side can recover a stable marker name.",
+            ));
+        } else {
+            output::warn(format!(
+                "island marker \"{name}\" found in {location} has no matching registry entry \
+                 and will not hydrate. \
+                 Ensure the component is exported as a named binding (e.g. \
+                 `export function {name}()` or `export const {name} = …`) with \
+                 the `\"use client\"` directive and is reachable from a file in pages/. \
+                 If `{name}` comes from a `displayName` assignment, verify the \
+                 scanner-visible export identifier matches.",
+            ));
+        }
+    }
+}
+
+/// Collect every non-empty `data-zfb-island` and `data-zfb-island-skip-ssr`
+/// attribute value in `html` using a `lol_html` element-selector pass.
+///
+/// Returns a deduplicated `BTreeSet` of marker names found in the page.
+///
+/// Uses the attribute selector (`[data-zfb-island]` / `[data-zfb-island-skip-ssr]`)
+/// rather than a substring scan — see module-level note for rationale.
+fn collect_marker_names_in_page(html: &str) -> BTreeSet<String> {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    let names: Rc<RefCell<BTreeSet<String>>> = Rc::new(RefCell::new(BTreeSet::new()));
+
+    // Selector for `data-zfb-island` attribute (non-empty only — empty value
+    // is the skeleton placeholder that the runtime skips; runtime.ts:362-367
+    // skips hydrating elements whose data-zfb-island attribute is empty).
+    let island_selector: Selector = "[data-zfb-island]"
+        .parse()
+        .expect("static selector is valid");
+    // Selector for the SSR-skip variant.
+    let skip_ssr_selector: Selector = "[data-zfb-island-skip-ssr]"
+        .parse()
+        .expect("static selector is valid");
+
+    let names_a = Rc::clone(&names);
+    let names_b = Rc::clone(&names);
+
+    let settings: RewriteStrSettings<'_, '_> = RewriteStrSettings {
+        element_content_handlers: vec![
+            (
+                Cow::Borrowed(&island_selector),
+                ElementContentHandlers::default().element(move |el: &mut Element<'_, '_, _>| {
+                    if let Some(val) = el.get_attribute("data-zfb-island") {
+                        if !val.is_empty() {
+                            names_a.borrow_mut().insert(val);
+                        }
+                    }
+                    Ok(())
+                }),
+            ),
+            (
+                Cow::Borrowed(&skip_ssr_selector),
+                ElementContentHandlers::default().element(move |el: &mut Element<'_, '_, _>| {
+                    if let Some(val) = el.get_attribute("data-zfb-island-skip-ssr") {
+                        if !val.is_empty() {
+                            names_b.borrow_mut().insert(val);
+                        }
+                    }
+                    Ok(())
+                }),
+            ),
+        ],
+        ..RewriteStrSettings::new()
+    };
+
+    // We only need to scan (read-only) — discard the rewritten output.
+    let _ = lol_html::rewrite_str(html, settings);
+    Rc::try_unwrap(names).unwrap_or_default().into_inner()
+}
+
+fn is_html_path(p: &std::path::Path) -> bool {
+    matches!(
+        p.extension().and_then(|s| s.to_str()),
+        Some("html") | Some("htm")
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn write_html(dir: &std::path::Path, name: &str, body: &str) -> PathBuf {
+        let path = dir.join(name);
+        fs::write(&path, body).unwrap();
+        path
+    }
+
+    // --- collect_marker_names_in_page ----------------------------------------
+
+    #[test]
+    fn collect_finds_data_zfb_island_attribute() {
+        let html = r#"<div data-zfb-island="Counter"></div>"#;
+        let names = collect_marker_names_in_page(html);
+        assert!(names.contains("Counter"), "got: {names:?}");
+    }
+
+    #[test]
+    fn collect_finds_data_zfb_island_skip_ssr_attribute() {
+        let html = r#"<div data-zfb-island-skip-ssr="AiChat"></div>"#;
+        let names = collect_marker_names_in_page(html);
+        assert!(names.contains("AiChat"), "got: {names:?}");
+    }
+
+    #[test]
+    fn collect_skips_empty_value() {
+        // Empty data-zfb-island is the unfilled skeleton; runtime skips it too.
+        let html = r#"<div data-zfb-island=""></div>"#;
+        let names = collect_marker_names_in_page(html);
+        assert!(names.is_empty(), "expected empty set; got: {names:?}");
+    }
+
+    #[test]
+    fn collect_deduplicates_same_name_across_elements() {
+        let html = r#"
+            <div data-zfb-island="Counter"></div>
+            <div data-zfb-island="Counter"></div>
+        "#;
+        let names = collect_marker_names_in_page(html);
+        assert_eq!(names.len(), 1, "expected dedup; got: {names:?}");
+        assert!(names.contains("Counter"));
+    }
+
+    #[test]
+    fn collect_finds_multiple_distinct_markers() {
+        let html = r#"
+            <div data-zfb-island="Counter"></div>
+            <div data-zfb-island="Toggle"></div>
+            <div data-zfb-island-skip-ssr="AiModal"></div>
+        "#;
+        let names = collect_marker_names_in_page(html);
+        assert!(names.contains("Counter"), "got: {names:?}");
+        assert!(names.contains("Toggle"), "got: {names:?}");
+        assert!(names.contains("AiModal"), "got: {names:?}");
+    }
+
+    /// Code fence / pre-code literals must NOT trigger — the selector-based
+    /// approach means only real DOM elements match, not text content inside
+    /// `<pre>` or Markdown-rendered code blocks.
+    #[test]
+    fn collect_does_not_false_positive_on_code_fence_literal() {
+        let html = r#"
+            <!doctype html><html><body>
+            <pre><code>data-zfb-island="FakeName"</code></pre>
+            </body></html>
+        "#;
+        let names = collect_marker_names_in_page(html);
+        assert!(
+            !names.contains("FakeName"),
+            "code-fence text must not match; got: {names:?}"
+        );
+    }
+
+    // --- check_island_markers (file I/O path) --------------------------------
+
+    /// A page with a rendered marker absent from the registry produces one warn.
+    #[test]
+    fn check_warns_for_unknown_marker() {
+        let tmp = tempdir().unwrap();
+        let page = write_html(
+            tmp.path(),
+            "index.html",
+            r#"<!doctype html><html><body>
+                <div data-zfb-island="MissingWidget" data-props="{}"></div>
+            </body></html>"#,
+        );
+        // The registry is empty — MissingWidget was never scanned.
+        let registered = BTreeSet::new();
+        // check_island_markers is non-fatal; capture by running it and
+        // verifying collect found the name (the warn itself is side-effectful
+        // and not directly assertable, but collect is the path under test).
+        let found = collect_marker_names_in_page(&fs::read_to_string(&page).unwrap());
+        assert!(found.contains("MissingWidget"), "got: {found:?}");
+        // Calling the top-level function must not panic.
+        check_island_markers(&[page], &registered);
+    }
+
+    /// A fully registered site should not trigger any warning (no panic
+    /// either, but that's trivially checked by the test completing).
+    #[test]
+    fn check_clean_site_no_warnings() {
+        let tmp = tempdir().unwrap();
+        let page = write_html(
+            tmp.path(),
+            "index.html",
+            r#"<!doctype html><html><body>
+                <div data-zfb-island="Counter" data-props="{}"></div>
+            </body></html>"#,
+        );
+        let mut registered = BTreeSet::new();
+        registered.insert("Counter".to_string());
+        check_island_markers(&[page], &registered);
+    }
+
+    /// An empty attribute value (skeleton placeholder) must not warn.
+    #[test]
+    fn check_skips_empty_attribute_value() {
+        let tmp = tempdir().unwrap();
+        let page = write_html(
+            tmp.path(),
+            "index.html",
+            r#"<!doctype html><html><body>
+                <div data-zfb-island=""></div>
+            </body></html>"#,
+        );
+        let registered = BTreeSet::new();
+        // collect must return empty — meaning check_island_markers emits no warn.
+        let found = collect_marker_names_in_page(&fs::read_to_string(&page).unwrap());
+        assert!(
+            found.is_empty(),
+            "empty value must not be collected; got: {found:?}"
+        );
+        check_island_markers(&[page], &registered);
+    }
+
+    /// Non-HTML files (XML, JSON, …) are skipped by `is_html_path`.
+    #[test]
+    fn check_skips_non_html_files() {
+        let tmp = tempdir().unwrap();
+        let xml = tmp.path().join("feed.xml");
+        fs::write(&xml, r#"<item data-zfb-island="Ghost"></item>"#).unwrap();
+        let registered = BTreeSet::new();
+        // No panic; the XML file should be ignored (is_html_path returns false).
+        check_island_markers(&[xml], &registered);
+    }
+
+    /// The check runs even when the registry is completely empty (zero registered
+    /// islands + rendered marker = the #984 scenario).
+    #[test]
+    fn check_runs_with_empty_registry() {
+        let tmp = tempdir().unwrap();
+        let page = write_html(
+            tmp.path(),
+            "about.html",
+            r#"<!doctype html><html><body>
+                <div data-zfb-island="OrphanIsland" data-props="{}"></div>
+            </body></html>"#,
+        );
+        // No islands registered at all.
+        let registered = BTreeSet::new();
+        // Must not panic; the warning is the intended side-effect.
+        let found = collect_marker_names_in_page(&fs::read_to_string(&page).unwrap());
+        assert!(found.contains("OrphanIsland"), "got: {found:?}");
+        check_island_markers(&[page], &registered);
+    }
+}

--- a/crates/zfb/src/commands/link_base_rewrite.rs
+++ b/crates/zfb/src/commands/link_base_rewrite.rs
@@ -88,23 +88,15 @@ pub fn apply_link_base_rewrite(
         if !is_html_path(page) {
             continue;
         }
-        let bytes = std::fs::read(page).with_context(|| {
-            format!(
-                "link-base-rewrite: failed to read {}",
-                page.display()
-            )
-        })?;
+        let bytes = std::fs::read(page)
+            .with_context(|| format!("link-base-rewrite: failed to read {}", page.display()))?;
         // The renderer wrote UTF-8 HTML; bail if a binary-ish file
         // somehow snuck through with a `.html` extension instead of
         // silently corrupting it via lossy decoding.
-        let html = std::str::from_utf8(&bytes).with_context(|| {
-            format!(
-                "link-base-rewrite: {} is not valid UTF-8",
-                page.display()
-            )
-        })?;
-        let new_html = rewrite_links_in_html(html, &prefix, add_trailing_slash)
-            .with_context(|| {
+        let html = std::str::from_utf8(&bytes)
+            .with_context(|| format!("link-base-rewrite: {} is not valid UTF-8", page.display()))?;
+        let new_html =
+            rewrite_links_in_html(html, &prefix, add_trailing_slash).with_context(|| {
                 format!(
                     "link-base-rewrite: lol_html failed on {} (under {})",
                     page.display(),
@@ -113,10 +105,7 @@ pub fn apply_link_base_rewrite(
             })?;
         if new_html != html {
             std::fs::write(page, new_html).with_context(|| {
-                format!(
-                    "link-base-rewrite: failed to write {}",
-                    page.display()
-                )
+                format!("link-base-rewrite: failed to write {}", page.display())
             })?;
         }
     }
@@ -250,22 +239,14 @@ mod tests {
             "http://example.com/x",
             "https://example.com/x",
         ] {
-            assert_eq!(
-                compute_prefixed(v, "/foo"),
-                None,
-                "expected skip for {v}"
-            );
+            assert_eq!(compute_prefixed(v, "/foo"), None, "expected skip for {v}");
         }
     }
 
     #[test]
     fn compute_prefixed_skips_relative_paths() {
         for v in ["foo.html", "./foo", "../foo", "page", "page/sub.html"] {
-            assert_eq!(
-                compute_prefixed(v, "/foo"),
-                None,
-                "expected skip for {v}"
-            );
+            assert_eq!(compute_prefixed(v, "/foo"), None, "expected skip for {v}");
         }
     }
 
@@ -385,10 +366,7 @@ mod tests {
             );
         }
         // And nothing got prefixed.
-        assert!(
-            !out.contains("/foo/"),
-            "no rewrites expected; got: {out}"
-        );
+        assert!(!out.contains("/foo/"), "no rewrites expected; got: {out}");
     }
 
     #[test]
@@ -415,10 +393,7 @@ mod tests {
         // Already-prefixed stays as-is.
         assert!(out.contains(r#"href="/foo/already""#), "got: {out}");
         // External stays as-is.
-        assert!(
-            out.contains(r#"href="https://example.com/""#),
-            "got: {out}"
-        );
+        assert!(out.contains(r#"href="https://example.com/""#), "got: {out}");
     }
 
     #[test]
@@ -465,7 +440,8 @@ mod tests {
         let tmp = tempdir().unwrap();
         let body = r#"<!doctype html><html><body><a href="/about">About</a></body></html>"#;
         let p = write_file(tmp.path(), "index.html", body);
-        apply_link_base_rewrite(tmp.path(), std::slice::from_ref(&p), Some("/foo/"), false).unwrap();
+        apply_link_base_rewrite(tmp.path(), std::slice::from_ref(&p), Some("/foo/"), false)
+            .unwrap();
         let after = fs::read_to_string(&p).unwrap();
         assert!(
             after.contains(r#"href="/foo/about""#),
@@ -492,7 +468,13 @@ mod tests {
         let tmp = tempdir().unwrap();
         let body = r#"<a href="/about">about</a>"#;
         let p = write_file(tmp.path(), "index.html", body);
-        apply_link_base_rewrite(tmp.path(), std::slice::from_ref(&p), Some("https://cdn.example.com/"), false).unwrap();
+        apply_link_base_rewrite(
+            tmp.path(),
+            std::slice::from_ref(&p),
+            Some("https://cdn.example.com/"),
+            false,
+        )
+        .unwrap();
         let after = fs::read_to_string(&p).unwrap();
         assert_eq!(after, body, "user links should stay same-origin");
     }
@@ -502,12 +484,10 @@ mod tests {
         let tmp = tempdir().unwrap();
         let xml_body = r#"<?xml version="1.0"?><feed><link href="/post/1"/></feed>"#;
         let xml = write_file(tmp.path(), "feed.xml", xml_body);
-        apply_link_base_rewrite(tmp.path(), std::slice::from_ref(&xml), Some("/foo"), false).unwrap();
+        apply_link_base_rewrite(tmp.path(), std::slice::from_ref(&xml), Some("/foo"), false)
+            .unwrap();
         let after = fs::read_to_string(&xml).unwrap();
-        assert_eq!(
-            after, xml_body,
-            "non-HTML file should not be touched"
-        );
+        assert_eq!(after, xml_body, "non-HTML file should not be touched");
     }
 
     #[test]
@@ -517,7 +497,8 @@ mod tests {
             <form action="/submit" method="post"><button>go</button></form>
         </body></html>"#;
         let p = write_file(tmp.path(), "index.html", body);
-        apply_link_base_rewrite(tmp.path(), std::slice::from_ref(&p), Some("/foo/"), false).unwrap();
+        apply_link_base_rewrite(tmp.path(), std::slice::from_ref(&p), Some("/foo/"), false)
+            .unwrap();
         let after = fs::read_to_string(&p).unwrap();
         assert!(
             after.contains(r#"action="/foo/submit""#),
@@ -532,9 +513,11 @@ mod tests {
         let tmp = tempdir().unwrap();
         let body = r#"<a href="/about">about</a>"#;
         let p = write_file(tmp.path(), "index.html", body);
-        apply_link_base_rewrite(tmp.path(), std::slice::from_ref(&p), Some("/foo/"), false).unwrap();
+        apply_link_base_rewrite(tmp.path(), std::slice::from_ref(&p), Some("/foo/"), false)
+            .unwrap();
         let after_first = fs::read_to_string(&p).unwrap();
-        apply_link_base_rewrite(tmp.path(), std::slice::from_ref(&p), Some("/foo/"), false).unwrap();
+        apply_link_base_rewrite(tmp.path(), std::slice::from_ref(&p), Some("/foo/"), false)
+            .unwrap();
         let after_second = fs::read_to_string(&p).unwrap();
         assert_eq!(after_first, after_second);
         assert!(after_second.contains(r#"href="/foo/about""#));
@@ -549,7 +532,8 @@ mod tests {
             <a href="/legal" data-no-base>legal-stays-bare</a>
         </body></html>"#;
         let p = write_file(tmp.path(), "index.html", body);
-        apply_link_base_rewrite(tmp.path(), std::slice::from_ref(&p), Some("/foo/"), false).unwrap();
+        apply_link_base_rewrite(tmp.path(), std::slice::from_ref(&p), Some("/foo/"), false)
+            .unwrap();
         let after = fs::read_to_string(&p).unwrap();
         assert!(after.contains(r#"href="/foo/about""#), "got: {after}");
         assert!(after.contains(r#"href="/legal""#), "got: {after}");

--- a/crates/zfb/src/commands/mod.rs
+++ b/crates/zfb/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod build;
 pub mod bundler_input;
 pub mod check;
 pub mod dev;
+pub mod island_marker_check;
 pub mod link_base_rewrite;
 pub mod new;
 pub mod plugins;

--- a/crates/zfb/src/commands/new.rs
+++ b/crates/zfb/src/commands/new.rs
@@ -192,7 +192,9 @@ fn validate_project_name(name: &str) -> anyhow::Result<()> {
     }
     let path = Path::new(name);
     if path.is_absolute() {
-        anyhow::bail!("project name '{name}' must be a relative directory name, not an absolute path");
+        anyhow::bail!(
+            "project name '{name}' must be a relative directory name, not an absolute path"
+        );
     }
     if path
         .components()
@@ -206,7 +208,11 @@ fn validate_project_name(name: &str) -> anyhow::Result<()> {
 fn available_templates() -> Vec<String> {
     TEMPLATES
         .dirs()
-        .filter_map(|d| d.path().file_name().map(|n| n.to_string_lossy().into_owned()))
+        .filter_map(|d| {
+            d.path()
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+        })
         .collect()
 }
 
@@ -360,7 +366,15 @@ mod tests {
         assert!(validate_project_name("My_Site.v2").is_ok());
 
         // Rejected shapes — path traversal, separators, absolute paths.
-        for bad in ["", ".", "..", "../evil", "foo/bar", "foo\\bar", "/etc/passwd"] {
+        for bad in [
+            "",
+            ".",
+            "..",
+            "../evil",
+            "foo/bar",
+            "foo\\bar",
+            "/etc/passwd",
+        ] {
             assert!(
                 validate_project_name(bad).is_err(),
                 "expected '{bad}' to be rejected"
@@ -481,7 +495,10 @@ mod tests {
         let expected_version =
             option_env!("ZFB_RELEASE_VERSION").unwrap_or(env!("CARGO_PKG_VERSION"));
         let ph = workspace_dep_placeholder();
-        assert!(ph.starts_with('='), "placeholder must be an exact pin: {ph}");
+        assert!(
+            ph.starts_with('='),
+            "placeholder must be an exact pin: {ph}"
+        );
         assert_eq!(ph, format!("={expected_version}"));
     }
 
@@ -581,12 +598,18 @@ mod tests {
 
         // Check for README.md.
         let readme = dir.get_file("node-free/README.md");
-        assert!(readme.is_some(), "node-free template must contain README.md");
+        assert!(
+            readme.is_some(),
+            "node-free template must contain README.md"
+        );
 
         // Check for at least one .tsx page (using known paths since
         // include_dir's Dir::files() is non-recursive).
         let has_tsx_page = dir.get_file("node-free/pages/index.tsx").is_some();
-        assert!(has_tsx_page, "node-free template must contain pages/index.tsx");
+        assert!(
+            has_tsx_page,
+            "node-free template must contain pages/index.tsx"
+        );
 
         // Content collections work under the embedded V8 host (the
         // snapshot is baked into the bundle, so `getCollection` resolves
@@ -677,9 +700,15 @@ mod tests {
 
         // At least one .tsx page must be present somewhere under pages/.
         let pages_dir = dest.join("pages");
-        assert!(pages_dir.exists(), "scaffolded site must have a pages/ directory");
+        assert!(
+            pages_dir.exists(),
+            "scaffolded site must have a pages/ directory"
+        );
         let has_tsx = walkdir_has_extension(&pages_dir, "tsx");
-        assert!(has_tsx, "scaffolded pages/ must contain at least one .tsx file");
+        assert!(
+            has_tsx,
+            "scaffolded pages/ must contain at least one .tsx file"
+        );
 
         // content/ ships with the template now — getCollection() resolves
         // from the in-bundle snapshot under the embedded V8 host, so the

--- a/crates/zfb/src/commands/plugins.rs
+++ b/crates/zfb/src/commands/plugins.rs
@@ -53,10 +53,9 @@ pub async fn maybe_spawn_host(config: &Config) -> Result<Option<PluginHost>> {
     if specs.is_empty() {
         return Ok(None);
     }
-    let host =
-        PluginHost::spawn_with_timeout(specs, None, config.plugin_hook_timeout_secs)
-            .await
-            .context("plugin lifecycle: failed to spawn the plugin host")?;
+    let host = PluginHost::spawn_with_timeout(specs, None, config.plugin_hook_timeout_secs)
+        .await
+        .context("plugin lifecycle: failed to spawn the plugin host")?;
     Ok(Some(host))
 }
 
@@ -265,9 +264,8 @@ pub async fn build_dev_middleware_set(
             plugin: r.plugin,
         })
         .collect();
-    let dispatcher: Arc<dyn DevMiddlewareDispatcher> = Arc::new(HostDispatcher {
-        host: host.clone(),
-    });
+    let dispatcher: Arc<dyn DevMiddlewareDispatcher> =
+        Arc::new(HostDispatcher { host: host.clone() });
     Ok(Some(DevMiddlewareSet {
         registrations: Arc::new(registrations),
         dispatcher,
@@ -280,7 +278,10 @@ mod tests {
     use crate::config::PluginConfig;
 
     fn cfg_with_plugins(entries: Vec<PluginConfig>) -> Config {
-        Config { plugins: entries, ..Config::default() }
+        Config {
+            plugins: entries,
+            ..Config::default()
+        }
     }
 
     #[test]

--- a/crates/zfb/src/commands/preview.rs
+++ b/crates/zfb/src/commands/preview.rs
@@ -60,7 +60,7 @@ use crate::output;
 
 // Re-export from the canonical source so callers that already reference
 // `zfb::commands::preview::EXPECTED_WRANGLER_VERSION` keep compiling.
-pub use zfb_toolchain_pins::{EXPECTED_WRANGLER_VERSION, EXPECTED_WORKERD_VERSION};
+pub use zfb_toolchain_pins::{EXPECTED_WORKERD_VERSION, EXPECTED_WRANGLER_VERSION};
 
 /// Built-in default port for `zfb preview` when neither the CLI nor the
 /// project config supplies one. 4321 keeps `dev` (3000) and `preview`
@@ -101,15 +101,16 @@ pub async fn run(args: &PreviewArgs) -> Result<()> {
     //    the precedence note in the module doc comment.
     let outdir = resolve_under_root(&project_root, &args.outdir);
     let port = resolve_port(args.port, cfg.port, DEFAULT_PREVIEW_PORT);
-    let host = resolve_host(args.host.as_deref(), cfg.host.as_deref(), DEFAULT_PREVIEW_HOST);
+    let host = resolve_host(
+        args.host.as_deref(),
+        cfg.host.as_deref(),
+        DEFAULT_PREVIEW_HOST,
+    );
 
     // Verify the output directory exists *before* binding the port so
     // missing-build errors don't leave a half-started server behind.
     if !outdir.exists() {
-        anyhow::bail!(
-            "{} does not exist — run zfb build first",
-            outdir.display()
-        );
+        anyhow::bail!("{} does not exist — run zfb build first", outdir.display());
     }
 
     // 3. Branch on adapter. `AdapterChoice::from_config` validates the
@@ -404,10 +405,7 @@ async fn not_found_response(dist_root: &Path) -> Response {
 /// same code path avoids the two tables drifting over time.
 fn content_type_for_path(path: &Path) -> String {
     // Extract the extension without allocating when there is none.
-    let ext = path
-        .extension()
-        .and_then(|e| e.to_str())
-        .unwrap_or("");
+    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
     zfb_server::content_type_for_extension(ext)
 }
 
@@ -560,10 +558,7 @@ fn version_shape(raw_token: &str) -> Option<String> {
         && !maj.is_empty()
         && !min.is_empty()
         && !patch.is_empty()
-        && patch
-            .chars()
-            .next()
-            .is_some_and(|c| c.is_ascii_digit())
+        && patch.chars().next().is_some_and(|c| c.is_ascii_digit())
     {
         Some(body.to_string())
     } else {
@@ -784,10 +779,7 @@ mod tests {
             content_type_for_path(Path::new("foo.js")),
             "application/javascript; charset=utf-8"
         );
-        assert_eq!(
-            content_type_for_path(Path::new("foo.svg")),
-            "image/svg+xml"
-        );
+        assert_eq!(content_type_for_path(Path::new("foo.svg")), "image/svg+xml");
         assert_eq!(content_type_for_path(Path::new("foo.png")), "image/png");
         assert_eq!(
             content_type_for_path(Path::new("foo.wasm")),
@@ -976,12 +968,7 @@ mod tests {
         let router = build_static_router(dist.path().to_path_buf());
 
         let resp = router
-            .oneshot(
-                Request::builder()
-                    .uri("/nope")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(Request::builder().uri("/nope").body(Body::empty()).unwrap())
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
@@ -1005,12 +992,7 @@ mod tests {
         let router = build_static_router(dir.path().to_path_buf());
 
         let resp = router
-            .oneshot(
-                Request::builder()
-                    .uri("/nope")
-                    .body(Body::empty())
-                    .unwrap(),
-            )
+            .oneshot(Request::builder().uri("/nope").body(Body::empty()).unwrap())
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
@@ -1128,8 +1110,12 @@ mod tests {
     fn wrangler_command_threads_user_supplied_port() {
         // `--port` must reflect whatever resolve_port produced — so
         // overriding from the CLI propagates all the way through.
-        let cmd =
-            build_wrangler_command(Path::new("/x"), Path::new("/x/dist"), DEFAULT_PREVIEW_HOST, 9000);
+        let cmd = build_wrangler_command(
+            Path::new("/x"),
+            Path::new("/x/dist"),
+            DEFAULT_PREVIEW_HOST,
+            9000,
+        );
         let args: Vec<String> = cmd
             .as_std()
             .get_args()
@@ -1262,10 +1248,7 @@ mod tests {
             );
         }
         // Unset = no value returned by the getter.
-        assert!(
-            !env_truthy(key, |_| None),
-            "unset env var must be falsy",
-        );
+        assert!(!env_truthy(key, |_| None), "unset env var must be falsy",);
     }
 
     // -------------------------------------------------------------------
@@ -1321,7 +1304,11 @@ mod tests {
         let dist = TempDir::new().unwrap();
         fs::write(dist.path().join("real.html"), b"<h1>real</h1>").unwrap();
         // Symlink inside dist pointing at another file inside dist.
-        symlink(dist.path().join("real.html"), dist.path().join("alias.html")).unwrap();
+        symlink(
+            dist.path().join("real.html"),
+            dist.path().join("alias.html"),
+        )
+        .unwrap();
 
         let router = build_static_router(dist.path().to_path_buf());
 
@@ -1341,6 +1328,9 @@ mod tests {
             "in-root symlink in preview dist must be served"
         );
         let body = body_string(resp).await;
-        assert!(body.contains("real"), "served body must match the symlink target");
+        assert!(
+            body.contains("real"),
+            "served body must match the symlink target"
+        );
     }
 }

--- a/crates/zfb/src/commands/resolve.rs
+++ b/crates/zfb/src/commands/resolve.rs
@@ -54,9 +54,12 @@ pub fn validate_outdir_safety(project_root: &Path, outdir: &Path) -> Result<()> 
         .canonicalize()
         .with_context(|| format!("failed to canonicalize outdir {}", outdir.display()))?;
 
-    let canonical_root = project_root
-        .canonicalize()
-        .with_context(|| format!("failed to canonicalize project root {}", project_root.display()))?;
+    let canonical_root = project_root.canonicalize().with_context(|| {
+        format!(
+            "failed to canonicalize project root {}",
+            project_root.display()
+        )
+    })?;
 
     if canonical_out == canonical_root || canonical_root.starts_with(&canonical_out) {
         bail!(
@@ -87,22 +90,19 @@ pub fn wipe_outdir_contents(outdir: &Path) -> Result<()> {
         Ok(rd) => rd,
         Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(()),
         Err(e) => {
-            return Err(e).with_context(|| {
-                format!("failed to read outdir {} for wiping", outdir.display())
-            })
+            return Err(e)
+                .with_context(|| format!("failed to read outdir {} for wiping", outdir.display()))
         }
     };
 
     for entry in entries {
-        let entry = entry.with_context(|| {
-            format!("failed to iterate outdir entries in {}", outdir.display())
-        })?;
+        let entry = entry
+            .with_context(|| format!("failed to iterate outdir entries in {}", outdir.display()))?;
         let path = entry.path();
 
         // Use symlink_metadata so we detect symlinks without following them.
-        let meta = std::fs::symlink_metadata(&path).with_context(|| {
-            format!("failed to stat {} during outdir wipe", path.display())
-        })?;
+        let meta = std::fs::symlink_metadata(&path)
+            .with_context(|| format!("failed to stat {} during outdir wipe", path.display()))?;
 
         if meta.file_type().is_symlink() {
             // Remove the link itself; do NOT recurse through it.
@@ -119,11 +119,13 @@ pub fn wipe_outdir_contents(outdir: &Path) -> Result<()> {
             };
             #[cfg(not(windows))]
             let rm_result = std::fs::remove_file(&path);
-            rm_result
-                .with_context(|| format!("failed to remove symlink {} from outdir", path.display()))?;
+            rm_result.with_context(|| {
+                format!("failed to remove symlink {} from outdir", path.display())
+            })?;
         } else if meta.is_dir() {
-            std::fs::remove_dir_all(&path)
-                .with_context(|| format!("failed to remove directory {} from outdir", path.display()))?;
+            std::fs::remove_dir_all(&path).with_context(|| {
+                format!("failed to remove directory {} from outdir", path.display())
+            })?;
         } else {
             std::fs::remove_file(&path)
                 .with_context(|| format!("failed to remove file {} from outdir", path.display()))?;
@@ -172,7 +174,11 @@ pub fn resolve_addr(host: &str, port: u16) -> Result<SocketAddr> {
         // Prefer IPv4 so the printed URL (http://localhost:PORT/) and the
         // actual bound address are on the same family; fall back to first if
         // the resolver returns only IPv6 (e.g. some Docker / minimal containers).
-        addrs.iter().find(|a| a.is_ipv4()).or_else(|| addrs.first()).copied()
+        addrs
+            .iter()
+            .find(|a| a.is_ipv4())
+            .or_else(|| addrs.first())
+            .copied()
     } else {
         addrs.first().copied()
     };
@@ -289,7 +295,10 @@ mod tests {
         assert!(loopback.ip().is_loopback());
 
         let any = resolve_addr("0.0.0.0", 4321).unwrap();
-        assert!(any.ip().is_unspecified(), "0.0.0.0 must bind all interfaces");
+        assert!(
+            any.ip().is_unspecified(),
+            "0.0.0.0 must bind all interfaces"
+        );
     }
 
     /// Verify that `resolve_addr("localhost", …)` returns an IPv4 loopback
@@ -414,7 +423,10 @@ mod tests {
         wipe_outdir_contents(&outdir).unwrap();
 
         assert!(!link.exists(), "symlink must be removed from outdir");
-        assert!(target.exists(), "symlink target outside outdir must be untouched");
+        assert!(
+            target.exists(),
+            "symlink target outside outdir must be untouched"
+        );
         assert_eq!(std::fs::read_to_string(&target).unwrap(), "keep me");
     }
 

--- a/crates/zfb/src/config.rs
+++ b/crates/zfb/src/config.rs
@@ -1039,9 +1039,9 @@ impl ExternalLinksConfig {
     #[must_use]
     pub fn into_content_config(self) -> zfb_content::ExternalLinksConfig {
         zfb_content::ExternalLinksConfig {
-            rel: self.rel.unwrap_or_else(|| {
-                vec!["noopener".to_string(), "noreferrer".to_string()]
-            }),
+            rel: self
+                .rel
+                .unwrap_or_else(|| vec!["noopener".to_string(), "noreferrer".to_string()]),
             target: self.target.unwrap_or_else(|| "_blank".to_string()),
         }
     }
@@ -1334,10 +1334,7 @@ pub async fn load_from_dir(dir: &Path) -> Result<Config> {
 
 /// Variant of [`load_from_dir`] with explicit knobs. Most callers want
 /// [`load_from_dir`].
-pub async fn load_from_dir_with_options(
-    dir: &Path,
-    opts: &LoadOptions,
-) -> Result<Config> {
+pub async fn load_from_dir_with_options(dir: &Path, opts: &LoadOptions) -> Result<Config> {
     let ts_path = dir.join("zfb.config.ts");
     let json_path = dir.join("zfb.config.json");
 
@@ -1485,11 +1482,7 @@ fn resolve_plugin_path_to_file_url(name: &str, dir: &Path) -> Result<Option<Stri
 /// parse the JSON envelope (`{ config, plugins }`) the loader emits, and
 /// merge the resolved plugin module specifiers back onto
 /// `Config.plugins[].resolved_module`.
-async fn load_from_ts_file(
-    ts_path: &Path,
-    dir: &Path,
-    opts: &LoadOptions,
-) -> Result<Config> {
+async fn load_from_ts_file(ts_path: &Path, dir: &Path, opts: &LoadOptions) -> Result<Config> {
     let json = if let Some(canned) = opts.test_default_export_json.as_deref() {
         canned.to_string()
     } else {
@@ -1617,12 +1610,11 @@ async fn load_ts_via_inprocess_v8(
 
     // Evaluate in a dedicated OS thread so V8 startup doesn't pin a
     // tokio worker (V8 boot can take hundreds of ms).
-    let raw_value = tokio::task::spawn_blocking(move || {
-        ThreadedConfigEvaluator::eval_bundle(&bundle_src)
-    })
-    .await
-    .map_err(|e| anyhow!("config eval join error: {e}"))?
-    .map_err(|e| anyhow!("embedded V8 evaluator failed: {e}"))?;
+    let raw_value =
+        tokio::task::spawn_blocking(move || ThreadedConfigEvaluator::eval_bundle(&bundle_src))
+            .await
+            .map_err(|e| anyhow!("config eval join error: {e}"))?
+            .map_err(|e| anyhow!("embedded V8 evaluator failed: {e}"))?;
 
     // raw_value is the user's `default` export as a serde_json::Value.
     // We need to walk the plugins[] array and resolve each entry's `name`
@@ -1659,8 +1651,7 @@ async fn load_ts_via_inprocess_v8(
         "config": raw_value,
         "plugins": resolved_plugins,
     });
-    serde_json::to_string(&envelope)
-        .context("config loader: failed to serialise V8 eval envelope")
+    serde_json::to_string(&envelope).context("config loader: failed to serialise V8 eval envelope")
 }
 
 /// Internal envelope shape produced by the TS config evaluator.
@@ -1775,11 +1766,7 @@ fn resolve_esbuild_binary_with_handle(
 /// Slim-build fallback: available only when `embed_v8` is disabled so the
 /// node subprocess path is preserved for the slim-build audience.
 #[cfg(not(feature = "embed_v8"))]
-async fn load_ts_via_subprocess(
-    ts_path: &Path,
-    dir: &Path,
-    opts: &LoadOptions,
-) -> Result<String> {
+async fn load_ts_via_subprocess(ts_path: &Path, dir: &Path, opts: &LoadOptions) -> Result<String> {
     // The TempDir handle (when the embedded extraction tier is taken) must
     // outlive every subprocess spawn below — esbuild and node both reference
     // the extracted binary path. Drop only happens at function return.
@@ -1914,19 +1901,16 @@ fn validate(cfg: &Config, dir: &Path) -> Result<()> {
         if !seen.insert(c.name.as_str()) {
             bail!("duplicate collection name {:?}", c.name);
         }
-        ensure_path_in_root(&c.path, dir)
-            .with_context(|| format!("collection {:?}", c.name))?;
+        ensure_path_in_root(&c.path, dir).with_context(|| format!("collection {:?}", c.name))?;
     }
     if let Some(ch) = &cfg.code_highlight {
         if let Some(td) = &ch.themes_dir {
-            ensure_path_in_root(td, dir)
-                .context("codeHighlight.themesDir")?;
+            ensure_path_in_root(td, dir).context("codeHighlight.themesDir")?;
         }
     }
     if let Some(rml) = &cfg.resolve_markdown_links {
         if !rml.docs_dir.as_os_str().is_empty() {
-            ensure_path_in_root(&rml.docs_dir, dir)
-                .context("resolveMarkdownLinks.docsDir")?;
+            ensure_path_in_root(&rml.docs_dir, dir).context("resolveMarkdownLinks.docsDir")?;
         }
         for (i, d) in rml.dirs.iter().enumerate() {
             ensure_path_in_root(&d.dir, dir)
@@ -1938,8 +1922,7 @@ fn validate(cfg: &Config, dir: &Path) -> Result<()> {
         // path-style base must start with `/` so the rendered asset
         // URLs (`/pj/foo/assets/...`) match the on-disk dist layout.
         let trimmed = b.trim();
-        let looks_absolute_url =
-            trimmed.starts_with("http://") || trimmed.starts_with("https://");
+        let looks_absolute_url = trimmed.starts_with("http://") || trimmed.starts_with("https://");
         if !trimmed.is_empty() && !looks_absolute_url && !trimmed.starts_with('/') {
             bail!(
                 "base {:?} must start with `/` (e.g. \"/pj/zudo-doc/\") or be an absolute URL",
@@ -2018,10 +2001,7 @@ fn ensure_path_in_root(path: &Path, dir: &Path) -> Result<()> {
             Component::ParentDir => {
                 depth -= 1;
                 if depth < 0 {
-                    bail!(
-                        "path {:?} escapes the project root via `..`",
-                        path
-                    );
+                    bail!("path {:?} escapes the project root via `..`", path);
                 }
             }
             Component::Normal(_) | Component::CurDir => {
@@ -2112,8 +2092,7 @@ mod tests {
     #[test]
     fn json_schema_rejects_unknown_type_string() {
         let v = serde_json::json!({ "type": "timestamp" });
-        let err = JsonSchema::try_from_value(v)
-            .expect_err("unknown type should be rejected");
+        let err = JsonSchema::try_from_value(v).expect_err("unknown type should be rejected");
         assert!(err.contains("\"timestamp\""), "err: {err}");
         assert!(err.contains("not recognised"), "err: {err}");
     }
@@ -2121,32 +2100,30 @@ mod tests {
     #[test]
     fn json_schema_rejects_unknown_type_in_array() {
         let v = serde_json::json!({ "type": ["string", "date"] });
-        let err = JsonSchema::try_from_value(v)
-            .expect_err("unknown type in array should be rejected");
+        let err =
+            JsonSchema::try_from_value(v).expect_err("unknown type in array should be rejected");
         assert!(err.contains("\"date\""), "err: {err}");
     }
 
     #[test]
     fn json_schema_rejects_non_string_in_type_array() {
         let v = serde_json::json!({ "type": ["string", 42] });
-        let err = JsonSchema::try_from_value(v)
-            .expect_err("non-string in type array should be rejected");
+        let err =
+            JsonSchema::try_from_value(v).expect_err("non-string in type array should be rejected");
         assert!(err.contains("must contain strings"), "err: {err}");
     }
 
     #[test]
     fn json_schema_rejects_non_object_type_field() {
         let v = serde_json::json!({ "type": true });
-        let err = JsonSchema::try_from_value(v)
-            .expect_err("boolean type field should be rejected");
+        let err = JsonSchema::try_from_value(v).expect_err("boolean type field should be rejected");
         assert!(err.contains("must be a string or array"), "err: {err}");
     }
 
     #[test]
     fn json_schema_rejects_non_object_properties() {
         let v = serde_json::json!({ "type": "object", "properties": ["a", "b"] });
-        let err = JsonSchema::try_from_value(v)
-            .expect_err("array properties should be rejected");
+        let err = JsonSchema::try_from_value(v).expect_err("array properties should be rejected");
         assert!(err.contains("\"properties\""), "err: {err}");
         assert!(err.contains("must be a JSON object"), "err: {err}");
     }
@@ -2294,20 +2271,14 @@ mod tests {
         // The PR #1361 acceptance case: `/pj/zudo-doc/` ⇒
         // `/pj/zudo-doc` so concatenation with `/assets/...` produces
         // a single delimiter.
-        assert_eq!(
-            asset_url_base_prefix(Some("/pj/zudo-doc/")),
-            "/pj/zudo-doc"
-        );
+        assert_eq!(asset_url_base_prefix(Some("/pj/zudo-doc/")), "/pj/zudo-doc");
     }
 
     #[test]
     fn asset_url_base_prefix_subpath_without_trailing_slash_is_idempotent() {
         // Authors who omit the trailing slash get the same prefix as
         // those who include it.
-        assert_eq!(
-            asset_url_base_prefix(Some("/pj/zudo-doc")),
-            "/pj/zudo-doc"
-        );
+        assert_eq!(asset_url_base_prefix(Some("/pj/zudo-doc")), "/pj/zudo-doc");
     }
 
     #[test]
@@ -2397,7 +2368,10 @@ mod tests {
         .unwrap();
         let cfg = load_from_dir(tmp.path()).await.expect("load ok");
         let ch = cfg.code_highlight.as_ref().expect("codeHighlight present");
-        assert_eq!(ch.themes_dir.as_deref(), Some(std::path::Path::new("./themes")));
+        assert_eq!(
+            ch.themes_dir.as_deref(),
+            Some(std::path::Path::new("./themes"))
+        );
     }
 
     #[tokio::test]
@@ -2412,7 +2386,10 @@ mod tests {
         let cfg = load_from_dir(tmp.path()).await.expect("load ok");
         let ch = cfg.code_highlight.as_ref().expect("codeHighlight present");
         assert_eq!(ch.theme.as_deref(), Some("Dracula"));
-        assert_eq!(ch.themes_dir.as_deref(), Some(std::path::Path::new("themes")));
+        assert_eq!(
+            ch.themes_dir.as_deref(),
+            Some(std::path::Path::new("themes"))
+        );
     }
 
     #[tokio::test]
@@ -2424,7 +2401,9 @@ mod tests {
         )
         .await
         .unwrap();
-        let err = load_from_dir(tmp.path()).await.expect_err("must reject absolute path");
+        let err = load_from_dir(tmp.path())
+            .await
+            .expect_err("must reject absolute path");
         // anyhow chains context messages; use {:#} to get the full chain.
         let msg = format!("{err:#}");
         assert!(
@@ -2442,7 +2421,9 @@ mod tests {
         )
         .await
         .unwrap();
-        let err = load_from_dir(tmp.path()).await.expect_err("must reject .. escape");
+        let err = load_from_dir(tmp.path())
+            .await
+            .expect_err("must reject .. escape");
         let msg = format!("{err:#}");
         assert!(
             msg.contains("codeHighlight.themesDir"),
@@ -2542,10 +2523,7 @@ mod tests {
         assert_eq!(cfg.collections.len(), 2);
         assert_eq!(cfg.collections[0].name, "blog");
         assert_eq!(cfg.collections[1].path, PathBuf::from("content/docs"));
-        assert_eq!(
-            cfg.tailwind,
-            Some(TailwindConfig { enabled: false })
-        );
+        assert_eq!(cfg.tailwind, Some(TailwindConfig { enabled: false }));
         assert_eq!(cfg.plugins.len(), 1);
         assert_eq!(cfg.plugins[0].name, "./plugin.mjs");
     }
@@ -2570,9 +2548,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let err = load_from_dir(tmp.path())
-            .await
-            .expect_err("should reject");
+        let err = load_from_dir(tmp.path()).await.expect_err("should reject");
         let msg = format!("{err:#}");
         assert!(msg.contains("zfb.config.json"), "msg: {msg}");
         assert!(msg.contains("line"), "msg: {msg}");
@@ -2594,10 +2570,7 @@ mod tests {
             .await
             .expect_err("should reject duplicates");
         let msg = format!("{err:#}");
-        assert!(
-            msg.contains("duplicate collection name"),
-            "msg: {msg}"
-        );
+        assert!(msg.contains("duplicate collection name"), "msg: {msg}");
     }
 
     #[tokio::test]
@@ -2778,7 +2751,10 @@ mod tests {
             .await
             .expect_err("count mismatch must be rejected");
         let msg = format!("{err:#}");
-        assert!(msg.contains("plugin resolution count mismatch"), "msg: {msg}");
+        assert!(
+            msg.contains("plugin resolution count mismatch"),
+            "msg: {msg}"
+        );
     }
 
     #[tokio::test]
@@ -2831,10 +2807,7 @@ mod tests {
             .await
             .expect_err("should reject duplicates from TS too");
         let msg = format!("{err:#}");
-        assert!(
-            msg.contains("duplicate collection name"),
-            "msg: {msg}"
-        );
+        assert!(msg.contains("duplicate collection name"), "msg: {msg}");
     }
 
     #[tokio::test]
@@ -2842,12 +2815,9 @@ mod tests {
         // Both files present → TS wins. The JSON file is ignored and the
         // test override is used to inject the canned TS export JSON.
         let tmp = TempDir::new().unwrap();
-        tokio::fs::write(
-            tmp.path().join("zfb.config.json"),
-            r#"{"port": 5500}"#,
-        )
-        .await
-        .unwrap();
+        tokio::fs::write(tmp.path().join("zfb.config.json"), r#"{"port": 5500}"#)
+            .await
+            .unwrap();
         tokio::fs::write(
             tmp.path().join("zfb.config.ts"),
             "import { defineConfig } from \"zfb/config\";\n\
@@ -2871,12 +2841,9 @@ mod tests {
     async fn json_used_when_no_ts_present() {
         // Only a JSON file → JSON is loaded (TS is not required).
         let tmp = TempDir::new().unwrap();
-        tokio::fs::write(
-            tmp.path().join("zfb.config.json"),
-            r#"{"port": 5500}"#,
-        )
-        .await
-        .unwrap();
+        tokio::fs::write(tmp.path().join("zfb.config.json"), r#"{"port": 5500}"#)
+            .await
+            .unwrap();
         let cfg = load_from_dir(tmp.path()).await.expect("json load ok");
         assert_eq!(cfg.port, Some(5500));
     }
@@ -3002,9 +2969,10 @@ mod tests {
             .await
             .expect("bare specifier with installed package must not error");
         assert_eq!(cfg.plugins.len(), 1);
-        let resolved = cfg.plugins[0].resolved_module.as_deref().expect(
-            "bare specifier with node_modules present must populate resolved_module",
-        );
+        let resolved = cfg.plugins[0]
+            .resolved_module
+            .as_deref()
+            .expect("bare specifier with node_modules present must populate resolved_module");
         assert!(
             resolved.starts_with("file://"),
             "resolved_module should be a file:// URL, got {resolved:?}"
@@ -3128,10 +3096,7 @@ mod tests {
             msg.contains("not found in PATH"),
             "msg should call out PATH: {msg}"
         );
-        assert!(
-            msg.contains("Node.js"),
-            "msg should mention Node.js: {msg}"
-        );
+        assert!(msg.contains("Node.js"), "msg should mention Node.js: {msg}");
     }
 
     /// Sub #212 — when neither `LoadOptions::esbuild_binary` nor the
@@ -3193,7 +3158,10 @@ mod tests {
             msg.contains("zfb.config.ts"),
             "msg should name the file: {msg}"
         );
-        assert!(msg.contains("received"), "msg should echo the payload: {msg}");
+        assert!(
+            msg.contains("received"),
+            "msg should echo the payload: {msg}"
+        );
     }
 
     // --- MarkdownConfig / GFM resolution tests ----------------------------
@@ -3289,7 +3257,7 @@ mod tests {
         };
         let resolved = cfg.resolve_constructs(ResolvedGfmConstructs::CONSERVATIVE);
         assert!(resolved.strikethrough); // conservative-default stayed
-        assert!(!resolved.table);        // explicit override
+        assert!(!resolved.table); // explicit override
     }
 
     // Serde round-trip — the TS `gfm: true` shorthand and the
@@ -3385,7 +3353,10 @@ mod tests {
 
     #[tokio::test]
     async fn allowed_hosts_rejects_empty_and_bare_dot_entries() {
-        for bad in [r#"{ "allowedHosts": [""] }"#, r#"{ "allowedHosts": ["."] }"#] {
+        for bad in [
+            r#"{ "allowedHosts": [""] }"#,
+            r#"{ "allowedHosts": ["."] }"#,
+        ] {
             let tmp = TempDir::new().unwrap();
             tokio::fs::write(tmp.path().join("zfb.config.json"), bad)
                 .await
@@ -3459,7 +3430,8 @@ mod tests {
             .expect_err("relative path should be rejected");
         let msg = format!("{err:#}");
         assert!(
-            msg.contains("site") && (msg.contains("not a valid absolute URL") || msg.contains("scheme")),
+            msg.contains("site")
+                && (msg.contains("not a valid absolute URL") || msg.contains("scheme")),
             "expected error mentioning 'site' and URL validity; got: {msg}"
         );
     }
@@ -3468,12 +3440,9 @@ mod tests {
     async fn site_rejects_empty_string() {
         // Empty string has no semantic value for a canonical URL.
         let tmp = TempDir::new().unwrap();
-        tokio::fs::write(
-            tmp.path().join("zfb.config.json"),
-            r#"{ "site": "" }"#,
-        )
-        .await
-        .unwrap();
+        tokio::fs::write(tmp.path().join("zfb.config.json"), r#"{ "site": "" }"#)
+            .await
+            .unwrap();
         let err = load_from_dir(tmp.path())
             .await
             .expect_err("empty string should be rejected");
@@ -3521,7 +3490,9 @@ mod tests {
         let cfg = load_from_dir(tmp.path()).await.expect("load ok");
         assert_eq!(
             cfg.prefetch,
-            Some(PrefetchConfig { disabled: Some(true) }),
+            Some(PrefetchConfig {
+                disabled: Some(true)
+            }),
         );
     }
 
@@ -3589,8 +3560,8 @@ mod tests {
         assert_eq!(cfg.cjk_friendly, Some(true));
 
         // Absent field → None (default-on at resolve time).
-        let cfg: MarkdownConfig = serde_json::from_value(serde_json::json!({}))
-            .expect("empty object deserialises");
+        let cfg: MarkdownConfig =
+            serde_json::from_value(serde_json::json!({})).expect("empty object deserialises");
         assert_eq!(cfg.cjk_friendly, None);
     }
 
@@ -3645,8 +3616,8 @@ mod tests {
         assert_eq!(cfg.hard_breaks, Some(false));
 
         // Absent field → None (default-off at resolve time).
-        let cfg: MarkdownConfig = serde_json::from_value(serde_json::json!({}))
-            .expect("empty object deserialises");
+        let cfg: MarkdownConfig =
+            serde_json::from_value(serde_json::json!({})).expect("empty object deserialises");
         assert_eq!(cfg.hard_breaks, None);
     }
 
@@ -3674,8 +3645,8 @@ mod tests {
     fn bundle_absent_resolves_to_empty_exclude() {
         // Absent `bundle` key → None → resolver yields empty (skip nothing,
         // byte-identical to a build without the knob).
-        let cfg: Config = serde_json::from_value(serde_json::json!({}))
-            .expect("empty config deserialises");
+        let cfg: Config =
+            serde_json::from_value(serde_json::json!({})).expect("empty config deserialises");
         assert!(cfg.bundle.is_none());
         assert!(resolve_bundle_exclude(cfg.bundle.as_ref()).is_empty());
 
@@ -3705,8 +3676,8 @@ mod tests {
 
     #[test]
     fn bundle_absent_resolves_to_empty_main_fields_and_external() {
-        let cfg: Config = serde_json::from_value(serde_json::json!({}))
-            .expect("empty config deserialises");
+        let cfg: Config =
+            serde_json::from_value(serde_json::json!({})).expect("empty config deserialises");
         assert!(resolve_bundle_main_fields(cfg.bundle.as_ref()).is_empty());
         assert!(resolve_bundle_external(cfg.bundle.as_ref()).is_empty());
 
@@ -3737,11 +3708,9 @@ mod tests {
             (OutputMode::Hybrid, "hybrid"),
             (OutputMode::Auto, "auto"),
         ] {
-            let json = serde_json::to_string(&variant)
-                .expect("serialise OutputMode");
+            let json = serde_json::to_string(&variant).expect("serialise OutputMode");
             assert_eq!(json, format!("\"{wire}\""));
-            let parsed: OutputMode = serde_json::from_str(&json)
-                .expect("deserialise OutputMode");
+            let parsed: OutputMode = serde_json::from_str(&json).expect("deserialise OutputMode");
             assert_eq!(parsed, variant);
         }
     }
@@ -3801,20 +3770,14 @@ mod tests {
     #[tokio::test]
     async fn output_unknown_variant_is_rejected() {
         let tmp = TempDir::new().unwrap();
-        tokio::fs::write(
-            tmp.path().join("zfb.config.json"),
-            r#"{ "output": "ssr" }"#,
-        )
-        .await
-        .unwrap();
+        tokio::fs::write(tmp.path().join("zfb.config.json"), r#"{ "output": "ssr" }"#)
+            .await
+            .unwrap();
         let err = load_from_dir(tmp.path())
             .await
             .expect_err("unknown output variant should be rejected at load time");
         let msg = format!("{err:#}");
-        assert!(
-            msg.contains("ssr") || msg.contains("variant"),
-            "msg: {msg}"
-        );
+        assert!(msg.contains("ssr") || msg.contains("variant"), "msg: {msg}");
     }
 
     // --- Sub #417 V8 evaluator wiring tests ----------------------------------
@@ -4046,10 +4009,7 @@ mod tests {
             msg.contains("not found in PATH"),
             "msg should call out PATH: {msg}"
         );
-        assert!(
-            msg.contains("Node.js"),
-            "msg should mention Node.js: {msg}"
-        );
+        assert!(msg.contains("Node.js"), "msg should mention Node.js: {msg}");
     }
 
     // --- MarkdownFeaturesConfig tests (#566) ---------------------------------
@@ -4133,10 +4093,7 @@ mod tests {
         }))
         .expect("readingTime: true deserialises");
         let features = cfg.features.expect("features present");
-        assert_eq!(
-            features.reading_time,
-            Some(ReadingTimeFeature::Bool(true))
-        );
+        assert_eq!(features.reading_time, Some(ReadingTimeFeature::Bool(true)));
     }
 
     // readingTime: { bogus: true } must be rejected. `deny_unknown_fields` on
@@ -4321,9 +4278,8 @@ mod tests {
     // string parses as Short(...).
     #[test]
     fn directive_spec_untagged_ordering() {
-        let full: DirectiveSpec =
-            serde_json::from_value(serde_json::json!({ "component": "Kbd" }))
-                .expect("object deserialises");
+        let full: DirectiveSpec = serde_json::from_value(serde_json::json!({ "component": "Kbd" }))
+            .expect("object deserialises");
         assert!(matches!(full, DirectiveSpec::Full(_)));
         let short: DirectiveSpec =
             serde_json::from_value(serde_json::json!("Spoiler")).expect("string deserialises");

--- a/crates/zfb/src/diagnostics.rs
+++ b/crates/zfb/src/diagnostics.rs
@@ -35,8 +35,7 @@ use std::path::Path;
 
 // Re-export the core types so callers can keep using `zfb::diagnostics::*`.
 pub use zfb_diagnostics::{
-    locate_export_ident, project_relative, render_framed, DecodedPosition, Diagnostic,
-    FramedError,
+    locate_export_ident, project_relative, render_framed, DecodedPosition, Diagnostic, FramedError,
 };
 
 // ---------------------------------------------------------------------------
@@ -110,13 +109,9 @@ pub fn from_tsx_frontmatter_error(
     use zfb_content::TsxFrontmatterError;
     let file = project_relative(path, None);
     match err {
-        TsxFrontmatterError::Parse { message, .. } => Diagnostic::with_source(
-            file,
-            1,
-            1,
-            format!("TSX parse error: {message}"),
-            source,
-        ),
+        TsxFrontmatterError::Parse { message, .. } => {
+            Diagnostic::with_source(file, 1, 1, format!("TSX parse error: {message}"), source)
+        }
         TsxFrontmatterError::MissingFrontmatter { .. } => Diagnostic::with_source(
             file,
             1,
@@ -124,7 +119,9 @@ pub fn from_tsx_frontmatter_error(
             "missing required `export const frontmatter`",
             source,
         ),
-        TsxFrontmatterError::DuplicateExport { name, line, col, .. } => Diagnostic::with_source(
+        TsxFrontmatterError::DuplicateExport {
+            name, line, col, ..
+        } => Diagnostic::with_source(
             file,
             *line,
             *col,
@@ -132,18 +129,24 @@ pub fn from_tsx_frontmatter_error(
             source,
         ),
         TsxFrontmatterError::ComputedValue {
-            export, reason, line, col, ..
+            export,
+            reason,
+            line,
+            col,
+            ..
         } => Diagnostic::with_source(
             file,
             *line,
             *col,
-            format!(
-                "non-literal value not allowed in `export const {export}` ({reason})"
-            ),
+            format!("non-literal value not allowed in `export const {export}` ({reason})"),
             source,
         ),
         TsxFrontmatterError::WrongShape {
-            export, reason, line, col, ..
+            export,
+            reason,
+            line,
+            col,
+            ..
         } => Diagnostic::with_source(
             file,
             *line,
@@ -219,11 +222,16 @@ pub fn from_paths_error(
                  expected one of [{pretty}], got `{name}`"
             )
         }
-        PathsError::InvalidParamType { name, reason, route } => format!(
-            "paths() entry has invalid param `{name}` for route `{route}`: {reason}"
-        ),
+        PathsError::InvalidParamType {
+            name,
+            reason,
+            route,
+        } => format!("paths() entry has invalid param `{name}` for route `{route}`: {reason}"),
         PathsError::InvalidPathsExport {
-            field, reason, expected, route,
+            field,
+            reason,
+            expected,
+            route,
         } => {
             let field_note = match field {
                 Some(f) => format!(" at `{f}`"),
@@ -293,9 +301,7 @@ pub fn from_js_runtime_error(
         message,
         sourcemap_json,
         project_root,
-        |map, line, col| {
-            zfb_render::sourcemap::decode_position(map, line, col).map(RenderDecoded)
-        },
+        |map, line, col| zfb_render::sourcemap::decode_position(map, line, col).map(RenderDecoded),
     )
 }
 
@@ -423,8 +429,7 @@ mod tests {
         owo_colors::set_override(false);
         let src = "export default function Page() { return null; }\n";
         let path = PathBuf::from("pages/page.tsx");
-        let err =
-            zfb_content::extract_tsx_frontmatter(src, "page.tsx").expect_err("should fail");
+        let err = zfb_content::extract_tsx_frontmatter(src, "page.tsx").expect_err("should fail");
         let diag = from_tsx_frontmatter_error(&path, src, &err);
         let out = strip_ansi(&render_framed(&diag));
         assert!(
@@ -442,15 +447,11 @@ mod tests {
         owo_colors::set_override(false);
         let src = "\nexport const frontmatter = [1, 2, 3];\nexport default function Page() { return null; }\n";
         let path = PathBuf::from("pages/page.tsx");
-        let err =
-            zfb_content::extract_tsx_frontmatter(src, "page.tsx").expect_err("should fail");
+        let err = zfb_content::extract_tsx_frontmatter(src, "page.tsx").expect_err("should fail");
         let diag = from_tsx_frontmatter_error(&path, src, &err);
         let out = strip_ansi(&render_framed(&diag));
         // Frame should point at line 2 (1-based) of the source.
-        assert!(
-            out.contains(" --> pages/page.tsx:2:"),
-            "got:\n{out}"
-        );
+        assert!(out.contains(" --> pages/page.tsx:2:"), "got:\n{out}");
         assert!(out.contains("export const frontmatter"), "got:\n{out}");
         assert!(out.contains("must be an object literal"), "got:\n{out}");
     }
@@ -505,6 +506,9 @@ mod tests {
         let d = from_js_runtime_error(&path, bundle, 2, 7, "boom", None, None);
         let out = strip_ansi(&render_framed(&d));
         assert!(out.contains("JS runtime error"), "got:\n{out}");
-        assert!(out.contains(" --> .zfb/build/ssg-render.js:2:7\n"), "got:\n{out}");
+        assert!(
+            out.contains(" --> .zfb/build/ssg-render.js:2:7\n"),
+            "got:\n{out}"
+        );
     }
 }

--- a/crates/zfb/src/node_resolve.rs
+++ b/crates/zfb/src/node_resolve.rs
@@ -147,8 +147,7 @@ mod tests {
             if ty.is_dir() {
                 copy_dir_all(&entry.path(), &dst.join(entry.file_name()));
             } else {
-                std::fs::copy(entry.path(), dst.join(entry.file_name()))
-                    .expect("copy file");
+                std::fs::copy(entry.path(), dst.join(entry.file_name())).expect("copy file");
             }
         }
     }
@@ -193,9 +192,7 @@ mod tests {
         let tmp = TempDir::new().expect("create TempDir");
         let node_modules = tmp.path().join("parent").join("node_modules");
 
-        for entry in std::fs::read_dir(&src_root)
-            .expect("read parent-walk fixture src")
-        {
+        for entry in std::fs::read_dir(&src_root).expect("read parent-walk fixture src") {
             let entry = entry.expect("read dir entry");
             let dst = node_modules.join(entry.file_name());
             copy_dir_all(&entry.path(), &dst);
@@ -215,8 +212,8 @@ mod tests {
     #[test]
     fn a_main_field() {
         let tmp = build_fixture("main-field");
-        let result = resolve_node_bare_specifier("pkg-main", tmp.path())
-            .expect("should resolve pkg-main");
+        let result =
+            resolve_node_bare_specifier("pkg-main", tmp.path()).expect("should resolve pkg-main");
         assert!(
             result.starts_with("file://"),
             "expected file:// URL, got: {result}"
@@ -233,7 +230,10 @@ mod tests {
         let tmp = build_fixture("exports-string");
         let result = resolve_node_bare_specifier("pkg-exports-str", tmp.path())
             .expect("should resolve pkg-exports-str");
-        assert!(result.starts_with("file://"), "expected file:// URL, got: {result}");
+        assert!(
+            result.starts_with("file://"),
+            "expected file:// URL, got: {result}"
+        );
         assert!(
             result.ends_with("/x.js"),
             "expected to resolve to x.js, got: {result}"
@@ -246,7 +246,10 @@ mod tests {
         let tmp = build_fixture("exports-object");
         let result = resolve_node_bare_specifier("pkg-exports-obj", tmp.path())
             .expect("should resolve pkg-exports-obj");
-        assert!(result.starts_with("file://"), "expected file:// URL, got: {result}");
+        assert!(
+            result.starts_with("file://"),
+            "expected file:// URL, got: {result}"
+        );
         assert!(
             result.ends_with("/x.js"),
             "expected to resolve to x.js, got: {result}"
@@ -261,9 +264,12 @@ mod tests {
     #[test]
     fn d_conditional_exports_picks_import_branch() {
         let tmp = build_fixture("exports-conditional");
-        let result = resolve_node_bare_specifier("pkg-cond", tmp.path())
-            .expect("should resolve pkg-cond");
-        assert!(result.starts_with("file://"), "expected file:// URL, got: {result}");
+        let result =
+            resolve_node_bare_specifier("pkg-cond", tmp.path()).expect("should resolve pkg-cond");
+        assert!(
+            result.starts_with("file://"),
+            "expected file:// URL, got: {result}"
+        );
         assert!(
             result.ends_with("/index.mjs"),
             "expected to resolve to index.mjs (import branch), got: {result}"
@@ -280,7 +286,10 @@ mod tests {
         let tmp = build_fixture("scoped-package");
         let result = resolve_node_bare_specifier("@scope/pkg", tmp.path())
             .expect("should resolve @scope/pkg");
-        assert!(result.starts_with("file://"), "expected file:// URL, got: {result}");
+        assert!(
+            result.starts_with("file://"),
+            "expected file:// URL, got: {result}"
+        );
         assert!(
             result.contains("@scope/pkg"),
             "expected path to contain @scope/pkg, got: {result}"
@@ -299,7 +308,10 @@ mod tests {
         let (_tmp, child) = build_parent_walk_fixture();
         let result = resolve_node_bare_specifier("pkg-parent", &child)
             .expect("should walk up and find pkg-parent");
-        assert!(result.starts_with("file://"), "expected file:// URL, got: {result}");
+        assert!(
+            result.starts_with("file://"),
+            "expected file:// URL, got: {result}"
+        );
         assert!(
             result.ends_with("/index.js"),
             "expected to resolve to index.js, got: {result}"
@@ -330,10 +342,12 @@ mod tests {
     #[test]
     fn h_real_plugin_shape_snapshot() {
         let tmp = build_fixture("real-plugin-shape");
-        let result =
-            resolve_node_bare_specifier("@takazudo/zfb-plugin-example", tmp.path())
-                .expect("should resolve @takazudo/zfb-plugin-example");
-        assert!(result.starts_with("file://"), "expected file:// URL, got: {result}");
+        let result = resolve_node_bare_specifier("@takazudo/zfb-plugin-example", tmp.path())
+            .expect("should resolve @takazudo/zfb-plugin-example");
+        assert!(
+            result.starts_with("file://"),
+            "expected file:// URL, got: {result}"
+        );
         // Must resolve to the `import` branch, not `default` (CJS) or `types` (d.ts).
         assert!(
             result.ends_with("/dist/index.mjs"),
@@ -356,8 +370,8 @@ mod tests {
     #[test]
     fn rejects_empty_name() {
         let tmp = TempDir::new().expect("create TempDir");
-        let err = resolve_node_bare_specifier("", tmp.path())
-            .expect_err("empty name should be rejected");
+        let err =
+            resolve_node_bare_specifier("", tmp.path()).expect_err("empty name should be rejected");
         assert!(err.to_string().contains("non-empty"), "got: {err}");
     }
 

--- a/crates/zfb/src/output.rs
+++ b/crates/zfb/src/output.rs
@@ -119,8 +119,7 @@ pub fn ready(url: &str) {
 fn fmt_ready_multi(scheme: &str, port: u16, network_urls: &[String]) -> String {
     let arrow = "→".if_supports_color(Stream::Stdout, |t| t.green().to_string());
     let local_url = format!("{}://localhost:{}/", scheme, port);
-    let local_styled =
-        local_url.if_supports_color(Stream::Stdout, |t| t.bold().to_string());
+    let local_styled = local_url.if_supports_color(Stream::Stdout, |t| t.bold().to_string());
     let mut out = format!("{} ready\n", arrow);
     out.push_str(&format!("  Local:    {}\n", local_styled));
     if network_urls.is_empty() {
@@ -216,9 +215,9 @@ impl BuildProgress {
         // The template is intentionally kept simple; if it fails to parse
         // (which shouldn't happen given the literal string), we fall back
         // to indicatif's default style.
-        if let Ok(style) = ProgressStyle::with_template(
-            "{spinner:.cyan} [{bar:30.green/dim}] {pos}/{len} {msg}",
-        ) {
+        if let Ok(style) =
+            ProgressStyle::with_template("{spinner:.cyan} [{bar:30.green/dim}] {pos}/{len} {msg}")
+        {
             bar.set_style(style.progress_chars("=> "));
         }
         Self { bar }
@@ -244,7 +243,12 @@ impl BuildProgress {
 #[allow(dead_code)]
 fn fmt_summary(count: u64, elapsed: Duration) -> String {
     let mark = "✓".if_supports_color(Stream::Stdout, |t| t.green().to_string());
-    format!("{} {} pages built in {:.2}s", mark, count, elapsed.as_secs_f64())
+    format!(
+        "{} {} pages built in {:.2}s",
+        mark,
+        count,
+        elapsed.as_secs_f64()
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -466,10 +470,9 @@ mod tests {
 
     #[test]
     fn format_error_surfaces_path_line_hint() {
-        let err: anyhow::Error =
-            Err::<(), _>(anyhow!("invalid value at config.toml:12"))
-                .context("parsing zfb.toml")
-                .unwrap_err();
+        let err: anyhow::Error = Err::<(), _>(anyhow!("invalid value at config.toml:12"))
+            .context("parsing zfb.toml")
+            .unwrap_err();
 
         let rendered = format_error(&err);
         assert!(
@@ -480,10 +483,9 @@ mod tests {
 
     #[test]
     fn format_error_does_not_treat_urls_as_locations() {
-        let err: anyhow::Error =
-            Err::<(), _>(anyhow!("connection refused: http://localhost:8080"))
-                .context("starting dev server")
-                .unwrap_err();
+        let err: anyhow::Error = Err::<(), _>(anyhow!("connection refused: http://localhost:8080"))
+            .context("starting dev server")
+            .unwrap_err();
 
         let rendered = format_error(&err);
         assert!(
@@ -525,13 +527,15 @@ mod tests {
             "line 1\nline 2 has the bug\nline 3\n",
         );
         let err: anyhow::Error =
-            anyhow::Error::new(crate::diagnostics::FramedError(diag))
-                .context("rendering page");
+            anyhow::Error::new(crate::diagnostics::FramedError(diag)).context("rendering page");
 
         let rendered = format_error(&err);
         // Framed renderer used → starts with the framed header.
         assert!(rendered.starts_with("error: kaboom\n"), "got:\n{rendered}");
-        assert!(rendered.contains(" --> posts/intro.md:2:8\n"), "got:\n{rendered}");
+        assert!(
+            rendered.contains(" --> posts/intro.md:2:8\n"),
+            "got:\n{rendered}"
+        );
         // anyhow `.context(...)` messages are also surfaced — they
         // were silently dropped before. The framed body does not
         // already contain "rendering page", so it must show up under

--- a/crates/zfb/src/render_pipeline.rs
+++ b/crates/zfb/src/render_pipeline.rs
@@ -53,11 +53,13 @@
 //!    surfaces that error verbatim instead of swallowing it.
 
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
 use include_dir::{include_dir, Dir};
+use sha2::{Digest as _, Sha256};
 use zfb_build::renderer::RouteUniverseEntry;
 #[cfg(feature = "embed_v8")]
 use zfb_build::EmbeddedV8Host;
@@ -457,9 +459,23 @@ pub fn expand_dynamic_routes(
     project_root: &Path,
     cache: &mut PathsCache,
 ) -> anyhow::Result<DynamicExpansion> {
+    expand_dynamic_routes_cached(deferred, project_root, cache, None)
+}
+
+/// [`expand_dynamic_routes`] with an optional cross-call
+/// [`SourceExtractCache`] (#994 item C): on a per-file content-hash hit
+/// the static `paths()` SWC parse is skipped. `zfb dev` passes its
+/// session cache; `zfb build` goes through the plain wrapper (`None`)
+/// and is byte-for-byte unchanged.
+pub fn expand_dynamic_routes_cached(
+    deferred: &[PendingDynamicRoute],
+    project_root: &Path,
+    cache: &mut PathsCache,
+    mut extract_cache: Option<&mut SourceExtractCache>,
+) -> anyhow::Result<DynamicExpansion> {
     let mut out = DynamicExpansion::default();
     for route in deferred {
-        match try_expand_one(route, project_root, cache) {
+        match try_expand_one(route, project_root, cache, extract_cache.as_deref_mut()) {
             Ok((entries, params_entries)) => {
                 out.resolved.extend(entries);
                 out.resolved_with_params.extend(params_entries);
@@ -486,6 +502,99 @@ pub fn expand_dynamic_routes(
         }
     }
     Ok(out)
+}
+
+/// Cached prerender classification for one TSX/TS page source
+/// (#994 item C). Mirrors exactly the three ways
+/// [`build_prerender_map`] folds an `extract_tsx_frontmatter` outcome
+/// into the map, so replaying a cached entry is observationally
+/// identical to re-parsing unchanged bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CachedPrerender {
+    /// Frontmatter present and parsed — `prerender` flag extracted.
+    Value(bool),
+    /// No `export const frontmatter` at all — valid; no map entry
+    /// (renderer falls back to the SSG default) and no warning (#505).
+    AbsentFrontmatter,
+    /// Frontmatter present but malformed — no map entry; the warning is
+    /// emitted only when the entry is COMPUTED (cache miss), so the
+    /// per-tick repeat for an unchanged broken page dedupes to
+    /// once-per-edit.
+    Malformed,
+}
+
+/// Per-file content-hash cache for the SWC-parse extraction passes that
+/// run on every dev refresh tick (#994 item C): the
+/// [`build_prerender_map`] TSX-frontmatter extraction and the
+/// [`expand_dynamic_routes`] static `paths()` extraction. Both are pure
+/// functions of the file bytes, so entries are keyed by the SHA-256 of
+/// the bytes read this call — the read itself always happens (reads are
+/// cheap; only the SWC parse is skipped on a hit), which is also what
+/// makes invalidation exact: ANY byte change produces a different key.
+/// Read errors and parse errors are never cached — they fall through to
+/// the identical code path as today, every call.
+#[derive(Debug, Default)]
+pub struct SourceExtractCache {
+    /// abs source path -> (content hash, prerender classification).
+    prerender: HashMap<PathBuf, ([u8; 32], CachedPrerender)>,
+    /// abs source path -> (content hash, static `paths()` extraction).
+    paths: HashMap<PathBuf, ([u8; 32], PathsExtraction)>,
+    hits: u64,
+    misses: u64,
+}
+
+impl SourceExtractCache {
+    /// Construct an empty cache.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of per-file lookups answered from the cache (SWC parse
+    /// skipped). Exposed for tests and diagnostics.
+    pub fn hit_count(&self) -> u64 {
+        self.hits
+    }
+
+    /// Number of per-file lookups that had to (re)parse.
+    pub fn miss_count(&self) -> u64 {
+        self.misses
+    }
+}
+
+/// SHA-256 of `bytes` — the [`SourceExtractCache`] key material.
+fn sha256_bytes(bytes: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hasher.finalize().into()
+}
+
+/// [`extract_paths`] behind the optional [`SourceExtractCache`]
+/// (#994 item C). On a content-hash hit the SWC parse is skipped and the
+/// cached [`PathsExtraction`] is replayed. Parse errors propagate
+/// uncached, so a broken source re-parses (and re-reports) every call,
+/// exactly as without the cache.
+fn extract_paths_cached(
+    abs: &Path,
+    source: &str,
+    file_name: &str,
+    cache: Option<&mut SourceExtractCache>,
+) -> Result<PathsExtraction, PathsExtractError> {
+    let Some(cache) = cache else {
+        return extract_paths(source, file_name);
+    };
+    let hash = sha256_bytes(source.as_bytes());
+    if let Some((cached_hash, cached)) = cache.paths.get(abs) {
+        if *cached_hash == hash {
+            cache.hits += 1;
+            return Ok(cached.clone());
+        }
+    }
+    let computed = extract_paths(source, file_name)?;
+    cache.misses += 1;
+    cache
+        .paths
+        .insert(abs.to_path_buf(), (hash, computed.clone()));
+    Ok(computed)
 }
 
 /// Typed failure shape from `try_expand_one`.
@@ -516,6 +625,7 @@ fn try_expand_one(
     route: &PendingDynamicRoute,
     project_root: &Path,
     cache: &mut PathsCache,
+    extract_cache: Option<&mut SourceExtractCache>,
 ) -> Result<(Vec<RouteUniverseEntry>, Vec<DynamicResolvedEntry>), TryExpandFailure> {
     let abs = if route.source_path.is_absolute() {
         route.source_path.clone()
@@ -528,7 +638,7 @@ fn try_expand_one(
         .unwrap_or_else(|| route.source_path.display().to_string());
     let source = std::fs::read_to_string(&abs)
         .map_err(|e| TryExpandFailure::Other(format!("could not read {} ({e})", abs.display())))?;
-    let extraction = match extract_paths(&source, &file_name) {
+    let extraction = match extract_paths_cached(&abs, &source, &file_name, extract_cache) {
         Ok(x) => x,
         Err(PathsExtractError::Parse { file, message }) => {
             return Err(TryExpandFailure::Other(format!(
@@ -1105,7 +1215,23 @@ pub fn is_ssr_route(prerender_map: &BTreeMap<String, bool>, template: &str) -> b
 pub fn build_prerender_map(
     routes: &[Route],
     project_root: &Path,
+    warn_unreadable: impl FnMut(&str),
+) -> BTreeMap<String, bool> {
+    build_prerender_map_cached(routes, project_root, warn_unreadable, None)
+}
+
+/// [`build_prerender_map`] with an optional cross-call
+/// [`SourceExtractCache`] (#994 item C): on a per-file content-hash hit
+/// the TSX-frontmatter SWC parse is skipped and the cached
+/// classification is replayed. `zfb dev` passes its session cache;
+/// `zfb build` goes through the plain wrapper (`None`) and is
+/// byte-for-byte unchanged. Unreadable files are never cached — they
+/// warn-and-skip on every call, exactly as without the cache.
+pub fn build_prerender_map_cached(
+    routes: &[Route],
+    project_root: &Path,
     mut warn_unreadable: impl FnMut(&str),
+    mut cache: Option<&mut SourceExtractCache>,
 ) -> BTreeMap<String, bool> {
     let mut map = BTreeMap::new();
     for route in routes {
@@ -1133,33 +1259,73 @@ pub fn build_prerender_map(
                 continue;
             }
         };
-        let file_name = abs
-            .file_name()
-            .map(|s| s.to_string_lossy().into_owned())
-            .unwrap_or_else(|| "<unknown>".into());
-        match extract_tsx_frontmatter(&source, &file_name) {
-            Ok(fm) => {
-                map.insert(route.template(), fm.prerender);
-            }
-            // A route page with no `export const frontmatter` is valid — the
-            // export is optional and an absent one simply means "use the SSG
-            // default". Warning on it is misleading (it reads as "your page is
-            // broken") and fires on every frontmatter-less page, so stay silent
-            // and let the missing-key default of `true` (SSG) apply. See #505.
-            Err(TsxFrontmatterError::MissingFrontmatter { .. }) => {}
-            // Any other extraction error means the frontmatter IS present but
-            // malformed (parse error, duplicate/computed/wrong-shape export).
-            // That's a real mistake worth surfacing.
-            Err(e) => {
-                warn_unreadable(&format!(
-                    "frontmatter extraction failed for {} ({}); defaulting to SSG",
-                    abs.display(),
-                    e
-                ));
-            }
+        let classification =
+            classify_prerender_cached(&abs, &source, &mut warn_unreadable, cache.as_deref_mut());
+        if let CachedPrerender::Value(prerender) = classification {
+            map.insert(route.template(), prerender);
         }
     }
     map
+}
+
+/// Classify one TSX/TS page source's `prerender` frontmatter, going
+/// through the optional [`SourceExtractCache`] (#994 item C). The
+/// classification (and the once-per-computation malformed-frontmatter
+/// warning) is exactly [`build_prerender_map`]'s historical per-file
+/// logic, factored out so the cached and uncached paths cannot drift.
+fn classify_prerender_cached(
+    abs: &Path,
+    source: &str,
+    warn_unreadable: &mut impl FnMut(&str),
+    cache: Option<&mut SourceExtractCache>,
+) -> CachedPrerender {
+    let Some(cache) = cache else {
+        return classify_prerender(abs, source, warn_unreadable);
+    };
+    let hash = sha256_bytes(source.as_bytes());
+    if let Some((cached_hash, cached)) = cache.prerender.get(abs) {
+        if *cached_hash == hash {
+            cache.hits += 1;
+            return *cached;
+        }
+    }
+    let computed = classify_prerender(abs, source, warn_unreadable);
+    cache.misses += 1;
+    cache.prerender.insert(abs.to_path_buf(), (hash, computed));
+    computed
+}
+
+/// Uncached per-file prerender classification — one
+/// [`extract_tsx_frontmatter`] call folded into [`CachedPrerender`].
+fn classify_prerender(
+    abs: &Path,
+    source: &str,
+    warn_unreadable: &mut impl FnMut(&str),
+) -> CachedPrerender {
+    let file_name = abs
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "<unknown>".into());
+    match extract_tsx_frontmatter(source, &file_name) {
+        Ok(fm) => CachedPrerender::Value(fm.prerender),
+        // A route page with no `export const frontmatter` is valid — the
+        // export is optional and an absent one simply means "use the SSG
+        // default". Warning on it is misleading (it reads as "your page is
+        // broken") and fires on every frontmatter-less page, so stay silent
+        // and let the missing-key default of `true` (SSG) apply. See #505.
+        Err(TsxFrontmatterError::MissingFrontmatter { .. }) => CachedPrerender::AbsentFrontmatter,
+        // Any other extraction error means the frontmatter IS present but
+        // malformed (parse error, duplicate/computed/wrong-shape export).
+        // That's a real mistake worth surfacing.
+        Err(e) => {
+            warn_unreadable(&format!(
+                "frontmatter extraction failed for {} ({}); defaulting to SSG",
+                abs.display(),
+                e
+            ));
+            CachedPrerender::Malformed
+        }
+    }
 }
 
 /// Verify that `@takazudo/zfb-runtime` is resolvable for the current build.
@@ -1417,6 +1583,92 @@ mod tests {
             "expected malformed.tsx in warning, got: {}",
             warnings[0]
         );
+    }
+
+    /// #994 item C — the per-file content-hash cache replays the
+    /// prerender classification on unchanged bytes (skipping the SWC
+    /// parse and deduping the malformed-frontmatter warning to once per
+    /// computation) and recomputes exactly when the bytes change.
+    #[test]
+    fn build_prerender_map_cached_replays_and_invalidates_on_content_change() {
+        let dir = tempdir().unwrap();
+        let pages = dir.path().join("pages");
+        std::fs::create_dir_all(&pages).unwrap();
+        std::fs::write(
+            pages.join("about.tsx"),
+            "export const frontmatter = { title: 'A' };\nexport const prerender = false;\nexport default function() { return null; }\n",
+        )
+        .unwrap();
+        std::fs::write(
+            pages.join("malformed.tsx"),
+            "const t = 'x';\nexport const frontmatter = { title: t };\nexport default function() { return null; }\n",
+        )
+        .unwrap();
+
+        let routes = vec![
+            static_route(vec!["about"], "pages/about.tsx"),
+            static_route(vec!["malformed"], "pages/malformed.tsx"),
+        ];
+
+        let mut cache = SourceExtractCache::new();
+        let mut warnings: Vec<String> = Vec::new();
+        let map1 = build_prerender_map_cached(
+            &routes,
+            dir.path(),
+            |msg| warnings.push(msg.to_string()),
+            Some(&mut cache),
+        );
+        assert_eq!(map1.get("/about"), Some(&false));
+        assert!(!map1.contains_key("/malformed"));
+        assert_eq!(
+            warnings.len(),
+            1,
+            "malformed warns on compute: {warnings:?}"
+        );
+        assert_eq!(cache.hit_count(), 0);
+        assert_eq!(cache.miss_count(), 2);
+
+        // Second pass with unchanged bytes: identical map, all hits, and
+        // the malformed warning is NOT repeated (deduped to once-per-edit).
+        let map2 = build_prerender_map_cached(
+            &routes,
+            dir.path(),
+            |msg| warnings.push(msg.to_string()),
+            Some(&mut cache),
+        );
+        assert_eq!(map1, map2, "cache replay must be observationally identical");
+        assert_eq!(
+            warnings.len(),
+            1,
+            "no repeated warning on a cache hit: {warnings:?}"
+        );
+        assert_eq!(cache.hit_count(), 2);
+        assert_eq!(cache.miss_count(), 2);
+
+        // Edit about.tsx (drop `prerender = false`): the content hash
+        // changes, so only that file recomputes — and the new
+        // classification (frontmatter present, prerender default true)
+        // is reflected. The unchanged malformed page still hits (and
+        // still does not re-warn).
+        std::fs::write(
+            pages.join("about.tsx"),
+            "export const frontmatter = { title: 'A' };\nexport default function() { return null; }\n",
+        )
+        .unwrap();
+        let map3 = build_prerender_map_cached(
+            &routes,
+            dir.path(),
+            |msg| warnings.push(msg.to_string()),
+            Some(&mut cache),
+        );
+        assert_eq!(
+            map3.get("/about"),
+            Some(&true),
+            "edited page must be reclassified from fresh bytes: {map3:?}"
+        );
+        assert_eq!(warnings.len(), 1, "no new warnings: {warnings:?}");
+        assert_eq!(cache.hit_count(), 3, "unchanged malformed page hits");
+        assert_eq!(cache.miss_count(), 3, "edited page recomputes");
     }
 
     #[test]
@@ -1745,6 +1997,75 @@ mod tests {
         assert_eq!(out2.resolved.len(), 10);
         assert_eq!(cache.miss_count(), 1, "second expand: miss_count unchanged");
         assert_eq!(cache.hit_count(), 1, "second expand: expected 1 hit");
+    }
+
+    /// #994 item C — `extract_paths` goes through the per-file
+    /// content-hash cache: unchanged sources skip the SWC parse on
+    /// re-expansion; an edit recomputes and the NEW `paths()` output is
+    /// reflected (invalidation keyed on exact bytes, so a stale entry
+    /// can never leak).
+    #[test]
+    fn expand_dynamic_routes_cached_hits_and_invalidates_on_edit() {
+        let body = r#"export function paths() { return [{ params: { slug: "one" } }]; }"#;
+        let (dir, pending) = stage_dynamic_page(
+            "pages/blog/[slug].tsx",
+            vec![
+                Segment::Static("blog".into()),
+                Segment::Dynamic("slug".into()),
+            ],
+            "/blog/:slug",
+            body,
+        );
+
+        let mut paths_cache = PathsCache::new();
+        let mut extract_cache = SourceExtractCache::new();
+        let out1 = expand_dynamic_routes_cached(
+            std::slice::from_ref(&pending),
+            dir.path(),
+            &mut paths_cache,
+            Some(&mut extract_cache),
+        )
+        .expect("first expansion");
+        assert_eq!(out1.resolved.len(), 1);
+        assert_eq!(out1.resolved[0].url_path, "/blog/one");
+        assert_eq!(extract_cache.hit_count(), 0);
+        assert_eq!(extract_cache.miss_count(), 1);
+
+        // Unchanged bytes: the extraction is replayed from the cache and
+        // the expansion output is identical.
+        let out2 = expand_dynamic_routes_cached(
+            std::slice::from_ref(&pending),
+            dir.path(),
+            &mut paths_cache,
+            Some(&mut extract_cache),
+        )
+        .expect("second expansion");
+        assert_eq!(out2.resolved.len(), 1);
+        assert_eq!(out2.resolved[0].url_path, "/blog/one");
+        assert_eq!(extract_cache.hit_count(), 1);
+        assert_eq!(extract_cache.miss_count(), 1);
+
+        // Edit the source: the content hash changes, the parse re-runs,
+        // and the new paths() output wins.
+        std::fs::write(
+            dir.path().join("pages/blog/[slug].tsx"),
+            r#"export function paths() { return [{ params: { slug: "two" } }]; }"#,
+        )
+        .unwrap();
+        let out3 = expand_dynamic_routes_cached(
+            &[pending],
+            dir.path(),
+            &mut paths_cache,
+            Some(&mut extract_cache),
+        )
+        .expect("third expansion");
+        assert_eq!(out3.resolved.len(), 1);
+        assert_eq!(
+            out3.resolved[0].url_path, "/blog/two",
+            "edited paths() must be re-extracted from fresh bytes"
+        );
+        assert_eq!(extract_cache.hit_count(), 1);
+        assert_eq!(extract_cache.miss_count(), 2);
     }
 
     #[test]

--- a/crates/zfb/src/render_pipeline.rs
+++ b/crates/zfb/src/render_pipeline.rs
@@ -53,13 +53,11 @@
 //!    surfaces that error verbatim instead of swallowing it.
 
 use std::collections::BTreeMap;
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use anyhow::{Context, Result};
 use include_dir::{include_dir, Dir};
-use sha2::{Digest as _, Sha256};
 use zfb_build::renderer::RouteUniverseEntry;
 #[cfg(feature = "embed_v8")]
 use zfb_build::EmbeddedV8Host;
@@ -459,23 +457,9 @@ pub fn expand_dynamic_routes(
     project_root: &Path,
     cache: &mut PathsCache,
 ) -> anyhow::Result<DynamicExpansion> {
-    expand_dynamic_routes_cached(deferred, project_root, cache, None)
-}
-
-/// [`expand_dynamic_routes`] with an optional cross-call
-/// [`SourceExtractCache`] (#994 item C): on a per-file content-hash hit
-/// the static `paths()` SWC parse is skipped. `zfb dev` passes its
-/// session cache; `zfb build` goes through the plain wrapper (`None`)
-/// and is byte-for-byte unchanged.
-pub fn expand_dynamic_routes_cached(
-    deferred: &[PendingDynamicRoute],
-    project_root: &Path,
-    cache: &mut PathsCache,
-    mut extract_cache: Option<&mut SourceExtractCache>,
-) -> anyhow::Result<DynamicExpansion> {
     let mut out = DynamicExpansion::default();
     for route in deferred {
-        match try_expand_one(route, project_root, cache, extract_cache.as_deref_mut()) {
+        match try_expand_one(route, project_root, cache) {
             Ok((entries, params_entries)) => {
                 out.resolved.extend(entries);
                 out.resolved_with_params.extend(params_entries);
@@ -502,99 +486,6 @@ pub fn expand_dynamic_routes_cached(
         }
     }
     Ok(out)
-}
-
-/// Cached prerender classification for one TSX/TS page source
-/// (#994 item C). Mirrors exactly the three ways
-/// [`build_prerender_map`] folds an `extract_tsx_frontmatter` outcome
-/// into the map, so replaying a cached entry is observationally
-/// identical to re-parsing unchanged bytes.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum CachedPrerender {
-    /// Frontmatter present and parsed — `prerender` flag extracted.
-    Value(bool),
-    /// No `export const frontmatter` at all — valid; no map entry
-    /// (renderer falls back to the SSG default) and no warning (#505).
-    AbsentFrontmatter,
-    /// Frontmatter present but malformed — no map entry; the warning is
-    /// emitted only when the entry is COMPUTED (cache miss), so the
-    /// per-tick repeat for an unchanged broken page dedupes to
-    /// once-per-edit.
-    Malformed,
-}
-
-/// Per-file content-hash cache for the SWC-parse extraction passes that
-/// run on every dev refresh tick (#994 item C): the
-/// [`build_prerender_map`] TSX-frontmatter extraction and the
-/// [`expand_dynamic_routes`] static `paths()` extraction. Both are pure
-/// functions of the file bytes, so entries are keyed by the SHA-256 of
-/// the bytes read this call — the read itself always happens (reads are
-/// cheap; only the SWC parse is skipped on a hit), which is also what
-/// makes invalidation exact: ANY byte change produces a different key.
-/// Read errors and parse errors are never cached — they fall through to
-/// the identical code path as today, every call.
-#[derive(Debug, Default)]
-pub struct SourceExtractCache {
-    /// abs source path -> (content hash, prerender classification).
-    prerender: HashMap<PathBuf, ([u8; 32], CachedPrerender)>,
-    /// abs source path -> (content hash, static `paths()` extraction).
-    paths: HashMap<PathBuf, ([u8; 32], PathsExtraction)>,
-    hits: u64,
-    misses: u64,
-}
-
-impl SourceExtractCache {
-    /// Construct an empty cache.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Number of per-file lookups answered from the cache (SWC parse
-    /// skipped). Exposed for tests and diagnostics.
-    pub fn hit_count(&self) -> u64 {
-        self.hits
-    }
-
-    /// Number of per-file lookups that had to (re)parse.
-    pub fn miss_count(&self) -> u64 {
-        self.misses
-    }
-}
-
-/// SHA-256 of `bytes` — the [`SourceExtractCache`] key material.
-fn sha256_bytes(bytes: &[u8]) -> [u8; 32] {
-    let mut hasher = Sha256::new();
-    hasher.update(bytes);
-    hasher.finalize().into()
-}
-
-/// [`extract_paths`] behind the optional [`SourceExtractCache`]
-/// (#994 item C). On a content-hash hit the SWC parse is skipped and the
-/// cached [`PathsExtraction`] is replayed. Parse errors propagate
-/// uncached, so a broken source re-parses (and re-reports) every call,
-/// exactly as without the cache.
-fn extract_paths_cached(
-    abs: &Path,
-    source: &str,
-    file_name: &str,
-    cache: Option<&mut SourceExtractCache>,
-) -> Result<PathsExtraction, PathsExtractError> {
-    let Some(cache) = cache else {
-        return extract_paths(source, file_name);
-    };
-    let hash = sha256_bytes(source.as_bytes());
-    if let Some((cached_hash, cached)) = cache.paths.get(abs) {
-        if *cached_hash == hash {
-            cache.hits += 1;
-            return Ok(cached.clone());
-        }
-    }
-    let computed = extract_paths(source, file_name)?;
-    cache.misses += 1;
-    cache
-        .paths
-        .insert(abs.to_path_buf(), (hash, computed.clone()));
-    Ok(computed)
 }
 
 /// Typed failure shape from `try_expand_one`.
@@ -625,7 +516,6 @@ fn try_expand_one(
     route: &PendingDynamicRoute,
     project_root: &Path,
     cache: &mut PathsCache,
-    extract_cache: Option<&mut SourceExtractCache>,
 ) -> Result<(Vec<RouteUniverseEntry>, Vec<DynamicResolvedEntry>), TryExpandFailure> {
     let abs = if route.source_path.is_absolute() {
         route.source_path.clone()
@@ -638,7 +528,7 @@ fn try_expand_one(
         .unwrap_or_else(|| route.source_path.display().to_string());
     let source = std::fs::read_to_string(&abs)
         .map_err(|e| TryExpandFailure::Other(format!("could not read {} ({e})", abs.display())))?;
-    let extraction = match extract_paths_cached(&abs, &source, &file_name, extract_cache) {
+    let extraction = match extract_paths(&source, &file_name) {
         Ok(x) => x,
         Err(PathsExtractError::Parse { file, message }) => {
             return Err(TryExpandFailure::Other(format!(
@@ -1215,23 +1105,7 @@ pub fn is_ssr_route(prerender_map: &BTreeMap<String, bool>, template: &str) -> b
 pub fn build_prerender_map(
     routes: &[Route],
     project_root: &Path,
-    warn_unreadable: impl FnMut(&str),
-) -> BTreeMap<String, bool> {
-    build_prerender_map_cached(routes, project_root, warn_unreadable, None)
-}
-
-/// [`build_prerender_map`] with an optional cross-call
-/// [`SourceExtractCache`] (#994 item C): on a per-file content-hash hit
-/// the TSX-frontmatter SWC parse is skipped and the cached
-/// classification is replayed. `zfb dev` passes its session cache;
-/// `zfb build` goes through the plain wrapper (`None`) and is
-/// byte-for-byte unchanged. Unreadable files are never cached — they
-/// warn-and-skip on every call, exactly as without the cache.
-pub fn build_prerender_map_cached(
-    routes: &[Route],
-    project_root: &Path,
     mut warn_unreadable: impl FnMut(&str),
-    mut cache: Option<&mut SourceExtractCache>,
 ) -> BTreeMap<String, bool> {
     let mut map = BTreeMap::new();
     for route in routes {
@@ -1259,73 +1133,33 @@ pub fn build_prerender_map_cached(
                 continue;
             }
         };
-        let classification =
-            classify_prerender_cached(&abs, &source, &mut warn_unreadable, cache.as_deref_mut());
-        if let CachedPrerender::Value(prerender) = classification {
-            map.insert(route.template(), prerender);
+        let file_name = abs
+            .file_name()
+            .map(|s| s.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "<unknown>".into());
+        match extract_tsx_frontmatter(&source, &file_name) {
+            Ok(fm) => {
+                map.insert(route.template(), fm.prerender);
+            }
+            // A route page with no `export const frontmatter` is valid — the
+            // export is optional and an absent one simply means "use the SSG
+            // default". Warning on it is misleading (it reads as "your page is
+            // broken") and fires on every frontmatter-less page, so stay silent
+            // and let the missing-key default of `true` (SSG) apply. See #505.
+            Err(TsxFrontmatterError::MissingFrontmatter { .. }) => {}
+            // Any other extraction error means the frontmatter IS present but
+            // malformed (parse error, duplicate/computed/wrong-shape export).
+            // That's a real mistake worth surfacing.
+            Err(e) => {
+                warn_unreadable(&format!(
+                    "frontmatter extraction failed for {} ({}); defaulting to SSG",
+                    abs.display(),
+                    e
+                ));
+            }
         }
     }
     map
-}
-
-/// Classify one TSX/TS page source's `prerender` frontmatter, going
-/// through the optional [`SourceExtractCache`] (#994 item C). The
-/// classification (and the once-per-computation malformed-frontmatter
-/// warning) is exactly [`build_prerender_map`]'s historical per-file
-/// logic, factored out so the cached and uncached paths cannot drift.
-fn classify_prerender_cached(
-    abs: &Path,
-    source: &str,
-    warn_unreadable: &mut impl FnMut(&str),
-    cache: Option<&mut SourceExtractCache>,
-) -> CachedPrerender {
-    let Some(cache) = cache else {
-        return classify_prerender(abs, source, warn_unreadable);
-    };
-    let hash = sha256_bytes(source.as_bytes());
-    if let Some((cached_hash, cached)) = cache.prerender.get(abs) {
-        if *cached_hash == hash {
-            cache.hits += 1;
-            return *cached;
-        }
-    }
-    let computed = classify_prerender(abs, source, warn_unreadable);
-    cache.misses += 1;
-    cache.prerender.insert(abs.to_path_buf(), (hash, computed));
-    computed
-}
-
-/// Uncached per-file prerender classification — one
-/// [`extract_tsx_frontmatter`] call folded into [`CachedPrerender`].
-fn classify_prerender(
-    abs: &Path,
-    source: &str,
-    warn_unreadable: &mut impl FnMut(&str),
-) -> CachedPrerender {
-    let file_name = abs
-        .file_name()
-        .map(|s| s.to_string_lossy().into_owned())
-        .unwrap_or_else(|| "<unknown>".into());
-    match extract_tsx_frontmatter(source, &file_name) {
-        Ok(fm) => CachedPrerender::Value(fm.prerender),
-        // A route page with no `export const frontmatter` is valid — the
-        // export is optional and an absent one simply means "use the SSG
-        // default". Warning on it is misleading (it reads as "your page is
-        // broken") and fires on every frontmatter-less page, so stay silent
-        // and let the missing-key default of `true` (SSG) apply. See #505.
-        Err(TsxFrontmatterError::MissingFrontmatter { .. }) => CachedPrerender::AbsentFrontmatter,
-        // Any other extraction error means the frontmatter IS present but
-        // malformed (parse error, duplicate/computed/wrong-shape export).
-        // That's a real mistake worth surfacing.
-        Err(e) => {
-            warn_unreadable(&format!(
-                "frontmatter extraction failed for {} ({}); defaulting to SSG",
-                abs.display(),
-                e
-            ));
-            CachedPrerender::Malformed
-        }
-    }
 }
 
 /// Verify that `@takazudo/zfb-runtime` is resolvable for the current build.
@@ -1583,92 +1417,6 @@ mod tests {
             "expected malformed.tsx in warning, got: {}",
             warnings[0]
         );
-    }
-
-    /// #994 item C — the per-file content-hash cache replays the
-    /// prerender classification on unchanged bytes (skipping the SWC
-    /// parse and deduping the malformed-frontmatter warning to once per
-    /// computation) and recomputes exactly when the bytes change.
-    #[test]
-    fn build_prerender_map_cached_replays_and_invalidates_on_content_change() {
-        let dir = tempdir().unwrap();
-        let pages = dir.path().join("pages");
-        std::fs::create_dir_all(&pages).unwrap();
-        std::fs::write(
-            pages.join("about.tsx"),
-            "export const frontmatter = { title: 'A' };\nexport const prerender = false;\nexport default function() { return null; }\n",
-        )
-        .unwrap();
-        std::fs::write(
-            pages.join("malformed.tsx"),
-            "const t = 'x';\nexport const frontmatter = { title: t };\nexport default function() { return null; }\n",
-        )
-        .unwrap();
-
-        let routes = vec![
-            static_route(vec!["about"], "pages/about.tsx"),
-            static_route(vec!["malformed"], "pages/malformed.tsx"),
-        ];
-
-        let mut cache = SourceExtractCache::new();
-        let mut warnings: Vec<String> = Vec::new();
-        let map1 = build_prerender_map_cached(
-            &routes,
-            dir.path(),
-            |msg| warnings.push(msg.to_string()),
-            Some(&mut cache),
-        );
-        assert_eq!(map1.get("/about"), Some(&false));
-        assert!(!map1.contains_key("/malformed"));
-        assert_eq!(
-            warnings.len(),
-            1,
-            "malformed warns on compute: {warnings:?}"
-        );
-        assert_eq!(cache.hit_count(), 0);
-        assert_eq!(cache.miss_count(), 2);
-
-        // Second pass with unchanged bytes: identical map, all hits, and
-        // the malformed warning is NOT repeated (deduped to once-per-edit).
-        let map2 = build_prerender_map_cached(
-            &routes,
-            dir.path(),
-            |msg| warnings.push(msg.to_string()),
-            Some(&mut cache),
-        );
-        assert_eq!(map1, map2, "cache replay must be observationally identical");
-        assert_eq!(
-            warnings.len(),
-            1,
-            "no repeated warning on a cache hit: {warnings:?}"
-        );
-        assert_eq!(cache.hit_count(), 2);
-        assert_eq!(cache.miss_count(), 2);
-
-        // Edit about.tsx (drop `prerender = false`): the content hash
-        // changes, so only that file recomputes — and the new
-        // classification (frontmatter present, prerender default true)
-        // is reflected. The unchanged malformed page still hits (and
-        // still does not re-warn).
-        std::fs::write(
-            pages.join("about.tsx"),
-            "export const frontmatter = { title: 'A' };\nexport default function() { return null; }\n",
-        )
-        .unwrap();
-        let map3 = build_prerender_map_cached(
-            &routes,
-            dir.path(),
-            |msg| warnings.push(msg.to_string()),
-            Some(&mut cache),
-        );
-        assert_eq!(
-            map3.get("/about"),
-            Some(&true),
-            "edited page must be reclassified from fresh bytes: {map3:?}"
-        );
-        assert_eq!(warnings.len(), 1, "no new warnings: {warnings:?}");
-        assert_eq!(cache.hit_count(), 3, "unchanged malformed page hits");
-        assert_eq!(cache.miss_count(), 3, "edited page recomputes");
     }
 
     #[test]
@@ -1997,75 +1745,6 @@ mod tests {
         assert_eq!(out2.resolved.len(), 10);
         assert_eq!(cache.miss_count(), 1, "second expand: miss_count unchanged");
         assert_eq!(cache.hit_count(), 1, "second expand: expected 1 hit");
-    }
-
-    /// #994 item C — `extract_paths` goes through the per-file
-    /// content-hash cache: unchanged sources skip the SWC parse on
-    /// re-expansion; an edit recomputes and the NEW `paths()` output is
-    /// reflected (invalidation keyed on exact bytes, so a stale entry
-    /// can never leak).
-    #[test]
-    fn expand_dynamic_routes_cached_hits_and_invalidates_on_edit() {
-        let body = r#"export function paths() { return [{ params: { slug: "one" } }]; }"#;
-        let (dir, pending) = stage_dynamic_page(
-            "pages/blog/[slug].tsx",
-            vec![
-                Segment::Static("blog".into()),
-                Segment::Dynamic("slug".into()),
-            ],
-            "/blog/:slug",
-            body,
-        );
-
-        let mut paths_cache = PathsCache::new();
-        let mut extract_cache = SourceExtractCache::new();
-        let out1 = expand_dynamic_routes_cached(
-            std::slice::from_ref(&pending),
-            dir.path(),
-            &mut paths_cache,
-            Some(&mut extract_cache),
-        )
-        .expect("first expansion");
-        assert_eq!(out1.resolved.len(), 1);
-        assert_eq!(out1.resolved[0].url_path, "/blog/one");
-        assert_eq!(extract_cache.hit_count(), 0);
-        assert_eq!(extract_cache.miss_count(), 1);
-
-        // Unchanged bytes: the extraction is replayed from the cache and
-        // the expansion output is identical.
-        let out2 = expand_dynamic_routes_cached(
-            std::slice::from_ref(&pending),
-            dir.path(),
-            &mut paths_cache,
-            Some(&mut extract_cache),
-        )
-        .expect("second expansion");
-        assert_eq!(out2.resolved.len(), 1);
-        assert_eq!(out2.resolved[0].url_path, "/blog/one");
-        assert_eq!(extract_cache.hit_count(), 1);
-        assert_eq!(extract_cache.miss_count(), 1);
-
-        // Edit the source: the content hash changes, the parse re-runs,
-        // and the new paths() output wins.
-        std::fs::write(
-            dir.path().join("pages/blog/[slug].tsx"),
-            r#"export function paths() { return [{ params: { slug: "two" } }]; }"#,
-        )
-        .unwrap();
-        let out3 = expand_dynamic_routes_cached(
-            &[pending],
-            dir.path(),
-            &mut paths_cache,
-            Some(&mut extract_cache),
-        )
-        .expect("third expansion");
-        assert_eq!(out3.resolved.len(), 1);
-        assert_eq!(
-            out3.resolved[0].url_path, "/blog/two",
-            "edited paths() must be re-extracted from fresh bytes"
-        );
-        assert_eq!(extract_cache.hit_count(), 1);
-        assert_eq!(extract_cache.miss_count(), 2);
     }
 
     #[test]

--- a/crates/zfb/src/ssr_adapter.rs
+++ b/crates/zfb/src/ssr_adapter.rs
@@ -78,20 +78,16 @@ impl SsrDispatcher for EmbeddedV8SsrAdapter {
                 Ok(g) => g,
                 Err(p) => p.into_inner(),
             };
-            let st = guard
-                .as_mut()
-                .ok_or_else(|| {
-                    zfb_build::renderer::RendererError::EmbeddedV8(
-                        "renderer state has been shut down".into(),
-                    )
-                })?;
-            let host = st
-                .embedded_v8_host_mut()
-                .ok_or_else(|| {
-                    zfb_build::renderer::RendererError::EmbeddedV8(
-                        "renderer is not backed by an embedded V8 host".into(),
-                    )
-                })?;
+            let st = guard.as_mut().ok_or_else(|| {
+                zfb_build::renderer::RendererError::EmbeddedV8(
+                    "renderer state has been shut down".into(),
+                )
+            })?;
+            let host = st.embedded_v8_host_mut().ok_or_else(|| {
+                zfb_build::renderer::RendererError::EmbeddedV8(
+                    "renderer is not backed by an embedded V8 host".into(),
+                )
+            })?;
             host.dispatch_fetch_full(
                 &request.url_path,
                 &request.method,

--- a/crates/zfb/src/v8_host_adapter.rs
+++ b/crates/zfb/src/v8_host_adapter.rs
@@ -27,9 +27,7 @@ use std::sync::mpsc;
 use std::thread;
 
 use zfb_build::renderer::{EmbeddedV8Host, HttpResponseLike, RendererError};
-use zfb_render::{
-    BundleModuleLoader, EmbeddedV8RenderHost, HttpRequestLike, PluginRegistryHooks,
-};
+use zfb_render::{BundleModuleLoader, EmbeddedV8RenderHost, HttpRequestLike, PluginRegistryHooks};
 
 /// Message sent from the caller thread to the V8 host thread.
 ///
@@ -100,10 +98,8 @@ impl Drop for ThreadedV8Host {
             // Bounded join: if isolate teardown inside deno_core wedges, we
             // detach rather than hang the process.  A generous deadline is
             // fine — the goal is bounding the worst case, not a tight cutoff.
-            let _ = crate::bounded_join::join_with_deadline(
-                handle,
-                std::time::Duration::from_secs(10),
-            );
+            let _ =
+                crate::bounded_join::join_with_deadline(handle, std::time::Duration::from_secs(10));
         }
     }
 }
@@ -288,7 +284,9 @@ impl ThreadedV8Host {
                     // rx is closed (ThreadedV8Host was dropped); exit cleanly.
                 });
             })
-            .map_err(|e| RendererError::EmbeddedV8(format!("could not spawn V8 host thread: {e}")))?;
+            .map_err(|e| {
+                RendererError::EmbeddedV8(format!("could not spawn V8 host thread: {e}"))
+            })?;
 
         // Wait for the host to signal that boot succeeded.
         match boot_rx.recv() {
@@ -386,9 +384,9 @@ impl ThreadedV8Host {
             RendererError::EmbeddedV8("V8 host thread has exited unexpectedly".into())
         })?;
         // Block until the reply arrives.
-        reply_rx.recv().map_err(|_| {
-            RendererError::EmbeddedV8("V8 host thread closed reply channel".into())
-        })?
+        reply_rx
+            .recv()
+            .map_err(|_| RendererError::EmbeddedV8("V8 host thread closed reply channel".into()))?
     }
 }
 
@@ -442,10 +440,7 @@ pub fn translate_setup_registries_to_hooks(
     }
     let mut virtual_modules: HashMap<String, zfb_render::VirtualModuleHook> = HashMap::new();
     for (specifier, vm_entry) in registries.virtual_modules.iter() {
-        let source = virtual_sources
-            .get(specifier)
-            .cloned()
-            .unwrap_or_default();
+        let source = virtual_sources.get(specifier).cloned().unwrap_or_default();
         virtual_modules.insert(
             specifier.clone(),
             zfb_render::VirtualModuleHook {

--- a/crates/zfb/tests/build_cleans_outdir.rs
+++ b/crates/zfb/tests/build_cleans_outdir.rs
@@ -76,7 +76,11 @@ fn run_zfb_build(root: &Path, esbuild: &Path) -> std::process::Output {
 
 /// Run `zfb build` in `root` with the supplied esbuild path, also passing
 /// `--outdir <outdir_arg>`.
-fn run_zfb_build_with_outdir(root: &Path, esbuild: &Path, outdir_arg: &str) -> std::process::Output {
+fn run_zfb_build_with_outdir(
+    root: &Path,
+    esbuild: &Path,
+    outdir_arg: &str,
+) -> std::process::Output {
     Command::new(zfb_binary!())
         .arg("build")
         .arg("--outdir")
@@ -133,11 +137,18 @@ fn stale_assets_and_orphan_html_are_removed_on_rebuild() {
     fs::write(&orphan_html, b"<html><body>dead page</body></html>").unwrap();
 
     assert!(stale_js.exists(), "stale JS must exist before rebuild");
-    assert!(orphan_html.exists(), "orphan HTML must exist before rebuild");
+    assert!(
+        orphan_html.exists(),
+        "orphan HTML must exist before rebuild"
+    );
 
     // Second build — wipe must remove the stale files.
     let out2 = run_zfb_build(root, &esbuild);
-    assert!(out2.status.success(), "second build failed\n{}", dump(&out2));
+    assert!(
+        out2.status.success(),
+        "second build failed\n{}",
+        dump(&out2)
+    );
 
     assert!(
         !stale_js.exists(),
@@ -187,7 +198,11 @@ fn dist_as_symlink_survives_with_fresh_target_contents() {
     symlink(&real_dist, &dist_link).unwrap();
 
     let out = run_zfb_build(root, &esbuild);
-    assert!(out.status.success(), "build with dist-as-symlink failed\n{}", dump(&out));
+    assert!(
+        out.status.success(),
+        "build with dist-as-symlink failed\n{}",
+        dump(&out)
+    );
 
     // The symlink must still be a symlink (not replaced by a directory).
     let meta = fs::symlink_metadata(&dist_link).expect("symlink_metadata on dist link");
@@ -243,7 +258,11 @@ fn child_symlink_in_dist_is_unlinked_target_untouched() {
 
     // Second build — the wipe must remove the link, not follow it.
     let out2 = run_zfb_build(root, &esbuild);
-    assert!(out2.status.success(), "second build failed\n{}", dump(&out2));
+    assert!(
+        out2.status.success(),
+        "second build failed\n{}",
+        dump(&out2)
+    );
 
     assert!(
         !child_link.exists(),

--- a/crates/zfb/tests/content_snapshot_no_deferred.rs
+++ b/crates/zfb/tests/content_snapshot_no_deferred.rs
@@ -92,8 +92,7 @@ fn getstaticprops_collection_appears_in_rendered_html() {
         "dist/index.html must be written by zfb build; \
          stdout: {stdout}\nstderr: {stderr}"
     );
-    let html = fs::read_to_string(&index_html)
-        .expect("read dist/index.html");
+    let html = fs::read_to_string(&index_html).expect("read dist/index.html");
 
     // The load-bearing assertion for issue #495: the content snapshot must
     // be embedded and getCollection("posts") must see the one fixture post.

--- a/crates/zfb/tests/css_modules_components_build.rs
+++ b/crates/zfb/tests/css_modules_components_build.rs
@@ -294,7 +294,8 @@ fn build_and_assert_corp_shape(
     for (path, original) in module_css_paths.iter().zip(original_module_css.iter()) {
         let current = fs::read_to_string(path).unwrap_or_default();
         assert_eq!(
-            &current, original,
+            &current,
+            original,
             "the user's source file at {} was modified by the build — \
              this is the symlink-write corruption hazard described in the \
              file-level //! doc comment. Wave 2's fix MUST replace the symlink \
@@ -377,9 +378,7 @@ fn build_and_assert_corp_shape(
                 .unwrap_or(false)
         })
         .unwrap_or_else(|| {
-            panic!(
-                "expected dist/assets/styles-<hash>.css to be emitted; got: {css_paths:#?}"
-            )
+            panic!("expected dist/assets/styles-<hash>.css to be emitted; got: {css_paths:#?}")
         });
     let css_body = fs::read_to_string(styles_css).unwrap();
 

--- a/crates/zfb/tests/diagnostics_fixtures.rs
+++ b/crates/zfb/tests/diagnostics_fixtures.rs
@@ -15,8 +15,8 @@
 use std::path::PathBuf;
 
 use zfb::diagnostics::{
-    from_directive_diagnostic, from_frontmatter_error, from_js_runtime_error,
-    from_paths_error, render_framed,
+    from_directive_diagnostic, from_frontmatter_error, from_js_runtime_error, from_paths_error,
+    render_framed,
 };
 use zfb_content::plugins::DirectiveDiagnostic;
 use zfb_render::paths::PathsError;
@@ -25,8 +25,8 @@ fn fixture(name: &str) -> (PathBuf, String) {
     let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests/fixtures/error-ux")
         .join(name);
-    let text = std::fs::read_to_string(&path)
-        .unwrap_or_else(|e| panic!("read fixture {name}: {e}"));
+    let text =
+        std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("read fixture {name}: {e}"));
     (path, text)
 }
 
@@ -74,7 +74,10 @@ fn frontmatter_yaml_error_frames_offending_line() {
         "must include relative path: {out}"
     );
     // Snippet must include the offending bracketed value.
-    assert!(out.contains("title: [unterminated"), "snippet missing: {out}");
+    assert!(
+        out.contains("title: [unterminated"),
+        "snippet missing: {out}"
+    );
     // Exactly one caret on its own line.
     assert!(
         out.matches("\n  | ").filter(|_| true).count() >= 1,
@@ -124,13 +127,8 @@ fn paths_missing_param_frames_export_paths_line() {
         Ok(zfb_render::paths_extract::PathsExtraction::Literal(v)) => v,
         other => unreachable!("expected literal extraction, got {other:?}"),
     };
-    let err = zfb_render::paths::resolve_paths(
-        &mut cache,
-        "blog/[slug].tsx",
-        &segs,
-        &extracted,
-    )
-    .expect_err("must fail with MissingParam");
+    let err = zfb_render::paths::resolve_paths(&mut cache, "blog/[slug].tsx", &segs, &extracted)
+        .expect_err("must fail with MissingParam");
     assert!(matches!(err, PathsError::MissingParam { .. }));
     let d = from_paths_error(&path, &src, &err);
     let out = strip_ansi(&render_framed(&d));
@@ -143,7 +141,10 @@ fn paths_missing_param_frames_export_paths_line() {
         out.contains("paths-missing-param.tsx:7:"),
         "expected caret on `export function paths` line 7: {out}"
     );
-    assert!(out.contains("export function paths"), "snippet missing: {out}");
+    assert!(
+        out.contains("export function paths"),
+        "snippet missing: {out}"
+    );
 }
 
 #[test]
@@ -158,13 +159,8 @@ fn paths_shape_error_frames_export_paths_line() {
         Ok(zfb_render::paths_extract::PathsExtraction::Literal(v)) => v,
         other => unreachable!("expected literal extraction, got {other:?}"),
     };
-    let err = zfb_render::paths::resolve_paths(
-        &mut cache,
-        "[slug].tsx",
-        &segs,
-        &extracted,
-    )
-    .expect_err("must fail");
+    let err = zfb_render::paths::resolve_paths(&mut cache, "[slug].tsx", &segs, &extracted)
+        .expect_err("must fail");
     assert!(matches!(err, PathsError::InvalidPathsExport { .. }));
     let d = from_paths_error(&path, &src, &err);
     let out = strip_ansi(&render_framed(&d));

--- a/crates/zfb/tests/version_stamp.rs
+++ b/crates/zfb/tests/version_stamp.rs
@@ -31,14 +31,7 @@ fn version_stamp_from_env() {
     // env!("CARGO") is the path to the cargo binary that invoked this test,
     // guaranteed to exist and match the toolchain in use.
     let output = Command::new(env!("CARGO"))
-        .args([
-            "run",
-            "--quiet",
-            "--package",
-            "zfb",
-            "--",
-            "--version",
-        ])
+        .args(["run", "--quiet", "--package", "zfb", "--", "--version"])
         .env("ZFB_RELEASE_VERSION", test_version)
         .env("CARGO_TARGET_DIR", &isolated_target)
         // Suppress build.rs binary downloads: binaries already staged in the


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/987

---

## Summary

- **rustfmt enforcement (#988, closes the #986 decision):** one-off `cargo fmt --all` across 60 drifted files (isolated commit, listed in a new `.git-blame-ignore-revs`) + a `cargo fmt --all --check` fail-fast gate in health.yml right after toolchain setup.
- **Islands scanner fix (#989, from #984):** `export { Foo as default }` (the tsup/esbuild-compiled default-export shape) now registers `("default", marker: "Foo")` — dist-shipped islands hydrate instead of silently dying. Only the marker fallback branch changed; tests cover the alias, string-literal, mixed, and re-export forms.
- **Build-time island diagnostic (#990, from #984):** prod builds now warn (non-fatal, one deduped line per name) when a rendered `data-zfb-island` marker has no registry entry — lol_html selector pass over post-processable pages, modeled on link_base_rewrite; runs even with zero registered islands.
- **Dev refresh-floor attack (#991–#994, from #982):** measure → decide → implement. `ZFB_DEV_TIMING=1` per-tick phase instrumentation; a persistent shadow-tree session in `bundle()` (compute-always / write-only-if-changed + visited-set prune + dirty-reset; byte-identical to fresh bundles so the #940 skip key is untouched); process-lifetime embedded-esbuild extraction; PathsCache persisted across ticks. A third candidate (prerender-map content-hash cache) was implemented, measured below its threshold (−2ms vs ≥8ms bar), and reverted per the locked rule.
- **Review hardening:** codex review found a stale-shadow-directory edge (directory→file source mutation breaking session rebuilds) — fixed with write-time type-conflict healing + written-map subtree invalidation + regression tests.

## Measured result

Body-edit dev tick refresh: **716ms → 644ms median** (−10%; pooled interleaved release-binary sessions on docs/, 228 pages, WSL2). Phase splits, thresholds, and per-lever verdicts are on epic #987. The #961 reopen trigger was re-evaluated with the new numbers (rendering now dominates full fan-out tick classes) — recommendation posted on #961, which stays open as the deferred tracker.

## Changes

- `.github/workflows/health.yml`: `cargo fmt --all --check` gate; `.git-blame-ignore-revs` (new)
- `crates/zfb-islands`: scanner ExportSpecifier::Named marker fallback + tests; bundler doc comments
- `crates/zfb/src/commands/island_marker_check.rs` (new) + `build.rs`/`dev.rs` plumbing: marker-vs-registry warning; `emit_prod_assets` now returns the marker-name set
- `crates/zfb/src/commands/dev.rs`: ZFB_DEV_TIMING phase timers; shadow-session + paths-cache wiring on the dev renderer
- `crates/zfb-build/src/bundler.rs`: `ShadowSession` / `bundle_with_session()` / ShadowWriter seam + path-type-flip healing; `tests/bundler_shadow_session.rs` (new, byte-equivalence + prune + type-flip suites)
- `crates/zfb/src/commands/bundler_input.rs`: pre-resolved esbuild handle (process-lifetime extraction)
- 60-file mechanical rustfmt commit (8c0b14a, blame-ignored)

## Test Plan

- `cargo test --workspace` (2665 tests), `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings` — all green on the branch
- Dev-invariant suites (#727 two-page swap, #940 skip-key ordering, #956 skip gates, #958 route-set comparison, #659 boot/refresh parity) green
- Live dev smoke on docs/: body/frontmatter/.tsx ticks re-render, livereload SSE fires; Phase-B skip verified on comment-only edits
- Measurement methodology + raw medians recorded on epic #987

Closes #987. Closes #988. Closes #989. Closes #990. Closes #991. Closes #992. Closes #993. Closes #994. Closes #995.