### PR TITLE
docs(embed): canonical .json config + ZFB_ESBUILD_BIN escape hatch for .ts (#1040)

### DIFF
--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -6710,6 +6710,9 @@ mod tests {
         let msg = format!("{err}");
 
         assert!(msg.contains("ZFB_ESBUILD_BIN"), "msg: {msg}");
+        // This substring comes from the interpolated slot path
+        // (`slot.display()` = the `DEFAULT_ESBUILD_SLOT`-shaped path), not
+        // the error prose — the prose no longer names the workspace slot.
         assert!(msg.contains("crates/zfb/binaries/esbuild"), "msg: {msg}");
         assert!(msg.contains("zfb.config.json"), "msg: {msg}");
     }

--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -5012,10 +5012,11 @@ where
     if !slot.exists() {
         return Err(anyhow!(
             "bundler: esbuild binary not found at default slot {}. \
-             Either set ZFB_ESBUILD_BIN to a usable esbuild CLI, or stage \
-             the binary at the slot path. The release-engineering epic \
-             that downloads it has not landed yet (see \
-             crates/zfb/binaries/esbuild/README.md).",
+             Evaluating a `zfb.config.ts` needs an esbuild CLI binary: set \
+             ZFB_ESBUILD_BIN to one (or, in a workspace checkout, stage the \
+             binary at that slot path). If you are embedding zfb-server as a \
+             library, prefer shipping a `zfb.config.json` instead — the JSON \
+             config path needs no esbuild at all.",
             slot.display(),
         ));
     }
@@ -6687,8 +6688,10 @@ mod tests {
     fn missing_esbuild_binary_returns_actionable_error() {
         // When neither an explicit override nor the env var nor the
         // default slot is present, the bundler must error with a
-        // pointer to BOTH escape hatches (`ZFB_ESBUILD_BIN` and the
-        // release-tarball slot). This keeps operators unstuck.
+        // pointer to every escape hatch: `ZFB_ESBUILD_BIN`, the
+        // release-tarball slot, AND (for out-of-repo embedders) the
+        // `zfb.config.json` path that needs no esbuild (#1040). This
+        // keeps both workspace operators and library embedders unstuck.
         //
         // Drive the env path via an injected getter and the slot path
         // via `slot_override` so the test does not mutate `std::env`
@@ -6708,6 +6711,7 @@ mod tests {
 
         assert!(msg.contains("ZFB_ESBUILD_BIN"), "msg: {msg}");
         assert!(msg.contains("crates/zfb/binaries/esbuild"), "msg: {msg}");
+        assert!(msg.contains("zfb.config.json"), "msg: {msg}");
     }
 
     #[test]

--- a/crates/zfb-server/src/embed.rs
+++ b/crates/zfb-server/src/embed.rs
@@ -32,6 +32,16 @@
 //! escape hatch and is likewise budget-excluded by design (§3.2:
 //! "optional, not counted toward the ≤ 10 method budget").
 //!
+//! NOTE (issue #1040): a `ServerBuilder::esbuild_binary()` override is
+//! intentionally NOT provided. Evaluating a `.ts` config on a default
+//! (V8) build needs an esbuild binary, but `ZFB_ESBUILD_BIN` already
+//! overrides esbuild discovery (resolution tier 2 in `zfb-build`) and a
+//! `zfb.config.json` embed config needs no esbuild at all. Adding a
+//! builder method would spend the single remaining budget slot
+//! re-exposing an env var that already works. Add one only if a real
+//! out-of-repo embedder must use `.ts` AND genuinely cannot set the
+//! env var.
+//!
 //! ## Threading: `serve_in_thread`
 //!
 //! [`serve_in_thread`](Server::serve_in_thread) mirrors the pattern in

--- a/docs/src/content/docs/guides/embed-as-library.mdx
+++ b/docs/src/content/docs/guides/embed-as-library.mdx
@@ -57,6 +57,21 @@ Key choices the builder commits to:
 
 The async terminal `Server::serve(self, shutdown).await` is also available for hosts that already drive their own tokio runtime.
 
+### Config format: prefer `zfb.config.json`
+
+`config_path` accepts both `zfb.config.json` and `zfb.config.ts`. For an embedded server, **`zfb.config.json` is the recommended format** — it is read directly with no build step (every example in this guide uses it).
+
+`zfb.config.ts` is also supported, but evaluating a TypeScript config first bundles it with **esbuild**, and an embedded `zfb-server` does not ship its own esbuild binary (unlike the `zfb` CLI). So an out-of-repo embedder pointing `config_path` at a `.ts` file must either:
+
+- ship or generate a `zfb.config.json` instead — needs no esbuild at all, the simplest path; or
+- set the `ZFB_ESBUILD_BIN` environment variable to a usable esbuild CLI binary before calling `build()`.
+
+<Note>
+
+If a `.ts` config fails with an "esbuild binary not found" error, this is the cause — switch to `zfb.config.json` or set `ZFB_ESBUILD_BIN`.
+
+</Note>
+
 ## Request-extension injection
 
 `ServerBuilder::with_request_extension::<T>(value)` registers a per-process value to be cloned into every incoming request's `http::Extensions` map. The handler reads it via `req.extensions().get::<T>()`:


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1040

---

## Summary
Resolve #1040 with the agreed **documentation-only** approach — no new public API, no esbuild vendoring into `zfb-server`. Decision reached via a design-panel + adversarial analysis: the failing scenario (out-of-repo embedder shipping a `.ts` config on a default V8 build with no `ZFB_ESBUILD_BIN`) is a rare conjunction, and the `.json` embed path already sidesteps esbuild entirely — so the fix is to steer embedders to `.json` and document the env-var escape hatch, not to build machinery.

## Changes
- **`docs/.../embed-as-library.mdx`** — new "Config format: prefer `zfb.config.json`" subsection: `.json` is the recommended embed format (needs no esbuild); `.ts` on a default build needs an esbuild binary, so out-of-repo embedders either ship `.json` or set `ZFB_ESBUILD_BIN`. Includes a `<Note>` mapping the "esbuild binary not found" error to its cause.
- **`crates/zfb-build/src/bundler.rs`** — rewrite the esbuild-not-found error so it's actionable for **both** workspace devs and library embedders (ship `zfb.config.json` / set `ZFB_ESBUILD_BIN`) instead of pointing at an internal workspace README external embedders can't see. Extend the existing test to assert the `zfb.config.json` hint.
- **`crates/zfb-server/src/embed.rs`** — record the deliberate decision **not** to add `ServerBuilder::esbuild_binary()` next to the method-budget note (`ZFB_ESBUILD_BIN` already overrides discovery at resolution tier 2; a builder method would spend the last budget slot re-exposing it).

## Test Plan
- `cargo check -p zfb-build --no-default-features` (V8-free) — clean.
- `cargo test -p zfb-build --lib --no-default-features missing_esbuild_binary_returns_actionable_error` — passes (asserts the new `zfb.config.json` hint + existing `ZFB_ESBUILD_BIN`/slot hints).
- Full V8 `health` gate validated by CI.
- Reviewed by 2 Opus reviewers (codex out of credits): all factual claims verified against the code; clean.

Closes #1040