### PR TITLE
docs(zfb-server): fix stale ServerMode::Embed doc comment

### DIFF
--- a/crates/zfb-server/src/embed.rs
+++ b/crates/zfb-server/src/embed.rs
@@ -98,8 +98,9 @@ pub enum ServerMode {
     /// migration off its bespoke router).
     Preview,
     /// Embed mode. Same shape as `Preview` but signals "running inside
-    /// a host application" — reserved for follow-up wiring of
-    /// per-request Tauri context, SSR handlers, etc.
+    /// a host application". Per-request context and SSR handlers are
+    /// wired via [`ServerBuilder::with_request_extension`] and
+    /// [`ServerBuilder::with_ssr_handler`].
     Embed,
 }
 


### PR DESCRIPTION
Auto-fix (`-fix`) for the `agent-found` finding raised during the embed-lib-enh (#1036/#1037/#1038) workflow.

`ServerMode::Embed`'s doc comment said per-request context and SSR handlers were "reserved for follow-up wiring", but `ServerBuilder::with_request_extension` and `with_ssr_handler` already implement them. Comment corrected to reference the wired methods.

Doc-comment-only change.

Closes #1041