### PR TITLE
fix(release): idempotent, conflict-tolerant npm publish (recover from partial-publish 403)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -708,90 +708,36 @@ jobs:
           fi
 
       # ── Publish ───────────────────────────────────────────────────────────
-      # Platform packages (zfb-darwin-*, zfb-linux-*, zfb-win32-*) MUST be
-      # published via `npm publish` (not pnpm). pnpm pack — which pnpm
-      # publish calls internally — normalises all file modes to 0644,
-      # stripping the executable bit from the zfb binary. npm pack/publish
-      # preserves the source file mode set by the chmod +x steps above.
-      # See issue #447 / #441 for root cause analysis.
+      # The publish loop lives in scripts/publish-npm-packages.sh (shared by both
+      # the normal and mixed-provenance steps below). It is IDEMPOTENT (skips any
+      # <name>@<version> already on the registry) and TOLERANT of npm's double-PUT
+      # race (a lost-ACK retry that 403s "cannot publish over the previously
+      # published versions"), so a partial publish can be safely re-run and a
+      # transient network blip can't abort the release mid-way. See the script
+      # header and the v0.1.0-next.42 incident for the full rationale.
       #
-      # Non-platform packages (@takazudo/zfb, @takazudo/zfb-runtime,
-      # @takazudo/zfb-adapter-cloudflare, create-zfb) continue to use
-      # `pnpm -r publish` so workspace:* peer-dep rewrites are applied.
+      # Platform packages (zfb-darwin-*, zfb-linux-*, zfb-win32-*) are still
+      # published via `npm publish` (not pnpm): pnpm pack normalises file modes to
+      # 0644, stripping the binary's 0755 exec bit; npm preserves it (#447 / #441).
+      # Non-platform packages use `pnpm publish` so workspace:* deps are rewritten.
+      # DIST_TAG and ALSO_LATEST are inherited from $GITHUB_ENV (set above).
 
       # Normal path: every package published with OIDC-attested --provenance.
       - name: Publish to npm
         if: ${{ inputs.dry_run != true && needs.detect-mac-local.outputs.mac_local_present != 'true' }}
         shell: bash
-        run: |
-          # Platform packages: use npm publish to preserve the executable bit.
-          for dir in \
-            packages/zfb-darwin-arm64 \
-            packages/zfb-darwin-x64 \
-            packages/zfb-linux-arm64-gnu \
-            packages/zfb-linux-x64-gnu \
-            packages/zfb-win32-x64-msvc; do
-            ( cd "$dir" && npm publish --tag "$DIST_TAG" --access public --provenance )
-          done
-          # Non-platform packages: use pnpm publish for workspace:* rewriting.
-          pnpm -r \
-            --filter '!@takazudo/zfb-darwin-arm64' \
-            --filter '!@takazudo/zfb-darwin-x64' \
-            --filter '!@takazudo/zfb-linux-arm64-gnu' \
-            --filter '!@takazudo/zfb-linux-x64-gnu' \
-            --filter '!@takazudo/zfb-win32-x64-msvc' \
-            publish --tag "$DIST_TAG" --no-git-checks --access public --provenance
-
-          # ── Prerelease dual-tag: advance `latest` while still in prerelease phase ──
-          # ALSO_LATEST=1 is set by "Check if latest should also advance" when the
-          # current registry `latest` is empty or itself a prerelease.  Runs AFTER
-          # all packages are published so a partial publish never clobbers `latest`.
-          # Each `npm dist-tag add` is retried with backoff; persistent failures are
-          # surfaced loudly with the manual remediation command.  See #481.
-          if [[ "$ALSO_LATEST" == "1" ]]; then
-            ZFB_SEMVER=$(node -p "require('./packages/zfb/package.json').version")
-            bash scripts/advance-latest-dist-tag.sh "$ZFB_SEMVER"
-          fi
+        run: bash scripts/publish-npm-packages.sh all-provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # Mixed-provenance path: the macOS-x64 binary was built locally (outside this
-      # GHA job) so it cannot carry OIDC provenance. Publish that one package
-      # WITHOUT --provenance and every other package WITH --provenance (option B).
-      # See RELEASE_DAY_CHECKLIST.md.
+      # GHA job) so it cannot carry OIDC provenance. The `mac-local` mode publishes
+      # zfb-darwin-x64 WITHOUT --provenance and every other package WITH it
+      # (option B). See RELEASE_DAY_CHECKLIST.md and the script header.
       - name: Publish to npm (mixed provenance — local macOS-x64)
         if: ${{ inputs.dry_run != true && needs.detect-mac-local.outputs.mac_local_present == 'true' }}
         shell: bash
