### PR TITLE
fix(content): data-file skip warning respects include/exclude globs

### DIFF
--- a/crates/zfb-content/src/collection.rs
+++ b/crates/zfb-content/src/collection.rs
@@ -456,11 +456,25 @@ where
     T: DeserializeOwned + garde::Validate<Context = ()>,
 {
     let mut files: Vec<PathBuf> = Vec::new();
-    collect_collection_files(dir, &mut files).map_err(|e| CollectionError::Io {
-        path: dir.to_path_buf(),
-        source: e,
+    let mut skipped_data_files: Vec<PathBuf> = Vec::new();
+    collect_collection_files(dir, &mut files, &mut skipped_data_files).map_err(|e| {
+        CollectionError::Io {
+            path: dir.to_path_buf(),
+            source: e,
+        }
     })?;
     files.sort();
+    skipped_data_files.sort();
+
+    // Warn only for data files the consumer's include/exclude globs have
+    // not already filtered out (zfb#1032) — those are the only ones being
+    // *silently* dropped, which is what the #856 warning exists for.
+    for path in warnable_data_files(dir, &skipped_data_files, filter) {
+        eprintln!(
+            "zfb warning: unsupported data-file extension in collection — file will be skipped: {}",
+            path.display()
+        );
+    }
 
     // Apply include + exclude globs against POSIX-normalised relative
     // paths. The fast-path skips the per-entry check entirely when no
@@ -689,7 +703,11 @@ fn data_type_for(schema: Option<&JsonValue>, indent: usize) -> String {
 // internals
 // -----------------------------------------------------------------------------
 
-fn collect_collection_files(dir: &Path, out: &mut Vec<PathBuf>) -> std::io::Result<()> {
+fn collect_collection_files(
+    dir: &Path,
+    out: &mut Vec<PathBuf>,
+    skipped_data_files: &mut Vec<PathBuf>,
+) -> std::io::Result<()> {
     if !dir.exists() {
         return Ok(());
     }
@@ -714,19 +732,42 @@ fn collect_collection_files(dir: &Path, out: &mut Vec<PathBuf>) -> std::io::Resu
         // `WalkDir::follow_links(false)` in zfb-router::scan.
         let file_type = entry.file_type()?;
         if file_type.is_dir() {
-            collect_collection_files(&path, out)?;
+            collect_collection_files(&path, out, skipped_data_files)?;
         } else if file_type.is_file() {
             if is_collection_entry(&path) {
                 out.push(path);
             } else if is_unsupported_data_file(&path) {
-                eprintln!(
-                    "zfb warning: unsupported data-file extension in collection — file will be skipped: {}",
-                    path.display()
-                );
+                // Collected instead of warned inline: the caller owns the
+                // include/exclude filter, and only data files the consumer
+                // has NOT already filtered out deserve the #856 warning
+                // (zfb#1032). See `warnable_data_files`.
+                skipped_data_files.push(path);
             }
         }
     }
     Ok(())
+}
+
+/// Filter the walker's skipped data files down to the ones that deserve
+/// the #856 "unsupported data-file extension" warning: only files the
+/// collection's `include` / `exclude` globs have NOT already filtered out
+/// (zfb#1032). A file rejected by the consumer's explicit globs is not
+/// *silently* dropped — the config already states the intent — so warning
+/// for it is pure noise. With no globs configured, [`CollectionFilter::matches`]
+/// passes everything, preserving the original warn-on-every-data-file
+/// behaviour for legacy callers.
+fn warnable_data_files<'a>(
+    dir: &Path,
+    skipped: &'a [PathBuf],
+    filter: &CollectionFilter,
+) -> Vec<&'a PathBuf> {
+    skipped
+        .iter()
+        .filter(|p| {
+            let rel = p.strip_prefix(dir).unwrap_or(p);
+            filter.matches(&path_to_posix_string(rel))
+        })
+        .collect()
 }
 
 fn is_collection_entry(path: &Path) -> bool {
@@ -1662,6 +1703,60 @@ declare module \"zfb/content\" {\n\
             "only entry.md should be returned; data files must be skipped"
         );
         assert_eq!(out[0].slug, "entry");
+    }
+
+    /// The #856 data-file warning must respect include/exclude globs
+    /// (zfb#1032): only data files the consumer's config has NOT already
+    /// filtered out are "silently dropped" and deserve the warning.
+    #[test]
+    fn warnable_data_files_respects_include_exclude_globs() {
+        let dir = Path::new("/proj/content/docs");
+        let skipped = vec![
+            PathBuf::from("/proj/content/docs/sub-p/_category_.json"),
+            PathBuf::from("/proj/content/docs/data.yaml"),
+        ];
+
+        // No filter → every data file warns (original #856 behaviour).
+        let none = CollectionFilter::none();
+        assert_eq!(warnable_data_files(dir, &skipped, &none).len(), 2);
+
+        // The issue's repro: `include: ['**/*.md', '**/*.mdx']` already
+        // states that data files are not entries — no warning, nested or
+        // top-level alike.
+        let md_only = filter(Some(&["**/*.md", "**/*.mdx"]), None, None);
+        assert!(warnable_data_files(dir, &skipped, &md_only).is_empty());
+
+        // An exclude glob silences exactly the files it matches.
+        let exc = filter(None, Some(&["**/_category_.json"]), None);
+        let warned = warnable_data_files(dir, &skipped, &exc);
+        assert_eq!(warned.len(), 1);
+        assert!(warned[0].ends_with("data.yaml"));
+
+        // An include glob that DOES cover the data file → still warns:
+        // the extension skip would drop it silently, which is exactly
+        // what #856 exists to surface.
+        let all = filter(Some(&["**/*"]), None, None);
+        assert_eq!(warnable_data_files(dir, &skipped, &all).len(), 2);
+
+        // `idStripSuffix` alone is not an include/exclude statement —
+        // warning eligibility is unaffected.
+        let strip_only = filter(None, None, Some(".en"));
+        assert_eq!(warnable_data_files(dir, &skipped, &strip_only).len(), 2);
+    }
+
+    /// End-to-end walk with an include filter and a data file present:
+    /// entries are unaffected by the zfb#1032 warning change (the fix
+    /// only alters whether the stderr warning fires).
+    #[test]
+    fn walk_with_include_still_skips_data_files() {
+        let tmp = TmpDir::new("inc-data");
+        tmp.write("entry.md", &valid_md("Entry"));
+        tmp.write("sub/_category_.json", r#"{"label": "Sub"}"#);
+        let filter = filter(Some(&["**/*.md", "**/*.mdx"]), None, None);
+        let out: Vec<Entry<TestSchema>> =
+            walk_collection_with_cache_and_filter(tmp.path(), None, None, &filter).unwrap();
+        let slugs: Vec<&str> = out.iter().map(|e| e.slug.as_str()).collect();
+        assert_eq!(slugs, vec!["entry"]);
     }
 
     /// `derive_slug_for_file` (issue #958) must mirror the walker's slug

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -53,7 +53,7 @@ docs/
 - Optional: `description`, `sidebar_position` (number), `sidebar_label`, `category`, `tags`
 - Sidebar order is driven by `sidebar_position`
 - Sidebar category label comes from the `index.mdx` frontmatter in each directory, or from a `_category_.json` file when there is no `index.mdx`
-- `_category_.json` files are NOT disposable: the zfb content-collection loader skips them as data files (emitting a benign build warning), but the docs app's nav layer (`loadCategoryMeta` via `resolveNavSource`) still reads them for category `label`, `position`, `description`, `sortOrder`, and `noPage`. Deleting them can regress sidebar/category nav (e.g. `api`, `architecture`, generated Claude sections).
+- `_category_.json` files are NOT disposable: the zfb content-collection loader skips them as data files (emitting a benign build warning — silenced when the collection's `include`/`exclude` globs already filter the file out, see zfb#1032), but the docs app's nav layer (`loadCategoryMeta` via `resolveNavSource`) still reads them for category `label`, `position`, `description`, `sortOrder`, and `noPage`. Deleting them can regress sidebar/category nav (e.g. `api`, `architecture`, generated Claude sections).
 
 ### Links
 


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1032

---

## Summary

- Fixes #1032: the #856 "unsupported data-file extension" warning fired inside the collection walker before include/exclude globs were evaluated, so files the consumer had explicitly filtered out (e.g. `_category_.json` under `include: ['**/*.md', '**/*.mdx']`) still produced warning noise on every build, with no consumer-side opt-out.
- The warning is now glob-aware: it fires only for data files that pass the collection's `include`/`exclude` filter — i.e. files that would otherwise be *silently* dropped, which is what the warning exists to surface.
- No new config API (the issue's preferred approach). Collections without globs warn exactly as before.

## Changes

- `crates/zfb-content/src/collection.rs`
    - `collect_collection_files` collects skipped data files into a `skipped_data_files` vec instead of warning inline (the walker has no filter knowledge; the caller does).
    - New pure helper `warnable_data_files(dir, skipped, filter)` keeps only files whose POSIX-relative path passes `CollectionFilter::matches` (include/exclude only — `idStripSuffix` does not affect eligibility).
    - `walk_collection_with_cache_and_filter` emits the unchanged warning text for exactly those files, sorted for deterministic order.
- `docs/CLAUDE.md`: noted the glob-silencing behavior next to the existing `_category_.json` warning mention.

## Test Plan

- New unit test `warnable_data_files_respects_include_exclude_globs`: no filter → all data files warn; `include: ['**/*.md','**/*.mdx']` (the issue's repro) → silent; exclude glob → silences only matching files; include glob covering the data file → still warns; `idStripSuffix` alone → no effect.
- New unit test `walk_with_include_still_skips_data_files`: end-to-end walk with include globs + `_category_.json` present yields the same entry set.
- Full workspace suite: 2808 passed, 0 failed. Clippy + fmt clean. All 7 CI checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)