### PR TITLE
test-reliability: deterministic ETXTBSY retry coverage + loud esbuild-gate skips

### DIFF
--- a/crates/zfb-test-utils/README.md
+++ b/crates/zfb-test-utils/README.md
@@ -13,12 +13,21 @@ for snapshot comparison.
 Finds an esbuild binary suitable for integration tests. Resolution order:
 
 1. `ZFB_ESBUILD_BIN` env var — if set and points to an existing file, return immediately.
-2. Workspace-local slot: `<workspace_root>/crates/zfb/binaries/esbuild/<binary>`.
-3. pnpm nested store: `node_modules/.pnpm/*/node_modules/@esbuild/<suffix>/bin/<binary>`.
-4. pnpm flat store: `node_modules/.pnpm/node_modules/esbuild/bin/<binary>`.
+2. Workspace-local slot: `<workspace_root>/crates/zfb/binaries/esbuild/<binary>`, probed for
+   every candidate workspace root. Roots are re-derived **at runtime** (walk up from
+   `current_dir()`, then `current_exe()` ancestry, looking for the `Cargo.toml` + `crates/`
+   marker); the compile-time `CARGO_MANIFEST_DIR`-derived root is only a fallback. A stale
+   rlib reused from another checkout path (shared target dir, issue #1007) therefore cannot
+   pin an outdated path and silently skip gated tests.
+3. pnpm nested store, per root: `node_modules/.pnpm/*/node_modules/@esbuild/<suffix>/bin/<binary>`.
+4. pnpm flat store, per root: `node_modules/.pnpm/node_modules/esbuild/bin/<binary>`.
 5. Portable `PATH` walk via `std::env::split_paths` (no `which` shell-out — absent on Windows).
 
-Returns `None` if no candidate is found. Callers should gate with:
+Returns `None` if no candidate is found — a graceful skip; machines without esbuild stay
+green. Panics **only** on the harness-bug state: the expected slot binary exists as a file
+under a candidate root, yet lookup still failed (the issue #1007 silent-skip incident). The
+slot directory being non-empty never triggers the panic (it permanently holds `.gitkeep`
+and `README.md`). Callers should gate with:
 
 ```rust,ignore
 let Some(esbuild) = zfb_test_utils::locate_esbuild() else { return; };

--- a/crates/zfb-test-utils/src/lib.rs
+++ b/crates/zfb-test-utils/src/lib.rs
@@ -1,7 +1,7 @@
 mod html_normalize;
 pub use html_normalize::normalize_html;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Locate an esbuild binary suitable for integration tests.
 ///
@@ -10,11 +10,13 @@ use std::path::PathBuf;
 /// 1. `ZFB_ESBUILD_BIN` env var — if set and points to an existing file,
 ///    return it immediately.
 /// 2. Workspace-local slot:
-///    `<workspace_root>/crates/zfb/binaries/esbuild/<binary>`.
+///    `<workspace_root>/crates/zfb/binaries/esbuild/<binary>`, probed for
+///    every candidate workspace root (see
+///    [`candidate_workspace_roots`] — runtime cwd walk-up first, then
+///    `current_exe` ancestry, with the compile-time
+///    `CARGO_MANIFEST_DIR`-derived root only as a fallback).
 ///    Binary name is `esbuild` on Unix, `esbuild.exe` on Windows.
-///    Workspace root is two parents up from `CARGO_MANIFEST_DIR`
-///    (i.e. `crates/zfb-test-utils` → `crates` → repo root).
-/// 3. Workspace-root pnpm nested store:
+/// 3. pnpm nested store, per candidate root:
 ///    `node_modules/.pnpm/*/node_modules/@esbuild/<suffix>/bin/<binary>`
 ///    where `*` is each directory entry under `.pnpm` (pnpm's content-
 ///    addressed layout). Mirrors the shape in
@@ -22,7 +24,7 @@ use std::path::PathBuf;
 ///    Note: the pnpm Windows package puts the binary at the package root
 ///    rather than under `bin/`; this path uses `bin/` uniformly following
 ///    the spec — a future Windows fix can adjust the suffix path if needed.
-/// 4. Workspace-root flat pnpm store:
+/// 4. Flat pnpm store, per candidate root:
 ///    `node_modules/.pnpm/node_modules/esbuild/bin/<binary>` — kept for
 ///    parity with `crates/zfb-build/tests/embedded_v8_snapshot_e2e.rs`.
 /// 5. Portable PATH walk — iterates `$PATH` entries via
@@ -30,7 +32,32 @@ use std::path::PathBuf;
 ///    checks `<entry>/<binary>`. Does NOT shell out to `which`, which is
 ///    absent on Windows.
 ///
-/// Returns `None` if no candidate exists. Callers should gate with
+/// # Why the workspace root is re-derived at runtime (issue #1007)
+///
+/// The previous implementation derived the root exclusively from
+/// compile-time `env!("CARGO_MANIFEST_DIR")`. Cargo deliberately keeps
+/// compiled artifacts relocatable: dep-info source paths are stored
+/// package-root-relative and the per-unit env vars cargo itself sets
+/// (`CARGO_MANIFEST_DIR` among them) are excluded from the env-dep
+/// freshness check (`translate_dep_info` in cargo's fingerprint module).
+/// With a shared target dir (e.g. a global `build.target-dir`), an rlib
+/// compiled from another checkout of this workspace — a since-deleted
+/// `worktrees/<topic>/` path — is reused as "fresh", and its baked-in
+/// root points at a directory that no longer has (or never had) the slot
+/// binary. Every gated test then silently skipped. Runtime re-derivation
+/// makes a stale rlib unable to pin an outdated path.
+///
+/// # Panics
+///
+/// Panics **only** on the harness-bug state: the expected platform slot
+/// binary (`crates/zfb/binaries/esbuild/<binary>`) exists as a file under
+/// a candidate workspace root, yet the lookup above still failed. That
+/// state is never a legitimately-missing esbuild, and silently skipping
+/// it is exactly the issue #1007 incident. When esbuild is genuinely
+/// absent (no slot binary, no pnpm store hit, no PATH hit) the function
+/// returns `None` so machines without esbuild skip gracefully.
+///
+/// Callers should gate with
 /// `let Some(esbuild) = locate_esbuild() else { return; }` to skip
 /// gracefully, matching the convention in all existing integration tests.
 pub fn locate_esbuild() -> Option<PathBuf> {
@@ -43,24 +70,20 @@ pub fn locate_esbuild() -> Option<PathBuf> {
     }
 
     let binary = esbuild_binary_name();
-    // Workspace root: two parents up from this crate's manifest directory.
-    // CARGO_MANIFEST_DIR = <repo>/crates/zfb-test-utils → parent = <repo>/crates → parent = <repo>
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let workspace = manifest_dir
-        .parent()
-        .and_then(|p| p.parent())
-        .map(|p| p.to_path_buf());
+    let roots = candidate_workspace_roots();
 
-    if let Some(ref workspace) = workspace {
-        // Step 2: workspace-local binary slot.
-        let slot = workspace.join("crates/zfb/binaries/esbuild").join(binary);
+    // Step 2: workspace-local binary slot, per candidate root.
+    for root in &roots {
+        let slot = slot_binary_path(root, binary);
         if slot.is_file() {
             return Some(slot);
         }
+    }
 
+    for root in &roots {
         // Step 3: pnpm nested store — node_modules/.pnpm/*/node_modules/@esbuild/<suffix>/bin/<binary>.
         if let Some(suffix) = esbuild_npm_suffix() {
-            let pnpm_dir = workspace.join("node_modules/.pnpm");
+            let pnpm_dir = root.join("node_modules/.pnpm");
             if let Ok(rd) = std::fs::read_dir(&pnpm_dir) {
                 for entry in rd.flatten() {
                     let cand = entry
@@ -77,7 +100,7 @@ pub fn locate_esbuild() -> Option<PathBuf> {
         }
 
         // Step 4: flat pnpm store — node_modules/.pnpm/node_modules/esbuild/bin/<binary>.
-        let flat_slot = workspace
+        let flat_slot = root
             .join("node_modules/.pnpm/node_modules/esbuild/bin")
             .join(binary);
         if flat_slot.is_file() {
@@ -95,7 +118,134 @@ pub fn locate_esbuild() -> Option<PathBuf> {
         }
     }
 
-    None
+    // Lookup failed. Tripwire (issue #1007): if the expected slot binary
+    // exists under any candidate root, this is a harness bug — a silent
+    // skip here is exactly the incident class this guards against.
+    let checked_slots: Vec<(PathBuf, bool)> = roots
+        .iter()
+        .map(|root| {
+            let slot = slot_binary_path(root, binary);
+            let is_file = slot.is_file();
+            (slot, is_file)
+        })
+        .collect();
+    match classify_failed_lookup(&checked_slots) {
+        SkipKind::GenuinelyAbsent => {
+            eprintln!(
+                "zfb-test-utils: esbuild not found (ZFB_ESBUILD_BIN, workspace slot, \
+                 pnpm stores, PATH all missed) — gated test skipped"
+            );
+            None
+        }
+        SkipKind::HarnessBug { present_slots } => panic!(
+            "zfb-test-utils harness bug (issue #1007): the esbuild slot binary exists at \
+             {present:?} but locate_esbuild() failed to return it. Checked slot paths: \
+             {checked:?}. This state must never become a silent skip — fix the lookup.",
+            present = present_slots,
+            checked = checked_slots
+                .iter()
+                .map(|(p, _)| p.display().to_string())
+                .collect::<Vec<_>>(),
+        ),
+    }
+}
+
+/// Candidate workspace roots for the slot/pnpm probes, highest priority
+/// first, deduplicated:
+///
+/// 1. Ancestors of `std::env::current_dir()` that look like the workspace
+///    root (`Cargo.toml` file + `crates/` dir). Cargo runs test binaries
+///    with the crate's manifest dir as cwd, so this finds the *real*
+///    checkout the tests run from — including a `worktrees/<topic>/` root
+///    first and the enclosing main repo root after it.
+/// 2. Ancestors of `std::env::current_exe()` — covers runners that invoke
+///    the test binary from an unrelated cwd, as long as the target dir
+///    lives inside the workspace (a shared/global target dir won't match;
+///    that's fine, this is an extra probe).
+/// 3. The compile-time `CARGO_MANIFEST_DIR`-derived root, kept as a
+///    fallback only. This value can be stale when a shared target dir
+///    reuses an rlib compiled from another checkout path (issue #1007),
+///    which is why it is probed last.
+pub fn candidate_workspace_roots() -> Vec<PathBuf> {
+    let mut roots: Vec<PathBuf> = Vec::new();
+
+    if let Ok(cwd) = std::env::current_dir() {
+        for dir in cwd.ancestors() {
+            if is_workspace_root(dir) {
+                push_unique(&mut roots, dir.to_path_buf());
+            }
+        }
+    }
+
+    if let Ok(exe) = std::env::current_exe() {
+        for dir in exe.ancestors() {
+            if is_workspace_root(dir) {
+                push_unique(&mut roots, dir.to_path_buf());
+            }
+        }
+    }
+
+    // CARGO_MANIFEST_DIR = <repo>/crates/zfb-test-utils → parent = <repo>/crates → parent = <repo>.
+    // Pushed unconditionally (no marker check): if stale it simply fails
+    // the file probes, preserving the pre-#1007 fallback behavior.
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    if let Some(root) = manifest_dir.parent().and_then(Path::parent) {
+        push_unique(&mut roots, root.to_path_buf());
+    }
+
+    roots
+}
+
+/// Classification of a failed esbuild lookup, decided from explicit probe
+/// inputs so the panic contract is hermetically testable (issue #1007).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SkipKind {
+    /// No slot binary exists anywhere we know to look — esbuild is
+    /// genuinely absent and the caller should skip gracefully.
+    GenuinelyAbsent,
+    /// At least one expected slot binary path IS a file, yet the lookup
+    /// failed to return it — a harness bug that must panic loudly.
+    HarnessBug {
+        /// The slot paths that exist as files despite the failed lookup.
+        present_slots: Vec<PathBuf>,
+    },
+}
+
+/// Decide how a failed lookup must behave.
+///
+/// `checked_slots` pairs each expected platform slot path
+/// (`<root>/crates/zfb/binaries/esbuild/<binary>`) with whether that exact
+/// path is a file. Only a present slot *binary* triggers
+/// [`SkipKind::HarnessBug`] — the slot *directory* being non-empty never
+/// does (it permanently holds `.gitkeep` and `README.md`).
+pub fn classify_failed_lookup(checked_slots: &[(PathBuf, bool)]) -> SkipKind {
+    let present_slots: Vec<PathBuf> = checked_slots
+        .iter()
+        .filter(|(_, is_file)| *is_file)
+        .map(|(path, _)| path.clone())
+        .collect();
+    if present_slots.is_empty() {
+        SkipKind::GenuinelyAbsent
+    } else {
+        SkipKind::HarnessBug { present_slots }
+    }
+}
+
+/// Expected platform slot binary path under `root`.
+fn slot_binary_path(root: &Path, binary: &str) -> PathBuf {
+    root.join("crates/zfb/binaries/esbuild").join(binary)
+}
+
+/// A directory is treated as a workspace root when it has a `Cargo.toml`
+/// file and a `crates/` directory — the layout of this workspace.
+fn is_workspace_root(dir: &Path) -> bool {
+    dir.join("Cargo.toml").is_file() && dir.join("crates").is_dir()
+}
+
+fn push_unique(roots: &mut Vec<PathBuf>, root: PathBuf) {
+    if !roots.contains(&root) {
+        roots.push(root);
+    }
 }
 
 /// Returns the esbuild binary file name for the current platform.

--- a/crates/zfb-test-utils/src/lib.rs
+++ b/crates/zfb-test-utils/src/lib.rs
@@ -141,7 +141,10 @@ pub fn locate_esbuild() -> Option<PathBuf> {
             "zfb-test-utils harness bug (issue #1007): the esbuild slot binary exists at \
              {present:?} but locate_esbuild() failed to return it. Checked slot paths: \
              {checked:?}. This state must never become a silent skip — fix the lookup.",
-            present = present_slots,
+            present = present_slots
+                .iter()
+                .map(|p| p.display().to_string())
+                .collect::<Vec<_>>(),
             checked = checked_slots
                 .iter()
                 .map(|(p, _)| p.display().to_string())

--- a/crates/zfb-test-utils/tests/locate_esbuild_self.rs
+++ b/crates/zfb-test-utils/tests/locate_esbuild_self.rs
@@ -1,21 +1,45 @@
 //! Compile-time + runtime sanity check for `locate_esbuild()`.
 //!
-//! Verifies that:
+//! Contract (issue #1007 / #1015):
 //! 1. The function compiles and links correctly.
-//! 2. It does not panic under any circumstances (returning `None` is fine).
+//! 2. It never panics when esbuild is genuinely absent (returning `None`
+//!    is the graceful skip) AND never panics when lookup succeeds.
+//!    It panics ONLY on the harness-bug state: the expected slot binary
+//!    (`crates/zfb/binaries/esbuild/<binary>`) exists as a file under a
+//!    candidate workspace root, yet lookup still failed. A healthy
+//!    checkout can never be in that state, so calling it here is safe on
+//!    machines with and without esbuild.
+//! 3. The workspace root is re-derived at runtime, so a stale rlib
+//!    (compiled from a since-moved/deleted checkout path) cannot pin an
+//!    outdated compile-time path and silently skip gated tests.
+//!
+//! The panic-vs-graceful decision is factored into the pure
+//! `classify_failed_lookup` function so it is testable hermetically —
+//! the tests below MUST keep passing on machines WITHOUT the slot binary.
 //!
 //! This test does NOT check for the macro — `CARGO_BIN_EXE_zfb` is only
 //! set when compiling integration tests for the `zfb` binary crate; using
 //! `zfb_binary!()` here would cause a compile error.
 
-use zfb_test_utils::locate_esbuild;
+use std::path::PathBuf;
+
+use zfb_test_utils::{candidate_workspace_roots, classify_failed_lookup, locate_esbuild, SkipKind};
+
+fn esbuild_binary_name() -> &'static str {
+    if cfg!(windows) {
+        "esbuild.exe"
+    } else {
+        "esbuild"
+    }
+}
 
 #[test]
-fn locate_esbuild_does_not_panic() {
+fn locate_esbuild_does_not_panic_in_legitimate_environments() {
     // Returning None is perfectly valid — the test environment may not have
-    // esbuild installed. We only assert the call completes without panicking.
+    // esbuild installed. The only panic path is the harness-bug state (slot
+    // binary present but lookup failed), which a correct lookup makes
+    // unreachable on a healthy checkout.
     let _result = locate_esbuild();
-    // If we reach here, the function ran successfully.
 }
 
 #[test]
@@ -31,4 +55,81 @@ fn locate_esbuild_returns_existing_file_when_env_set() {
     }
     // If ZFB_ESBUILD_BIN is not set or doesn't point to a file, the test
     // passes trivially — this branch is just a bonus correctness check.
+}
+
+#[test]
+fn runtime_derivation_finds_real_workspace_from_test_cwd() {
+    // Cargo runs test binaries with the crate manifest dir as cwd
+    // (crates/zfb-test-utils), so the runtime walk-up must find the
+    // enclosing workspace root regardless of what path was baked in at
+    // compile time. This is the stale-rlib defense from issue #1007.
+    let roots = candidate_workspace_roots();
+    assert!(
+        !roots.is_empty(),
+        "candidate_workspace_roots() must always yield at least the compile-time fallback"
+    );
+    assert!(
+        roots
+            .iter()
+            .any(|r| r.join("crates/zfb-test-utils/Cargo.toml").is_file()),
+        "no candidate root contains crates/zfb-test-utils — runtime derivation failed; \
+         candidates: {roots:?}"
+    );
+}
+
+#[test]
+fn slot_binary_present_implies_lookup_succeeds() {
+    // The exact issue #1007 incident state: the slot binary exists yet
+    // locate_esbuild() returns None. That must now be impossible.
+    // Conditional on the slot binary existing so machines without it
+    // (where this test trivially passes) stay green.
+    let slot_present = candidate_workspace_roots().iter().any(|root| {
+        root.join("crates/zfb/binaries/esbuild")
+            .join(esbuild_binary_name())
+            .is_file()
+    });
+    if slot_present {
+        assert!(
+            locate_esbuild().is_some(),
+            "slot binary exists but locate_esbuild() returned None — the #1007 silent-skip \
+             state has regressed"
+        );
+    }
+}
+
+#[test]
+fn classify_failed_lookup_is_graceful_when_no_slot_binary_exists() {
+    // Genuinely-absent esbuild: no probe found a file. Machines without
+    // esbuild must skip gracefully, never turn red.
+    assert_eq!(classify_failed_lookup(&[]), SkipKind::GenuinelyAbsent);
+    assert_eq!(
+        classify_failed_lookup(&[
+            (
+                PathBuf::from("/repo/crates/zfb/binaries/esbuild/esbuild"),
+                false
+            ),
+            (
+                PathBuf::from("/stale/worktree/crates/zfb/binaries/esbuild/esbuild"),
+                false
+            ),
+        ]),
+        SkipKind::GenuinelyAbsent,
+        "absent slot binaries must classify as a graceful skip — the slot dir being \
+         non-empty (.gitkeep, README.md) must never matter"
+    );
+}
+
+#[test]
+fn classify_failed_lookup_flags_harness_bug_when_slot_binary_present() {
+    // The hermetic encoding of the #1007 incident: a slot path IS a file,
+    // yet lookup failed. This must classify as the loud-panic state and
+    // carry the offending paths for the diagnostic.
+    let present = PathBuf::from("/repo/crates/zfb/binaries/esbuild/esbuild");
+    let absent = PathBuf::from("/stale/worktree/crates/zfb/binaries/esbuild/esbuild");
+    match classify_failed_lookup(&[(absent, false), (present.clone(), true)]) {
+        SkipKind::HarnessBug { present_slots } => {
+            assert_eq!(present_slots, vec![present]);
+        }
+        other => panic!("expected SkipKind::HarnessBug, got {other:?}"),
+    }
 }

--- a/crates/zfb-test-utils/tests/locate_esbuild_self.rs
+++ b/crates/zfb-test-utils/tests/locate_esbuild_self.rs
@@ -75,6 +75,16 @@ fn runtime_derivation_finds_real_workspace_from_test_cwd() {
         "no candidate root contains crates/zfb-test-utils — runtime derivation failed; \
          candidates: {roots:?}"
     );
+    // Positively prove the RUNTIME derivation (not just the compile-time
+    // fallback, which would also satisfy the assert above on a fresh
+    // build): at least one candidate root must be an ancestor of the
+    // process cwd, which only the runtime walk-up can produce.
+    let cwd = std::env::current_dir().expect("test process must have a cwd");
+    assert!(
+        roots.iter().any(|r| cwd.starts_with(r)),
+        "no candidate root is an ancestor of the test cwd {cwd:?} — the runtime cwd \
+         walk-up is broken; candidates: {roots:?}"
+    );
 }
 
 #[test]

--- a/crates/zfb/Cargo.toml
+++ b/crates/zfb/Cargo.toml
@@ -140,6 +140,10 @@ tar = "0.4"
 [dev-dependencies]
 tempfile = { workspace = true }
 tower = { version = "0.5", features = ["util"] }
+# `test-util` enables `start_paused` on `#[tokio::test]` for virtual-time
+# backoff in the ETXTBSY retry tests (zfb#1014). Dev-only — production
+# feature set (`rt-multi-thread`, `macros`, …) is unchanged.
+tokio = { version = "1", features = ["test-util"] }
 zfb-test-utils = { path = "../zfb-test-utils" }
 # Process-group kill for build_terminates e2e (#654).
 # libc is already a transitive dep (via wait-timeout); adding it here

--- a/crates/zfb/src/config.rs
+++ b/crates/zfb/src/config.rs
@@ -1498,6 +1498,22 @@ async fn load_from_ts_file(ts_path: &Path, dir: &Path, opts: &LoadOptions) -> Re
     parse_loader_envelope(&json, ts_path)
 }
 
+/// Boxed future returned by an attempt closure passed to [`output_bounded_with`].
+///
+/// The erased `Pin<Box<dyn Future<...>>>` seam avoids the borrow-checker
+/// friction that arises when `FnMut() -> Fut` (with a named `Fut` type
+/// parameter) re-borrows `&mut Command` across loop iterations.
+type AttemptFut = std::pin::Pin<
+    Box<
+        dyn std::future::Future<
+            Output = Result<
+                std::io::Result<std::process::Output>,
+                tokio::time::error::Elapsed,
+            >,
+        >,
+    >,
+>;
+
 /// Spawn `cmd` and wait for output, bounded by `timeout`.
 ///
 /// `Command::output()` reads stdout/stderr pipes to EOF, so any grandchild
@@ -1516,20 +1532,7 @@ async fn output_bounded(
 ) -> Result<std::io::Result<std::process::Output>> {
     cmd.kill_on_drop(true);
     output_bounded_with(
-        || {
-            let fut = cmd.output();
-            Box::pin(tokio::time::timeout(timeout, fut))
-                as std::pin::Pin<
-                    Box<
-                        dyn std::future::Future<
-                            Output = Result<
-                                std::io::Result<std::process::Output>,
-                                tokio::time::error::Elapsed,
-                            >,
-                        >,
-                    >,
-                >
-        },
+        || Box::pin(tokio::time::timeout(timeout, cmd.output())) as AttemptFut,
         timeout,
         name,
     )
@@ -1539,27 +1542,13 @@ async fn output_bounded(
 /// Private generic helper that owns the ETXTBSY-classify/sleep/retry/exhaustion
 /// logic for [`output_bounded`]. The `attempt` closure produces one
 /// timeout-wrapped spawn attempt; this helper drives the retry loop.
-///
-/// Using `FnMut() -> Pin<Box<dyn Future<...>>>` rather than a plain
-/// `FnMut() -> Fut` avoids the borrow-checker friction that arises when
-/// re-borrowing `&mut Command` across loop iterations through a named type
-/// parameter (the erased box breaks the lifetime dependency).
 async fn output_bounded_with<F>(
     mut attempt: F,
     timeout: std::time::Duration,
     name: &str,
 ) -> Result<std::io::Result<std::process::Output>>
 where
-    F: FnMut() -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<
-                Output = Result<
-                    std::io::Result<std::process::Output>,
-                    tokio::time::error::Elapsed,
-                >,
-            >,
-        >,
-    >,
+    F: FnMut() -> AttemptFut,
 {
     let mut etxtbsy_attempts = 0u32;
     loop {
@@ -4483,18 +4472,7 @@ mod tests {
     ///
     /// `#[cfg(unix)]` because `ExitStatusExt::from_raw` is Unix-only.
     #[cfg(unix)]
-    fn make_attempt(
-        result: std::io::Result<std::process::Output>,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<
-                Output = Result<
-                    std::io::Result<std::process::Output>,
-                    tokio::time::error::Elapsed,
-                >,
-            >,
-        >,
-    > {
+    fn make_attempt(result: std::io::Result<std::process::Output>) -> AttemptFut {
         Box::pin(std::future::ready(Ok(result)))
     }
 
@@ -4508,12 +4486,6 @@ mod tests {
 
         let counter = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
         let counter_clone = counter.clone();
-
-        let success_output = std::process::Output {
-            status: std::process::ExitStatus::from_raw(0),
-            stdout: vec![],
-            stderr: vec![],
-        };
 
         // Attempt returns ETXTBSY twice, then succeeds.
         let attempt = move || {
@@ -4529,8 +4501,6 @@ mod tests {
             };
             make_attempt(result)
         };
-
-        let _ = success_output; // suppress unused warning
 
         let result = output_bounded_with(
             attempt,

--- a/crates/zfb/src/config.rs
+++ b/crates/zfb/src/config.rs
@@ -1515,9 +1515,55 @@ async fn output_bounded(
     name: &str,
 ) -> Result<std::io::Result<std::process::Output>> {
     cmd.kill_on_drop(true);
-    let mut etxtbsy_attempts = 0;
+    output_bounded_with(
+        || {
+            let fut = cmd.output();
+            Box::pin(tokio::time::timeout(timeout, fut))
+                as std::pin::Pin<
+                    Box<
+                        dyn std::future::Future<
+                            Output = Result<
+                                std::io::Result<std::process::Output>,
+                                tokio::time::error::Elapsed,
+                            >,
+                        >,
+                    >,
+                >
+        },
+        timeout,
+        name,
+    )
+    .await
+}
+
+/// Private generic helper that owns the ETXTBSY-classify/sleep/retry/exhaustion
+/// logic for [`output_bounded`]. The `attempt` closure produces one
+/// timeout-wrapped spawn attempt; this helper drives the retry loop.
+///
+/// Using `FnMut() -> Pin<Box<dyn Future<...>>>` rather than a plain
+/// `FnMut() -> Fut` avoids the borrow-checker friction that arises when
+/// re-borrowing `&mut Command` across loop iterations through a named type
+/// parameter (the erased box breaks the lifetime dependency).
+async fn output_bounded_with<F>(
+    mut attempt: F,
+    timeout: std::time::Duration,
+    name: &str,
+) -> Result<std::io::Result<std::process::Output>>
+where
+    F: FnMut() -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<
+                Output = Result<
+                    std::io::Result<std::process::Output>,
+                    tokio::time::error::Elapsed,
+                >,
+            >,
+        >,
+    >,
+{
+    let mut etxtbsy_attempts = 0u32;
     loop {
-        match tokio::time::timeout(timeout, cmd.output()).await {
+        match attempt().await {
             // ETXTBSY ("Text file busy") spawn retry (zfb#1008): the binary
             // being spawned may have JUST been extracted to a tempfile
             // (render_pipeline::embedded_binary). If an unrelated thread
@@ -4428,5 +4474,120 @@ mod tests {
             .expect("spawn failure is the inner io::Result, not the timeout Err");
         let err = result.expect_err("spawning a nonexistent binary must fail");
         assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
+    }
+
+    // --- output_bounded_with injectable-seam tests --------------------------------
+
+    /// Helper: build the `Pin<Box<dyn Future<...>>>` type alias expected by
+    /// `output_bounded_with` from a pre-resolved `io::Result<Output>`.
+    ///
+    /// `#[cfg(unix)]` because `ExitStatusExt::from_raw` is Unix-only.
+    #[cfg(unix)]
+    fn make_attempt(
+        result: std::io::Result<std::process::Output>,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<
+                Output = Result<
+                    std::io::Result<std::process::Output>,
+                    tokio::time::error::Elapsed,
+                >,
+            >,
+        >,
+    > {
+        Box::pin(std::future::ready(Ok(result)))
+    }
+
+    /// `output_bounded_with` retries `ExecutableFileBusy` errors and
+    /// succeeds on the third attempt. Virtual time (`start_paused`) keeps
+    /// the linear-backoff sleeps instant.
+    #[cfg(unix)]
+    #[tokio::test(start_paused = true)]
+    async fn output_bounded_with_retries_etxtbsy_then_succeeds() {
+        use std::os::unix::process::ExitStatusExt as _;
+
+        let counter = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let counter_clone = counter.clone();
+
+        let success_output = std::process::Output {
+            status: std::process::ExitStatus::from_raw(0),
+            stdout: vec![],
+            stderr: vec![],
+        };
+
+        // Attempt returns ETXTBSY twice, then succeeds.
+        let attempt = move || {
+            let n = counter_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let result: std::io::Result<std::process::Output> = if n < 2 {
+                Err(std::io::Error::from(std::io::ErrorKind::ExecutableFileBusy))
+            } else {
+                Ok(std::process::Output {
+                    status: std::process::ExitStatus::from_raw(0),
+                    stdout: vec![],
+                    stderr: vec![],
+                })
+            };
+            make_attempt(result)
+        };
+
+        let _ = success_output; // suppress unused warning
+
+        let result = output_bounded_with(
+            attempt,
+            std::time::Duration::from_secs(300),
+            "test-retry-succeed",
+        )
+        .await
+        .expect("should succeed after retries");
+
+        assert!(result.is_ok(), "inner result should be Ok on success");
+        assert_eq!(
+            counter.load(std::sync::atomic::Ordering::SeqCst),
+            3,
+            "expected exactly 3 attempts (2 ETXTBSY + 1 success)"
+        );
+    }
+
+    /// `output_bounded_with` exhausts all ETXTBSY retries and surfaces the
+    /// `ExecutableFileBusy` error as the inner `io::Result`. Virtual time keeps
+    /// the linear-backoff sleeps instant.
+    ///
+    /// Total attempts = `ETXTBSY_MAX_RETRIES + 1` = 6:
+    /// one initial attempt plus up to 5 retries (guard: `etxtbsy_attempts < 5`).
+    #[cfg(unix)]
+    #[tokio::test(start_paused = true)]
+    async fn output_bounded_with_exhausts_retries_and_surfaces_etxtbsy() {
+        let counter = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let counter_clone = counter.clone();
+
+        let attempt = move || {
+            counter_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            make_attempt(Err(std::io::Error::from(
+                std::io::ErrorKind::ExecutableFileBusy,
+            )))
+        };
+
+        let result = output_bounded_with(
+            attempt,
+            std::time::Duration::from_secs(300),
+            "test-exhaustion",
+        )
+        .await
+        .expect("exhausted retries should surface as inner Err, not outer bail");
+
+        let err = result.expect_err("should be Err after exhaustion");
+        assert_eq!(
+            err.kind(),
+            std::io::ErrorKind::ExecutableFileBusy,
+            "exhausted error must be ExecutableFileBusy"
+        );
+        // Verify the actual loop contract: 1 initial + ETXTBSY_MAX_RETRIES retries.
+        assert_eq!(
+            counter.load(std::sync::atomic::Ordering::SeqCst),
+            ETXTBSY_MAX_RETRIES + 1,
+            "expected {} total attempts (1 initial + {} retries)",
+            ETXTBSY_MAX_RETRIES + 1,
+            ETXTBSY_MAX_RETRIES,
+        );
     }
 }

--- a/crates/zfb/src/config.rs
+++ b/crates/zfb/src/config.rs
@@ -1506,10 +1506,7 @@ async fn load_from_ts_file(ts_path: &Path, dir: &Path, opts: &LoadOptions) -> Re
 type AttemptFut = std::pin::Pin<
     Box<
         dyn std::future::Future<
-            Output = Result<
-                std::io::Result<std::process::Output>,
-                tokio::time::error::Elapsed,
-            >,
+            Output = Result<std::io::Result<std::process::Output>, tokio::time::error::Elapsed>,
         >,
     >,
 >;


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1013

---

## Summary

- Adds deterministic test coverage for `output_bounded`'s ETXTBSY retry-then-succeed and retry-exhaustion paths via a private injectable spawn seam (#1014, resolves #1011's deferred design decision: seam is private, public signature and all 3 call sites unchanged).
- Stale-proofs `locate_esbuild()` with runtime workspace re-derivation and makes the esbuild-gate skip contract loud: "slot binary present but lookup failed" now panics with a path-naming diagnostic instead of silently skipping 76 gated tests as green (#1015, resolves #1007).
- Root cause of #1007 pinned and reproduced hermetically: a shared global `build.target-dir` plus cargo's artifact relocatability (package-root-relative dep-info; `CARGO_MANIFEST_DIR` excluded from the env-dep fingerprint) lets an rlib baked from another checkout path be reused as fresh.

## Changes

**`crates/zfb` (#1014 — ETXTBSY retry coverage)**
- `src/config.rs`: extracted the zfb#1008 ETXTBSY classify/sleep/retry/exhaustion loop into private `output_bounded_with` (injectable `AttemptFut` attempt closure); `output_bounded` is now a thin wrapper injecting the real `tokio::time::timeout(timeout, cmd.output())`. Rationale comment block kept attached to the retry logic.
- New tests (virtual time via `start_paused`, no real spawns, no wall-clock sleeps): retry-then-succeed (2×busy then Ok ⇒ success in exactly 3 attempts) and exhaustion (always busy ⇒ `ExecutableFileBusy` surfaces after exactly 6 attempts, matching the `etxtbsy_attempts < ETXTBSY_MAX_RETRIES` guard).
- `Cargo.toml`: dev-only `tokio` `test-util` feature (production feature set unchanged).

**`crates/zfb-test-utils` (#1015 — loud esbuild-gate skips)**
- `src/lib.rs`: workspace root re-derived at runtime (walk up from `current_dir()`), compile-time `CARGO_MANIFEST_DIR` kept as fallback; `ZFB_ESBUILD_BIN` override unchanged. New pure `classify_failed_lookup` decision fn: panics (with checked paths named) only when the platform slot binary file exists yet lookup failed — the harness-bug state; genuinely-absent esbuild keeps the graceful `None` skip. One `eprintln!` on the graceful-skip path.
- `tests/locate_esbuild_self.rs` + `README.md`: stale "never panics" contract docs replaced with the new contract; hermetic tests for the panic/skip classification and runtime root derivation.

## Test Plan

- `cargo test -p zfb --lib` — 426 passed (424 pre-existing + 2 new deterministic ETXTBSY tests).
- `cargo test -p zfb-test-utils` — 27 passed; clippy clean.
- `cargo test -p zfb-build --test bundler_resolve_links` with `--nocapture` — 6 passed with real esbuild execution (no skip lines), proving gated tests genuinely run with the slot binary present.
- CI on this PR runs the full workspace suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)