-        run: |
-          # Platform packages: use npm publish to preserve the executable bit.
-          # darwin-x64 was built locally (no GHA provenance) — omit --provenance.
-          ( cd packages/zfb-darwin-x64 && npm publish --tag "$DIST_TAG" --access public )
-          for dir in \
-            packages/zfb-darwin-arm64 \
-            packages/zfb-linux-arm64-gnu \
-            packages/zfb-linux-x64-gnu \
-            packages/zfb-win32-x64-msvc; do
-            ( cd "$dir" && npm publish --tag "$DIST_TAG" --access public --provenance )
-          done
-          # Non-platform packages: use pnpm publish for workspace:* rewriting.
-          pnpm -r \
-            --filter '!@takazudo/zfb-darwin-arm64' \
-            --filter '!@takazudo/zfb-darwin-x64' \
-            --filter '!@takazudo/zfb-linux-arm64-gnu' \
-            --filter '!@takazudo/zfb-linux-x64-gnu' \
-            --filter '!@takazudo/zfb-win32-x64-msvc' \
-            publish --tag "$DIST_TAG" --no-git-checks --access public --provenance
-
-          # ── Prerelease dual-tag: advance `latest` while still in prerelease phase ──
-          # ALSO_LATEST=1 is set by "Check if latest should also advance" when the
-          # current registry `latest` is empty or itself a prerelease.  Runs AFTER
-          # all packages are published so a partial publish never clobbers `latest`.
-          # Each `npm dist-tag add` is retried with backoff; persistent failures are
-          # surfaced loudly with the manual remediation command.  See #481.
-          if [[ "$ALSO_LATEST" == "1" ]]; then
-            ZFB_SEMVER=$(node -p "require('./packages/zfb/package.json').version")
-            bash scripts/advance-latest-dist-tag.sh "$ZFB_SEMVER"
-          fi
+        run: bash scripts/publish-npm-packages.sh mac-local
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/scripts/publish-npm-packages.sh
+++ b/scripts/publish-npm-packages.sh
@@ -33,10 +33,11 @@
 #
 # Non-platform packages (@takazudo/zfb, @takazudo/zfb-runtime,
 # @takazudo/zfb-adapter-cloudflare, create-zfb) are published with
-# `pnpm --filter <name> publish` so pnpm rewrites their `workspace:*` deps to
-# concrete versions at pack time. Published one-at-a-time (not a bulk
-# `pnpm -r publish`) so the idempotent/tolerant wrapper applies per package and a
-# mid-list conflict cannot abort the rest.
+# `pnpm -r --filter <name> publish` so pnpm rewrites their `workspace:*` deps to
+# concrete versions at pack time. Published one package per call (a recursive
+# publish scoped to a single --filter) rather than one bulk `pnpm -r publish`
+# over the whole set, so the idempotent/tolerant wrapper applies per package and
+# a mid-list conflict cannot abort the rest.
 #
 # Usage:
 #   scripts/publish-npm-packages.sh <all-provenance|mac-local>
@@ -209,10 +210,12 @@ publish_nonplatform_packages() {
     if should_skip_publish "$name" "$version"; then
       continue
     fi
-    # --fail-if-no-match: a derived name that matches no workspace package is a
-    # loud failure, never a silent no-op.
+    # `pnpm -r --filter "$name"` scopes a recursive publish to exactly this one
+    # package (verified: packs only "$name", and -r keeps the filter semantics
+    # explicit and version-robust). --fail-if-no-match makes a name that matches
+    # no workspace package a loud failure, never a silent no-op.
     _run_and_classify "$name" "$version" \
-      pnpm --filter "$name" --fail-if-no-match publish \
+      pnpm -r --filter "$name" --fail-if-no-match publish \
       --tag "$DIST_TAG" --no-git-checks --access public --provenance
   done
 }

