### PR TITLE
Adopt zudo-test-wisdom testing essentials (tiers, Rust flaky pipeline, b4push)

### DIFF
--- a/.github/ISSUE_TEMPLATE/flaky-quarantine.md
+++ b/.github/ISSUE_TEMPLATE/flaky-quarantine.md
@@ -1,0 +1,52 @@
+---
+name: Flaky test quarantine
+about: Track a quarantined flaky test. The inline marker next to the test links here.
+title: "[flaky] <crate/file>::<test name>"
+labels: flaky
+---
+
+<!--
+This issue is the paper trail for ONE quarantined flaky test, per the
+zudo-test-wisdom quarantine pipeline (see CLAUDE.md → Testing → Flaky tests).
+
+Quarantine is a pipeline with an exit, not a parking lot. Before opening this,
+confirm Step 0 below — a test that can pass NOWHERE is broken, not flaky.
+
+The quarantined test must carry an inline marker pointing back at this issue, e.g.
+    #[ignore = "flaky: https://github.com/Takazudo/zudo-front-builder/issues/<N>"]   // Rust
+    // @flaky: <issue-url>                                                            // TS
+-->
+
+## Test
+
+- Location: `<crate-or-package>/<path>::<test_name>`
+- Marker added in: `<commit / PR>`
+
+## Step 0 — has it ever genuinely passed?
+
+> A test that has never produced a real green run is **broken, not flaky** — fix or delete it, do not quarantine.
+
+- [ ] Confirmed at least one genuine green run (not pass-by-skip) on some host: `<run URL / local evidence>`
+
+## Symptom
+
+<How does it fail? How often? Local only, CI only, or both? Paste a failing run URL.>
+
+## Suspected root cause
+
+The five usual causes (fix the cause, do not add a sleep):
+
+- [ ] Timing wait / fixed `sleep` (use an event/condition-keyed wait instead)
+- [ ] Waiting on the wrong completion signal
+- [ ] Animation / transition / async work in flight
+- [ ] Shared or test-order-coupled state
+- [ ] Startup / readiness race
+- [ ] Other: <describe>
+
+## Exit — fix / demote / delete (with a deadline)
+
+> Quarantine suspends **product** coverage, not just test coverage: the behavior this test guards is unguarded until it is fixed.
+
+- Owner: <who>
+- Deadline: <date>
+- Decision: <fix | demote to a lower level | delete and watch>

--- a/.mdx-formatter.json
+++ b/.mdx-formatter.json
@@ -9,9 +9,7 @@
     ".pnpm-store/**",
     "__inbox/**",
     "**/.playwright-cli/**",
