### PR TITLE
islands: register only component exports (#998); scan npm-dist use-client islands + docs directives (#999)

### DIFF
--- a/crates/zfb-islands/src/esbuild.rs
+++ b/crates/zfb-islands/src/esbuild.rs
@@ -1220,6 +1220,36 @@ pub(crate) fn build_esbuild_args_with_entry_name(
     args
 }
 
+/// JS boolean expression that tests whether `value_var` is component-shaped:
+/// a plain function, or a compat `memo()`/`forwardRef()` object carrying
+/// `$$typeof` (issue #998). `dollar_receiver` is the expression used to read
+/// `.$$typeof` off the value — the per-island sites (TS `.tsx` entries where
+/// the value is typed `any`) cast via `(Component as any)`, the shared-bundle
+/// sites read it directly. Hoisted so all four island render paths share one
+/// predicate instead of copy-pasting it.
+fn component_shape_predicate(value_var: &str, dollar_receiver: &str) -> String {
+    format!(
+        "typeof {value_var} === \"function\" || (typeof {value_var} === \"object\" && {value_var} !== null && {dollar_receiver}.$$typeof)"
+    )
+}
+
+/// JS `console.warn(...)` statement emitted when an island export is not
+/// component-shaped (issue #998). `export_name_expr` / `module_label_expr`
+/// are JS expressions naming the export and its source module; `action` is
+/// the skipped-verb phrase (`"registration"` for the shared bundle,
+/// `"mount"` for per-island). Hoisted so all four island render paths emit
+/// one identical warning string instead of copy-pasting it.
+fn non_component_warn(
+    value_var: &str,
+    export_name_expr: &str,
+    module_label_expr: &str,
+    action: &str,
+) -> String {
+    format!(
+        "console.warn(\"[zfb] island export \" + {export_name_expr} + \" from \" + {module_label_expr} + \" is not a component (got \" + ({value_var} === null ? \"null\" : typeof {value_var}) + \"); skipping {action}.\");"
+    )
+}
+
 /// Generate the synthetic single-entry source for the legacy shared
 /// bundle.
 ///
@@ -1250,28 +1280,22 @@ pub(crate) fn build_esbuild_args_with_entry_name(
 ///
 /// The synthesised entry imports each island as a namespace and
 /// **registers** it into a manifest at top-level using a
-/// `__zfb_register(ns, exportName, fallback)` helper: the helper picks
-/// the component (named export first, then `default`), reads its
-/// `displayName ?? name` to derive the **registered name** the SSR
-/// markers carry, and stashes a Preact-mount thunk under that key.
+/// `__zfb_register(ns, exportName, markerName, moduleLabel)` helper: the
+/// helper picks the component (`__zfb_pick` — named export first, then
+/// `default`) and stashes a mount thunk under `markerName`.
 ///
-/// Why dynamic key derivation rather than a static literal?
-///
-/// The SSR side (`packages/zfb/src/island.ts::captureComponentName`)
-/// computes the marker value `data-zfb-island="…"` from the JSX
-/// child's runtime identity (`type.displayName ?? type.name`). For
-/// host-shape islands authored as
-/// `export default function SidebarToggle(...)`, the scanner records
-/// `Island::component_name = "default"` (the export-side name), while
-/// the SSR marker is `"SidebarToggle"` (the function-identifier
-/// name). Keying the manifest on `Island::component_name` straight
-/// from the bundler — which the original #146 fix did — collapses
-/// every host-shape island onto the literal `"default"` key, esbuild
-/// flags duplicate-key warnings and only the last survives, and at
-/// runtime no marker ever matches. Reading `displayName ?? name` off
-/// the component at module-init time mirrors the SSR derivation
-/// exactly so both sides of the boundary agree (issue #147 / Wave 6
-/// follow-up).
+/// `markerName` is the **scanner-derived SSR-marker name** baked into the
+/// generated source as a static JSON literal — NOT a runtime
+/// `displayName ?? name` read. It matches the value the SSR side
+/// (`packages/zfb/src/island.ts::captureComponentName`, which derives
+/// `data-zfb-island="…"` from `type.displayName ?? type.name`) writes onto
+/// the marker, so both sides of the boundary agree on the key. Keying on
+/// the export-side `Island::component_name` instead would collapse every
+/// host-shape default-export island onto the literal `"default"` key (issue
+/// #149); a runtime `function.name` read is unsafe because esbuild
+/// minification renames functions (lesson from PR #148). `moduleLabel`
+/// names the source module in the non-component skip warning (#998). See
+/// the inline `__zfb_register` comment below for the full rationale.
 ///
 /// The runtime's `mountIslands` accepts this object shape directly
 /// (no second dynamic import) — see the `IslandManifestValue`
@@ -1389,14 +1413,15 @@ pub fn render_shared_bundle_entry_source(
     // `ns.default`. That mirrors `render_island_entry_source` for the
     // per-island path.
     //
-    // `__zfb_register(ns, exportName, markerName)` writes a Preact
-    // mount thunk for the resolved component under the **static
-    // marker name** the scanner discovered for this island (issue
-    // #149). The marker name is a JSON-encoded literal in the
-    // generated source, NOT a runtime introspection of
-    // `displayName ?? name` — that's the lesson from the previous
-    // round (PR #148): esbuild minification renames functions, so
+    // `__zfb_register(ns, exportName, markerName, moduleLabel)` writes a
+    // mount thunk for the resolved component under the **static marker
+    // name** the scanner discovered for this island (issue #149). The marker
+    // name is a JSON-encoded literal in the generated source, NOT a runtime
+    // introspection of `displayName ?? name` — that's the lesson from the
+    // previous round (PR #148): esbuild minification renames functions, so
     // `function.name` is unstable and unsafe to key the manifest on.
+    // `moduleLabel` names the source module in the non-component skip
+    // warning (#998).
     //
     // The mount thunk picks `hydrate` vs `render` based on the SSR /
     // SSR-skip mode the runtime supplies, mirroring the per-island
@@ -1412,16 +1437,24 @@ function __zfb_pick(ns, exportName) {\n\
     // the per-island path's `FrameworkKind` arms exactly. Keeping the
     // helper-function shape identical across frameworks (same name, same
     // args, same `__zfb_manifest[markerName]` slot) means only the thunk
-    // internals change.
-    match framework {
-        FrameworkKind::Preact => out.push_str(
-            "function __zfb_register(ns, exportName, markerName, moduleLabel) {\n\
+    // internals change. The guard prelude (component-shape check + the
+    // non-component skip warning) is identical for both frameworks, so it
+    // is built once from the shared helpers (#998).
+    let register_prelude = format!(
+        "function __zfb_register(ns, exportName, markerName, moduleLabel) {{\n\
   const C = __zfb_pick(ns, exportName);\n\
-  if (!(typeof C === \"function\" || (typeof C === \"object\" && C !== null && C.$$typeof))) {\n\
-    console.warn(\"[zfb] island export \" + exportName + \" from \" + moduleLabel + \" is not a component (got \" + (C === null ? \"null\" : typeof C) + \"); skipping registration.\");\n\
+  if (!({predicate})) {{\n\
+    {warn}\n\
     return;\n\
-  }\n\
-  __zfb_manifest[markerName] = {\n\
+  }}\n",
+        predicate = component_shape_predicate("C", "C"),
+        warn = non_component_warn("C", "exportName", "moduleLabel", "registration"),
+    );
+    match framework {
+        FrameworkKind::Preact => {
+            out.push_str(&register_prelude);
+            out.push_str(
+                "  __zfb_manifest[markerName] = {\n\
     mount: (props, element, mode) => {\n\
       const v = h(C, props);\n\
       if (mode === \"hydrate\") { hydrate(v, element); } else { render(v, element); }\n\
@@ -1429,15 +1462,12 @@ function __zfb_pick(ns, exportName) {\n\
     unmount: (element) => { render(null, element); },\n\
   };\n\
 }\n",
-        ),
-        FrameworkKind::React => out.push_str(
-            "function __zfb_register(ns, exportName, markerName, moduleLabel) {\n\
-  const C = __zfb_pick(ns, exportName);\n\
-  if (!(typeof C === \"function\" || (typeof C === \"object\" && C !== null && C.$$typeof))) {\n\
-    console.warn(\"[zfb] island export \" + exportName + \" from \" + moduleLabel + \" is not a component (got \" + (C === null ? \"null\" : typeof C) + \"); skipping registration.\");\n\
-    return;\n\
-  }\n\
-  __zfb_manifest[markerName] = {\n\
+            );
+        }
+        FrameworkKind::React => {
+            out.push_str(&register_prelude);
+            out.push_str(
+                "  __zfb_manifest[markerName] = {\n\
     mount: (props, element, mode) => {\n\
       const v = createElement(C, props);\n\
       if (mode === \"hydrate\") {\n\
@@ -1455,7 +1485,8 @@ function __zfb_pick(ns, exportName) {\n\
     },\n\
   };\n\
 }\n",
-        ),
+            );
+        }
     }
     // One register call per island. The `__zfb_register(...)` calls
     // are top-level side effects esbuild MUST preserve, and they
@@ -1504,6 +1535,12 @@ pub fn render_island_entry_source(framework: FrameworkKind, island: &Island) -> 
     let path_lit = json_string(&path);
     let component_name = &island.component_name;
     let component_lit = json_string(component_name);
+    // Component-shape guard + non-component skip warning, hoisted into the
+    // shared helpers so the shared-bundle path and both per-island framework
+    // arms emit one identical snippet (#998). `Component` is typed `any`
+    // here (it comes off `(Mod as any)[…]`), so the `$$typeof` read is cast.
+    let predicate = component_shape_predicate("Component", "(Component as any)");
+    let warn = non_component_warn("Component", &component_lit, &path_lit, "mount");
     match framework {
         FrameworkKind::Preact => format!(
             r#"// Generated by zfb-islands::EsbuildSubprocessBundler::bundle_per_island
@@ -1515,9 +1552,9 @@ const Component = (Mod as any)[{component_lit}] ?? (Mod as any).default;
 // carrying `$$typeof`. Anything else (a string/object constant that slipped
 // through as an island marker) is skipped with a loud warning rather than
 // handed to h() — which would otherwise build a DOM element from a bogus type.
-const __zfb_ok = typeof Component === "function" || (typeof Component === "object" && Component !== null && (Component as any).$$typeof);
+const __zfb_ok = {predicate};
 if (!__zfb_ok) {{
-  console.warn("[zfb] island export " + {component_lit} + " from " + {path_lit} + " is not a component (got " + (Component === null ? "null" : typeof Component) + "); skipping mount.");
+  {warn}
 }}
 export function mount(props, element, mode) {{
   if (!__zfb_ok) return;
@@ -1547,9 +1584,9 @@ const Component = (Mod as any)[{component_lit}] ?? (Mod as any).default;
 // as an island marker) is skipped with a loud warning rather than handed to
 // createElement() — which would otherwise try to build a DOM element from a
 // bogus type.
-const __zfb_ok = typeof Component === "function" || (typeof Component === "object" && Component !== null && (Component as any).$$typeof);
+const __zfb_ok = {predicate};
 if (!__zfb_ok) {{
-  console.warn("[zfb] island export " + {component_lit} + " from " + {path_lit} + " is not a component (got " + (Component === null ? "null" : typeof Component) + "); skipping mount.");
+  {warn}
 }}
 const __zfb_roots = new WeakMap();
 export function mount(props, element, mode) {{

--- a/crates/zfb-islands/src/esbuild.rs
+++ b/crates/zfb-islands/src/esbuild.rs
@@ -1415,9 +1415,12 @@ function __zfb_pick(ns, exportName) {\n\
     // internals change.
     match framework {
         FrameworkKind::Preact => out.push_str(
-            "function __zfb_register(ns, exportName, markerName) {\n\
+            "function __zfb_register(ns, exportName, markerName, moduleLabel) {\n\
   const C = __zfb_pick(ns, exportName);\n\
-  if (!C) return;\n\
+  if (!(typeof C === \"function\" || (typeof C === \"object\" && C !== null && C.$$typeof))) {\n\
+    console.warn(\"[zfb] island export \" + exportName + \" from \" + moduleLabel + \" is not a component (got \" + (C === null ? \"null\" : typeof C) + \"); skipping registration.\");\n\
+    return;\n\
+  }\n\
   __zfb_manifest[markerName] = {\n\
     mount: (props, element, mode) => {\n\
       const v = h(C, props);\n\
@@ -1428,9 +1431,12 @@ function __zfb_pick(ns, exportName) {\n\
 }\n",
         ),
         FrameworkKind::React => out.push_str(
-            "function __zfb_register(ns, exportName, markerName) {\n\
+            "function __zfb_register(ns, exportName, markerName, moduleLabel) {\n\
   const C = __zfb_pick(ns, exportName);\n\
-  if (!C) return;\n\
+  if (!(typeof C === \"function\" || (typeof C === \"object\" && C !== null && C.$$typeof))) {\n\
+    console.warn(\"[zfb] island export \" + exportName + \" from \" + moduleLabel + \" is not a component (got \" + (C === null ? \"null\" : typeof C) + \"); skipping registration.\");\n\
+    return;\n\
+  }\n\
   __zfb_manifest[markerName] = {\n\
     mount: (props, element, mode) => {\n\
       const v = createElement(C, props);\n\
@@ -1468,8 +1474,12 @@ function __zfb_pick(ns, exportName) {\n\
     for (i, island) in islands.iter().enumerate() {
         let name_lit = json_string(&island.component_name);
         let marker_lit = json_string(&island.marker_name);
+        // Issue #998: pass the resolved source path as `moduleLabel` so the
+        // non-component skip warning can name which module the bad export
+        // came from.
+        let module_lit = json_string(&island.source_path.to_string_lossy());
         out.push_str(&format!(
-            "__zfb_register(__zfb_island_{i}, {name_lit}, {marker_lit});\n"
+            "__zfb_register(__zfb_island_{i}, {name_lit}, {marker_lit}, {module_lit});\n"
         ));
     }
     out.push_str("mountIslands(__zfb_manifest);\n");
@@ -1500,7 +1510,17 @@ pub fn render_island_entry_source(framework: FrameworkKind, island: &Island) -> 
 import * as Mod from {path_lit};
 import {{ h, hydrate, render }} from "preact";
 const Component = (Mod as any)[{component_lit}] ?? (Mod as any).default;
+// Issue #998: only mount component-shaped exports. A plain function is a
+// component; the compat memo()/forwardRef() helpers produce an object
+// carrying `$$typeof`. Anything else (a string/object constant that slipped
+// through as an island marker) is skipped with a loud warning rather than
+// handed to h() — which would otherwise build a DOM element from a bogus type.
+const __zfb_ok = typeof Component === "function" || (typeof Component === "object" && Component !== null && (Component as any).$$typeof);
+if (!__zfb_ok) {{
+  console.warn("[zfb] island export " + {component_lit} + " from " + {path_lit} + " is not a component (got " + (Component === null ? "null" : typeof Component) + "); skipping mount.");
+}}
 export function mount(props, element, mode) {{
+  if (!__zfb_ok) return;
   const vnode = h(Component, props);
   if (mode === "hydrate") {{
     hydrate(vnode, element);
@@ -1509,6 +1529,7 @@ export function mount(props, element, mode) {{
   }}
 }}
 export function unmount(element) {{
+  if (!__zfb_ok) return;
   render(null, element);
 }}
 export default mount;
@@ -1520,8 +1541,19 @@ import * as Mod from {path_lit};
 import {{ createElement }} from "react";
 import {{ hydrateRoot, createRoot }} from "react-dom/client";
 const Component = (Mod as any)[{component_lit}] ?? (Mod as any).default;
+// Issue #998: only mount component-shaped exports. A plain function is a
+// component; react memo()/forwardRef() produce an object carrying
+// `$$typeof`. Anything else (a string/object constant that slipped through
+// as an island marker) is skipped with a loud warning rather than handed to
+// createElement() — which would otherwise try to build a DOM element from a
+// bogus type.
+const __zfb_ok = typeof Component === "function" || (typeof Component === "object" && Component !== null && (Component as any).$$typeof);
+if (!__zfb_ok) {{
+  console.warn("[zfb] island export " + {component_lit} + " from " + {path_lit} + " is not a component (got " + (Component === null ? "null" : typeof Component) + "); skipping mount.");
+}}
 const __zfb_roots = new WeakMap();
 export function mount(props, element, mode) {{
+  if (!__zfb_ok) return;
   const vnode = createElement(Component, props);
   if (mode === "hydrate") {{
     const root = hydrateRoot(element, vnode);
@@ -2138,11 +2170,11 @@ mod tests {
             "missing mountIslands call: {src}"
         );
         assert!(
-            src.contains("__zfb_register(__zfb_island_0, \"Counter\", \"Counter\");"),
+            src.contains("__zfb_register(__zfb_island_0, \"Counter\", \"Counter\","),
             "expected register call for Counter: {src}"
         );
         assert!(
-            src.contains("__zfb_register(__zfb_island_1, \"Modal\", \"Modal\");"),
+            src.contains("__zfb_register(__zfb_island_1, \"Modal\", \"Modal\","),
             "expected register call for Modal: {src}"
         );
     }
@@ -2299,8 +2331,8 @@ mod tests {
             !src.contains("function __zfb_keyFor("),
             "issue #149: runtime introspection helper must be gone:\n{src}"
         );
-        assert!(src.contains("__zfb_register(__zfb_island_0, \"Counter\", \"Counter\");"));
-        assert!(src.contains("__zfb_register(__zfb_island_1, \"Modal\", \"Modal\");"));
+        assert!(src.contains("__zfb_register(__zfb_island_0, \"Counter\", \"Counter\","));
+        assert!(src.contains("__zfb_register(__zfb_island_1, \"Modal\", \"Modal\","));
 
         // hydrate vs render branching mirrors render_island_entry_source.
         assert!(src.contains(r#"if (mode === "hydrate") { hydrate(v, element); }"#));
@@ -2355,8 +2387,8 @@ mod tests {
         // The shared helper shape is unchanged; only the thunk bodies differ.
         assert!(src.contains("function __zfb_pick("));
         assert!(src.contains("function __zfb_register("));
-        assert!(src.contains("__zfb_register(__zfb_island_0, \"Counter\", \"Counter\");"));
-        assert!(src.contains("__zfb_register(__zfb_island_1, \"Modal\", \"Modal\");"));
+        assert!(src.contains("__zfb_register(__zfb_island_0, \"Counter\", \"Counter\","));
+        assert!(src.contains("__zfb_register(__zfb_island_1, \"Modal\", \"Modal\","));
 
         // React mount glue: createElement + hydrateRoot/createRoot, and an
         // unmount thunk that disposes the stored root.
@@ -2419,15 +2451,15 @@ mod tests {
         // export-side `component_name = "default"`. Static literal —
         // not derived at runtime.
         assert!(
-            src.contains("__zfb_register(__zfb_island_0, \"default\", \"SidebarToggle\");"),
+            src.contains("__zfb_register(__zfb_island_0, \"default\", \"SidebarToggle\","),
             "expected SidebarToggle marker:\n{src}"
         );
         assert!(
-            src.contains("__zfb_register(__zfb_island_1, \"default\", \"ThemeToggle\");"),
+            src.contains("__zfb_register(__zfb_island_1, \"default\", \"ThemeToggle\","),
             "expected ThemeToggle marker:\n{src}"
         );
         assert!(
-            src.contains("__zfb_register(__zfb_island_2, \"default\", \"AiChatModal\");"),
+            src.contains("__zfb_register(__zfb_island_2, \"default\", \"AiChatModal\","),
             "expected AiChatModal marker:\n{src}"
         );
 
@@ -2468,10 +2500,10 @@ mod tests {
         // round-trip lands on the wrapper component). The manifest key
         // is the SSR marker name.
         assert!(
-            src.contains("__zfb_register(__zfb_island_0, \"AiChatModalIsland\", \"AiChatModal\");")
+            src.contains("__zfb_register(__zfb_island_0, \"AiChatModalIsland\", \"AiChatModal\",")
         );
         assert!(src
-            .contains("__zfb_register(__zfb_island_1, \"ImageEnlargeIsland\", \"ImageEnlarge\");"));
+            .contains("__zfb_register(__zfb_island_1, \"ImageEnlargeIsland\", \"ImageEnlarge\","));
     }
 
     /// Regression for issue #138.
@@ -2539,9 +2571,9 @@ mod tests {
         );
         assert!(in_memory.contains(r#"import { mountIslands } from "@takazudo/zfb/runtime""#));
         assert!(in_memory.contains("mountIslands(__zfb_manifest);"));
-        assert!(in_memory.contains("__zfb_register(__zfb_island_0, \"Counter\", \"Counter\");"));
-        assert!(in_memory.contains("__zfb_register(__zfb_island_1, \"Modal\", \"Modal\");"));
-        assert!(in_memory.contains("__zfb_register(__zfb_island_2, \"Sidebar\", \"Sidebar\");"));
+        assert!(in_memory.contains("__zfb_register(__zfb_island_0, \"Counter\", \"Counter\","));
+        assert!(in_memory.contains("__zfb_register(__zfb_island_1, \"Modal\", \"Modal\","));
+        assert!(in_memory.contains("__zfb_register(__zfb_island_2, \"Sidebar\", \"Sidebar\","));
     }
 
     #[test]

--- a/crates/zfb-islands/src/scanner.rs
+++ b/crates/zfb-islands/src/scanner.rs
@@ -347,6 +347,21 @@ impl FsResolver {
         true
     }
 
+    /// True when `dir` has any `node_modules` path component — i.e. the
+    /// importer is itself inside an installed package's tree.
+    ///
+    /// Used to scope the regular-npm-package descent (issue #999): a bare
+    /// import made from inside a package's dist must NOT crawl into OTHER
+    /// packages (no framework dependency-graph walk), so only project-source
+    /// imports (importer outside `node_modules`) are allowed to enter a
+    /// regular npm package. Mirrors the `node_modules`-segment heuristic
+    /// [`Self::is_workspace_package`] already uses.
+    fn is_inside_node_modules(dir: &Path) -> bool {
+        dir.components().any(|comp| {
+            matches!(comp, Component::Normal(name) if name == std::ffi::OsStr::new("node_modules"))
+        })
+    }
+
     /// Split a bare specifier into `(package, subpath)` where the
     /// package portion is the name pnpm resolves under `node_modules/`
     /// (`pkg` or `@scope/pkg`) and the subpath is the rest of the
@@ -437,10 +452,21 @@ impl FsResolver {
             return None;
         }
 
-        // 1) package.json hints — read once, try fields in priority order.
+        // 1) package.json hints — read once, try in priority order.
         let pkg_json_path = pkg_dir.join("package.json");
         if let Ok(text) = std::fs::read_to_string(&pkg_json_path) {
             if let Ok(value) = serde_json::from_str::<serde_json::Value>(&text) {
+                // `exports["."]` first: modern packages (e.g. a published
+                // `"type": "module"` dist with no `main`/`module`) expose
+                // their entry only through the `exports` map, and Node
+                // ignores `main` entirely once `exports` is present. This
+                // is the shape `@takazudo/zudo-doc` ships (issue #999).
+                if let Some(target) = resolve_exports_dot(&value) {
+                    let candidate = pkg_dir.join(&target);
+                    if let Some(found) = probe_dir_or_file(candidate) {
+                        return Some(found);
+                    }
+                }
                 for field in ["source", "module", "main"] {
                     if let Some(rel) = value.get(field).and_then(|v| v.as_str()) {
                         let candidate = pkg_dir.join(rel);
@@ -753,6 +779,50 @@ fn resolve_exports_subpath(pkg_json: &serde_json::Value, subpath: &str) -> Optio
     flatten_exports_entry(entry)
 }
 
+/// Resolve the top-level package entry (`import "@scope/pkg"`, no subpath)
+/// from a parsed `package.json` `exports` field. Returns the redirected
+/// on-disk relative path, if any.
+///
+/// Handles the three `exports` shapes a top-level entry can take:
+///
+/// - **Shorthand string / array** — `"exports": "./index.js"` or
+///   `["./a.js", "./b.js"]` — flattened directly (first usable string).
+/// - **Subpath map** — `{ ".": <entry>, "./sub": … }` — the `"."` entry is
+///   flattened. A subpath map with no explicit `"."` key has no top-level
+///   entry, so `None` is returned (the caller falls back to
+///   `module`/`main`).
+/// - **Dot-condition object** — `{ "import": "…", "default": "…" }` with no
+///   `"./"`-prefixed keys — the whole object IS the dot export's condition
+///   set, flattened in the usual `source → default → import` priority.
+///
+/// Conditional flattening (and the `module`/`require`/`types` conditions it
+/// intentionally skips) is shared with [`flatten_exports_entry`]; see its
+/// docs. This is the `"."` analogue of [`resolve_exports_subpath`], added
+/// for issue #999 (npm dist packages that expose their entry only through
+/// `exports`, with no `main`/`module`).
+fn resolve_exports_dot(pkg_json: &serde_json::Value) -> Option<String> {
+    let exports = pkg_json.get("exports")?;
+    match exports {
+        serde_json::Value::String(_) | serde_json::Value::Array(_) => {
+            flatten_exports_entry(exports)
+        }
+        serde_json::Value::Object(map) => {
+            if let Some(dot) = map.get(".") {
+                flatten_exports_entry(dot)
+            } else if map.keys().any(|k| k.starts_with("./")) {
+                // A subpath map without an explicit "." entry: no
+                // top-level export. Fall back to `module`/`main`.
+                None
+            } else {
+                // No "./"-prefixed keys: the object is the dot export's
+                // condition set (e.g. `{ "import": …, "default": … }`).
+                flatten_exports_entry(exports)
+            }
+        }
+        _ => None,
+    }
+}
+
 /// Recursively pick a target string out of an `exports` entry value.
 ///
 /// Plain strings are returned verbatim; conditional objects are
@@ -764,7 +834,13 @@ fn flatten_exports_entry(value: &serde_json::Value) -> Option<String> {
     match value {
         serde_json::Value::String(s) => Some(s.clone()),
         serde_json::Value::Object(_) => {
-            for cond in ["source", "default", "import"] {
+            // Priority: `source` (un-built TS workspace source) → `module`
+            // / `default` (ESM dist) → `import` (ESM entry condition).
+            // `require`/`types`/`node` are intentionally skipped — we only
+            // scan ESM source. `default` is kept ahead of `import` to
+            // preserve the pre-#999 contract (see the
+            // `resolve_exports_subpath_prefers_*` tests).
+            for cond in ["source", "module", "default", "import"] {
                 if let Some(inner) = value.get(cond) {
                     if let Some(found) = flatten_exports_entry(inner) {
                         return Some(found);
@@ -857,17 +933,31 @@ impl Resolver for FsResolver {
             // work; failing the probe also means we skip them silently.
             let (pkg_name, subpath) = Self::split_bare_specifier(specifier);
             let pkg_dir = Self::locate_node_modules_pkg(importer_dir, &pkg_name)?;
-            // Only descend into bare specifiers that resolve to
-            // pnpm-workspace packages. Real installed dependencies
-            // (`preact`, `react`, `zfb-runtime`, …) live behind a
-            // symlink whose canonical target is itself inside
-            // `node_modules/.pnpm/`, so they fail this check and the
-            // scanner skips them silently — matching the pre-#122
-            // behaviour for non-workspace imports. See codex-review on
-            // PR #125: probing every bare specifier turned every
-            // `import "preact/hooks"` into a transitive scan of the
-            // installed framework on every build.
-            if !Self::is_workspace_package(&pkg_dir) {
+            // Descent policy for bare specifiers (issue #999):
+            //
+            // - **pnpm-workspace packages** (a symlink at
+            //   `node_modules/<pkg>` whose canonical target lives OUTSIDE
+            //   `node_modules/`) are always entered — un-built TS source
+            //   carries `"use client"` islands.
+            // - **Regular npm packages** (a published `@scope/pkg`
+            //   consumed from npm; the symlink resolves into
+            //   `node_modules/.pnpm/…`) are entered ONLY when the import
+            //   originates from PROJECT SOURCE — i.e. the importer is not
+            //   itself inside `node_modules`. This is the #999 npm-dist
+            //   islands path: a page/component importing a dist-shipped
+            //   `"use client"` module (directly, or through the package's
+            //   own barrels via relative imports) must register its
+            //   islands. A bare import made from INSIDE a package's dist
+            //   (dist → `preact`, dist → `@takazudo/zfb-runtime`, …) is
+            //   NOT followed, so the scan never crawls the framework
+            //   dependency graph — only the importing package's own
+            //   relative-import closure is walked. This preserves the
+            //   PR #125 guarantee (no transitive `node_modules` walk for
+            //   framework imports) at the package boundary while still
+            //   surfacing islands published in npm dist.
+            if !Self::is_workspace_package(&pkg_dir)
+                && Self::is_inside_node_modules(importer_dir)
+            {
                 return None;
             }
             return self
@@ -3965,23 +4055,28 @@ mod tests {
         assert_eq!(plain_sub, ("preact".to_string(), "hooks".to_string()));
     }
 
-    /// Headline regression test for codex-review on PR #125: a project
-    /// with both a real `node_modules/preact` (a regular installed
-    /// dependency, NOT a symlink to a workspace) AND a workspace
-    /// package linked under `node_modules/@scope/pkg` must
-    /// (a) discover the workspace package's `"use client"` islands
-    ///     via the bare-specifier probe, and
-    /// (b) NOT descend into preact's transitive imports — every
-    ///     framework import (`preact`, `preact/hooks`, `react`, …)
-    ///     stops at the resolver and ships zero islands of its own.
+    /// Headline regression test descended from codex-review on PR #125,
+    /// updated for issue #999. A project with a real `node_modules/preact`
+    /// (a regular installed dependency, NOT a workspace symlink) AND a
+    /// workspace package linked under `node_modules/<pkg>` must:
     ///
-    /// Before the fix, scan_islands probed every bare specifier, so
-    /// `import { useState } from "preact/hooks"` walked into
-    /// node_modules/preact on every build. The new check requires a
-    /// workspace symlink shape before descending.
+    /// (a) discover the workspace package's `"use client"` islands via the
+    ///     bare-specifier probe, and
+    /// (b) NOT crawl the framework's transitive *bare-dependency* graph —
+    ///     a `preact/hooks` module that pulls preact core via a bare
+    ///     `import "preact"` must stop at that bare import, so an island
+    ///     hiding in preact core never surfaces.
+    ///
+    /// #999 changed the rule: a bare import *from project source* now does
+    /// enter a regular npm package (that is how npm-dist islands get
+    /// registered), so the directly-imported `preact/hooks` module IS
+    /// scanned — but because it carries no directive it contributes no
+    /// island, and its own bare `import "preact"` (made from INSIDE
+    /// `node_modules`) is not followed. The net effect is unchanged from
+    /// the #125 guarantee: the framework's dependency graph is never walked.
     #[cfg(unix)]
     #[test]
-    fn fs_resolver_skips_real_node_modules_pkg_but_descends_into_workspace_link() {
+    fn fs_resolver_enters_pkg_from_project_source_but_never_crawls_bare_dep_graph() {
         use std::fs;
         let dir = tempfile::tempdir().expect("tempdir");
         let pages = dir.path().join("pages");
@@ -3996,8 +4091,10 @@ mod tests {
             r#"{ "name": "preact", "main": "dist/preact.js" }"#,
         )
         .unwrap();
-        // If the scanner ever descended into preact, this island
-        // would surface — the test asserts it does NOT.
+        // preact CORE carries a sneaky island. It is reachable ONLY via a
+        // bare `import "preact"` made from inside `preact/hooks` (below) —
+        // a bare import from inside node_modules, which the scanner must
+        // NOT follow. The test asserts this island never surfaces.
         fs::write(
             preact_dist.join("preact.js"),
             r#""use client";
@@ -4005,14 +4102,17 @@ mod tests {
             "#,
         )
         .unwrap();
-        // Add a `preact/hooks` subpath entry too — same shape: real
-        // directory, regular dependency. Must be skipped.
+        // The directly-imported `preact/hooks` subpath: a realistic
+        // framework module with NO directive that pulls preact core via a
+        // bare specifier. It IS scanned now (project source imports it),
+        // but contributes no island, and its bare `import "preact"` is the
+        // edge that must not be crawled.
         let preact_hooks = preact.join("hooks");
         fs::create_dir_all(&preact_hooks).unwrap();
         fs::write(
             preact_hooks.join("index.js"),
-            r#""use client";
-            export function HooksSneakIn() {}
+            r#"import { options } from "preact";
+            export function useState() {}
             "#,
         )
         .unwrap();
@@ -4051,13 +4151,14 @@ mod tests {
 
         let resolver = FsResolver::new();
         let islands = scan_islands(&[pages.join("home.tsx")], &resolver).unwrap();
-        // Only the workspace island surfaces — preact must NOT be
-        // descended into despite living on disk.
+        // Only the workspace island surfaces. `preact/hooks` is scanned
+        // (no island) but its bare `import "preact"` is not followed, so
+        // `PreactSneaksIn` in preact core never appears.
         let names: Vec<&str> = islands.iter().map(|i| i.component_name.as_str()).collect();
         assert_eq!(
             names,
             vec!["WorkspaceCounter"],
-            "expected only the workspace island; preact must be skipped: {islands:?}",
+            "expected only the workspace island; preact core must not be crawled: {islands:?}",
         );
     }
 

--- a/crates/zfb-islands/src/scanner.rs
+++ b/crates/zfb-islands/src/scanner.rs
@@ -408,18 +408,35 @@ impl FsResolver {
     /// entries (`*` wildcards) are intentionally not handled here.
     ///
     /// Bare-package imports (no subpath) read `package.json` and try
-    /// `source` (the convention pnpm-workspace TypeScript packages use
-    /// for un-built sources), then `module`, then `main`. If
-    /// `package.json` is missing or doesn't point at a scannable file,
-    /// fall back to probing `src/index.<ext>` and `index.<ext>` inside
+    /// `exports["."]` first, then `source` (the convention pnpm-workspace
+    /// TypeScript packages use for un-built sources), then `module`, then
+    /// `main`. If `package.json` is missing or doesn't point at a scannable
+    /// file, fall back to probing `src/index.<ext>` and `index.<ext>` inside
     /// the package root — both common shapes for un-built workspace
     /// packages.
+    ///
+    /// **`exports` encapsulation gate** (`is_workspace = false`): Node treats
+    /// a package declaring `exports` as encapsulated — `main`/`module`/
+    /// top-level files are unreachable, and only the conditions listed in
+    /// `exports` resolve. So when a REGULAR npm package has an `exports`
+    /// field that yields no usable ESM target (e.g. a require-only CJS map),
+    /// it is inert to this ESM-only scanner: the `source`/`module`/`main`
+    /// and conventional `src/index`/`index` fallbacks are skipped, so a
+    /// stray top-level `index.js` the `exports` gate forbids is never scanned
+    /// (issue #999 require-only CJS hole). Workspace packages
+    /// (`is_workspace = true`) keep the fallback — their un-built TS source
+    /// commonly predates / omits an `exports` map.
     ///
     /// All resolved paths are clamped to live inside `pkg_dir` (after
     /// canonicalisation): a malicious `package.json` with
     /// `"source": "../../etc/passwd"` cannot punch out of the package
     /// directory.
-    fn probe_package_entry(&self, pkg_dir: &Path, subpath: &str) -> Option<PathBuf> {
+    fn probe_package_entry(
+        &self,
+        pkg_dir: &Path,
+        subpath: &str,
+        is_workspace: bool,
+    ) -> Option<PathBuf> {
         // Canonicalise once for clamp comparisons; if the package dir
         // can't be canonicalised (e.g. doesn't exist), fall back to the
         // raw path — the probe's `is_file()` checks will then fail
@@ -473,6 +490,15 @@ impl FsResolver {
                     if let Some(found) = probe_dir_or_file(candidate) {
                         return Some(found);
                     }
+                } else if !is_workspace && value.get("exports").is_some() {
+                    // `exports` present on a REGULAR npm package but no usable
+                    // ESM target: Node treats `exports` as an encapsulation
+                    // boundary, so `main`/`module`/top-level files are
+                    // unreachable. Bail out WITHOUT the conventional probe
+                    // below, which would otherwise scan a stray top-level
+                    // `index.js` the `exports` gate forbids (issue #999
+                    // require-only CJS hole). Workspace packages fall through.
+                    return None;
                 }
                 for field in ["source", "module", "main"] {
                     if let Some(rel) = value.get(field).and_then(|v| v.as_str()) {
@@ -847,6 +873,11 @@ fn flatten_exports_entry(value: &serde_json::Value) -> Option<String> {
             // scan ESM source. `default` is kept ahead of `import` to
             // preserve the pre-#999 contract (see the
             // `resolve_exports_subpath_prefers_*` tests).
+            // NOTE: Node resolves `exports` conditions in the order the
+            // package author writes them; this scanner deliberately imposes a
+            // fixed ESM-only priority instead — pinning `module` ahead of
+            // `default` — diverging from Node's author-controlled
+            // condition-order semantics.
             for cond in ["source", "module", "default", "import"] {
                 if let Some(inner) = value.get(cond) {
                     if let Some(found) = flatten_exports_entry(inner) {
@@ -940,50 +971,32 @@ impl Resolver for FsResolver {
             // work; failing the probe also means we skip them silently.
             let (pkg_name, subpath) = Self::split_bare_specifier(specifier);
             let pkg_dir = Self::locate_node_modules_pkg(importer_dir, &pkg_name)?;
-            // Descent policy for bare specifiers (issue #999):
+            // Descent policy for bare specifiers:
             //
             // - **pnpm-workspace packages** (a symlink at
             //   `node_modules/<pkg>` whose canonical target lives OUTSIDE
             //   `node_modules/`) are always entered — un-built TS source
             //   carries `"use client"` islands.
-            // - **Regular npm packages** (a published `@scope/pkg`
-            //   consumed from npm; the symlink resolves into
-            //   `node_modules/.pnpm/…`) are entered when the importer is
-            //   NOT itself inside `node_modules`. This is the #999 npm-dist
-            //   islands path: a page/component importing a dist-shipped
-            //   `"use client"` module (directly, or through the package's
-            //   own barrels via relative imports) must register its
-            //   islands.
+            // - **Regular npm packages** (the symlink resolves into
+            //   `node_modules/.pnpm/…`, or a plain installed dir) are entered
+            //   ONLY when the importer is NOT itself inside `node_modules` —
+            //   i.e. a page/component in project (or workspace-package)
+            //   source reaching a dist-shipped `"use client"` module
+            //   directly, or through the package's own relative-import
+            //   barrels.
             //
-            // The single hard invariant (the part of the PR #125 guarantee
-            // that still holds unconditionally): a bare import made from
-            // INSIDE `node_modules` — i.e. one regular package's dist
-            // reaching for `preact`, `@takazudo/zfb-runtime`, another
-            // `@scope/pkg`, … — is NEVER followed. So the scan never walks
-            // the *transitive* framework dependency graph; once inside a
-            // regular package only its own RELATIVE-import closure is
-            // traversed.
-            //
-            // What #999 DOES relax vs PR #125: a regular package's directly
-            // imported entry/subpath is now scanned (one parse, plus its
-            // relative closure), even for framework packages like `preact`.
-            // PR #125 skipped these outright. The cost is bounded — no
-            // transitive crawl — and real framework dist carries no
-            // `"use client"`, so no spurious islands are emitted; the
-            // trade is accepting those extra entry parses in exchange for
-            // surfacing islands genuinely published in npm dist. Note this
-            // relaxation also applies when the importer is a *workspace
-            // package's* source (which lives outside `node_modules`), not
-            // only top-level project source — distinguishing the two would
-            // require threading project-root provenance through the
-            // resolver, which is out of scope here.
-            if !Self::is_workspace_package(&pkg_dir)
-                && Self::is_inside_node_modules(importer_dir)
-            {
+            // Hard invariant: a bare import made from INSIDE `node_modules`
+            // — one package's dist reaching for `preact`,
+            // `@takazudo/zfb-runtime`, another `@scope/pkg`, … — is NEVER
+            // followed. The scan never walks the transitive framework
+            // dependency graph; once inside a regular package only its own
+            // RELATIVE-import closure is traversed.
+            let is_workspace = Self::is_workspace_package(&pkg_dir);
+            if !is_workspace && Self::is_inside_node_modules(importer_dir) {
                 return None;
             }
             return self
-                .probe_package_entry(&pkg_dir, &subpath)
+                .probe_package_entry(&pkg_dir, &subpath, is_workspace)
                 .map(canonicalize);
         }
 
@@ -4058,6 +4071,34 @@ mod tests {
         let json: serde_json::Value =
             serde_json::from_str(r#"{ "exports": { "./a": { "import": "I" } } }"#).unwrap();
         assert_eq!(resolve_exports_subpath(&json, "a"), Some("I".to_string()));
+    }
+
+    #[test]
+    fn resolve_exports_subpath_prefers_module_over_default() {
+        // `module` is pinned ahead of `default` regardless of the order the
+        // author writes the conditions — here `default` is written FIRST yet
+        // the `module` target must win. This intentionally diverges from
+        // Node's author-controlled condition-order semantics (ESM-only
+        // scanner; see `flatten_exports_entry`).
+        let json: serde_json::Value =
+            serde_json::from_str(r#"{ "exports": { "./a": { "default": "D", "module": "M" } } }"#)
+                .unwrap();
+        assert_eq!(resolve_exports_subpath(&json, "a"), Some("M".to_string()));
+    }
+
+    #[test]
+    fn resolve_exports_dot_prefers_module_over_default() {
+        // Same `module`-over-`default` precedence through the `"."` path —
+        // `default` written first, `module` still wins.
+        let json: serde_json::Value =
+            serde_json::from_str(r#"{ "exports": { ".": { "default": "D", "module": "M" } } }"#)
+                .unwrap();
+        assert_eq!(resolve_exports_dot(&json), Some("M".to_string()));
+
+        // And via the dot-condition-object shorthand (no `"./"` keys).
+        let json: serde_json::Value =
+            serde_json::from_str(r#"{ "exports": { "default": "D", "module": "M" } }"#).unwrap();
+        assert_eq!(resolve_exports_dot(&json), Some("M".to_string()));
     }
 
     #[test]

--- a/crates/zfb-islands/src/scanner.rs
+++ b/crates/zfb-islands/src/scanner.rs
@@ -941,20 +941,35 @@ impl Resolver for FsResolver {
             //   carries `"use client"` islands.
             // - **Regular npm packages** (a published `@scope/pkg`
             //   consumed from npm; the symlink resolves into
-            //   `node_modules/.pnpm/…`) are entered ONLY when the import
-            //   originates from PROJECT SOURCE — i.e. the importer is not
-            //   itself inside `node_modules`. This is the #999 npm-dist
+            //   `node_modules/.pnpm/…`) are entered when the importer is
+            //   NOT itself inside `node_modules`. This is the #999 npm-dist
             //   islands path: a page/component importing a dist-shipped
             //   `"use client"` module (directly, or through the package's
             //   own barrels via relative imports) must register its
-            //   islands. A bare import made from INSIDE a package's dist
-            //   (dist → `preact`, dist → `@takazudo/zfb-runtime`, …) is
-            //   NOT followed, so the scan never crawls the framework
-            //   dependency graph — only the importing package's own
-            //   relative-import closure is walked. This preserves the
-            //   PR #125 guarantee (no transitive `node_modules` walk for
-            //   framework imports) at the package boundary while still
-            //   surfacing islands published in npm dist.
+            //   islands.
+            //
+            // The single hard invariant (the part of the PR #125 guarantee
+            // that still holds unconditionally): a bare import made from
+            // INSIDE `node_modules` — i.e. one regular package's dist
+            // reaching for `preact`, `@takazudo/zfb-runtime`, another
+            // `@scope/pkg`, … — is NEVER followed. So the scan never walks
+            // the *transitive* framework dependency graph; once inside a
+            // regular package only its own RELATIVE-import closure is
+            // traversed.
+            //
+            // What #999 DOES relax vs PR #125: a regular package's directly
+            // imported entry/subpath is now scanned (one parse, plus its
+            // relative closure), even for framework packages like `preact`.
+            // PR #125 skipped these outright. The cost is bounded — no
+            // transitive crawl — and real framework dist carries no
+            // `"use client"`, so no spurious islands are emitted; the
+            // trade is accepting those extra entry parses in exchange for
+            // surfacing islands genuinely published in npm dist. Note this
+            // relaxation also applies when the importer is a *workspace
+            // package's* source (which lives outside `node_modules`), not
+            // only top-level project source — distinguishing the two would
+            // require threading project-root provenance through the
+            // resolver, which is out of scope here.
             if !Self::is_workspace_package(&pkg_dir)
                 && Self::is_inside_node_modules(importer_dir)
             {
@@ -3936,6 +3951,68 @@ mod tests {
         assert_eq!(resolve_exports_subpath(&json, "anything"), None);
     }
 
+    #[test]
+    fn resolve_exports_dot_reads_subpath_map_dot_entry() {
+        // The real `@takazudo/zudo-doc` shape: a subpath map whose "."
+        // entry is a `{ types, default }` conditional object.
+        let json: serde_json::Value = serde_json::from_str(
+            r#"{ "exports": { ".": { "types": "./dist/index.d.ts", "default": "./dist/index.js" },
+                              "./sub": { "default": "./dist/sub/index.js" } } }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            resolve_exports_dot(&json),
+            Some("./dist/index.js".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_exports_dot_handles_shorthand_string_and_array() {
+        let string_form: serde_json::Value =
+            serde_json::from_str(r#"{ "exports": "./index.js" }"#).unwrap();
+        assert_eq!(
+            resolve_exports_dot(&string_form),
+            Some("./index.js".to_string())
+        );
+
+        let array_form: serde_json::Value =
+            serde_json::from_str(r#"{ "exports": ["./index.mjs", "./index.js"] }"#).unwrap();
+        assert_eq!(
+            resolve_exports_dot(&array_form),
+            Some("./index.mjs".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_exports_dot_handles_dot_condition_object_without_subpath_keys() {
+        // `{ "import": …, "default": … }` with no "./"-prefixed keys IS the
+        // dot export's condition set — flatten it directly.
+        let json: serde_json::Value = serde_json::from_str(
+            r#"{ "exports": { "import": "./esm/index.js", "require": "./cjs/index.cjs" } }"#,
+        )
+        .unwrap();
+        assert_eq!(
+            resolve_exports_dot(&json),
+            Some("./esm/index.js".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_exports_dot_returns_none_for_subpath_map_without_dot() {
+        // A subpath map that does not declare "." has no top-level entry —
+        // the caller falls back to `module`/`main`.
+        let json: serde_json::Value =
+            serde_json::from_str(r#"{ "exports": { "./sub": "./dist/sub.js" } }"#).unwrap();
+        assert_eq!(resolve_exports_dot(&json), None);
+    }
+
+    #[test]
+    fn resolve_exports_dot_returns_none_when_no_exports_field() {
+        let json: serde_json::Value =
+            serde_json::from_str(r#"{ "name": "foo", "main": "./index.js" }"#).unwrap();
+        assert_eq!(resolve_exports_dot(&json), None);
+    }
+
     /// Hostile `package.json` `"source": "../../escape.tsx"` must NOT
     /// resolve outside the package directory — the workspace probe
     /// clamps every resolved path inside `node_modules/<pkg>/`.
@@ -4159,6 +4236,147 @@ mod tests {
             names,
             vec!["WorkspaceCounter"],
             "expected only the workspace island; preact core must not be crawled: {islands:?}",
+        );
+    }
+
+    /// #999: `exports["."]` must take precedence over the legacy `main`
+    /// field for a top-level (`import "@scope/pkg"`) regular-package entry —
+    /// Node ignores `main` once `exports` is present, and the real
+    /// `@takazudo/zudo-doc` ships only `exports`. Pin that `exports` wins
+    /// when BOTH are present, so a future reorder of the two probe blocks
+    /// is caught.
+    #[cfg(unix)]
+    #[test]
+    fn fs_resolver_prefers_exports_dot_over_main_for_regular_package() {
+        use std::fs;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+
+        // Regular npm package (a real directory under node_modules) with
+        // BOTH `exports["."]` and `main` — pointing at DIFFERENT files,
+        // each carrying a distinct island.
+        let pkg = root.join("node_modules").join("@acme").join("widgets");
+        fs::create_dir_all(pkg.join("esm")).unwrap();
+        fs::create_dir_all(pkg.join("legacy")).unwrap();
+        fs::write(
+            pkg.join("package.json"),
+            r#"{ "name": "@acme/widgets", "type": "module",
+                "main": "./legacy/index.js",
+                "exports": { ".": { "default": "./esm/index.js" } } }"#,
+        )
+        .unwrap();
+        fs::write(
+            pkg.join("esm/index.js"),
+            "\"use client\";\nexport function FromExports() {}\n",
+        )
+        .unwrap();
+        fs::write(
+            pkg.join("legacy/index.js"),
+            "\"use client\";\nexport function FromMain() {}\n",
+        )
+        .unwrap();
+
+        let pages = root.join("pages");
+        fs::create_dir_all(&pages).unwrap();
+        fs::write(
+            pages.join("home.tsx"),
+            "import { FromExports } from \"@acme/widgets\";\nexport default function Home() {}\n",
+        )
+        .unwrap();
+
+        let resolver = FsResolver::new();
+        let islands = scan_islands(&[pages.join("home.tsx")], &resolver).unwrap();
+        let names: Vec<&str> = islands.iter().map(|i| i.component_name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["FromExports"],
+            "exports[\".\"] must win over main: {islands:?}",
+        );
+    }
+
+    /// #999 boundary invariant, from a WORKSPACE-package importer: even
+    /// though a workspace package's source lives outside `node_modules` (so
+    /// the regular-package descent relaxation applies to its bare imports
+    /// too — see the `resolve` policy comment), the hard guarantee still
+    /// holds: a bare import made from INSIDE a regular package's dist is
+    /// never followed. So a workspace package importing a regular package
+    /// scans that package's own entry but does NOT crawl the regular
+    /// package's transitive bare-dependency graph. This is the part of the
+    /// PR #125 guarantee that survives #999 unconditionally.
+    #[cfg(unix)]
+    #[test]
+    fn workspace_source_entering_regular_pkg_does_not_crawl_its_bare_dep_graph() {
+        use std::fs;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let root = dir.path();
+
+        // Workspace package (symlinked into node_modules, source outside it)
+        // whose `"use client"` source imports a regular npm package.
+        let ws = root.join("workspace").join("ws-pkg");
+        let ws_src = ws.join("src");
+        fs::create_dir_all(&ws_src).unwrap();
+        make_workspace_link(&ws, &root.join("node_modules").join("ws-pkg"));
+        fs::write(
+            ws.join("package.json"),
+            r#"{ "name": "ws-pkg", "source": "src/index.tsx" }"#,
+        )
+        .unwrap();
+        fs::write(
+            ws_src.join("index.tsx"),
+            "\"use client\";\nimport { Widget } from \"@acme/widgets\";\nexport function WsIsland() {}\n",
+        )
+        .unwrap();
+
+        // Regular npm package: its entry has an island AND a bare import of
+        // a peer dependency whose own module carries a sneaky island. The
+        // entry's island IS registered (directly imported); the peer's must
+        // NOT be (reached only via a bare import from inside node_modules).
+        let widgets = root.join("node_modules").join("@acme").join("widgets");
+        fs::create_dir_all(widgets.join("dist")).unwrap();
+        fs::write(
+            widgets.join("package.json"),
+            r#"{ "name": "@acme/widgets", "type": "module",
+                "exports": { ".": { "default": "./dist/index.js" } } }"#,
+        )
+        .unwrap();
+        fs::write(
+            widgets.join("dist/index.js"),
+            "\"use client\";\nimport { x } from \"peer-dep\";\nexport function Widget() {}\n",
+        )
+        .unwrap();
+
+        let peer = root.join("node_modules").join("peer-dep");
+        fs::create_dir_all(&peer).unwrap();
+        fs::write(
+            peer.join("package.json"),
+            r#"{ "name": "peer-dep", "type": "module", "exports": { ".": { "default": "./index.js" } } }"#,
+        )
+        .unwrap();
+        fs::write(
+            peer.join("index.js"),
+            "\"use client\";\nexport function PeerSneaksIn() {}\n",
+        )
+        .unwrap();
+
+        let pages = root.join("pages");
+        fs::create_dir_all(&pages).unwrap();
+        fs::write(
+            pages.join("home.tsx"),
+            "import { WsIsland } from \"ws-pkg\";\nexport default function Home() {}\n",
+        )
+        .unwrap();
+
+        let resolver = FsResolver::new();
+        let islands = scan_islands(&[pages.join("home.tsx")], &resolver).unwrap();
+        let mut names: Vec<&str> = islands.iter().map(|i| i.component_name.as_str()).collect();
+        names.sort_unstable();
+        // The workspace island and the directly-imported regular-package
+        // entry island both register; the peer dependency's island, reached
+        // only via a bare import from inside @acme/widgets/dist, must not.
+        assert_eq!(
+            names,
+            vec!["Widget", "WsIsland"],
+            "peer-dep reached via bare import from inside node_modules must not be crawled: {islands:?}",
         );
     }
 

--- a/crates/zfb-islands/src/scanner.rs
+++ b/crates/zfb-islands/src/scanner.rs
@@ -44,11 +44,18 @@
 //!
 //! - `export function Foo() {}` → `"Foo"`
 //! - `export class Foo {}` → `"Foo"`
-//! - `export const Foo = …` (and `let` / `var`) → `"Foo"`
-//! - `export default …` → the literal string `"default"`
-//! - `export { A, B as C }` → `"A"`, `"C"`
-//! - `export * as ns from "./mod"` → `"ns"`
+//! - `export const Foo = …` (and `let` / `var`) → `"Foo"` when the
+//!   initialiser is component-plausible (function/arrow/call/tagged
+//!   template/identifier/…); a clearly-non-component literal value is
+//!   dropped (issue #998).
+//! - `export default …` → the literal string `"default"` (a
+//!   clearly-non-component literal default is dropped, issue #998)
+//! - `export { A, B as C }` → `"A"`, `"C"` (a local re-export resolving
+//!   to a clearly-non-component binding is dropped, issue #998)
 //! - `export d from "./mod"` (rare) → `"d"`
+//!
+//! `export * as ns from "./mod"` is NOT registered: a module-namespace
+//! object is never a mountable component (issue #998).
 //!
 //! The pair `(source_path, component_name)` is the stable identity used
 //! for dedup and ordering. Re-exports without a local declaration of the
@@ -1650,6 +1657,80 @@ struct IslandRecord {
     marker_name: String,
 }
 
+/// Return `true` when an initialiser expression is *clearly* a
+/// non-component value that must NOT be registered as a mountable island
+/// (issue #998).
+///
+/// The rule is deliberately CONSERVATIVE — it drops only shapes that can
+/// never be a component:
+///
+/// - primitive/literal values (`'foo'`, `42`, `true`, `null`, `/re/`, `1n`)
+/// - untagged template strings (`` `foo${x}` ``)
+/// - array literals
+/// - object literals
+///
+/// Everything else is treated as component-plausible and KEPT: function
+/// expressions, arrow functions, ANY call expression (`memo(...)`,
+/// `forwardRef(...)`, `lazy(...)`, `styled(...)`, `connect(...)(...)` — no
+/// callee whitelist), tagged templates (`` styled.div`…` `` parse as
+/// `Expr::TaggedTpl`, distinct from `Expr::Tpl`), bare identifiers,
+/// conditional expressions, `as`-casts / `satisfies`, member access, and
+/// anything else. When in doubt, keep.
+///
+/// `export const SIDEBAR_STORAGE_KEY = 'zudo-doc-sidebar-visible'` — the
+/// repro from #998 — is a string literal and gets dropped here.
+fn init_is_clearly_non_component(init: &Expr) -> bool {
+    match init {
+        Expr::Lit(_) | Expr::Tpl(_) | Expr::Array(_) | Expr::Object(_) => true,
+        // Peel a redundant wrapping paren and re-test. TS casts
+        // (`x as T`, `x satisfies T`, `x!`) are intentionally NOT peeled:
+        // the spec treats them as ambiguous and keeps them.
+        Expr::Paren(p) => init_is_clearly_non_component(&p.expr),
+        _ => false,
+    }
+}
+
+/// `true` when a single `const`/`let`/`var` declarator's initialiser is a
+/// clearly-non-component value. A declarator with no initialiser
+/// (`let Foo;`) is ambiguous → kept.
+fn var_declarator_is_clearly_non_component(d: &VarDeclarator) -> bool {
+    match d.init.as_ref() {
+        Some(init) => init_is_clearly_non_component(init),
+        None => false,
+    }
+}
+
+/// Collect the names of module-local `const`/`let`/`var` bindings whose
+/// initialiser is a clearly-non-component value (see
+/// [`init_is_clearly_non_component`]).
+///
+/// Used to drop *local* named re-exports — `const KEY = 'x'; export { KEY }`
+/// — that resolve to a non-component binding (issue #998). Bindings that
+/// are functions, classes, component-shaped initialisers, OR imported from
+/// another module are absent from this set, so a re-export of such a
+/// binding stays registered (resolving cross-module re-exports is out of
+/// scope; those are kept permissively).
+fn collect_non_component_local_bindings(module: &Module) -> HashSet<String> {
+    let mut out: HashSet<String> = HashSet::new();
+    for item in &module.body {
+        let decl = match item {
+            ModuleItem::Stmt(Stmt::Decl(decl)) => decl,
+            ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ed)) => &ed.decl,
+            _ => continue,
+        };
+        if let Decl::Var(v) = decl {
+            for d in &v.decls {
+                if let Pat::Ident(bi) = &d.name {
+                    if var_declarator_is_clearly_non_component(d) {
+                        out.insert(bi.id.sym.to_string());
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
 /// Walk the module's exports and pair each one with its SSR-marker name.
 ///
 /// The marker name is what the SSR side will write into the
@@ -1682,12 +1763,30 @@ struct IslandRecord {
 /// When found, the literal first-argument string overrides the
 /// rule-based `marker_name` so the manifest key matches
 /// `data-zfb-island-skip-ssr="X"` rather than the wrapper's identifier.
+///
+/// ## Component filtering (issue #998)
+///
+/// Clearly-non-component exports are dropped so they never become
+/// mountable-island registry entries — a string/number/object/array
+/// literal export of a `"use client"` module (e.g.
+/// `export const SIDEBAR_STORAGE_KEY = 'zudo-doc-sidebar-visible'`) is not
+/// a component. The filter is conservative (see
+/// [`init_is_clearly_non_component`]): only literal-shaped values, untagged
+/// template strings, `export * as ns from "…"` namespace re-exports, and
+/// local re-exports resolving to such values are dropped; everything
+/// ambiguous is kept. Re-exports from another module
+/// (`export { Foo } from "./x"`) are kept permissively.
 fn exported_island_records(module: &Module) -> Vec<IslandRecord> {
     // 1. Build a side-table of `local_ident -> renderSsrSkipPlaceholder
     //    first-arg literal` for every function/variable declaration in
     //    the module body. Used below to override marker_name on the
     //    matching exported declaration.
     let body_markers = collect_body_markers(module);
+
+    // Names of module-local bindings whose value is clearly a
+    // non-component (issue #998) so local named re-exports of them can be
+    // dropped below.
+    let non_component_locals = collect_non_component_local_bindings(module);
 
     let mut out: Vec<IslandRecord> = Vec::new();
     for item in &module.body {
@@ -1721,6 +1820,12 @@ fn exported_island_records(module: &Module) -> Vec<IslandRecord> {
                 Decl::Var(v) => {
                     for d in &v.decls {
                         if let Pat::Ident(bi) = &d.name {
+                            // Issue #998: drop clearly-non-component exports
+                            // (`export const KEY = 'x'`) so a string / number /
+                            // object literal never becomes a mountable island.
+                            if var_declarator_is_clearly_non_component(d) {
+                                continue;
+                            }
                             let name = bi.id.sym.to_string();
                             let marker_from_init = marker_from_var_initialiser(d);
                             let marker = marker_from_init
@@ -1766,6 +1871,11 @@ fn exported_island_records(module: &Module) -> Vec<IslandRecord> {
                 }
             },
             ModuleDecl::ExportDefaultExpr(ee) => {
+                // Issue #998: `export default 'foo'` / `export default { … }`
+                // — a clearly-non-component default is not a mountable island.
+                if init_is_clearly_non_component(&ee.expr) {
+                    continue;
+                }
                 // `export default <expr>` — try to recover an identifier
                 // from common shapes (`export default Foo`,
                 // `export default forwardRef(Foo)`). Otherwise fall back
@@ -1797,6 +1907,16 @@ fn exported_island_records(module: &Module) -> Vec<IslandRecord> {
                             // `n.orig` — that's what the body-marker
                             // table is keyed on.
                             let local = module_export_name(&n.orig);
+                            // Issue #998: a *local* named re-export whose
+                            // binding resolves to a clearly-non-component
+                            // value (`const KEY = 'x'; export { KEY }`) must
+                            // not be registered. Re-exports from another
+                            // module (`export { Foo } from './x'`) carry a
+                            // `src` and are kept permissively — resolving the
+                            // other module is out of scope.
+                            if named.src.is_none() && non_component_locals.contains(&local) {
+                                continue;
+                            }
                             let marker = body_markers.get(&local).cloned().unwrap_or_else(|| {
                                 // `export { Foo as default }` — the exported alias
                                 // is "default" but the SSR side uses
@@ -1821,12 +1941,11 @@ fn exported_island_records(module: &Module) -> Vec<IslandRecord> {
                                 marker_name: name,
                             });
                         }
-                        ExportSpecifier::Namespace(n) => {
-                            let name = module_export_name(&n.name);
-                            out.push(IslandRecord {
-                                component_name: name.clone(),
-                                marker_name: name,
-                            });
+                        ExportSpecifier::Namespace(_n) => {
+                            // Issue #998: `export * as ns from "…"` binds a
+                            // module-namespace object, which is never a
+                            // mountable component — drop it.
+                            continue;
                         }
                     }
                 }
@@ -2692,13 +2811,16 @@ mod tests {
         let islands = scan_islands(&[root().join("pages/home.tsx")], &resolver).unwrap();
         let names: Vec<String> = islands.iter().map(|i| i.component_name.clone()).collect();
         // Sorted lexicographically by component name for the same source
-        // path: Bar, Foo, Qux, RenamedBaz, default.
+        // path: Bar, Foo, RenamedBaz, default.
+        //
+        // Issue #998: `export const Qux = 1` is a number-literal export —
+        // never a component — and is now dropped from the registry rather
+        // than registered as a mountable island.
         assert_eq!(
             names,
             vec![
                 "Bar".to_string(),
                 "Foo".to_string(),
-                "Qux".to_string(),
                 "RenamedBaz".to_string(),
                 "default".to_string(),
             ]

--- a/crates/zfb-islands/tests/export_filter.rs
+++ b/crates/zfb-islands/tests/export_filter.rs
@@ -1,0 +1,408 @@
+//! Issue #998 — only component-valued exports of `"use client"` modules
+//! become mountable-island registry entries.
+//!
+//! Two layers are covered:
+//!
+//! 1. **Build-time AST filter** (`scanner::exported_island_records`, via the
+//!    public [`scan_islands`] API) — clearly-non-component exports (string /
+//!    number / object / array literals, untagged template strings,
+//!    `export * as ns`, and local re-exports resolving to such values) are
+//!    dropped; functions, classes, call expressions (`memo`/`forwardRef`/
+//!    `lazy`/`styled`/…), tagged templates, and anything ambiguous are kept.
+//!
+//! 2. **Generated-source runtime guard** (`render_island_entry_source` /
+//!    `render_shared_bundle_entry_source`) — the per-island and shared
+//!    bundle entries reject non-component values with a loud `console.warn`
+//!    instead of a truthy-only check that would hand a bogus type to
+//!    `h()` / `createElement()`.
+//!
+//! These live in a dedicated test file (NOT appended to `integration.rs`)
+//! so a sibling topic adding tests there cannot conflict.
+
+use std::path::PathBuf;
+
+use zfb_islands::{
+    render_island_entry_source, render_shared_bundle_entry_source, scan_islands, FrameworkKind,
+    InMemoryResolver, Island,
+};
+
+fn root() -> PathBuf {
+    PathBuf::from("/proj")
+}
+
+/// Scan from a single page and return `(component_name, marker_name)` pairs
+/// for the given source file, sorted for stable assertions.
+fn records_for(resolver: &InMemoryResolver, source_rel: &str) -> Vec<(String, String)> {
+    let islands = scan_islands(&[root().join("pages/home.tsx")], resolver).unwrap();
+    let source = root().join(source_rel);
+    let mut out: Vec<(String, String)> = islands
+        .iter()
+        .filter(|i| i.source_path == source)
+        .map(|i| (i.component_name.clone(), i.marker_name.clone()))
+        .collect();
+    out.sort();
+    out
+}
+
+fn component_names(resolver: &InMemoryResolver, source_rel: &str) -> Vec<String> {
+    records_for(resolver, source_rel)
+        .into_iter()
+        .map(|(c, _)| c)
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Build-time AST filter
+// ---------------------------------------------------------------------------
+
+#[test]
+fn string_const_export_alongside_default_component_is_dropped() {
+    // The exact repro from issue #998: a `"use client"` component module
+    // that also exports a string constant (a localStorage key shared with
+    // SSR code). Only the default component must be registered; the string
+    // constant must NOT become a mountable island.
+    let resolver = InMemoryResolver::new()
+        .with_file(
+            root().join("pages/home.tsx"),
+            r#"import DesktopSidebarToggle from "../components/desktop-sidebar-toggle";
+            export default function Home() { return <DesktopSidebarToggle/>; }
+            "#,
+        )
+        .with_file(
+            root().join("components/desktop-sidebar-toggle.tsx"),
+            r#""use client";
+            export const SIDEBAR_STORAGE_KEY = 'zudo-doc-sidebar-visible';
+            export default function DesktopSidebarToggle() { return null; }
+            "#,
+        );
+
+    let records = records_for(&resolver, "components/desktop-sidebar-toggle.tsx");
+    assert_eq!(
+        records,
+        vec![("default".to_string(), "DesktopSidebarToggle".to_string())],
+        "only the default component must be registered; SIDEBAR_STORAGE_KEY \
+         (a string constant) must be dropped"
+    );
+}
+
+#[test]
+fn number_object_and_array_literal_const_exports_are_dropped() {
+    let resolver = InMemoryResolver::new()
+        .with_file(
+            root().join("pages/home.tsx"),
+            r#"import { Widget } from "../components/literals";
+            export default function Home() { return <Widget/>; }
+            "#,
+        )
+        .with_file(
+            root().join("components/literals.tsx"),
+            r#""use client";
+            export const COUNT = 42;
+            export const ENABLED = true;
+            export const NOTHING = null;
+            export const CONFIG = { a: 1 };
+            export const LIST = [1, 2, 3];
+            export const LABEL = `static string`;
+            export function Widget() { return null; }
+            "#,
+        );
+
+    assert_eq!(
+        component_names(&resolver, "components/literals.tsx"),
+        vec!["Widget".to_string()],
+        "primitive / object / array / template-string constants must all be dropped"
+    );
+}
+
+#[test]
+fn call_expression_exports_are_retained() {
+    // memo(...) / forwardRef(...) / lazy(...) / styled(...) /
+    // connect(...)(...) — ANY call expression is kept (no callee whitelist).
+    let resolver = InMemoryResolver::new()
+        .with_file(
+            root().join("pages/home.tsx"),
+            r#"import { Memoized } from "../components/calls";
+            export default function Home() { return <Memoized/>; }
+            "#,
+        )
+        .with_file(
+            root().join("components/calls.tsx"),
+            r#""use client";
+            export const Memoized = memo(() => null);
+            export const Forwarded = forwardRef(function Inner() { return null; });
+            export const Lazied = lazy(() => import("./x"));
+            export const Connected = connect(mapState)(function Base() { return null; });
+            "#,
+        );
+
+    assert_eq!(
+        component_names(&resolver, "components/calls.tsx"),
+        vec![
+            "Connected".to_string(),
+            "Forwarded".to_string(),
+            "Lazied".to_string(),
+            "Memoized".to_string(),
+        ],
+        "every call-expression export must be retained"
+    );
+}
+
+#[test]
+fn tagged_template_export_is_retained() {
+    // `styled.div\`...\`` parses as a tagged template (Expr::TaggedTpl),
+    // distinct from an untagged template string — it must be kept.
+    let resolver = InMemoryResolver::new()
+        .with_file(
+            root().join("pages/home.tsx"),
+            r#"import { Box } from "../components/styled";
+            export default function Home() { return <Box/>; }
+            "#,
+        )
+        .with_file(
+            root().join("components/styled.tsx"),
+            "\"use client\";\nexport const Box = styled.div`color: red;`;\n",
+        );
+
+    assert_eq!(
+        component_names(&resolver, "components/styled.tsx"),
+        vec!["Box".to_string()],
+        "tagged-template export must be retained"
+    );
+}
+
+#[test]
+fn local_alias_export_of_arrow_const_is_retained() {
+    // `const Foo = () => null; export { Foo as Bar }` — the local binding
+    // resolves to a component shape and must be kept under the alias.
+    let resolver = InMemoryResolver::new()
+        .with_file(
+            root().join("pages/home.tsx"),
+            r#"import { Bar } from "../components/alias";
+            export default function Home() { return <Bar/>; }
+            "#,
+        )
+        .with_file(
+            root().join("components/alias.tsx"),
+            r#""use client";
+            const Foo = () => null;
+            export { Foo as Bar };
+            "#,
+        );
+
+    assert_eq!(
+        component_names(&resolver, "components/alias.tsx"),
+        vec!["Bar".to_string()],
+        "local alias of an arrow-function const must be retained"
+    );
+}
+
+#[test]
+fn local_alias_export_as_default_of_function_is_retained() {
+    // `function Foo() {}; export { Foo as default }` — the compiled
+    // tsup/esbuild shape for `export default function Foo()`. Must be kept.
+    let resolver = InMemoryResolver::new()
+        .with_file(
+            root().join("pages/home.tsx"),
+            r#"import Foo from "../components/default-alias";
+            export default function Home() { return <Foo/>; }
+            "#,
+        )
+        .with_file(
+            root().join("components/default-alias.tsx"),
+            r#""use client";
+            function Foo() { return null; }
+            export { Foo as default };
+            "#,
+        );
+
+    assert_eq!(
+        records_for(&resolver, "components/default-alias.tsx"),
+        vec![("default".to_string(), "Foo".to_string())],
+        "function re-exported as default must be retained with its local marker"
+    );
+}
+
+#[test]
+fn local_non_component_reexport_is_dropped() {
+    // The re-export mirror of the #998 repro:
+    // `const KEY = 'x'; export { KEY }` resolves to a string constant and
+    // must be dropped, while a sibling component re-export is retained.
+    let resolver = InMemoryResolver::new()
+        .with_file(
+            root().join("pages/home.tsx"),
+            r#"import { Widget } from "../components/reexport";
+            export default function Home() { return <Widget/>; }
+            "#,
+        )
+        .with_file(
+            root().join("components/reexport.tsx"),
+            r#""use client";
+            const SIDEBAR_STORAGE_KEY = 'zudo-doc-sidebar-visible';
+            const Widget = () => null;
+            export { SIDEBAR_STORAGE_KEY, Widget };
+            "#,
+        );
+
+    assert_eq!(
+        component_names(&resolver, "components/reexport.tsx"),
+        vec!["Widget".to_string()],
+        "a local re-export resolving to a string constant must be dropped"
+    );
+}
+
+#[test]
+fn namespace_reexport_is_dropped() {
+    // `export * as ns from "…"` binds a module-namespace object — never a
+    // mountable component. It must be dropped while a sibling component is
+    // retained.
+    let resolver = InMemoryResolver::new()
+        .with_file(
+            root().join("pages/home.tsx"),
+            r#"import { Widget } from "../components/widget";
+            export default function Home() { return <Widget/>; }
+            "#,
+        )
+        .with_file(
+            root().join("components/widget.tsx"),
+            r#""use client";
+            export * as utils from "./utils";
+            export function Widget() { return null; }
+            "#,
+        )
+        .with_file(
+            root().join("components/utils.tsx"),
+            r#"export const helper = 1;
+            "#,
+        );
+
+    assert_eq!(
+        component_names(&resolver, "components/widget.tsx"),
+        vec!["Widget".to_string()],
+        "`export * as utils` namespace re-export must be dropped"
+    );
+}
+
+#[test]
+fn source_reexport_is_kept_permissively() {
+    // `export { Button } from "./button"` — resolving the other module is
+    // out of scope, so the re-export is kept permissively (compiled package
+    // barrels use this shape).
+    let resolver = InMemoryResolver::new()
+        .with_file(
+            root().join("pages/home.tsx"),
+            r#"import { Widget } from "../components/barrel";
+            export default function Home() { return <Widget/>; }
+            "#,
+        )
+        .with_file(
+            root().join("components/barrel.tsx"),
+            r#""use client";
+            export { Button } from "./button";
+            export function Widget() { return null; }
+            "#,
+        )
+        .with_file(
+            root().join("components/button.tsx"),
+            r#"export function Button() { return null; }
+            "#,
+        );
+
+    assert_eq!(
+        component_names(&resolver, "components/barrel.tsx"),
+        vec!["Button".to_string(), "Widget".to_string()],
+        "a cross-module source re-export must be kept permissively"
+    );
+}
+
+#[test]
+fn default_string_literal_export_is_dropped() {
+    // `export default 'foo'` is a clearly-non-component default; the module
+    // then yields no islands at all (no near-miss assertion here, just that
+    // the bogus default is not registered).
+    let resolver = InMemoryResolver::new()
+        .with_file(
+            root().join("pages/home.tsx"),
+            r#"import { Widget } from "../components/default-string";
+            export default function Home() { return <Widget/>; }
+            "#,
+        )
+        .with_file(
+            root().join("components/default-string.tsx"),
+            r#""use client";
+            export function Widget() { return null; }
+            export default 'just-a-string';
+            "#,
+        );
+
+    assert_eq!(
+        component_names(&resolver, "components/default-string.tsx"),
+        vec!["Widget".to_string()],
+        "`export default 'string'` must be dropped"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Generated-source runtime guard
+// ---------------------------------------------------------------------------
+
+#[test]
+fn shared_bundle_entry_uses_component_shape_guard_not_truthy_only() {
+    let islands = vec![Island::new("Counter", "/abs/components/Counter.tsx")];
+
+    for framework in [FrameworkKind::Preact, FrameworkKind::React] {
+        let src = render_shared_bundle_entry_source(framework, &islands, false);
+        // The old truthy-only guard must be gone.
+        assert!(
+            !src.contains("if (!C) return;"),
+            "truthy-only guard `if (!C) return;` must be replaced ({framework:?}):\n{src}"
+        );
+        // Component-shape guard present.
+        assert!(
+            src.contains("typeof C === \"function\""),
+            "expected typeof-function check ({framework:?}):\n{src}"
+        );
+        assert!(
+            src.contains("C.$$typeof"),
+            "expected $$typeof object check for memo/forwardRef ({framework:?}):\n{src}"
+        );
+        // Loud, non-silent rejection naming the export + module.
+        assert!(
+            src.contains("console.warn(") && src.contains("is not a component"),
+            "expected a loud console.warn on rejection ({framework:?}):\n{src}"
+        );
+        // The module label is threaded through as the 4th register arg.
+        assert!(
+            src.contains(
+                "__zfb_register(__zfb_island_0, \"Counter\", \"Counter\", \"/abs/components/Counter.tsx\");"
+            ),
+            "expected module label passed as the 4th __zfb_register arg ({framework:?}):\n{src}"
+        );
+    }
+}
+
+#[test]
+fn per_island_entry_guards_mount_with_component_shape_check() {
+    let island = Island::new("Counter", "/abs/components/Counter.tsx");
+
+    for framework in [FrameworkKind::Preact, FrameworkKind::React] {
+        let src = render_island_entry_source(framework, &island);
+        assert!(
+            src.contains("typeof Component === \"function\""),
+            "expected typeof-function guard ({framework:?}):\n{src}"
+        );
+        assert!(
+            src.contains("$$typeof"),
+            "expected $$typeof object check ({framework:?}):\n{src}"
+        );
+        assert!(
+            src.contains("if (!__zfb_ok) return;"),
+            "mount must bail out when the export is not a component ({framework:?}):\n{src}"
+        );
+        assert!(
+            src.contains("console.warn(")
+                && src.contains("is not a component")
+                && src.contains("/abs/components/Counter.tsx"),
+            "expected a loud console.warn naming the module ({framework:?}):\n{src}"
+        );
+    }
+}

--- a/crates/zfb-islands/tests/export_filter.rs
+++ b/crates/zfb-islands/tests/export_filter.rs
@@ -341,6 +341,71 @@ fn default_string_literal_export_is_dropped() {
     );
 }
 
+#[test]
+fn parenthesized_literal_const_export_is_dropped() {
+    // Documented spec decision (issue #998): `init_is_clearly_non_component`
+    // peels a redundant wrapping paren (`Expr::Paren`) before classifying,
+    // so `export const K = ("str");` is still recognised as a string literal
+    // and dropped — the paren must not shield a non-component value from the
+    // filter.
+    let resolver = InMemoryResolver::new()
+        .with_file(
+            root().join("pages/home.tsx"),
+            r#"import { Widget } from "../components/paren-literal";
+            export default function Home() { return <Widget/>; }
+            "#,
+        )
+        .with_file(
+            root().join("components/paren-literal.tsx"),
+            r#""use client";
+            export const K = ("str");
+            export function Widget() { return null; }
+            "#,
+        );
+
+    assert_eq!(
+        component_names(&resolver, "components/paren-literal.tsx"),
+        vec!["Widget".to_string()],
+        "a parenthesized string-literal const must be peeled and dropped"
+    );
+}
+
+#[test]
+fn ts_cast_const_exports_are_retained_as_ambiguous() {
+    // Documented spec decision (issue #998): TS casts (`as` / `satisfies` /
+    // non-null `!`) are intentionally NOT peeled by
+    // `init_is_clearly_non_component`. A cast hides the runtime shape, so the
+    // value stays ambiguous and IS registered rather than dropped — even
+    // though the underlying expressions here are object literals, the cast
+    // wrapper keeps them in (mirrors the conservative "keep ambiguous"
+    // policy that retains `memo()` / `forwardRef()` call exports).
+    let resolver = InMemoryResolver::new()
+        .with_file(
+            root().join("pages/home.tsx"),
+            r#"import { AsCast } from "../components/ts-casts";
+            export default function Home() { return <AsCast/>; }
+            "#,
+        )
+        .with_file(
+            root().join("components/ts-casts.tsx"),
+            r#""use client";
+            export const AsCast = ({} as any);
+            export const SatisfiesCast = ({} satisfies unknown);
+            export const NonNullCast = ({})!;
+            "#,
+        );
+
+    assert_eq!(
+        component_names(&resolver, "components/ts-casts.tsx"),
+        vec![
+            "AsCast".to_string(),
+            "NonNullCast".to_string(),
+            "SatisfiesCast".to_string(),
+        ],
+        "TS cast exports must stay ambiguous and be retained (casts are not peeled)"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Generated-source runtime guard
 // ---------------------------------------------------------------------------

--- a/crates/zfb-islands/tests/npm_dist_islands.rs
+++ b/crates/zfb-islands/tests/npm_dist_islands.rs
@@ -290,6 +290,47 @@ fn bare_import_from_inside_a_package_is_not_followed() {
     assert_eq!(scan_component_names(&page), vec!["Widget".to_string()]);
 }
 
+/// ESM-only contract (traversal policy point 5): the scanner does not
+/// implement CJS `module.exports` analysis. A regular package that exposes
+/// only a `require` condition (no `import`/`module`/`default`) has no ESM
+/// entry to resolve, so nothing is scanned and no island is emitted — even
+/// when the would-be CJS file contains a `"use client"` directive. This
+/// keeps CJS-only dependencies silently inert rather than mis-registered.
+#[test]
+fn require_only_cjs_package_yields_no_island() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+
+    let pkg = root.join("node_modules/@acme/legacy");
+    write(
+        &pkg.join("package.json"),
+        r#"{ "name": "@acme/legacy",
+            "exports": { ".": { "require": "./dist/index.cjs" } } }"#,
+    );
+    // A CJS file — even if it carried a directive, there is no `import`
+    // condition to route the scanner here.
+    write(
+        &pkg.join("dist/index.cjs"),
+        r#""use client";
+        function Legacy() { return null; }
+        module.exports = { Legacy };
+        "#,
+    );
+
+    let page = root.join("pages/home.tsx");
+    write(
+        &page,
+        r#"import { Legacy } from "@acme/legacy";
+        export default function Home() { return null; }
+        "#,
+    );
+
+    assert!(
+        scan_component_names(&page).is_empty(),
+        "a require-only CJS package must contribute no islands"
+    );
+}
+
 /// When a local project-source component and a package-provided component
 /// share a marker name (e.g. both named `ThemeToggle`), the scanner emits
 /// two distinct islands (keyed by `(source_path, name)`), and the manifest

--- a/crates/zfb-islands/tests/npm_dist_islands.rs
+++ b/crates/zfb-islands/tests/npm_dist_islands.rs
@@ -227,7 +227,7 @@ fn issue_999_theme_toggle_shape_via_subpath_export_is_registered() {
     );
 
     let resolver = FsResolver::new();
-    let islands = scan_islands(&[page.clone()], &resolver).expect("scan");
+    let islands = scan_islands(std::slice::from_ref(&page), &resolver).expect("scan");
     let island = islands
         .iter()
         .find(|i| i.component_name == "ThemeToggle")
@@ -335,7 +335,7 @@ fn duplicate_marker_name_across_sources_is_recorded_as_a_collision() {
     );
 
     let resolver = FsResolver::new();
-    let islands = scan_islands(&[page.clone()], &resolver).expect("scan");
+    let islands = scan_islands(std::slice::from_ref(&page), &resolver).expect("scan");
     // Two distinct source files, same marker name.
     let theme_islands: Vec<&PathBuf> = islands
         .iter()

--- a/crates/zfb-islands/tests/npm_dist_islands.rs
+++ b/crates/zfb-islands/tests/npm_dist_islands.rs
@@ -1,0 +1,360 @@
+//! Issue #999 — scanner support for `"use client"` islands shipped in the
+//! compiled dist of a *regular npm package* (consumed from `node_modules`,
+//! not a pnpm-workspace symlink).
+//!
+//! Before #999 the scanner only descended into pnpm-workspace packages
+//! (`node_modules/<pkg>` symlinked to source OUTSIDE `node_modules`).
+//! Regular installed packages were skipped wholesale, so a downstream
+//! `create-zudo-doc` project consuming `@takazudo/zudo-doc` from npm never
+//! registered the package's dist-shipped islands (`Toc`, `MobileToc`,
+//! `Sidebar`, a directly-imported `ThemeToggle`, …) and they shipped dead.
+//!
+//! These tests pin the new resolution behaviour against real on-disk
+//! fixtures (the feature is filesystem-specific — `node_modules` layout,
+//! pnpm symlinks, `package.json` `exports`), exercising the public API
+//! (`scan_islands` + `FsResolver`) exactly as the build pipeline does.
+//!
+//! Traversal policy under test (agreed in plan review):
+//! 1. Enter a regular npm package only via a bare-specifier import from
+//!    PROJECT SOURCE (importer outside `node_modules`).
+//! 2. `package.json` `exports` resolution is first-class: exact subpath
+//!    entries, top-level `"."`, conditional objects (ESM-preferring).
+//! 3. Once inside the package, RELATIVE imports are followed (so barrels
+//!    without `"use client"` are traversed through to the real modules).
+//! 4. Bare imports made from INSIDE a package are never followed — the
+//!    framework dependency graph (`preact`, `@takazudo/zfb-runtime`, …) is
+//!    not crawled.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use zfb_islands::{scan_islands, FsResolver, Manifest};
+
+/// Write `body` to `path`, creating parent directories first.
+fn write(path: &Path, body: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent dirs");
+    }
+    fs::write(path, body).expect("write fixture file");
+}
+
+/// Scan a single page and return the sorted component names.
+fn scan_component_names(page: &Path) -> Vec<String> {
+    let resolver = FsResolver::new();
+    let islands = scan_islands(&[page.to_path_buf()], &resolver).expect("scan");
+    islands.iter().map(|i| i.component_name.clone()).collect()
+}
+
+/// A regular npm package laid out as a flat `node_modules/<pkg>` directory
+/// (npm/yarn-classic layout — a real dir, NOT a workspace symlink) whose
+/// dist module carries `"use client"` must register its islands when a
+/// page imports it.
+#[test]
+fn flat_regular_npm_package_use_client_module_is_registered() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+
+    // node_modules/@acme/widgets — a real directory (regular package).
+    let pkg = root.join("node_modules/@acme/widgets");
+    write(
+        &pkg.join("package.json"),
+        r#"{ "name": "@acme/widgets", "type": "module",
+            "exports": { "./widget": { "types": "./dist/widget.d.ts", "default": "./dist/widget.js" } } }"#,
+    );
+    write(
+        &pkg.join("dist/widget.js"),
+        r#""use client";
+        import { signal } from "preact/signals";
+        export function Widget() { return null; }
+        Widget.displayName = "Widget";
+        "#,
+    );
+
+    // Project source imports the dist subpath directly.
+    let page = root.join("pages/home.tsx");
+    write(
+        &page,
+        r#"import { Widget } from "@acme/widgets/widget";
+        export default function Home() { return null; }
+        "#,
+    );
+
+    assert_eq!(scan_component_names(&page), vec!["Widget".to_string()]);
+}
+
+/// pnpm consumer layout: `node_modules/@acme/widgets` is a SYMLINK into
+/// `node_modules/.pnpm/.../node_modules/@acme/widgets`. Its canonical path
+/// still contains a `node_modules/` segment, so it is a *regular* package
+/// (not a workspace package), yet a page importing it must still register
+/// its dist island.
+#[cfg(unix)]
+#[test]
+fn pnpm_symlinked_regular_package_use_client_module_is_registered() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+
+    // The real package lives in the pnpm content store.
+    let store = root.join("node_modules/.pnpm/@acme+widgets@1.0.0/node_modules/@acme/widgets");
+    write(
+        &store.join("package.json"),
+        r#"{ "name": "@acme/widgets", "type": "module",
+            "exports": { "./widget": { "default": "./dist/widget.js" } } }"#,
+    );
+    write(
+        &store.join("dist/widget.js"),
+        r#""use client";
+        export function Widget() { return null; }
+        "#,
+    );
+
+    // node_modules/@acme/widgets -> the store path (pnpm's symlink shape).
+    let link = root.join("node_modules/@acme/widgets");
+    fs::create_dir_all(link.parent().unwrap()).unwrap();
+    std::os::unix::fs::symlink(&store, &link).expect("symlink pnpm package");
+
+    let page = root.join("pages/home.tsx");
+    write(
+        &page,
+        r#"import { Widget } from "@acme/widgets/widget";
+        export default function Home() { return null; }
+        "#,
+    );
+
+    assert_eq!(scan_component_names(&page), vec!["Widget".to_string()]);
+}
+
+/// The barrel case (the decisive shape from the real `@takazudo/zudo-doc`
+/// dist): a page imports the package's top-level entry (`exports["."]`),
+/// which is a barrel `index.js` WITHOUT `"use client"` that re-exports
+/// relative modules — one of which (`./toc.js`) IS a `"use client"`
+/// module. The scanner must traverse the barrel's relative imports and
+/// register the island reached through it.
+#[test]
+fn barrel_without_use_client_is_traversed_to_relative_use_client_module() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+
+    let pkg = root.join("node_modules/@acme/docs");
+    write(
+        &pkg.join("package.json"),
+        r#"{ "name": "@acme/docs", "type": "module",
+            "exports": { ".": { "types": "./dist/index.d.ts", "default": "./dist/index.js" } } }"#,
+    );
+    // Top-level barrel: no directive, only relative re-exports.
+    write(
+        &pkg.join("dist/index.js"),
+        r#"import { Toc } from "./toc/toc.js";
+        export { Toc };
+        export { helper } from "./util.js";
+        "#,
+    );
+    // Relative leaf WITH the directive — the real island.
+    write(
+        &pkg.join("dist/toc/toc.js"),
+        r#""use client";
+        import { useState } from "preact/hooks";
+        export function Toc() { return null; }
+        Toc.displayName = "Toc";
+        "#,
+    );
+    // A non-island relative module reached through the barrel — must be
+    // followed but contributes nothing (no directive).
+    write(
+        &pkg.join("dist/util.js"),
+        r#"export function helper() { return 1; }
+        "#,
+    );
+
+    let page = root.join("pages/home.tsx");
+    write(
+        &page,
+        r#"import { Toc } from "@acme/docs";
+        export default function Home() { return null; }
+        "#,
+    );
+
+    assert_eq!(scan_component_names(&page), vec!["Toc".to_string()]);
+}
+
+/// The exact issue #999 `ThemeToggle` shape: a dist module with
+/// `"use client"` as its first line, a plain named export
+/// (`export { ThemeToggle };`, NOT the `as default` alias form), and a
+/// `displayName` assignment — reached via a `package.json` `exports`
+/// subpath (`"./theme-toggle"`) with the real `{ types, default }`
+/// conditional shape. A page importing `@scope/pkg/theme-toggle` directly
+/// must register `ThemeToggle`.
+#[test]
+fn issue_999_theme_toggle_shape_via_subpath_export_is_registered() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+
+    let pkg = root.join("node_modules/@takazudo/zudo-doc");
+    write(
+        &pkg.join("package.json"),
+        r#"{ "name": "@takazudo/zudo-doc", "type": "module",
+            "exports": {
+                "./theme-toggle": {
+                    "types": "./dist/theme-toggle/index.d.ts",
+                    "default": "./dist/theme-toggle/index.js"
+                }
+            } }"#,
+    );
+    write(
+        &pkg.join("dist/theme-toggle/index.js"),
+        r#""use client";
+        import { jsx } from "preact/jsx-runtime";
+        import { useState } from "preact/hooks";
+        import { applyColorScheme } from "./color-scheme-sync.js";
+        function ThemeToggle() { return null; }
+        ThemeToggle.displayName = "ThemeToggle";
+        export { ThemeToggle };
+        "#,
+    );
+    // Relative dependency of the dist module — followed, no island.
+    write(
+        &pkg.join("dist/theme-toggle/color-scheme-sync.js"),
+        r#"export function applyColorScheme() {}
+        "#,
+    );
+
+    // Mirrors the real `pages/lib/_header-with-defaults.tsx` import.
+    let page = root.join("pages/lib/_header-with-defaults.tsx");
+    write(
+        &page,
+        r#"import { ThemeToggle } from "@takazudo/zudo-doc/theme-toggle";
+        export default function Header() { return null; }
+        "#,
+    );
+
+    let resolver = FsResolver::new();
+    let islands = scan_islands(&[page.clone()], &resolver).expect("scan");
+    let island = islands
+        .iter()
+        .find(|i| i.component_name == "ThemeToggle")
+        .expect("ThemeToggle island registered");
+    // The named export keys the registry under the same marker the SSR
+    // side derives from `displayName`.
+    assert_eq!(island.marker_name, "ThemeToggle");
+}
+
+/// A bare import made from INSIDE a package's dist must NOT be followed:
+/// the package's own dist references its peer dependencies
+/// (`preact`-like) via bare specifiers, and the scanner must never crawl
+/// into them — even when such a peer (mischievously) carries
+/// `"use client"`. Only the directly-imported package's own island
+/// surfaces.
+#[test]
+fn bare_import_from_inside_a_package_is_not_followed() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+
+    // The package the page imports — has an island AND a bare import of a
+    // peer dependency.
+    let pkg = root.join("node_modules/@acme/widgets");
+    write(
+        &pkg.join("package.json"),
+        r#"{ "name": "@acme/widgets", "type": "module",
+            "exports": { ".": { "default": "./dist/index.js" } } }"#,
+    );
+    write(
+        &pkg.join("dist/index.js"),
+        r#""use client";
+        import { render } from "fake-preact";
+        export function Widget() { return null; }
+        "#,
+    );
+
+    // A peer "framework" package with a sneaky island — reachable only via
+    // the bare `import "fake-preact"` made from inside @acme/widgets/dist.
+    let peer = root.join("node_modules/fake-preact");
+    write(
+        &peer.join("package.json"),
+        r#"{ "name": "fake-preact", "type": "module", "exports": { ".": { "default": "./index.js" } } }"#,
+    );
+    write(
+        &peer.join("index.js"),
+        r#""use client";
+        export function PeerSneaksIn() { return null; }
+        "#,
+    );
+
+    let page = root.join("pages/home.tsx");
+    write(
+        &page,
+        r#"import { Widget } from "@acme/widgets";
+        export default function Home() { return null; }
+        "#,
+    );
+
+    // Only Widget — the peer's island must never be crawled into.
+    assert_eq!(scan_component_names(&page), vec!["Widget".to_string()]);
+}
+
+/// When a local project-source component and a package-provided component
+/// share a marker name (e.g. both named `ThemeToggle`), the scanner emits
+/// two distinct islands (keyed by `(source_path, name)`), and the manifest
+/// records a collision the build pass can warn on. This is the #999
+/// scenario that makes duplicate marker names likely once `node_modules`
+/// is scanned.
+#[test]
+fn duplicate_marker_name_across_sources_is_recorded_as_a_collision() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+
+    // Package-provided ThemeToggle.
+    let pkg = root.join("node_modules/@takazudo/zudo-doc");
+    write(
+        &pkg.join("package.json"),
+        r#"{ "name": "@takazudo/zudo-doc", "type": "module",
+            "exports": { "./theme-toggle": { "default": "./dist/theme-toggle/index.js" } } }"#,
+    );
+    write(
+        &pkg.join("dist/theme-toggle/index.js"),
+        r#""use client";
+        export function ThemeToggle() { return null; }
+        ThemeToggle.displayName = "ThemeToggle";
+        "#,
+    );
+
+    // Local project-source ThemeToggle with the same name.
+    let local = root.join("src/components/theme-toggle.tsx");
+    write(
+        &local,
+        r#""use client";
+        export function ThemeToggle() { return null; }
+        "#,
+    );
+
+    let page = root.join("pages/home.tsx");
+    write(
+        &page,
+        r#"import { ThemeToggle as Pkg } from "@takazudo/zudo-doc/theme-toggle";
+        import { ThemeToggle as Local } from "../src/components/theme-toggle";
+        export default function Home() { return null; }
+        "#,
+    );
+
+    let resolver = FsResolver::new();
+    let islands = scan_islands(&[page.clone()], &resolver).expect("scan");
+    // Two distinct source files, same marker name.
+    let theme_islands: Vec<&PathBuf> = islands
+        .iter()
+        .filter(|i| i.marker_name == "ThemeToggle")
+        .map(|i| &i.source_path)
+        .collect();
+    assert_eq!(
+        theme_islands.len(),
+        2,
+        "expected two ThemeToggle islands from distinct sources: {islands:?}"
+    );
+
+    let manifest = Manifest::from_islands(&islands);
+    let collisions = manifest.collisions();
+    assert_eq!(
+        collisions.len(),
+        1,
+        "expected exactly one marker-name collision: {collisions:?}"
+    );
+    assert_eq!(collisions[0].name, "ThemeToggle");
+    assert_ne!(collisions[0].kept_path, collisions[0].dropped_path);
+}

--- a/crates/zfb-islands/tests/npm_dist_islands.rs
+++ b/crates/zfb-islands/tests/npm_dist_islands.rs
@@ -331,6 +331,55 @@ fn require_only_cjs_package_yields_no_island() {
     );
 }
 
+/// Hardening for the #999 require-only CJS hole: a regular npm package whose
+/// `package.json` declares `exports` with ONLY `require` conditions (no
+/// usable ESM target) is `exports`-gated. Even when a STRAY top-level
+/// `index.js` carrying `"use client"` sits at the package root — the shape
+/// the conventional `src/index`/`index` probe would otherwise pick up — the
+/// package stays inert: Node treats `exports` as an encapsulation boundary,
+/// so that top-level file is unreachable and must never be scanned.
+#[test]
+fn require_only_cjs_package_with_stray_esm_index_stays_inert() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root = dir.path();
+
+    let pkg = root.join("node_modules/@acme/legacy");
+    write(
+        &pkg.join("package.json"),
+        r#"{ "name": "@acme/legacy",
+            "exports": { ".": { "require": "./dist/index.cjs" } } }"#,
+    );
+    write(
+        &pkg.join("dist/index.cjs"),
+        r#""use client";
+        function Legacy() { return null; }
+        module.exports = { Legacy };
+        "#,
+    );
+    // The stray top-level ESM `index.js` the `exports` gate forbids. Without
+    // the gate, the conventional `index` probe would resolve and scan it,
+    // registering `StrayIsland` — exactly the hole this test pins shut.
+    write(
+        &pkg.join("index.js"),
+        r#""use client";
+        export function StrayIsland() { return null; }
+        "#,
+    );
+
+    let page = root.join("pages/home.tsx");
+    write(
+        &page,
+        r#"import { Legacy } from "@acme/legacy";
+        export default function Home() { return null; }
+        "#,
+    );
+
+    assert!(
+        scan_component_names(&page).is_empty(),
+        "a require-only CJS package must stay inert despite a stray top-level index.js"
+    );
+}
+
 /// When a local project-source component and a package-provided component
 /// share a marker name (e.g. both named `ThemeToggle`), the scanner emits
 /// two distinct islands (keyed by `(source_path, name)`), and the manifest

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -1111,6 +1111,29 @@ pub(crate) fn build_default_islands_payload(
     let registered_marker_names: std::collections::BTreeSet<String> =
         islands_set.iter().map(|i| i.marker_name.clone()).collect();
 
+    // #999: scanning `node_modules` for dist-shipped islands makes
+    // duplicate marker names far more likely — e.g. a local
+    // `ThemeToggle` component and a package-provided `ThemeToggle` from
+    // `@takazudo/zudo-doc`. The manifest keys on marker name and keeps
+    // only the first by source-path sort order, silently dropping the
+    // rest; the dropped island then ships a dead SSR marker that never
+    // hydrates. Surface every such collision loudly with BOTH source
+    // paths so the author can disambiguate (rename one component, or give
+    // it a distinct `displayName`) instead of debugging a silent
+    // dead-island. This does not change selection behaviour — it only
+    // warns.
+    let island_manifest = zfb_islands::Manifest::from_islands(&islands_set);
+    for collision in island_manifest.collisions() {
+        output::warn(format!(
+            "island marker name collision: \"{}\" is produced by two different source files — \
+             keeping {} and dropping {}. Only the kept island will hydrate; rename one component \
+             or give it a distinct `displayName` so both register under unique marker names.",
+            collision.name,
+            collision.kept_path.display(),
+            collision.dropped_path.display(),
+        ));
+    }
+
     // Sub #212 follow-up — extend embedded-binary AND embedded-node_modules
     // extraction to the islands bundler.
     //

--- a/crates/zfb/src/commands/island_marker_check.rs
+++ b/crates/zfb/src/commands/island_marker_check.rs
@@ -121,7 +121,10 @@ pub fn check_island_markers(pages: &[PathBuf], registered_names: &BTreeSet<Strin
                  `export function {name}()` or `export const {name} = …`) with \
                  the `\"use client\"` directive and is reachable from a file in pages/. \
                  If `{name}` comes from a `displayName` assignment, verify the \
-                 scanner-visible export identifier matches.",
+                 scanner-visible export identifier matches. \
+                 If `{name}` is provided by an installed npm package, make sure it is \
+                 reachable through the package's `exports` map (a directly-imported \
+                 subpath, or a barrel the package re-exports it from).",
             ));
         }
     }

--- a/docs/src/components/ai-chat-modal.tsx
+++ b/docs/src/components/ai-chat-modal.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 // W6A stub — no-op default export.
 //
 // The host (zudo-doc showcase) ships a full AI-chat modal island here. In

--- a/docs/src/components/design-token-panel-bootstrap.tsx
+++ b/docs/src/components/design-token-panel-bootstrap.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 // W6A stub — no-op default Preact wrapper.
 //
 // When the designTokenPanel feature is enabled, the feature template

--- a/docs/src/components/doc-history.tsx
+++ b/docs/src/components/doc-history.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState, useEffect, useCallback, useMemo, useRef } from "preact/compat";
 import { diffLines } from "diff";
 import type { DocHistoryData, DocHistoryEntry } from "@/types/doc-history";

--- a/docs/src/components/image-enlarge.tsx
+++ b/docs/src/components/image-enlarge.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState, useEffect, useRef } from "preact/compat";
 import type { JSX } from "preact";
 


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/998
    - https://github.com/Takazudo/zudo-front-builder/issues/999
    - https://github.com/Takazudo/zudo-front-builder/issues/1000

---

## Summary

- **#998 — component-only island registration.** The scanner previously registered EVERY named export of a `"use client"` module as a mountable island (a `export const SIDEBAR_STORAGE_KEY = '…'` string constant got a registry entry whose `mount()` would have createElement'd a bogus DOM element). `exported_island_records()` now applies a conservative AST filter, and the generated bundle entries guard on component shape at runtime.
- **#999 — npm-dist island scanning + docs `"use client"`.** Six island markers shipped dead on the docs site. Cause A: four `docs/src/components` files lacked `"use client"` — directives added; DocHistory/ImageEnlarge hydration verified in a real browser. Cause B: `"use client"` modules inside REGULAR npm packages (e.g. `@takazudo/zudo-doc` dist) were never scanned — the scanner only descended into workspace packages. The scanner now enters regular npm packages and registers their islands.
- Review hardening: require-only-CJS packages with an `exports` map are no longer probed past their exports gate; duplicate island marker names across different sources now warn at build time.

Fixes #998, fixes #999. Tracking: #1000

## Changes

**Scanner — export filtering (#998)** (`crates/zfb-islands/src/scanner.rs`)
- Conservative component heuristic in `exported_island_records()`: KEEPS fn/class declarations, arrow/function-expression consts, any CallExpr (memo/forwardRef/lazy/styled/connect), tagged templates, resolved local aliases (`export { Foo as default }`), permissive cross-module re-exports, and ambiguous shapes (TS casts etc.); DROPS string/number/boolean/null/untagged-template/array/object literals, `export * as ns`, and re-exports resolving to dropped shapes.
- Generated mount guards (`esbuild.rs`, per-island AND shared-bundle entries, Preact AND React arms): truthy-only checks replaced with a component-shape predicate (`typeof === "function"` OR `$$typeof` object) + loud `console.warn` naming the rejected export; predicate/warn hoisted into shared helpers (byte-identical output across all 4 sites).

**Scanner — regular npm package islands (#999)** (`scanner.rs`, `build.rs`, `island_marker_check.rs`)
- Regular npm packages (canonical path under `node_modules`) are now entered via page-graph bare-specifier imports; relative imports are followed WITHIN the package (dist barrels without the directive importing `"use client"` files work); bare imports from inside a package to other packages are never followed (no transitive crawl — pinned by test with a fake `preact`).
- First-class `exports`-map resolution: exact subpaths, top-level `"."`, shorthand string, conditional objects preferring `module`/`import` (deliberately ESM-first; `module` over `default` pinned by tests). ESM-only: require-only CJS packages are inert, and an `exports` field that yields no ESM target no longer falls through to the conventional index probe.
- pnpm symlink layout (`node_modules/.pnpm/...`) handled and pinned by fixture tests.
- Build now warns when two different source files produce the same island marker name (silent overwrite before); marker-check warning hints at package-provided islands.

**Docs (#999 cause A)** — `"use client"` added to `ai-chat-modal.tsx`, `doc-history.tsx`, `image-enlarge.tsx`, `design-token-panel-bootstrap.tsx`.

**Tests** — +923 lines in two new suites: `tests/export_filter.rs` (filter spec incl. Paren-peel vs TS-cast branches) and `tests/npm_dist_islands.rs` (flat + pnpm layouts, barrel traversal, ThemeToggle dist shape from the #999 report, no-crawl invariant, CJS inertness, marker collisions).

## Test Plan

- `cargo test -p zfb-islands` (228 unit + export_filter + npm_dist_islands + integration) — green
- `cargo test -p zfb` — green; `cargo clippy --all-targets` clean; `cargo fmt` applied
- `pnpm docs:build` (pinned next.38 binary): the four local-component marker warnings are gone; only the expected pending-release trio (Toc/MobileToc/Sidebar — package islands, need a zfb release with this scanner fix + docs re-pin) remains
- Browser-verified on the built docs site (Playwright): DocHistory hydrates from empty SSR shell → History panel opens on click; ThemeToggle regression-free; consoles clean

## Notes

- Toc/MobileToc/Sidebar on the deployed docs site hydrate only after the next zfb release is published and the docs pin is bumped — engine fix is in this PR; the flip is release-gated.
- Follow-up (pre-existing, out of scope): #1002 — React per-island `unmount()` lacks the `__zfb_ok` gate the Preact arm has.