### PR TITLE
islands: gate React per-island unmount() on __zfb_ok (arm symmetry, #1002)

### DIFF
--- a/crates/zfb-islands/src/esbuild.rs
+++ b/crates/zfb-islands/src/esbuild.rs
@@ -1960,6 +1960,11 @@ mod tests {
             src.contains("root.unmount()"),
             "expected root.unmount() call in React unmount: {src}"
         );
+        // #1002: unmount must carry the same __zfb_ok gate as the Preact arm.
+        assert!(
+            src.contains("export function unmount(element) {\n  if (!__zfb_ok) return;"),
+            "expected __zfb_ok gate in React unmount: {src}"
+        );
     }
 
     #[test]

--- a/crates/zfb-islands/src/esbuild.rs
+++ b/crates/zfb-islands/src/esbuild.rs
@@ -1602,6 +1602,7 @@ export function mount(props, element, mode) {{
   }}
 }}
 export function unmount(element) {{
+  if (!__zfb_ok) return;
   const root = __zfb_roots.get(element);
   if (root) {{ root.unmount(); __zfb_roots.delete(element); }}
 }}


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1002

---

## Summary

Mirrors the Preact arm's `__zfb_ok` component-shape gate in the generated React per-island `unmount()` (esbuild.rs template). Functionally a no-op today — the React `__zfb_roots` WeakMap is only populated by the already-gated `mount()` — but the two framework arms now read identically, so guard semantics can't drift. A test assertion pins the gate.

Closes #1002

## Test Plan

- `cargo test -p zfb-islands` green (incl. new gate assertion in `render_island_entry_source_react_uses_client_apis`)
- Opus light-review: CLEAN (confirmed the shared-bundle React unmount thunk needs no equivalent gate — its registration prelude early-returns before the thunk is created)