### PR TITLE
fix(resolve-links): resolve directory-relative links (subpage/)

### DIFF
--- a/crates/zfb-build/tests/bundler_resolve_links.rs
+++ b/crates/zfb-build/tests/bundler_resolve_links.rs
@@ -309,6 +309,86 @@ fn resolve_links_disabled_preserves_raw_mdx_hrefs() {
     );
 }
 
+/// Fixture for the directory-relative link repro (zfb#1004):
+///
+/// - `content/docs/section/index.mdx` — links `[pkg](other-page/)`.
+/// - `content/docs/section/other-page.mdx` — the sibling target.
+fn write_dir_link_fixture_project(root: &std::path::Path) {
+    for d in ["pages", "content/docs/section", "components", "layouts"] {
+        fs::create_dir_all(root.join(d)).unwrap();
+    }
+    fs::write(
+        root.join("layouts/default.tsx"),
+        "export default function DefaultLayout({ children }) { return children; }\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("pages/index.mdx"),
+        "---\ntitle: Home\n---\n\nWelcome.\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("content/docs/section/other-page.mdx"),
+        "---\ntitle: Other Page\n---\n\nTarget body.\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("content/docs/section/index.mdx"),
+        "---\ntitle: Section Index\n---\n\n[pkg](other-page/)\n",
+    )
+    .unwrap();
+}
+
+/// (f) zfb#1004 — a directory-relative link (`other-page/`) from a category
+///     index page must resolve to the sibling page's route URL, and must
+///     NOT count as a broken link.
+///
+/// `linkValidation` is armed with `failOnBroken: true` — the configuration
+/// whose warning motivated the issue. Pre-fix, the href passed through
+/// verbatim, linkValidation classified it as an on-disk `FilePath`, the
+/// existence check failed, and the build errored. Post-fix the resolver
+/// rewrites it to a site-absolute URL, which linkValidation skips as
+/// URL-space — so a successful bundle proves the diagnostic is gone
+/// end-to-end.
+#[test]
+fn resolve_links_dir_relative_link_rewrites_to_route_url() {
+    let Some(esbuild) = locate_esbuild() else {
+        eprintln!("[bundler_resolve_links] no esbuild binary available; skipping.");
+        return;
+    };
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+    write_dir_link_fixture_project(&root);
+
+    let mut input = make_input_with_resolve(&root, &esbuild, "dist-f", OnBrokenLinks::Error);
+    input.pipeline_spec = zfb_content::PipelineSpec {
+        features: Some(zfb_content::MarkdownFeaturesConfig {
+            link_validation: Some(zfb_content::LinkValidationConfig {
+                fail_on_broken: Some(true),
+            }),
+            ..Default::default()
+        }),
+        build_context_roots: Some((root.clone(), root.join("public"))),
+        ..zfb_content::PipelineSpec::default()
+    };
+    let out = bundle(input).expect("bundle must succeed — dir-relative link is resolvable");
+
+    let body = fs::read_to_string(&out.bundle_path).expect("read bundle");
+    assert!(
+        body.contains("/docs/section/other-page/"),
+        "dir-relative link must be rewritten to /docs/section/other-page/. \
+         Bundle excerpt: {}",
+        &body[..body.len().min(800)]
+    );
+    assert!(
+        !body.contains("\"other-page/\""),
+        "the raw dir-relative href must not survive as a verbatim string \
+         literal in the bundle. Bundle excerpt: {}",
+        &body[..body.len().min(800)]
+    );
+}
+
 /// (e) zfb#939 — error mode must STILL fail when every MDX compile is a
 ///     process-global cache hit.
 ///

--- a/crates/zfb-content/src/plugins/resolve_links.rs
+++ b/crates/zfb-content/src/plugins/resolve_links.rs
@@ -16,6 +16,10 @@
 //! 3. `{name}/index.mdx`
 //! 4. `{name}/index.md`
 //!
+//! Directory-style hrefs (`{name}/`, zfb#1004) are treated as
+//! extensionless: trailing slashes are stripped before the candidate
+//! probe, so `other-page/` resolves exactly like `other-page` would.
+//!
 //! Resolved URLs always end with `/` (they come directly from the
 //! source map), which is shape-compatible with the trailing-slash mode
 //! of [`crate::plugins::StripMdExtensionPlugin`] (Sub 6 convergence).