-    "docs/src/content/docs/claude/**",
-    "docs/src/content/docs/claude-md/**",
-    "docs/src/content/docs/claude-skills/**"
+    "docs/src/content/docs/claude*/**"
   ],
   "addEmptyLinesInBlockJsx": {
     "blockComponents": [

--- a/.mdx-formatter.json
+++ b/.mdx-formatter.json
@@ -6,7 +6,12 @@
     "docs/dist/**",
     "docs/.zfb/**",
     "docs/.zfb-build/**",
-    ".pnpm-store/**"
+    ".pnpm-store/**",
+    "__inbox/**",
+    "**/.playwright-cli/**",
+    "docs/src/content/docs/claude/**",
+    "docs/src/content/docs/claude-md/**",
+    "docs/src/content/docs/claude-skills/**"
   ],
   "addEmptyLinesInBlockJsx": {
     "blockComponents": [

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,11 @@ dist/
 .pnpm-store/
 pnpm-lock.yaml
 docs/dist/
+# Gitignored local artifacts. Prettier does not read .gitignore, so without
+# these `pnpm format:check` (and `pnpm b4push`) false-fails on a dev tree where
+# these dirs exist, even though CI — a fresh checkout — never sees them.
+.playwright-cli/
+__inbox/
 # Snapshot fixture for the .d.ts emitter — must match the emitter's
 # byte-exact output, so prettier (which would re-flow the inline
 # interfaces) is not allowed to touch it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,3 +42,69 @@ Use only when you genuinely need to push from a worktree (rare). Never set this 
 
 - **Child agents working in `worktrees/*/`:** commit locally only. Pushing will fail with the message above — do not retry, do not invoke the bypass. Report back to the manager with the branch name and commit SHAs; the manager merges and pushes from the main repo.
 - **`/x-wt-teams` manager session:** the hook does not affect you. Your `git push` runs from the main repo (the cwd is the repo root, not `worktrees/...`). After every wave's local merges, push as usual. Do not pass `ALLOW_WORKTREE_PUSH` to children.
+
+## Testing
+
+zfb follows the **zudo-test-wisdom** strategy (the full guide: <https://takazudomodular.com/pj/zudo-test>). This section is the zfb-adapted, agent-facing summary — read it before writing or fixing tests. Every test sits on **two axes**:
+
+- **Level** = *what a test can see* (logic → DOM → build output → browser → pixels).
+- **Tier** = *where and when it runs* (inner loop → PR gate → scheduled → local heavy lane).
+
+The axes are independent. "Too heavy for the PR gate" is a **tier** question, never a reason to rewrite a test at a lower **level**.
+
+### Test levels (escalation ladder)
+
+| Level | What it sees | In zfb |
+|---|---|---|
+| 1 — Unit/logic | pure functions, transforms | `cargo test` unit tests; vitest unit tests |
+| 2 — DOM component | DOM structure, no CSS engine | `zfb-runtime` happy-dom vitest (the client router) |
+| 3 — Build output | emitted files **and emitted code that runs** | reading built `dist/`; the *dynamic-import-the-emitted-`_worker.js`* pattern in `zfb-adapter-cloudflare` (zfb is a code generator — string-equality proves the template was written, executing the artifact proves it threads `env`/`ctx`) |
+| 4 — E2E browser | real process / browser | `crates/zfb/tests/dev_serve_e2e.rs` (dev server). No Playwright browser E2E yet |
+| 5 — Visual | computed styles + pixels | the docs site / any UI — use `/verify-ui` + `/headless-browser` |
+| 6 — AI-based | final resort, **not for CI** | not used; only for canvas/zoom surfaces L4+L5 cannot reach |
+
+**Escalation rule:** when a test passes but the problem persists, **escalate to the next level — do not re-run the same test, and never tell the user to "clear cache."** If it's still broken, the code is still broken. Any CSS/layout/visibility work defaults to **Level 5**.
+
+### Execution tiers
+
+| Tier | What it is in zfb | Status |
+|---|---|---|
+| **T0 — inner loop** | `cargo check`/`clippy` + scoped `cargo test -p <crate>` (affected), `pnpm -r --if-present typecheck`, `pnpm -r test`. Retries 0. | run constantly while coding |
+| **T1 — PR gate** | `.github/workflows/health.yml` — fmt, `clippy -D warnings`, build, `cargo test --workspace`, `pnpm -r test`, `format:check`, actionlint, build-no-v8. | **the authoritative gate.** A PR is mergeable when its required checks are green |
+| **T3 — scheduled re-exam** | heavy/platform-bound lanes on a schedule | **DEFERRED until release.** zfb is pre-release WIP; standing up a nightly runner is not cost-justified yet. This is a **public repo** — no blacksmith, no self-hosted runners. Adopt at cutover |
+| **T4 — local heavy lane** | `pnpm b4push` (below) | convenience, not enforcement |
+
+**Do not scaffold unused tiers.** zfb needs T0 + T1 now; T4 is the new `b4push`; T3 is documented-but-deferred.
+
+### Required behavior (agents)
+
+1. **Declare the test plan first** — *what* you're testing, *which level*, *why* that level.
+2. **Match level to goal** — don't verify a Level-5 visual bug with a Level-1 logic test.
+3. **Escalate when a lower level passes but the problem persists** (never re-run, never "clear cache").
+4. **Default to Level 5 for any UI/CSS/visibility work.**
+5. **Report what was NOT tested** — state the blind spots.
+6. **Verification specs don't self-graduate.** A one-time "it was done" proof is tagged `#[ignore = "verification: <why>"]` (Rust) / `@verification` (TS) and excluded from gates. Propose promotion to a tier in the PR description; never self-promote.
+7. **Red checks block the author.** Any red check on a PR you authored blocks you, *even if it is not a required check* — the only exception is a test carrying `@flaky`/`flaky:` with a linked open issue.
+8. **Never game the gate.** Do not add `#[ignore]` / `test.skip`, a flaky tag, a loosened tolerance, or a deleted assertion **without a linked open issue**. Making a gate pass by editing existing assertions needs a fresh-context review — not the same session that wrote the change.
+9. **Scoped heavy verification.** When a change touches code covered only by a heavy/quarantined lane, run those tests on a capable host before declaring the work done.
+
+### Flaky tests
+
+zfb hits flakiness often (mostly **Rust timing/ordering** in the dev-server, SSE, and plugin-runner paths). Handle it as a pipeline, not a shrug.
+
+- **Retry budget:** local **0**; CI **1–2** with artifacts. **Pass-on-retry is a triage signal, not a success** — record it and schedule the fix. **More than 2 retries is a smell.**
+- **The `@flaky` quarantine pipeline (Rust):**
+  - **Step 0 — prove it ever genuinely passed** (not pass-by-skip) on some host. A test that can pass *nowhere* is **broken, not flaky** → fix or delete it now, no quarantine.
+  - **Quarantine requires a paper trail** — mark it `#[ignore = "flaky: <issue-url>"]` (the inline issue URL is mandatory). `cargo test` skips `#[ignore]`d tests, so it no longer blocks the gate.
+  - **It must still run somewhere, allowed-to-fail** — today, locally via `cargo test -- --ignored` (or `--include-ignored`); post-cutover, the T3 scheduled exam runs the quarantined set allowed-to-fail so failure data keeps flowing into the tracking issue.
+  - **Quarantine has an exit with a deadline — fix, demote, or delete.** It is not a parking lot. **Quarantine suspends *product* coverage, not just test coverage:** the behavior is unguarded until the test is fixed.
+- **The 5 deflaking root causes** (fix the cause, don't add a sleep): bare timing waits, `networkidle` on no-request SPA navs, animations in flight, shared/order-coupled state, hydration races. zfb's Rust flakes are mostly timing/ordering — prefer event/condition-keyed waits and deterministic scheduling over fixed `sleep`s (as `zfb-test-utils`'s SSE helpers and the `plugin_runner` timeouts already do).
+- **`cargo-nextest` (recommended next step, deferred):** CI uses plain `cargo test`, which has no native retry. `cargo nextest run` would give the CI retry budget (`--retries`), flaky-pass detection, per-test timeouts, and JUnit output for issue filing — **but nextest does not run doctests**, and zfb has doctests in ~15 crates. A migration must keep a separate `cargo test --doc` step or it silently drops doctest coverage; that's why it is deferred from the adoption PR rather than done blindly.
+
+### `b4push` — local pre-push pass (T4)
+
+`pnpm b4push` runs a **bounded** fast pass before pushing: shell-script syntax, `cargo fmt --check`, `pnpm format:check`, `pnpm -r --if-present typecheck`, `pnpm -r test`, and `cargo clippy` (warm tree). It is **not** the authoritative gate — `health.yml` is. b4push is the *fast subset*; the full `cargo test --workspace` runs in CI (V8 first-compile is 15–30 min, too heavy for a pre-push loop).
+
+- Escapes: `B4PUSH_SKIP_CLIPPY=1`, `B4PUSH_SKIP_JS_TEST=1`.
+- Heavy opt-in: `B4PUSH_FULL=1 pnpm b4push` adds `cargo test --workspace` for a thorough local run.
+- It is **not** wired into the git `pre-push` hook (that hook only enforces the worktree-push policy above) — run it manually before pushing.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "format:ts": "prettier --write \"**/*.{js,mjs,cjs,ts,tsx,json,yml,yaml}\"",
     "format:check:ts": "prettier --check \"**/*.{js,mjs,cjs,ts,tsx,json,yml,yaml}\"",
     "format:mdx": "pnpm dlx @takazudo/mdx-formatter --write '**/*.{md,mdx}'",
-    "format:check:mdx": "pnpm dlx @takazudo/mdx-formatter --check '**/*.{md,mdx}'"
+    "format:check:mdx": "pnpm dlx @takazudo/mdx-formatter --check '**/*.{md,mdx}'",
+    "//// === VALIDATION ===": "",
+    "b4push": "bash scripts/run-b4push.sh"
   },
   "devDependencies": {
     "lefthook": "^2.1.6",

--- a/scripts/run-b4push.sh
+++ b/scripts/run-b4push.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# b4push — bounded local quality gate, run before pushing the zfb workspace.
+#
+# This is the T4 "local heavy lane" from the zudo-test-wisdom strategy: a fast,
+# convenience pass — NOT the authoritative gate. The authoritative gate is CI
+# (.github/workflows/health.yml), which runs the full `cargo test --workspace`.
+# See the "Testing" section of CLAUDE.md.
+#
+# Why the full Rust test suite is NOT here by default: zfb embeds V8 (rusty_v8),
+# whose first compile is 15–30 min. Putting a cold `cargo test --workspace` in a
+# pre-push pass would blow the bounded budget, so b4push runs the fast checks and
+# leaves the full workspace test to CI (or to `B4PUSH_FULL=1`, below).
+#
+# Step order (cheap → expensive):
+#   1. Shell-script syntax check (bash -n)        — near-free, no compilation
+#   2. cargo fmt --check                          — near-free, no compilation
+#   3. pnpm format:check (prettier + mdx)         — fast
+#   4. pnpm typecheck (TS, --if-present)          — fast
+#   5. pnpm -r test (vitest)                      — fast
+#   6. cargo clippy -D warnings                   — fast on a WARM tree
+#   7. cargo test --workspace                     — opt-in only (B4PUSH_FULL=1)
+#
+# Env overrides:
+#   B4PUSH_SKIP_CLIPPY=1   — skip clippy (step 6); use on a cold tree to stay bounded
+#   B4PUSH_SKIP_JS_TEST=1  — skip the vitest suites (step 5)
+#   B4PUSH_FULL=1          — additionally run `cargo test --workspace` (step 7)
+
+START_TIME=$(date +%s)
+FAILURES=()
+CURRENT_STEP=0
+
+step() {
+  CURRENT_STEP=$((CURRENT_STEP + 1))
+  echo ""
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+  echo "▶ Step $CURRENT_STEP: $1"
+  echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+}
+
+pass() { echo "✅ $1"; }
+fail() { echo "❌ $1"; FAILURES+=("$1"); }
+skip() { echo "⏭  $1 (skipped)"; }
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT_DIR"
+
+# ── Step 1: Shell-script syntax check ─────────────────
+# Mirrors health.yml: parse-check install.sh, scripts/*.sh, tests/unit/*.sh.
+step "Shell-script syntax check (bash -n)"
+SH_OK=1
+for f in install.sh scripts/*.sh tests/unit/*.sh; do
+  [ -e "$f" ] || continue
+  if ! bash -n "$f"; then
+    echo "  syntax error in $f"
+    SH_OK=0
+  fi
+done
+if [ "$SH_OK" -eq 1 ]; then
+  pass "Shell-script syntax"
+else
+  fail "Shell-script syntax"
+fi
+
+# ── Step 2: Rust formatting ───────────────────────────
+step "Rust formatting (cargo fmt --check)"
+if cargo fmt --all --check; then
+  pass "cargo fmt"
+else
+  fail "cargo fmt (run \`cargo fmt --all\` to fix)"
+fi
+
+# ── Step 3: JS/MDX formatting ─────────────────────────
+step "JS/MDX formatting (pnpm format:check)"
+if pnpm format:check; then
+  pass "format:check"
+else
+  fail "format:check (run \`pnpm format\` to fix)"
+fi
+
+# ── Step 4: TypeScript typecheck ──────────────────────
+step "TypeScript typecheck (pnpm -r typecheck)"
+if pnpm -r --if-present typecheck; then
+  pass "typecheck"
+else
+  fail "typecheck"
+fi
+
+# ── Step 5: JS test suites (vitest) ───────────────────
+step "JS test suites (pnpm -r test)"
+if [ "${B4PUSH_SKIP_JS_TEST:-}" = "1" ]; then
+  skip "JS tests (B4PUSH_SKIP_JS_TEST=1)"
+else
+  if pnpm -r test; then
+    pass "JS tests"
+  else
+    fail "JS tests"
+  fi
+fi
+
+# ── Step 6: Rust lint (clippy) ────────────────────────
+# Fast on a warm tree; on a cold tree it triggers the V8 first-compile, so this
+# step is skippable to keep the pass bounded. CI runs it unconditionally.
+step "Rust lint (cargo clippy -D warnings)"
+if [ "${B4PUSH_SKIP_CLIPPY:-}" = "1" ]; then
+  skip "clippy (B4PUSH_SKIP_CLIPPY=1)"
+else
+  if cargo clippy --workspace --all-targets -- -D warnings; then
+    pass "clippy"
+  else
+    fail "clippy"
+  fi
+fi
+
+# ── Step 7: Full Rust test suite (opt-in) ─────────────
+# Off by default — this is what CI's health.yml exists to run. Turn it on for a
+# thorough local pass when you have a warm tree and time to spare.
+step "Full Rust test suite (cargo test --workspace)"
+if [ "${B4PUSH_FULL:-}" = "1" ]; then
+  if cargo test --workspace; then
+    pass "cargo test --workspace"
+  else
+    fail "cargo test --workspace"
+  fi
+else
+  skip "cargo test --workspace (set B4PUSH_FULL=1 to run; CI runs it on every PR)"
+fi
+
+# ── Summary ──────────────────────────────────────────
+END_TIME=$(date +%s)
+DURATION=$((END_TIME - START_TIME))
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  b4push SUMMARY (${DURATION}s)"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+if [ ${#FAILURES[@]} -eq 0 ]; then
+  echo "✅ All checks passed (or skipped). Safe to push."
+  echo "   Reminder: health.yml is the authoritative gate — b4push is the fast subset."
+  exit 0
+else
+  echo "❌ ${#FAILURES[@]} check(s) failed:"
+  for f in "${FAILURES[@]}"; do
+    echo "   - $f"
+  done
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adopts the essential parts of the **zudo-test-wisdom** testing strategy into zfb's testing environment. The bulk is agent-facing documentation in `CLAUDE.md`, plus a bounded local pre-push gate and the Rust-side flaky-quarantine scaffolding.

Scoped to zfb's reality:
- **Public repo** → no blacksmith, no self-hosted runners.
- **Pre-release** → T3 (scheduled "exam" CI) is documented but **deferred until release**, per the strategy's own rule. No cron workflow added.
- **No Playwright** → the Playwright-specific machinery (wait-debt ratchet, `--grep` flaky split) is intentionally **not** added.
- `health.yml` already **is** the T1 gate — this PR names it in the tier model, it does not rewrite it.

## Changes

- **`CLAUDE.md` → new "Testing" section** (the core): the two axes (level vs tier), the 6-level escalation ladder mapped to zfb's actual suites, named execution tiers (T0 inner loop · T1 = `health.yml` authoritative gate · T3 deferred · T4 = `b4push`), the required-behavior + anti-gaming rules, and the **Rust `@flaky` quarantine pipeline** with the local-0 / CI-1–2 retry budget. Notes `cargo-nextest` as a deferred next step (it does not run doctests, which zfb has in ~15 crates).
- **`scripts/run-b4push.sh` + `pnpm b4push`**: a bounded pre-push pass (shell syntax · `cargo fmt --check` · `format:check` · `typecheck` · vitest · clippy). The full `cargo test --workspace` is **not** in the default pass (V8 first-compile is 15–30 min) — it stays in CI, or runs locally via `B4PUSH_FULL=1`. Escapes: `B4PUSH_SKIP_CLIPPY=1`, `B4PUSH_SKIP_JS_TEST=1`.
- **`.github/ISSUE_TEMPLATE/flaky-quarantine.md` + `flaky` label**: the paper trail for one quarantined flaky test (Step-0 "ever genuinely passed?", inline-marker convention, 5 root causes, mandatory fix/demote/delete exit).
- **`.prettierignore` / `.mdx-formatter.json`**: exclude gitignored local artifacts (`.playwright-cli/`, `__inbox/`, generated `claude*` docs dirs) from the formatters. Surfaced by smoke-testing b4push — these made `pnpm format:check` red on a dev tree while green in CI (a fresh checkout never has them).

## Test Plan

- `pnpm b4push` (clippy + full-test skipped): green — shell syntax, `cargo fmt`, `format:check`, typecheck, and 141 vitest tests all pass.
- `pnpm format:check`: green after the ignore-list fix (was red locally on gitignored artifacts before).
- Rust source unchanged → `cargo clippy` / `cargo test --workspace` behavior is identical to `main` (verified by CI `health.yml` on this PR).
- Reviewed by `/codex-review`; its one finding (incomplete generated-dir exclude) fixed via a `claude*/**` glob.