### PR TITLE
[CF Local Dev Recipe Doc] Land the local Cloudflare dev recipe in the SSR+Cloudflare guide (EN + JA)

### DIFF
--- a/docs/src/content/docs-ja/guides/ssr-and-cloudflare-bindings.mdx
+++ b/docs/src/content/docs-ja/guides/ssr-and-cloudflare-bindings.mdx
@@ -109,7 +109,7 @@ pnpm add -D @takazudo/zfb-adapter-cloudflare
 compatibility_flags = ["nodejs_compat"]
 ```
 
-このフラグがないと、Worker は `node:async_hooks` を欠落モジュールとして示すエラーとともに起動に失敗します。より深い仕組みについては [SSR on a Worker (adapter mode)](../concepts/ssr-on-a-worker.mdx#the-getcloudflarecontext-trick) を参照してください。
+このフラグがないと、Worker は `node:async_hooks` を欠落モジュールとして示すエラーとともに起動に失敗します。より深い仕組みについては [SSR on a Worker (adapter mode)](../concepts/ssr-on-a-worker.mdx#getcloudflarecontext-のトリック) を参照してください。
 
 </Warning>
 
@@ -228,7 +228,122 @@ database_id = "<preview-uuid>"
 
 ## ローカル開発
 
-`wrangler pages dev dist/` は、ビルドされた `_worker.js` を**ローカル**の D1 データベース（`.wrangler/` 下の SQLite ファイル）とともにローカルで動かします。最初の実行前に、`wrangler d1 migrations apply webshop --local` でマイグレーションを適用してください。
+<Tip title="動作するエンドツーエンドの実例">
+
+[`zfb-example-webshop`](https://github.com/Takazudo/zfb-example-webshop)
+のデモは、まさにこのレシピを配線して動かしたものです。その `dev:cf` の
+package.json スクリプトと README の「ローカル開発」セクションは、以下で説明する
+2 プロセスのループそのものです。スニペットを断片的にコピーするより全体が組み上がった
+状態を見たい場合は、これをクローンしてください。（このデモはクライアント JS を一切
+出力しませんが、それはショップ自身の設計上の選択であって zfb の制限ではありません。
+ブラウザ JS が必要な場合、zfb は `clientScript()` 経由の `.client.*` クライアント
+スクリプトをサポートしています。）
+
+</Tip>
+
+アプリをローカルで動かす方法は 2 つあり、それぞれ異なる問いに答えます:
+
+- **`zfb dev`** — 高速なページ作成ループ。`prerender = false` のルートの SSR
+  **レンダリングコード**を埋め込みの V8 アイソレートを通して動かします（上記の
+  [`prerender = false` の dev と本番の同等性](#prerender-false-の-dev-と本番の同等性)
+  を参照）。ただし **Worker バインディングは一切公開しません**。`zfb dev` 下の SSR
+  ルートで `getCloudflareContext<Env>()` を呼び出しても `env` は得られないため、
+  `env.DB`（または他のバインディング）を読むルートはここでは動作しません。
+  バインディングに**触れない**ルートのレイアウト、スタイリング、ルーティングの反復作業に
+  使ってください。
+- **`wrangler pages dev dist/`** — バインディングをリアルに再現するループ。ビルドされた
+  `_worker.js` を**ローカル**の D1 データベース（`.wrangler/` 下の SQLite ファイル）に
+  対して動かし、実際の `compatibility_flags` を反映し、本物のバインディングのバグを
+  表面化します。`env` を読む SSR ルートの作業をするときはこちらを使ってください。
+
+このセクションの残りはバインディングをリアルに再現するループについて説明します。
+
+### 初回セットアップ
+
+ローカルの SQLite データベースに D1 マイグレーションを適用します（冪等 — 再実行しても
+安全です）:
+
+```sh
+wrangler d1 migrations apply webshop --local
+```
+
+`webshop` 引数は `wrangler.toml` の `database_name` と対応しています。存在しない場合は
+`.wrangler/state/v3/d1/...` が作成されます。
+
+### 編集→反映のループ
+
+2 つのプロセスを並べて動かします: `wrangler pages dev dist/`（`dist/` が変更されると
+自動リロード）と、ソースファイルを編集するたびに `zfb build` を再実行するウォッチャー
+です。最もきれいな方法は `devDependencies` の `concurrently` + `chokidar-cli` を使う
+ことです:
+
+```sh
+pnpm add -D concurrently chokidar-cli
+```
+
+次に `dev:cf` スクリプトを `package.json` に追加します（ウォッチのグロブはプロジェクトの
+レイアウトに合わせて調整してください）:
+
+```json
+{
+  "scripts": {
+    "dev:cf:setup": "wrangler d1 migrations apply webshop --local && pnpm build",
+    "dev:cf": "pnpm dev:cf:setup && concurrently --names 'wrangler,watch' --kill-others 'wrangler pages dev dist/ --port 8788' \"chokidar 'pages/**/*.tsx' 'components/**/*.tsx' 'layouts/**/*.tsx' 'lib/**/*.ts' 'styles/**/*.css' --command 'pnpm build' --initial false --debounce 200\""
+  }
+}
+```
+
+次を実行します:
+
+```sh
+pnpm dev:cf
+```
+
+TSX または CSS ソースファイルを編集すると、おおよそ 1〜2 秒でブラウザに変更が反映されます。
+ウォッチャーが 200 ms デバウンスし、`pnpm build` が `dist/` を再出力し、
+`wrangler pages dev` が `_zfb_inner.mjs` の内容の変更に気づいて Worker を自動リロード
+します。Ctrl-C で両プロセスがきれいに終了します。
+
+<Warning title="`pnpm dev` と `pnpm dev:cf` を同時に実行しないこと">
+
+`zfb dev` の `predev` ステップ（`rm -rf dist .zfb .zfb-build`）は、`wrangler pages dev`
+が現在配信中の `dist/` ディレクトリを消去します。wrangler プロセスは、その後のリビルドが
+リロードをトリガーしなくなる劣化状態に入る可能性があります。一度に一つのループを選んで
+ください。誤って両方を実行してしまった場合は、すべてを停止し、`pnpm build` を再実行して
+から `pnpm dev:cf` を再起動してください。
+
+</Warning>
+
+### トラブルシューティング
+
+**ポート 8788 で `Address already in use`。** 別の `wrangler pages dev` がまだ動いて
+います。`lsof -ti TCP:8788 | xargs kill` で終了させるか、wrangler の呼び出しに
+`--port 8789` を渡してください。
+
+**ページは表示されるが `env.DB` が undefined。** `wrangler.toml` に
+`compatibility_flags = ["nodejs_compat"]` がありません。このページの前にある
+**"compatibility_flags = ['nodejs_compat'] は必須"** の警告を参照してください。この
+フラグはアダプターが `env` を SSR ルートに引き渡すための必須条件であり、任意のオプト
+インではありません。
+
+**編集後もブラウザに古いコンテンツが表示される。** 通常、直前の `pnpm build` が失敗して
+います。`concurrently` の出力内の `[watch]` ストリームでビルドエラーを確認してください。
+wrangler のリロードは `dist/` が実際に更新されたときにのみ発火します。
+
+**カート / D1 データが消えた。** ローカルの SQLite DB は `.wrangler/state/v3/d1/...` 下に
+存在し、**リビルドをまたいで永続します**。`.wrangler/` を削除した場合、別の作業
+ディレクトリに切り替えた場合、または `wrangler.toml` の `database_name` を変更した場合に
+リセットされます。それらの後に `wrangler d1 migrations apply webshop --local` を再実行
+して新鮮なスキーマを取得してください。
+
+<Tip title="なぜ 1 つではなく 2 つのプロセスなのか">
+
+`zfb build` は（小さなプロジェクトではサブ秒で）十分に高速なため、ユーザーランドの
+ウォッチャーを通じて保存のたびに実行することは、組み込みの `--watch` モードと区別が
+つきません。2 プロセスのレシピは、wrangler の Worker リロードの動作を、再実装不要な
+ブラックボックスとして保持します。
+
+</Tip>
 
 [als]: https://nodejs.org/api/async_context.html
 [d1]: https://developers.cloudflare.com/d1/

--- a/docs/src/content/docs-ja/guides/ssr-and-cloudflare-bindings.mdx
+++ b/docs/src/content/docs-ja/guides/ssr-and-cloudflare-bindings.mdx
@@ -317,14 +317,24 @@ TSX または CSS ソースファイルを編集すると、おおよそ 1〜2 �
 ### トラブルシューティング
 
 **ポート 8788 で `Address already in use`。** 別の `wrangler pages dev` がまだ動いて
-います。`lsof -ti TCP:8788 | xargs kill` で終了させるか、wrangler の呼び出しに
-`--port 8789` を渡してください。
+います。`lsof -ti TCP:8788 -sTCP:LISTEN | xargs kill` で終了させるか、wrangler の
+呼び出しに `--port 8789` を渡してください。`-sTCP:LISTEN` フィルタが重要です。素の
+`lsof -ti TCP:8788` は接続中のブラウザ／クライアントの PID も返すため、これがないと
+`xargs kill` が無関係なアプリを巻き添えにする可能性があります。
 
-**ページは表示されるが `env.DB` が undefined。** `wrangler.toml` に
-`compatibility_flags = ["nodejs_compat"]` がありません。このページの前にある
-**"compatibility_flags = ['nodejs_compat'] は必須"** の警告を参照してください。この
-フラグはアダプターが `env` を SSR ルートに引き渡すための必須条件であり、任意のオプト
-インではありません。
+**Worker が `node:async_hooks` を名指しするエラーで起動に失敗する。** `wrangler.toml`
+に `compatibility_flags = ["nodejs_compat"]` がありません。アダプターは
+`node:async_hooks` をトップレベルでインポートするため、このフラグがないと Worker は
+そもそも起動しません。バインディングが欠けた状態でページを配信するのではなく、起動
+自体に失敗します。このページの前にある **"compatibility_flags = ['nodejs_compat'] は
+必須"** の警告を参照してください。このフラグはアダプターが `env` を SSR ルートに
+引き渡すための必須条件であり、任意のオプトインではありません。
+
+**ページは表示されるが `env.DB` が undefined。** Worker は起動しています（つまり
+`nodejs_compat` は設定済みです）が、D1 バインディングがそこに届いていません。
+`wrangler.toml` のバインディング名（`binding = "DB"`）が `env` で読むプロパティと
+一致していること、そしてそのバインディングを宣言する `wrangler.toml` のあるディレクトリ
+から `wrangler pages dev dist/` を起動したことを確認してください。
 
 **編集後もブラウザに古いコンテンツが表示される。** 通常、直前の `pnpm build` が失敗して
 います。`concurrently` の出力内の `[watch]` ストリームでビルドエラーを確認してください。

--- a/docs/src/content/docs/guides/ssr-and-cloudflare-bindings.mdx
+++ b/docs/src/content/docs/guides/ssr-and-cloudflare-bindings.mdx
@@ -283,10 +283,123 @@ database_id = "<preview-uuid>"
 
 ## Local development
 
-`wrangler pages dev dist/` runs the built `_worker.js` locally with a
-**local** D1 database (a SQLite file under `.wrangler/`). Apply your
-migrations to it with `wrangler d1 migrations apply webshop --local`
-before the first run.
+<Tip title="A working end-to-end example">
+
+The [`zfb-example-webshop`](https://github.com/Takazudo/zfb-example-webshop)
+demo is this exact recipe, wired up and running: its `dev:cf` package.json
+script and its README "Local development" section are the same two-process
+loop described below. Clone it if you want to see the whole thing assembled
+rather than copy the snippets piecemeal. (That demo ships no client JS — that
+is the shop's own design choice, not a zfb limitation; zfb supports
+`.client.*` client scripts via `clientScript()` when you do want browser JS.)
+
+</Tip>
+
+There are two ways to run the app locally, and they answer different questions:
+
+- **`zfb dev`** — fast page-authoring loop. It runs the SSR **render code** for
+  `prerender = false` routes through the embedded V8 isolate (see
+  [dev-prod parity for `prerender = false`](#dev-prod-parity-for-prerender-false)
+  above), but it exposes **no Worker bindings**: calling
+  `getCloudflareContext<Env>()` from an SSR route under `zfb dev` yields no
+  `env`, so any route that reads `env.DB` (or any other binding) cannot work
+  here. Use this for layout, styling, and routing iteration on routes that do
+  **not** touch bindings.
+- **`wrangler pages dev dist/`** — binding-realistic loop. Runs the built
+  `_worker.js` against a **local** D1 database (a SQLite file under
+  `.wrangler/`), serves your real `compatibility_flags`, and surfaces real
+  binding bugs. Use this whenever you're working on an SSR route that reads
+  `env`.
+
+The rest of this section covers the binding-realistic loop.
+
+### One-time setup
+
+Apply your D1 migrations to the local SQLite database (idempotent — safe to
+re-run):
+
+```sh
+wrangler d1 migrations apply webshop --local
+```
+
+The `webshop` argument matches `database_name` in your `wrangler.toml`. This
+creates `.wrangler/state/v3/d1/...` if it doesn't exist.
+
+### The edit-refresh loop
+
+Run two processes side-by-side: `wrangler pages dev dist/` (which auto-reloads
+when `dist/` changes) and a watcher that re-runs `zfb build` whenever you edit a
+source file. The cleanest way is `concurrently` + `chokidar-cli` from your
+`devDependencies`:
+
+```sh
+pnpm add -D concurrently chokidar-cli
+```
+
+Then add a `dev:cf` script to your `package.json` (adjust the watch globs to
+match your project layout):
+
+```json
+{
+  "scripts": {
+    "dev:cf:setup": "wrangler d1 migrations apply webshop --local && pnpm build",
+    "dev:cf": "pnpm dev:cf:setup && concurrently --names 'wrangler,watch' --kill-others 'wrangler pages dev dist/ --port 8788' \"chokidar 'pages/**/*.tsx' 'components/**/*.tsx' 'layouts/**/*.tsx' 'lib/**/*.ts' 'styles/**/*.css' --command 'pnpm build' --initial false --debounce 200\""
+  }
+}
+```
+
+Then:
+
+```sh
+pnpm dev:cf
+```
+
+Edit a TSX or CSS source file and the browser reflects the change in roughly
+1–2 seconds: the watcher debounces for 200 ms, `pnpm build` re-emits `dist/`,
+and `wrangler pages dev` notices the `_zfb_inner.mjs` content change and reloads
+the worker automatically. Ctrl-C kills both processes cleanly.
+
+<Warning title="Do NOT run `pnpm dev` and `pnpm dev:cf` at the same time">
+
+`zfb dev`'s `predev` step (`rm -rf dist .zfb .zfb-build`) wipes the `dist/`
+directory that `wrangler pages dev` is actively serving. The wrangler process
+can enter a degraded state where subsequent rebuilds no longer trigger reloads.
+Pick one loop at a time. If you accidentally ran both, stop everything, re-run
+`pnpm build`, and restart `pnpm dev:cf`.
+
+</Warning>
+
+### Troubleshooting
+
+**`Address already in use` on port 8788.** Another `wrangler pages dev` is still
+running. Either kill it (`lsof -ti TCP:8788 | xargs kill`) or pass `--port 8789`
+to the wrangler invocation.
+
+**The page renders but `env.DB` is undefined.** You're missing
+`compatibility_flags = ["nodejs_compat"]` in `wrangler.toml`. See the
+**"compatibility_flags = ['nodejs_compat'] is mandatory"** warning earlier on
+this page — that flag is a hard prerequisite for the adapter to thread `env`
+into your SSR routes, not an optional opt-in.
+
+**The browser shows stale content after an edit.** Usually the previous
+`pnpm build` failed. Check the `[watch]` stream in the `concurrently` output for
+a build error. The wrangler reload only fires when `dist/` actually updates.
+
+**My cart / D1 data disappeared.** The local SQLite DB lives under
+`.wrangler/state/v3/d1/...` and **persists across rebuilds**. It resets if you
+delete `.wrangler/`, switch to a different working directory, or change
+`database_name` in `wrangler.toml`. Re-run
+`wrangler d1 migrations apply webshop --local` after any of those to get a fresh
+schema.
+
+<Tip title="Why two processes, not one">
+
+`zfb build` is fast enough (sub-second on small projects) that running it on
+every save through a userland watcher is indistinguishable from a built-in
+`--watch` mode. The two-process recipe also keeps wrangler's worker-reload
+behaviour as a black box we don't have to re-implement.
+
+</Tip>
 
 [als]: https://nodejs.org/api/async_context.html
 [d1]: https://developers.cloudflare.com/d1/

--- a/docs/src/content/docs/guides/ssr-and-cloudflare-bindings.mdx
+++ b/docs/src/content/docs/guides/ssr-and-cloudflare-bindings.mdx
@@ -372,14 +372,24 @@ Pick one loop at a time. If you accidentally ran both, stop everything, re-run
 ### Troubleshooting
 
 **`Address already in use` on port 8788.** Another `wrangler pages dev` is still
-running. Either kill it (`lsof -ti TCP:8788 | xargs kill`) or pass `--port 8789`
-to the wrangler invocation.
+running. Either kill it (`lsof -ti TCP:8788 -sTCP:LISTEN | xargs kill`) or pass
+`--port 8789` to the wrangler invocation. The `-sTCP:LISTEN` filter is important:
+a bare `lsof -ti TCP:8788` also returns any connected browser/client PIDs, so
+without it `xargs kill` can take down unrelated apps.
 
-**The page renders but `env.DB` is undefined.** You're missing
-`compatibility_flags = ["nodejs_compat"]` in `wrangler.toml`. See the
+**The Worker fails to boot with an error naming `node:async_hooks`.** You're
+missing `compatibility_flags = ["nodejs_compat"]` in `wrangler.toml`. The adapter
+imports `node:async_hooks` at the top level, so without the flag the Worker never
+starts — it does **not** boot and serve a page with a missing binding. See the
 **"compatibility_flags = ['nodejs_compat'] is mandatory"** warning earlier on
 this page — that flag is a hard prerequisite for the adapter to thread `env`
 into your SSR routes, not an optional opt-in.
+
+**The page renders but `env.DB` is undefined.** The Worker booted (so
+`nodejs_compat` is set), but the D1 binding isn't reaching it. Check that the
+binding name in `wrangler.toml` (`binding = "DB"`) matches the property you read
+on `env`, and that you launched `wrangler pages dev dist/` from the directory
+whose `wrangler.toml` declares the binding.
 
 **The browser shows stale content after an edit.** Usually the previous
 `pnpm build` failed. Check the `[watch]` stream in the `concurrently` output for


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1044

---

## Summary

Lands the validated **local Cloudflare dev recipe** into the SSR + Cloudflare guide, in both locales:

- `docs/src/content/docs/guides/ssr-and-cloudflare-bindings.mdx` (EN)
- `docs/src/content/docs-ja/guides/ssr-and-cloudflare-bindings.mdx` (JA)

The thin ~6-line "Local development" stub is replaced with the full two-process recipe
(`wrangler pages dev dist/` + a `concurrently`/`chokidar` watch loop re-running `pnpm build`,
against a local D1), salvaged from the orphaned PR #543 and refreshed for zfb `0.1.0-next.44`.

### What's in it

- **Worked-example pointer** — a callout linking the [`zfb-example-webshop`](https://github.com/Takazudo/zfb-example-webshop) demo as the running end-to-end version of this recipe (the "see this example" framing).
- **Two-ways framing** — `zfb dev` (fast authoring loop, **no Worker bindings**) vs `wrangler pages dev dist/` (binding-realistic), with a correct same-page cross-link to the dev-prod-parity section.
- **next.44 accuracy** — keeps the "no bindings under `zfb dev`" truth; notes zfb *does* support client JS via `.client.*` / `clientScript()` (the demo's zero-JS is its own choice, not a zfb limit).
- **Troubleshooting fix** — corrects an error inherited from PR #543: a missing `compatibility_flags = ["nodejs_compat"]` makes the Worker **fail to boot** (naming `node:async_hooks`); it does not silently render with `env.DB` undefined. Split into two accurate entries.
- **Locale-correct anchors** — fixed the JA guide's link that pointed at the **English** fragment `#the-getcloudflarecontext-trick`; it now resolves to the real JA heading slug `#getcloudflarecontext-のトリック` (verified against the emitted heading id).

### Validation

- `pnpm docs:check` (tsc) — clean.
- `pnpm docs:build` — 245 pages, **zero broken-link/anchor diagnostics** (link validation is warn-only, so the full build output was scanned, not just the exit code). Both locale pages emit.

### Follow-up (post-merge)

When this PR merges, sub-issue #1046 closes the orphaned PR #543 with a supersede comment. Predecessor issues #537 / #538 / #539 / #541 are already closed (superseded by epic #1044).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