@@ -154,6 +158,17 @@ impl ResolveLinksPlugin {
                 // Link has a .md/.mdx extension but is not in the map → broken.
                 None => Err(()),
             };
+        }
+
+        // Directory-style hrefs (`other-page/`) are extensionless targets with
+        // a trailing slash. Strip it before candidate generation — otherwise
+        // candidate 1 becomes the never-matching `other-page/.mdx` and the
+        // href passes through verbatim, warning as broken once linkValidation
+        // is armed (zfb#1004). An all-slash href (`/`) strips to empty —
+        // nothing to probe.
+        let path_part = path_part.trim_end_matches('/');
+        if path_part.is_empty() {
+            return Ok(None);
         }
 
         // Extensionless path: skip anything that looks like an external URL
@@ -540,6 +555,138 @@ mod tests {
         let mut root = root_with_link("?x=1");
         plugin.visit(&mut root);
         assert_eq!(link_url(&root), "?x=1");
+        assert!(plugin.take_broken_links().is_empty());
+    }
+
+    // ---------- directory-style (trailing-slash) hrefs (zfb#1004) ----------
+
+    #[test]
+    fn dir_relative_resolves_sibling_mdx() {
+        // The zfb#1004 repro: `other-page/` from `section/index.mdx` must
+        // resolve to the sibling `section/other-page.mdx` route.
+        let dir = PathBuf::from("/site/docs/section");
+        let mut map = HashMap::new();
+        map.insert(
+            PathBuf::from("/site/docs/section/other-page.mdx"),
+            "/docs/section/other-page/".to_string(),
+        );
+        let mut plugin = ResolveLinksPlugin::new(ResolveMarkdownLinksOptions {
+            source_map: map,
+            source_dir: Some(dir),
+        });
+        let mut root = root_with_link("other-page/");
+        plugin.visit(&mut root);
+        assert_eq!(link_url(&root), "/docs/section/other-page/");
+        assert!(plugin.take_broken_links().is_empty());
+    }
+
+    #[test]
+    fn dir_relative_resolves_index_mdx() {
+        // `guide/` where the target is `guide/index.mdx`.
+        let dir = PathBuf::from("/site/docs");
+        let mut map = HashMap::new();
+        map.insert(
+            PathBuf::from("/site/docs/guide/index.mdx"),
+            "/docs/guide/".to_string(),
+        );
+        let mut plugin = ResolveLinksPlugin::new(ResolveMarkdownLinksOptions {
+            source_map: map,
+            source_dir: Some(dir),
+        });
+        let mut root = root_with_link("guide/");
+        plugin.visit(&mut root);
+        assert_eq!(link_url(&root), "/docs/guide/");
+    }
+
+    #[test]
+    fn dir_relative_dot_slash_form_resolves() {
+        // `./guide/` — explicit current-dir prefix plus trailing slash.
+        let dir = PathBuf::from("/site/docs");
+        let mut map = HashMap::new();
+        map.insert(
+            PathBuf::from("/site/docs/guide.mdx"),
+            "/docs/guide/".to_string(),
+        );
+        let mut plugin = ResolveLinksPlugin::new(ResolveMarkdownLinksOptions {
+            source_map: map,
+            source_dir: Some(dir),
+        });
+        let mut root = root_with_link("./guide/");
+        plugin.visit(&mut root);
+        assert_eq!(link_url(&root), "/docs/guide/");
+    }
+
+    #[test]
+    fn dir_relative_preserves_fragment() {
+        // `guide/#section` — suffix split happens before the slash strip,
+        // so the fragment must survive the rewrite.
+        let dir = PathBuf::from("/site/docs");
+        let mut map = HashMap::new();
+        map.insert(
+            PathBuf::from("/site/docs/guide.mdx"),
+            "/docs/guide/".to_string(),
+        );
+        let mut plugin = ResolveLinksPlugin::new(ResolveMarkdownLinksOptions {
+            source_map: map,
+            source_dir: Some(dir),
+        });
+        let mut root = root_with_link("guide/#section");
+        plugin.visit(&mut root);
+        assert_eq!(link_url(&root), "/docs/guide/#section");
+    }
+
+    #[test]
+    fn dir_relative_miss_left_alone() {
+        // No candidate matches — the directory-style href stays unchanged
+        // (it may point at a real served directory; linkValidation decides).
+        let dir = PathBuf::from("/site/docs");
+        let mut plugin = ResolveLinksPlugin::new(ResolveMarkdownLinksOptions {
+            source_map: HashMap::new(),
+            source_dir: Some(dir),
+        });
+        let mut root = root_with_link("missing/");
+        plugin.visit(&mut root);
+        assert_eq!(link_url(&root), "missing/");
+        assert!(plugin.take_broken_links().is_empty());
+    }
+
+    #[test]
+    fn dotted_dir_slug_left_alone() {
+        // `v1.0/` strips to `v1.0`, whose last segment carries a dot — the
+        // non-md-extension guard skips it, same as extensionless `v1.0`
+        // (pre-existing boundary, pinned here so the slash strip doesn't
+        // silently widen it).
+        let dir = PathBuf::from("/site/docs");
+        let mut map = HashMap::new();
+        map.insert(
+            PathBuf::from("/site/docs/v1.0.mdx"),
+            "/docs/v1.0/".to_string(),
+        );
+        let mut plugin = ResolveLinksPlugin::new(ResolveMarkdownLinksOptions {
+            source_map: map,
+            source_dir: Some(dir),
+        });
+        let mut root = root_with_link("v1.0/");
+        plugin.visit(&mut root);
+        assert_eq!(link_url(&root), "v1.0/");
+        assert!(plugin.take_broken_links().is_empty());
+    }
+
+    #[test]
+    fn root_slash_left_alone() {
+        // A bare `/` strips to an empty path — nothing to probe. Guards
+        // against the empty-name candidates (`.mdx`, `/index.mdx`)
+        // accidentally matching a map entry.
+        let dir = PathBuf::from("/site/docs");
+        let mut map = HashMap::new();
+        map.insert(PathBuf::from("/site/docs/index.mdx"), "/docs/".to_string());
+        let mut plugin = ResolveLinksPlugin::new(ResolveMarkdownLinksOptions {
+            source_map: map,
+            source_dir: Some(dir),
+        });
+        let mut root = root_with_link("/");
+        plugin.visit(&mut root);
+        assert_eq!(link_url(&root), "/");
         assert!(plugin.take_broken_links().is_empty());
     }
 