--- a/scripts/publish-npm-packages.sh
+++ b/scripts/publish-npm-packages.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+#
+# publish-npm-packages.sh — publish every zfb workspace package to npm,
+# idempotently and tolerant of npm's "double-PUT" race.
+#
+# WHY THIS EXISTS (incident: v0.1.0-next.42 partial publish)
+# ---------------------------------------------------------------------------
+# npm's publish PUT is not transactional from the client's point of view. A
+# network blip can lose the success ACK *after* the registry has already stored
+# the version; the client then retries and the registry answers:
+#
+#     403 ... You cannot publish over the previously published versions: X.Y.Z
+#
+# Under `set -e` that 403 aborted the whole release job mid-way, so v0.1.0-next.42
+# published 7 of 9 packages and left @takazudo/zfb-runtime + create-zfb behind —
+# and the job could NOT be safely re-run, because every already-published package
+# 403s again on a retry. This script removes both failure modes by making each
+# package's publish:
+#
+#   1. IDEMPOTENT       — skip if <name>@<version> is already on the registry, so
+#                         a partial publish can simply be re-run to completion.
+#   2. CONFLICT-TOLERANT — treat the SPECIFIC "cannot publish over the previously
+#                         published versions" / EPUBLISHCONFLICT error (and a
+#                         post-failure registry recheck) as a SKIP, while still
+#                         FAILING the job on any other publish error (auth,
+#                         validation, hard network failure, ...).
+#
+# Platform packages (zfb-darwin-*, zfb-linux-*, zfb-win32-*) are published with
+# `npm publish` (NOT pnpm): pnpm pack normalises file modes to 0644, stripping
+# the 0755 exec bit off the `zfb` binary; npm preserves it (issue #447 / #441).
+# The `( cd "$dir" && npm publish ... )` invocation below is kept byte-identical
+# to the original for that reason.
+#
+# Non-platform packages (@takazudo/zfb, @takazudo/zfb-runtime,
+# @takazudo/zfb-adapter-cloudflare, create-zfb) are published with
+# `pnpm --filter <name> publish` so pnpm rewrites their `workspace:*` deps to
+# concrete versions at pack time. Published one-at-a-time (not a bulk
+# `pnpm -r publish`) so the idempotent/tolerant wrapper applies per package and a
+# mid-list conflict cannot abort the rest.
+#
+# Usage:
+#   scripts/publish-npm-packages.sh <all-provenance|mac-local>
+#     all-provenance — every package (incl. zfb-darwin-x64) was built in CI, so
+#                      all carry OIDC-attested --provenance.
+#     mac-local      — zfb-darwin-x64 was built locally (outside this GHA job) and
+#                      cannot carry OIDC provenance, so it is published WITHOUT
+#                      --provenance; every other package keeps --provenance.
+#
+# Required env:
+#   DIST_TAG          npm dist-tag to publish under (next | latest).
+#   NODE_AUTH_TOKEN   npm auth token (set by the calling workflow step's env).
+# Optional env:
+#   ALSO_LATEST       "1" → after publishing, also advance the `latest` dist-tag
+#                     (prerelease dual-tag policy, see #481). Delegated to
+#                     scripts/advance-latest-dist-tag.sh, which has its own retry.
+#   PUBLISH_RECHECK_ATTEMPTS / PUBLISH_RECHECK_DELAY
+#                     post-failure registry-recheck tuning (defaults 3 / 2s);
+#                     the test suite sets DELAY=0 to stay fast.
+#
+# Must be run from the repository root (it `cd`s into packages/* and calls
+# scripts/advance-latest-dist-tag.sh by relative path).
+set -euo pipefail
+
+# Platform packages — npm publish, order irrelevant (no workspace:* deps).
+PLATFORM_DIRS=(
+  packages/zfb-darwin-arm64
+  packages/zfb-darwin-x64
+  packages/zfb-linux-arm64-gnu
+  packages/zfb-linux-x64-gnu
+  packages/zfb-win32-x64-msvc
+)
+
+# Non-platform packages — pnpm publish (workspace:* rewrite). Listed in
+# topological order: @takazudo/zfb is published before create-zfb (which depends
+# on it). npm does not validate dependency existence at publish time, so order
+# is not required for success, but matching pnpm -r's topological default keeps
+# the published set self-consistent at every intermediate moment.
+NONPLATFORM_DIRS=(
+  packages/zfb
+  packages/zfb-runtime
+  packages/zfb-adapter-cloudflare
+  packages/create-zfb
+)
+
+# Read a field from a package's manifest (name | version). Deriving the package
+# name from the manifest — rather than hard-coding it in a --filter string —
+# guarantees the pnpm filter always matches an existing package.
+manifest_field() {
+  node -p "require('./$1/package.json').$2"
+}
+
+# True when the npm error text is specifically "this exact version already
+# exists". Matching the phrase (NOT a bare E403) avoids swallowing a genuine
+# permissions 403 ("You do not have permission to publish ...").
+is_publish_conflict() {
+  printf '%s' "$1" | grep -qiE 'cannot publish over the previously published versions|EPUBLISHCONFLICT'
+}
+
+# Single-shot registry lookup: echoes the version if <name>@<version> is on the
+# registry, nothing otherwise. `|| true` so a not-found (npm view exits non-zero)
+# does not trip `set -e`.
+registry_version() {
+  npm view "$1@$2" version 2>/dev/null || true
+}
+
+# Post-failure recovery probe (with brief backoff for registry propagation lag):
+# returns 0 if <name>@<version> is on the registry within the recheck budget.
+registry_has_version() {
+  local name="$1" version="$2" attempt delay
+  delay="${PUBLISH_RECHECK_DELAY:-2}"
+  for attempt in $(seq 1 "${PUBLISH_RECHECK_ATTEMPTS:-3}"); do
+    if [[ "$(registry_version "$name" "$version")" == "$version" ]]; then
+      return 0
+    fi
+    if [[ "$delay" -gt 0 ]]; then
+      sleep "$delay"
+    fi
+  done
+  return 1
+}
+
+# True (and logs) when <name>@<version> is already on the registry — the caller
+# then skips the publish entirely (idempotent re-run path).
+should_skip_publish() {
+  local name="$1" version="$2"
+  if [[ -n "$(registry_version "$name" "$version")" ]]; then
+    echo "✓ ${name}@${version} already on the registry — skipping publish."
+    return 0
+  fi
+  return 1
+}
+
+# Decide what a publish exit status means.
+#   status 0                    → success.
+#   conflict error text         → already published (double-PUT race) → tolerate.
+#   non-conflict error, but the version IS now on the registry
+#                               → lost-ACK race (server committed, client died) → tolerate.
+#   any other error             → real failure → return the status (fail the job).
+classify_publish_result() {
+  local name="$1" version="$2" status="$3" outfile="$4"
+  if [[ "$status" -eq 0 ]]; then
+    echo "✓ published ${name}@${version}."
+    return 0
+  fi
+  if is_publish_conflict "$(cat "$outfile")"; then
+    echo "✓ ${name}@${version} already published (publish-conflict / double-PUT race) — tolerating as skip."
+    return 0
+  fi
+  if registry_has_version "$name" "$version"; then
+    echo "⚠ publish of ${name}@${version} exited ${status} without a conflict message, but the version IS now on the registry (lost-ACK race) — tolerating as skip."
+    return 0
+  fi
+  echo "::error::publish failed for ${name}@${version} (exit ${status}); not a publish-conflict and the version is not on the registry — failing the release."
+  return "$status"
+}
+
+# Run a publish command (passed as argv), capturing combined output for
+# classification. The pipeline MUST run under `set +e`: a non-zero publish would
+# otherwise abort the job via pipefail before we capture ${PIPESTATUS[0]}.
+# PIPESTATUS is read immediately after the pipeline, before any other command
+# resets it.
+_run_and_classify() {
+  local name="$1" version="$2"; shift 2
+  local tmp status rc
+  tmp="$(mktemp)"
+  echo "→ publishing ${name}@${version} (dist-tag ${DIST_TAG}) ..."
+  set +e
+  "$@" 2>&1 | tee "$tmp"
+  status=${PIPESTATUS[0]}
+  set -e
+  classify_publish_result "$name" "$version" "$status" "$tmp"
+  rc=$?
+  rm -f "$tmp"
+  return "$rc"
+}
+
+# Platform publish runner — kept byte-identical to the original invocation:
+# `npm publish` (not pnpm) run inside the package dir, so the 0755 exec bit on
+# the binary survives (issue #447 / #441). $2 ("" | "--provenance") is
+# intentionally word-split.
+# shellcheck disable=SC2086
+_npm_publish_dir() {
+  ( cd "$1" && npm publish --tag "$DIST_TAG" --access public $2 )
+}
+
+publish_platform_packages() {
+  local mode="$1" dir name version prov
+  for dir in "${PLATFORM_DIRS[@]}"; do
+    name="$(manifest_field "$dir" name)"
+    version="$(manifest_field "$dir" version)"
+    if should_skip_publish "$name" "$version"; then
+      continue
+    fi
+    prov="--provenance"
+    if [[ "$mode" == "mac-local" && "$dir" == "packages/zfb-darwin-x64" ]]; then
+      # Locally-built macOS-x64 binary: no GHA OIDC context → omit --provenance.
+      prov=""
+      echo "→ ${name}: locally-built macOS-x64 binary (no OIDC) — publishing WITHOUT --provenance."
+    fi
+    _run_and_classify "$name" "$version" _npm_publish_dir "$dir" "$prov"
+  done
+}
+
+publish_nonplatform_packages() {
+  local dir name version
+  for dir in "${NONPLATFORM_DIRS[@]}"; do
+    name="$(manifest_field "$dir" name)"
+    version="$(manifest_field "$dir" version)"
+    if should_skip_publish "$name" "$version"; then
+      continue
+    fi
+    # --fail-if-no-match: a derived name that matches no workspace package is a
+    # loud failure, never a silent no-op.
+    _run_and_classify "$name" "$version" \
+      pnpm --filter "$name" --fail-if-no-match publish \
+      --tag "$DIST_TAG" --no-git-checks --access public --provenance
+  done
+}
+
+# Prerelease dual-tag (#481): advance `latest` alongside `next` while still in
+# the prerelease phase. Runs only after every package is published (idempotently),
+# so a partial publish never clobbers `latest`. advance-latest-dist-tag.sh has its
+# own retry/backoff.
+maybe_advance_latest() {
+  if [[ "${ALSO_LATEST:-}" != "1" ]]; then
+    return 0
+  fi
+  local zfb_semver
+  zfb_semver="$(manifest_field packages/zfb version)"
+  echo "== Prerelease dual-tag: advancing 'latest' to ${zfb_semver} =="
+  bash scripts/advance-latest-dist-tag.sh "$zfb_semver"
+}
+
+main() {
+  local mode="${1:-}"
+  case "$mode" in
+    all-provenance | mac-local) ;;
+    *)
+      echo "::error::usage: $0 <all-provenance|mac-local> (got: '${mode}')"
+      return 2
+      ;;
+  esac
+  : "${DIST_TAG:?DIST_TAG must be set (the npm dist-tag, e.g. next|latest)}"
+  if [[ ! -f packages/zfb/package.json ]]; then
+    echo "::error::must be run from the repo root (packages/zfb/package.json not found in $(pwd))"
+    return 2
+  fi
+
+  echo "== Publishing all workspace packages (mode=${mode}, dist-tag=${DIST_TAG}) =="
+  publish_platform_packages "$mode"
+  publish_nonplatform_packages
+  maybe_advance_latest
+  echo "== Publish complete: every package is on the registry (newly published or already present). =="
+}
+
+# Sourced by the test suite (tests/unit/publish-npm-packages.sh) to exercise the
+# functions in isolation — only run main() when executed directly.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
+fi