--- a/crates/zfb-content/src/plugins/resolve_links.rs
+++ b/crates/zfb-content/src/plugins/resolve_links.rs
@@ -16,9 +16,12 @@
 //! 3. `{name}/index.mdx`
 //! 4. `{name}/index.md`
 //!
-//! Directory-style hrefs (`{name}/`, zfb#1004) are treated as
-//! extensionless: trailing slashes are stripped before the candidate
-//! probe, so `other-page/` resolves exactly like `other-page` would.
+//! Directory-style hrefs (`{name}/`, zfb#1004) probe the same four
+//! candidates after the trailing slash is stripped. Because the slash
+//! explicitly says "directory", a dotted last segment is NOT treated as
+//! a file extension (`v1.0/` probes `v1.0.mdx` … `v1.0/index.md`), and
+//! dot segments probe their index candidates only (`../` →
+//! `../index.mdx`, `../index.md`). A bare `/` is left alone.
 //!
 //! Resolved URLs always end with `/` (they come directly from the
 //! source map), which is shape-compatible with the trailing-slash mode
@@ -160,14 +163,35 @@ impl ResolveLinksPlugin {
             };
         }
 
-        // Directory-style hrefs (`other-page/`) are extensionless targets with
-        // a trailing slash. Strip it before candidate generation — otherwise
-        // candidate 1 becomes the never-matching `other-page/.mdx` and the
-        // href passes through verbatim, warning as broken once linkValidation
-        // is armed (zfb#1004). An all-slash href (`/`) strips to empty —
-        // nothing to probe.
-        let path_part = path_part.trim_end_matches('/');
-        if path_part.is_empty() {
+        // Directory-style hrefs (`other-page/`, `./`, `../`, `v1.0/` —
+        // zfb#1004): the trailing slash says "directory", so the
+        // non-md-extension guard below must NOT apply (`v1.0/` names a
+        // directory, not a file with extension `.0`). Strip the slash and
+        // probe sibling-file candidates ({name}.mdx/.md — their routes ARE
+        // `{name}/` in trailing-slash mode) plus the index candidates that
+        // already resolved pre-#1004 via the double-slash join quirk
+        // (`name//index.mdx`). Dot segments (`./`, `../`) get index
+        // candidates only — `..mdx` is not a thing.
+        if let Some(stripped) = path_part.strip_suffix('/') {
+            let name = stripped.trim_end_matches('/');
+            if name.is_empty() {
+                // Bare `/` is the site root — never rewrite it to the
+                // current directory's index.
+                return Ok(None);
+            }
+            let last_segment = name.rsplit('/').next().unwrap_or(name);
+            let file_candidates = (last_segment != "." && last_segment != "..")
+                .then(|| [format!("{name}.mdx"), format!("{name}.md")]);
+            let index_candidates = [format!("{name}/index.mdx"), format!("{name}/index.md")];
+            for candidate in file_candidates
+                .into_iter()
+                .flatten()
+                .chain(index_candidates)
+            {
+                if let Some(result) = self.lookup_path(&candidate, suffix) {
+                    return Ok(Some(result));
+                }
+            }
             return Ok(None);
         }
 
@@ -651,11 +675,10 @@ mod tests {
     }
 
     #[test]
-    fn dotted_dir_slug_left_alone() {
-        // `v1.0/` strips to `v1.0`, whose last segment carries a dot — the
-        // non-md-extension guard skips it, same as extensionless `v1.0`
-        // (pre-existing boundary, pinned here so the slash strip doesn't
-        // silently widen it).
+    fn dotted_dir_slug_resolves_sibling_mdx() {
+        // `v1.0/` — the trailing slash means "directory", so the dotted
+        // last segment is NOT a file extension. The sibling `v1.0.mdx`
+        // (whose route IS `v1.0/`) must resolve.
         let dir = PathBuf::from("/site/docs");
         let mut map = HashMap::new();
         map.insert(
@@ -668,8 +691,83 @@ mod tests {
         });
         let mut root = root_with_link("v1.0/");
         plugin.visit(&mut root);
-        assert_eq!(link_url(&root), "v1.0/");
+        assert_eq!(link_url(&root), "/docs/v1.0/");
+    }
+
+    #[test]
+    fn dotted_dir_slug_resolves_index_mdx() {
+        // `v1.0/` backed by `v1.0/index.mdx` resolved pre-#1004 via the
+        // double-slash join quirk — pinned so the dir-style branch keeps it.
+        let dir = PathBuf::from("/site/docs");
+        let mut map = HashMap::new();
+        map.insert(
+            PathBuf::from("/site/docs/v1.0/index.mdx"),
+            "/docs/v1.0/".to_string(),
+        );
+        let mut plugin = ResolveLinksPlugin::new(ResolveMarkdownLinksOptions {
+            source_map: map,
+            source_dir: Some(dir),
+        });
+        let mut root = root_with_link("v1.0/");
+        plugin.visit(&mut root);
+        assert_eq!(link_url(&root), "/docs/v1.0/");
+    }
+
+    #[test]
+    fn dotted_name_without_slash_still_skipped() {
+        // Extensionless `v1.0` (no trailing slash) keeps the pre-existing
+        // non-md-extension boundary: the dotted last segment looks like a
+        // file extension, so no candidates are probed.
+        let dir = PathBuf::from("/site/docs");
+        let mut map = HashMap::new();
+        map.insert(
+            PathBuf::from("/site/docs/v1.0.mdx"),
+            "/docs/v1.0/".to_string(),
+        );
+        let mut plugin = ResolveLinksPlugin::new(ResolveMarkdownLinksOptions {
+            source_map: map,
+            source_dir: Some(dir),
+        });
+        let mut root = root_with_link("v1.0");
+        plugin.visit(&mut root);
+        assert_eq!(link_url(&root), "v1.0");
         assert!(plugin.take_broken_links().is_empty());
+    }
+
+    #[test]
+    fn dot_slash_resolves_current_dir_index() {
+        // `./` resolved to the current directory's index pre-#1004 (via
+        // the `.//index.mdx` candidate) — the dir-style branch must keep
+        // that working.
+        let dir = PathBuf::from("/site/docs/guides");
+        let mut map = HashMap::new();
+        map.insert(
+            PathBuf::from("/site/docs/guides/index.mdx"),
+            "/docs/guides/".to_string(),
+        );
+        let mut plugin = ResolveLinksPlugin::new(ResolveMarkdownLinksOptions {
+            source_map: map,
+            source_dir: Some(dir),
+        });
+        let mut root = root_with_link("./");
+        plugin.visit(&mut root);
+        assert_eq!(link_url(&root), "/docs/guides/");
+    }
+
+    #[test]
+    fn dot_dot_slash_resolves_parent_index() {
+        // `../` resolved to the parent directory's index pre-#1004 — same
+        // pre-existing behavior pin as `./`.
+        let dir = PathBuf::from("/site/docs/guides");
+        let mut map = HashMap::new();
+        map.insert(PathBuf::from("/site/docs/index.mdx"), "/docs/".to_string());
+        let mut plugin = ResolveLinksPlugin::new(ResolveMarkdownLinksOptions {
+            source_map: map,
+            source_dir: Some(dir),
+        });
+        let mut root = root_with_link("../");
+        plugin.visit(&mut root);
+        assert_eq!(link_url(&root), "/docs/");
     }
 
     #[test]

--- a/docs/src/content/docs-ja/api/define-config.mdx
+++ b/docs/src/content/docs-ja/api/define-config.mdx
@@ -40,7 +40,7 @@ defineConfig(config: ZfbConfig): ZfbConfig
 - `stripMdExt?: boolean` — MDX コンパイル時に内部リンクの href から `.md` / `.mdx` 拡張子を取り除き、末尾に `/` を付与します。デフォルト: `false`。
 - `trailingSlash?: boolean` — base パスの書き換え時に、拡張子なしの絶対 href に末尾の `/` を付与します。デフォルト: `false`。
 - `markdown?: MarkdownConfig` — Markdown / MDX のパースオプション（例: GFM の切り替え）。[Markdown Features](/ja/docs/markdown-features/) のセクションを参照してください。
-- `resolveMarkdownLinks?: ResolveMarkdownLinksConfig` — マークダウンリンクリゾルバの設定。`[label](./other.mdx)` のリンクをレンダリング後のルート URL に書き換えるには有効にします。
+- `resolveMarkdownLinks?: ResolveMarkdownLinksConfig` — マークダウンリンクリゾルバの設定。`[label](./other.mdx)` のリンクをレンダリング後のルート URL に書き換えるには有効にします。拡張子なし（`./other`）およびディレクトリ形式（`other/`）のターゲットも解決され、`{name}.mdx` → `{name}.md` → `{name}/index.mdx` → `{name}/index.md` の順に探索されます。
 - `emitRoutesManifest?: boolean` — `zfb build` がビルド後のルートマニフェストを `<outDir>/__zfb/routes.json` に書き出すかどうか。デフォルト: `true`（書き出す）。`false` を設定すると抑制します。
 - `extraWatchPaths?: string[]` — プロジェクト内のソースルートに加えて、dev ウォッチャーが追跡する追加の絶対ファイルシステムパス。[プロジェクトルート外のパスを監視する](#プロジェクトルート外のパスを監視する) を参照してください。
 

--- a/docs/src/content/docs/api/define-config.mdx
+++ b/docs/src/content/docs/api/define-config.mdx
@@ -41,7 +41,7 @@ All keys are camelCase. The shape is enforced by the Rust serde deserializer (`c
 - `stripMdExt?: boolean` — strip `.md`/`.mdx` extensions from internal link hrefs during MDX compilation and append a trailing `/`. Default: `false`.
 - `trailingSlash?: boolean` — append a trailing `/` to extensionless absolute hrefs when rewriting base paths. Default: `false`.
 - `markdown?: MarkdownConfig` — Markdown/MDX parsing options (e.g. GFM toggle). See the [Markdown Features](../markdown-features/index.mdx) section.
-- `resolveMarkdownLinks?: ResolveMarkdownLinksConfig` — markdown link resolver settings. Enable to rewrite `[label](./other.mdx)` links to their rendered route URLs.
+- `resolveMarkdownLinks?: ResolveMarkdownLinksConfig` — markdown link resolver settings. Enable to rewrite `[label](./other.mdx)` links to their rendered route URLs. Extensionless (`./other`) and directory-style (`other/`) targets resolve too, probing `{name}.mdx` → `{name}.md` → `{name}/index.mdx` → `{name}/index.md`.
 - `emitRoutesManifest?: boolean` — whether `zfb build` writes the post-build route manifest to `<outDir>/__zfb/routes.json`. Default: `true` (emit). Set `false` to suppress.
 - `extraWatchPaths?: string[]` — extra absolute filesystem paths the dev watcher follows in addition to the in-project source roots. See [Watching paths outside the project root](#watching-paths-outside-the-project-root).
 

--- a/packages/zfb/src/config.ts
+++ b/packages/zfb/src/config.ts
@@ -302,7 +302,10 @@ export type ZfbConfig = {
    * mdast pipeline so author-written `[label](./other.mdx)` links are
    * rewritten to the corresponding rendered route URL — bypassing the
    * file→directory transformation that breaks relative paths in dist
-   * HTML when `foo.mdx` becomes `foo/index.html`.
+   * HTML when `foo.mdx` becomes `foo/index.html`. Extensionless
+   * (`./other`) and directory-style (`other/`) targets resolve too,
+   * probing `{name}.mdx`, `{name}.md`, `{name}/index.mdx`,
+   * `{name}/index.md` in that order.
    *
    * Two ways to specify the source dirs:
    *


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1004

---

## Summary

- `resolveMarkdownLinks` now resolves directory-relative hrefs like `[label](app-scaffold/)` to the rendered route URL, the same way `[label](./app-scaffold.mdx)` resolves. Closes #1004.
- Root cause: trailing-slash hrefs entered the extensionless candidate probe with the slash intact, so candidate 1 became the never-matching `{name}/.mdx` and the href passed through verbatim — warning as a broken link on every build since next.38's linkValidation hardening.
- Directory-style hrefs get their own probe branch: the trailing slash explicitly means "directory", so a dotted last segment is not treated as a file extension (`v1.0/` resolves), and dot segments (`./`, `../`) probe their `index.*` candidates only — preserving pre-existing behavior that the first cut of the fix would have regressed (caught by codex review).

## Changes

- `crates/zfb-content/src/plugins/resolve_links.rs`
  - `resolve()`: new directory-style branch before the non-md-extension guard. For `name/`: probes `{name}.mdx` → `{name}.md` → `{name}/index.mdx` → `{name}/index.md`. For `./` / `../`: index candidates only. Bare `/` is left alone (never rewritten to the current dir's index).
  - Module docs updated; 11 new unit tests (sibling `.mdx`, `index.mdx`, `./name/`, fragment preservation, miss-left-alone, bare `/`, `v1.0/` sibling + index, no-slash `v1.0` boundary, `./` current-dir index, `../` parent index).
- `crates/zfb-build/tests/bundler_resolve_links.rs`
  - New integration test mirroring the issue repro (`section/index.mdx` linking `other-page/` with sibling `other-page.mdx`), with `linkValidation` armed at `failOnBroken: true` — the exact configuration whose warning motivated the issue. Verified red without the fix.
- Docs: `define-config.mdx` (en/ja) and the `ZfbConfig.resolveMarkdownLinks` TS docstring now state the extensionless/directory-style probe order.

## Side findings (raised as issues, not part of this PR)

- #1006 — `bundler_shadow_session` tests fail locally on macOS (tempdir comment-path divergence)
- #1007 — esbuild-gated integration tests can silently skip locally, masking failures
- #1008 — ETXTBSY flake in `v8_eval_spawn_blocking_does_not_starve_event_loop` (hit this PR's CI; passed on rerun)

## Test Plan

- `cargo test -p zfb-content` — full crate green (26 tests in the resolve_links module)
- `cargo test -p zfb-build --test bundler_resolve_links` — all 6 integration tests green (verified actually executing, not skipping)
- `cargo test -p zfb-md-extras` — link_validation suite green
- fmt + clippy clean; CI green (health re-run after the unrelated #1008 flake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)