--- a/tests/unit/publish-npm-packages.sh
+++ b/tests/unit/publish-npm-packages.sh
@@ -1,0 +1,244 @@
+#!/bin/sh
+# shellcheck shell=sh
+#
+# tests/unit/publish-npm-packages.sh — offline unit + integration tests for
+# scripts/publish-npm-packages.sh (the idempotent, conflict-tolerant npm publish
+# orchestrator added after the v0.1.0-next.42 partial-publish incident).
+#
+# Runs entirely offline. `scripts/publish-npm-packages.sh` is bash; this harness
+# is POSIX sh (health.yml + run-b4push.sh invoke `sh tests/unit/*.sh`), so the
+# bash functions are exercised by sourcing the script inside `bash -c` and the
+# whole-script integration runs use mock `npm`/`pnpm` on PATH. `node` is the only
+# real tool consulted (reads local package.json — no network).
+#
+# Requires: sh, bash, node, mktemp, grep.
+#
+# Run:
+#   sh tests/unit/publish-npm-packages.sh
+
+set -eu
+
+# Run from the repo root regardless of the caller's cwd — the script under test
+# cd's into packages/* and reads packages/zfb/package.json.
+SELF_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH= cd -- "$SELF_DIR/../.." && pwd)
+cd "$REPO_ROOT"
+
+SCRIPT="scripts/publish-npm-packages.sh"
+
+PASS=0
+FAIL=0
+pass() { printf 'PASS: %s\n' "$1"; PASS=$((PASS + 1)); }
+fail() { printf 'FAIL: %s\n' "$1"; FAIL=$((FAIL + 1)); }
+
+if [ ! -f "$SCRIPT" ]; then
+  fail "script not found: $SCRIPT"
+  printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+  exit 1
+fi
+
+# assert_exit <desc> <expected-exit> <bash-snippet>
+# Sources the script (defines its functions; main() is NOT run thanks to the
+# BASH_SOURCE guard), neutralises set -e, then runs the snippet. The snippet's
+# exit status is compared to <expected-exit>. Output is suppressed.
+assert_exit() {
+  AE_DESC="$1"
+  AE_WANT="$2"
+  AE_SNIPPET="$3"
+  # `if` so a non-zero exit (an expected outcome under test) does not trip the
+  # harness's own `set -e`.
+  if bash -c ". ./$SCRIPT; set +e; ${AE_SNIPPET}" >/dev/null 2>&1; then
+    AE_GOT=0
+  else
+    AE_GOT=$?
+  fi
+  if [ "$AE_GOT" -eq "$AE_WANT" ]; then
+    pass "$AE_DESC"
+  else
+    fail "$AE_DESC (want exit $AE_WANT, got $AE_GOT)"
+  fi
+}
+
+# ── is_publish_conflict — matches the SPECIFIC conflict phrase only ────────────
+
+assert_exit 'is_publish_conflict: "cannot publish over the previously published versions" → match' 0 \
+  'is_publish_conflict "npm error code E403 You cannot publish over the previously published versions: 1.2.3"'
+
+assert_exit 'is_publish_conflict: EPUBLISHCONFLICT → match' 0 \
+  'is_publish_conflict "npm error code EPUBLISHCONFLICT"'
+
+assert_exit 'is_publish_conflict: permissions 403 → NO match (not swallowed)' 1 \
+  'is_publish_conflict "npm error 403 Forbidden You do not have permission to publish \"pkg\""'
+
+assert_exit 'is_publish_conflict: generic network error → NO match' 1 \
+  'is_publish_conflict "npm error network request to https://registry.npmjs.org failed ETIMEDOUT"'
+
+assert_exit 'is_publish_conflict: empty → NO match' 1 \
+  'is_publish_conflict ""'
+
+# ── should_skip_publish — skip iff already on the registry ─────────────────────
+
+assert_exit 'should_skip_publish: version present → skip (0)' 0 \
+  'npm() { echo "1.2.3"; }; should_skip_publish foo 1.2.3'
+
+assert_exit 'should_skip_publish: version absent → do not skip (1)' 1 \
+  'npm() { return 1; }; should_skip_publish foo 1.2.3'
+
+# ── classify_publish_result ───────────────────────────────────────────────────
+
+assert_exit 'classify: exit 0 → success (0)' 0 \
+  'classify_publish_result foo 1.2.3 0 /dev/null'
+
+assert_exit 'classify: conflict text → tolerate (0)' 0 \
+  'f=$(mktemp); printf "%s" "remote: You cannot publish over the previously published versions: 1.2.3" >"$f"; classify_publish_result foo 1.2.3 1 "$f"; r=$?; rm -f "$f"; exit $r'
+
+assert_exit 'classify: non-conflict error BUT version landed (lost-ACK) → tolerate (0)' 0 \
+  'f=$(mktemp); printf "%s" "socket hang up ECONNRESET" >"$f"; npm() { echo "1.2.3"; }; PUBLISH_RECHECK_DELAY=0 classify_publish_result foo 1.2.3 1 "$f"; r=$?; rm -f "$f"; exit $r'
+
+assert_exit 'classify: real error AND version NOT on registry → fail (1)' 1 \
+  'f=$(mktemp); printf "%s" "403 You do not have permission to publish" >"$f"; npm() { return 1; }; PUBLISH_RECHECK_DELAY=0 PUBLISH_RECHECK_ATTEMPTS=2 classify_publish_result foo 1.2.3 1 "$f"; r=$?; rm -f "$f"; exit $r'
+
+# ── Integration: whole-script runs with mock npm/pnpm on PATH ─────────────────
+
+# Build a throwaway PATH dir holding mock `npm` and `pnpm` executables.
+MOCK_BIN=$(mktemp -d)
+trap 'rm -rf "$MOCK_BIN" "${PUB_LOG:-}" "${DISTTAG_LOG:-}"' EXIT
+
+cat >"$MOCK_BIN/npm" <<'MOCK_NPM'
+#!/bin/sh
+# Mock npm: `view <name@version> version`, `publish` (cwd package), `dist-tag add`.
+case "$1" in
+  view)
+    spec="$2"
+    for e in $MOCK_EXISTING; do
+      if [ "$e" = "$spec" ]; then
+        printf '%s\n' "${spec##*@}"   # version part (after the last @)
+        exit 0
+      fi
+    done
+    exit 1   # not found — npm view exits non-zero
+    ;;
+  publish)
+    name=$(node -p "require('./package.json').name")
+    version=$(node -p "require('./package.json').version")
+    printf '%s@%s\n' "$name" "$version" >>"$MOCK_PUBLISH_LOG"
+    exit 0
+    ;;
+  dist-tag)
+    printf 'dist-tag %s\n' "$*" >>"${MOCK_DISTTAG_LOG:-/dev/null}"
+    exit 0
+    ;;
+  *) exit 0 ;;
+esac
+MOCK_NPM
+
+cat >"$MOCK_BIN/pnpm" <<'MOCK_PNPM'
+#!/bin/sh
+# Mock pnpm: record the --filter target of a `publish` invocation.
+filter=""
+is_publish=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --filter) filter="$2"; shift ;;
+    publish) is_publish=1 ;;
+  esac
+  shift
+done
+if [ "$is_publish" -eq 1 ]; then
+  printf '%s\n' "$filter" >>"$MOCK_PUBLISH_LOG"
+fi
+exit 0
+MOCK_PNPM
+
+chmod +x "$MOCK_BIN/npm" "$MOCK_BIN/pnpm"
+
+V=$(node -p "require('./packages/zfb/package.json').version")
+ALL_SPECS="@takazudo/zfb-darwin-arm64@$V @takazudo/zfb-darwin-x64@$V @takazudo/zfb-linux-arm64-gnu@$V @takazudo/zfb-linux-x64-gnu@$V @takazudo/zfb-win32-x64-msvc@$V @takazudo/zfb@$V @takazudo/zfb-runtime@$V @takazudo/zfb-adapter-cloudflare@$V create-zfb@$V"
+
+# log_has <name> — true iff the publish log has a line for exactly <name>
+# (matching <name> at line start followed by '@' or end-of-line, so
+# "@takazudo/zfb" does not match "@takazudo/zfb-runtime").
+log_has() {
+  grep -Eq "^$1(@|$)" "$PUB_LOG"
+}
+
+# Case 1 — idempotent re-run: 7 packages already published, only
+# @takazudo/zfb-runtime + create-zfb missing. Expect exit 0 and ONLY the two
+# missing ones published.
+PUB_LOG=$(mktemp)
+: >"$PUB_LOG"
+if PATH="$MOCK_BIN:$PATH" \
+   DIST_TAG=next \
+   MOCK_PUBLISH_LOG="$PUB_LOG" \
+   MOCK_EXISTING="@takazudo/zfb-darwin-arm64@$V @takazudo/zfb-darwin-x64@$V @takazudo/zfb-linux-arm64-gnu@$V @takazudo/zfb-linux-x64-gnu@$V @takazudo/zfb-win32-x64-msvc@$V @takazudo/zfb@$V @takazudo/zfb-adapter-cloudflare@$V" \
+   bash "$SCRIPT" all-provenance >/dev/null 2>&1; then
+  if log_has "@takazudo/zfb-runtime" && log_has "create-zfb" \
+     && ! log_has "@takazudo/zfb" && ! log_has "@takazudo/zfb-adapter-cloudflare" \
+     && ! log_has "@takazudo/zfb-darwin-x64"; then
+    pass "integration: idempotent re-run publishes ONLY the 2 missing packages"
+  else
+    fail "integration: idempotent re-run published the wrong set: $(tr '\n' ' ' <"$PUB_LOG")"
+  fi
+else
+  fail "integration: idempotent re-run exited non-zero"
+fi
+
+# Case 2 — fresh publish: nothing on the registry → all 9 packages published
+# (5 platform via npm publish, 4 non-platform via pnpm publish).
+PUB_LOG=$(mktemp)
+: >"$PUB_LOG"
+if PATH="$MOCK_BIN:$PATH" \
+   DIST_TAG=next \
+   MOCK_PUBLISH_LOG="$PUB_LOG" \
+   MOCK_EXISTING="" \
+   bash "$SCRIPT" all-provenance >/dev/null 2>&1; then
+  COUNT=$(grep -c . "$PUB_LOG" || true)
+  if [ "$COUNT" -eq 9 ] && log_has "@takazudo/zfb-darwin-x64" && log_has "create-zfb" && log_has "@takazudo/zfb-runtime"; then
+    pass "integration: fresh registry publishes all 9 packages"
+  else
+    fail "integration: fresh publish count=$COUNT (want 9): $(tr '\n' ' ' <"$PUB_LOG")"
+  fi
+else
+  fail "integration: fresh publish exited non-zero"
+fi
+
+# Case 3 — dual-tag wiring: everything already published (all skipped) AND
+# ALSO_LATEST=1 → the script still reaches maybe_advance_latest, which invokes
+# scripts/advance-latest-dist-tag.sh (→ mock `npm dist-tag add`). Expect exit 0
+# and a non-empty dist-tag log.
+PUB_LOG=$(mktemp)
+DISTTAG_LOG=$(mktemp)
+: >"$PUB_LOG"
+: >"$DISTTAG_LOG"
+if PATH="$MOCK_BIN:$PATH" \
+   DIST_TAG=next \
+   ALSO_LATEST=1 \
+   MOCK_PUBLISH_LOG="$PUB_LOG" \
+   MOCK_DISTTAG_LOG="$DISTTAG_LOG" \
+   MOCK_EXISTING="$ALL_SPECS" \
+   bash "$SCRIPT" all-provenance >/dev/null 2>&1; then
+  if [ ! -s "$PUB_LOG" ] && [ -s "$DISTTAG_LOG" ]; then
+    pass "integration: ALSO_LATEST=1 advances 'latest' even when all publishes are skipped"
+  else
+    fail "integration: dual-tag wiring (publog empty? $([ -s "$PUB_LOG" ] && echo no || echo yes); disttag ran? $([ -s "$DISTTAG_LOG" ] && echo yes || echo no))"
+  fi
+else
+  fail "integration: dual-tag run exited non-zero"
+fi
+
+# Case 4 — bad mode argument is rejected (exit 2).
+if PATH="$MOCK_BIN:$PATH" DIST_TAG=next bash "$SCRIPT" bogus-mode >/dev/null 2>&1; then
+  fail "integration: bad mode argument should have failed"
+else
+  RC=$?
+  if [ "$RC" -eq 2 ]; then
+    pass "integration: bad mode argument rejected (exit 2)"
+  else
+    fail "integration: bad mode argument exit $RC (want 2)"
+  fi
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

The `release.yml` npm `publish` job was non-idempotent and not tolerant of npm's double-PUT race. In the **v0.1.0-next.42** release it aborted mid-way with `E403 ... You cannot publish over the previously published versions: 0.1.0-next.42` on `@takazudo/zfb-adapter-cloudflare`: that package's first PUT had landed server-side, a network blip lost the ack, the client retried, got a 403, and the job died under `set -e`. Result — **7/9 packages published**, `@takazudo/zfb-runtime` + `create-zfb` left unpublished, and the job was **not safely re-runnable** (a re-run 403s on the 7 already-published packages, starting with `zfb-darwin-x64`).

This PR makes publishing **idempotent** and **conflict-tolerant** so a partial publish can simply be re-run to completion, and a transient network blip can no longer abort the release.

## Changes

- **New `scripts/publish-npm-packages.sh`** — one shared, idempotent, conflict-tolerant publish orchestrator invoked by both publish steps:
  - `should_skip_publish` — skips any `<name>@<version>` already on the registry (idempotent re-run).
  - `classify_publish_result` — treats the **specific** "cannot publish over the previously published versions" / `EPUBLISHCONFLICT` error as a skip, **plus** a post-failure `npm view` recheck (with backoff) for the lost-ACK case where the server committed but the client died without a conflict message. Any **other** error (auth, validation, hard network failure) still fails the job — a bare `E403`/permissions error is **not** swallowed.
  - Platform packages keep the **byte-identical** `( cd "$dir" && npm publish ... )` invocation (npm, in-dir, to preserve the binary's 0755 exec bit — #447/#441), with `--provenance` omitted only for the locally-built `zfb-darwin-x64` in `mac-local` mode.
  - Non-platform packages move from a bulk `pnpm -r publish` to a per-package `pnpm -r --filter <name> --fail-if-no-match publish` loop (topological order) so a mid-list conflict can't abort the rest; `workspace:*` rewrite + `prepublishOnly` preserved.
  - The prerelease dual-tag `latest` advancement (`advance-latest-dist-tag.sh`) moved into the script (behavior unchanged).
- **`release.yml`** — both near-identical "Publish to npm" steps collapse to a single `bash scripts/publish-npm-packages.sh <all-provenance|mac-local>` call (DIST_TAG / ALSO_LATEST inherited from `$GITHUB_ENV`).
- **`tests/unit/publish-npm-packages.sh`** — offline unit + integration tests (auto-discovered by `health.yml` + `run-b4push.sh`): the conflict/skip/classify logic, plus whole-script runs with mocked `npm`/`pnpm` proving idempotent re-run (only the 2 missing publish), fresh all-9 publish, dual-tag wiring, and bad-mode rejection. **15 passed, 0 failed.**

## Test Plan

- `sh tests/unit/publish-npm-packages.sh` — 15/15 pass.
- `bash -n` on the new script + test; YAML parse of `release.yml` (both publish steps well-formed, `env.NODE_AUTH_TOKEN` intact).
- pnpm `--dry-run` probes confirmed `pnpm -r --filter <name> publish` packs exactly the one selected package in pnpm 11.3.0.
- CI green (12/12), including `health` (runs the new test) and `actionlint`.
- **Not tested locally** (declared blind spots): shellcheck/actionlint have no local binary (no docker) — actionlint runs as a required CI check; the real-registry double-PUT race itself is not reproducible in CI (we test the tolerance logic, not the race); the mock `pnpm` can't catch a future removal of `-r` (documented in a code comment instead).