### PR TITLE
fix(dev): eager-render an in-place content edit reported as Created under load (#1058)

### DIFF
--- a/crates/zfb-build/src/orchestrator.rs
+++ b/crates/zfb-build/src/orchestrator.rs
@@ -52,6 +52,21 @@ use crate::pipeline::{AssetPipeline, BuildContext, BuildOutcome};
 use crate::plan::{PageSelection, RebuildPlan};
 use crate::policy::{classify_change_with_content_roots, GranularityPolicy, PathClass};
 
+/// `ZFB_DEV_TIMING` gate for the per-tick kind/narrowing trace (issue #1058).
+/// Same env var and truthy parser as `bundler_timing_enabled` and
+/// `crates/zfb/src/commands/dev.rs::dev_timing_enabled`, so one flag turns on
+/// the whole timing story. Unset/empty/unrecognized → off (zero hot-path cost).
+fn dev_timing_enabled() -> bool {
+    std::env::var("ZFB_DEV_TIMING")
+        .ok()
+        .as_deref()
+        .map(|raw| {
+            let t = raw.trim();
+            t.eq_ignore_ascii_case("1") || t.eq_ignore_ascii_case("true")
+        })
+        .unwrap_or(false)
+}
+
 /// Live watch-ADD discovery hook (issue #659).
 ///
 /// Invoked from [`BuildOrchestrator::tick_with_kinds`] /
@@ -600,6 +615,45 @@ impl<P: AssetPipeline> BuildOrchestrator<P> {
         ctx: &BuildContext,
         discover: Option<&DiscoveryHook>,
     ) -> Result<Option<BuildOutcome>> {
+        // Issue #1058 — normalize a spurious `Created` for an already-known
+        // content source back to `Modified`. On a loaded arm64 macOS host,
+        // FSEvents coalescing can deliver an in-place edit of an EXISTING
+        // file as `Created` (see `zfb_watcher::merge_kind` rule 2). Left as
+        // `Created` the change routes through the discovery regime (watch-ADD)
+        // instead of the in-place-edit regime, so the lazy path never
+        // eager-renders the edited entry's own route — the dropped eager
+        // render this issue tracks. A path the graph already knows as a
+        // content dependency (`consumers_of` is non-empty) cannot be
+        // genuinely new, so the `Created` flag is an artifact; a truly new
+        // file has no reverse edge yet and stays `Created` for discovery.
+        let changes: Vec<(PathBuf, ChangeKind)> = {
+            let graph = self.graph.lock().unwrap_or_else(|p| {
+                warn!(
+                    site = "tick_with_kinds::created_normalize",
+                    "graph mutex poisoned, recovering"
+                );
+                p.into_inner()
+            });
+            changes
+                .into_iter()
+                .map(|(path, kind)| {
+                    let spurious_created = kind == ChangeKind::Created
+                        && graph.consumers_of(&path).is_some_and(|c| !c.is_empty())
+                        && classify_change_with_content_roots(
+                            &path,
+                            &self.config.project_root,
+                            &self.config.policy.content_roots,
+                            |p| graph.is_global(p),
+                        ) == PathClass::Content;
+                    if spurious_created {
+                        (path, ChangeKind::Modified)
+                    } else {
+                        (path, kind)
+                    }
+                })
+                .collect()
+        };
+
         // Removal: drop graph edges for deleted files before planning and
         // collect the former consumers so they can be added to the plan.
         //
@@ -756,30 +810,21 @@ impl<P: AssetPipeline> BuildOrchestrator<P> {
             plan.add_prune_paths(discovered.vanished_output_paths);
         }
 
-        // Content-narrowing hint (issue #958). Produced iff this tick
-        // consists EXCLUSIVELY of in-place edits (`ChangeKind::Modified`)
-        // to content-collection files (`PathClass::Content`) and the
-        // assembled plan selects at least one page. Everything else —
-        // mixed ticks, Created (discovery regime), Removed (prune
-        // regime), Global, External, Data — never narrows (fallback G1).
-        // The classifier runs with the same config `plan_for_changes`
-        // uses, so the hint can never disagree with the plan fold.
-        // Purely advisory: the dev pipeline narrows each dynamic source's
-        // render fan-out to the changed entries' routes, with mandatory
-        // full-fan-out fallbacks downstream.
-        let modified_only_content = !changes.is_empty()
-            && changes
+        // Content-narrowing hint (issues #958 / #1058). Classify each
+        // change once (content vs not) under a single graph lock; the
+        // classifier runs with the same config `plan_for_changes` uses, so
+        // the hint can never disagree with the plan fold.
+        let content_flags: Vec<bool> = {
+            let graph = self.graph.lock().unwrap_or_else(|p| {
+                warn!(
+                    site = "tick_with_kinds::content_narrowing",
+                    "graph mutex poisoned, recovering"
+                );
+                p.into_inner()
+            });
+            changes
                 .iter()
-                .all(|(_, kind)| *kind == ChangeKind::Modified)
-            && {
-                let graph = self.graph.lock().unwrap_or_else(|p| {
-                    warn!(
-                        site = "tick_with_kinds::content_narrowing",
-                        "graph mutex poisoned, recovering"
-                    );
-                    p.into_inner()
-                });
-                changes.iter().all(|(path, _)| {
+                .map(|(path, _)| {
                     classify_change_with_content_roots(
                         path,
                         &self.config.project_root,
@@ -787,11 +832,72 @@ impl<P: AssetPipeline> BuildOrchestrator<P> {
                         |p| graph.is_global(p),
                     ) == PathClass::Content
                 })
-            };
-        if modified_only_content && !plan.pages.is_empty() {
+                .collect()
+        };
+
+        // Strict #958 gate (`fan_out_safe`): the tick consists EXCLUSIVELY
+        // of in-place `Modified` edits to content files. The eager fan-out
+        // narrowing requires this — a mixed tick (Created/Removed/Global/
+        // module change) can affect every page, so narrowing it would
+        // under-render (fallback G1).
+        let modified_only_content = !changes.is_empty()
+            && changes
+                .iter()
+                .zip(&content_flags)
+                .all(|((_, kind), is_content)| *kind == ChangeKind::Modified && *is_content);
+
+        // Permissive lazy eager basis (issue #1058): content files edited as
+        // `Modified` OR `Created`. `Created` is included because under
+        // FSEvents coalescing on a loaded arm64 macOS host an in-place edit
+        // of an EXISTING file can arrive as `Created` (see
+        // `zfb_watcher::merge_kind` rule 2), which would otherwise defeat
+        // the all-`Modified` gate and drop the eager render. Brand-new files
+        // are also `Created`+content but carry no routes yet, so the
+        // downstream route-table match renders nothing eager for them
+        // (discovery owns new routes). `Removed` content is excluded (prune
+        // regime).
+        let edited_content: Vec<PathBuf> = changes
+            .iter()
+            .zip(&content_flags)
+            .filter(|((_, kind), is_content)| {
+                **is_content && matches!(kind, ChangeKind::Modified | ChangeKind::Created)
+            })
+            .map(|((path, _), _)| path.clone())
+            .collect();
+
+        if !edited_content.is_empty() && !plan.pages.is_empty() {
             plan.content_narrowing = Some(crate::plan::ContentNarrowing {
-                changed_content: changes.iter().map(|(p, _)| p.clone()).collect(),
+                changed_content: edited_content,
+                fan_out_safe: modified_only_content,
             });
+        }
+
+        // `ZFB_DEV_TIMING=1` — surface the per-tick change kinds and the
+        // resulting narrowing decision (issue #1058, extending the #1028
+        // tick-class instrumentation). On a loaded arm64 macOS host an
+        // in-place content edit can arrive as `Created` (FSEvents coalescing,
+        // see `zfb_watcher::merge_kind` rule 2), which fails the all-`Modified`
+        // `modified_only_content` gate → no narrowing → the lazy path marks the
+        // route stale instead of eager-rendering it (the dropped eager render
+        // #1058 is about). A `narrowing=false` line whose kinds include a
+        // `Created` for an already-known content file is the smoking gun.
+        // Behind the existing flag so the hot path keeps zero overhead.
+        if dev_timing_enabled() {
+            let kinds: Vec<String> = changes
+                .iter()
+                .map(|(p, k)| {
+                    let name = p.file_name().and_then(|n| n.to_str()).unwrap_or("?");
+                    format!("{name}:{k:?}")
+                })
+                .collect();
+            eprintln!(
+                "[zfb-timing] tick(): kinds=[{}] eager_hint={} fan_out_safe={}",
+                kinds.join(", "),
+                plan.content_narrowing.is_some(),
+                plan.content_narrowing
+                    .as_ref()
+                    .is_some_and(|n| n.fan_out_safe)
+            );
         }
 
         if plan.is_noop() {
@@ -1330,9 +1436,10 @@ mod tests {
     }
 
     /// A tick made exclusively of Modified content files produces the
-    /// narrowing hint, carrying the changed paths verbatim.
+    /// narrowing hint, carrying the changed paths verbatim, and is
+    /// `fan_out_safe` (the eager path may narrow the fan-out).
     #[test]
-    fn modified_only_content_tick_produces_hint() {
+    fn modified_only_content_tick_produces_fan_out_safe_hint() {
         use zfb_watcher::ChangeKind;
         let pipeline = CountingPipeline::default();
         let applies = pipeline.applies.clone();
@@ -1353,15 +1460,19 @@ mod tests {
             plans[0].content_narrowing,
             Some(crate::plan::ContentNarrowing {
                 changed_content: vec![changed],
+                fan_out_safe: true,
             }),
-            "a Modified-only Content tick must carry the narrowing hint"
+            "a Modified-only Content tick must carry the fan-out-safe narrowing hint"
         );
     }
 
-    /// §3: a tick mixing a content edit with a module edit must NOT
-    /// produce the hint — module changes can affect every page's output.
+    /// §3 / #1058: a tick mixing a content edit with a module edit must NOT
+    /// be `fan_out_safe` — module changes can affect every page's output, so
+    /// the eager path must run the full fan-out (G1). It still carries the
+    /// edited CONTENT file for the lazy eager basis (the module is excluded),
+    /// so a body edit's own route can eager-render even in a mixed tick.
     #[test]
-    fn mixed_tick_with_module_trigger_produces_no_hint() {
+    fn mixed_tick_with_module_trigger_is_not_fan_out_safe() {
         use zfb_watcher::ChangeKind;
         let pipeline = CountingPipeline::default();
         let applies = pipeline.applies.clone();
@@ -1384,46 +1495,128 @@ mod tests {
         let plans = applies.lock().unwrap();
         assert_eq!(plans.len(), 1);
         assert_eq!(
-            plans[0].content_narrowing, None,
-            "a mixed content+module tick must not narrow (G1)"
+            plans[0].content_narrowing,
+            Some(crate::plan::ContentNarrowing {
+                // Only the content file — the module is not content-class.
+                changed_content: vec![PathBuf::from("/proj/content/post.md")],
+                fan_out_safe: false,
+            }),
+            "a mixed content+module tick must not be fan-out-safe (G1), but still \
+             carries the edited content for the lazy eager basis (#1058)"
         );
     }
 
-    /// §3: Created and Removed ticks never produce the hint — they run
-    /// the discovery / prune regimes, not the in-place-edit fast path.
+    /// #1058: a `Created` for an already-KNOWN content source (the graph
+    /// has consumers — here `post.md` feeds `c.tsx`) is a spurious FSEvents
+    /// coalescing artifact for an in-place edit, so it is normalized to
+    /// `Modified` at the top of the tick. The tick is then a pure in-place
+    /// content edit → `fan_out_safe`, exactly as a real `Modified` would be.
     #[test]
-    fn created_or_removed_tick_produces_no_hint() {
+    fn spurious_created_on_known_content_normalizes_to_modified() {
         use zfb_watcher::ChangeKind;
+        let pipeline = CountingPipeline::default();
+        let applies = pipeline.applies.clone();
+        let orch = make_orch(pipeline);
+        let dist = tempfile::tempdir().unwrap();
 
-        for kind in [ChangeKind::Created, ChangeKind::Removed] {
-            let pipeline = CountingPipeline::default();
-            let applies = pipeline.applies.clone();
-            let orch = make_orch(pipeline);
-            let dist = tempfile::tempdir().unwrap();
+        let post = PathBuf::from("/proj/content/post.md"); // known: consumers c.tsx
+        orch.tick_with_kinds(
+            vec![(post.clone(), ChangeKind::Created)],
+            &noop_ctx(dist.path()),
+            None,
+        )
+        .unwrap();
 
-            orch.tick_with_kinds(
-                vec![
-                    (PathBuf::from("/proj/content/post.md"), kind),
-                    // A Modified sibling keeps the tick non-noop even for
-                    // the Removed case (post.md's consumer is re-planned),
-                    // and proves one non-Modified change poisons the hint.
-                    (
-                        PathBuf::from("/proj/content/other.md"),
-                        ChangeKind::Modified,
-                    ),
-                ],
-                &noop_ctx(dist.path()),
-                None,
-            )
-            .unwrap();
+        let plans = applies.lock().unwrap();
+        assert_eq!(plans.len(), 1);
+        assert_eq!(
+            plans[0].content_narrowing,
+            Some(crate::plan::ContentNarrowing {
+                changed_content: vec![post],
+                fan_out_safe: true,
+            }),
+            "a Created for a known content source is normalized to a fan-out-safe edit (#1058)"
+        );
+    }
 
-            let plans = applies.lock().unwrap();
-            assert_eq!(plans.len(), 1, "tick must apply for kind {kind:?}");
-            assert_eq!(
-                plans[0].content_narrowing, None,
-                "a tick containing a {kind:?} change must not narrow (G1)"
-            );
-        }
+    /// #1058: a `Created` for a GENUINELY-NEW content file (`other.md` — no
+    /// reverse edge in the graph) is NOT normalized — it stays `Created` for
+    /// the discovery regime, so it poisons the strict gate (`!fan_out_safe`).
+    /// It is still carried in the lazy eager basis (harmless: it has no
+    /// routes yet, so the downstream route-table match renders nothing eager
+    /// for it).
+    #[test]
+    fn unknown_created_file_is_not_fan_out_safe() {
+        use zfb_watcher::ChangeKind;
+        let pipeline = CountingPipeline::default();
+        let applies = pipeline.applies.clone();
+        let orch = make_orch(pipeline);
+        let dist = tempfile::tempdir().unwrap();
+
+        let new_file = PathBuf::from("/proj/content/other.md"); // unknown / new
+        let known = PathBuf::from("/proj/content/post.md"); // known: consumers c.tsx
+        orch.tick_with_kinds(
+            vec![
+                (new_file.clone(), ChangeKind::Created),
+                (known.clone(), ChangeKind::Modified),
+            ],
+            &noop_ctx(dist.path()),
+            None,
+        )
+        .unwrap();
+
+        let plans = applies.lock().unwrap();
+        assert_eq!(plans.len(), 1);
+        let narrowing = plans[0]
+            .content_narrowing
+            .as_ref()
+            .expect("tick carries the lazy eager basis");
+        assert!(
+            !narrowing.fan_out_safe,
+            "a genuinely-new Created file poisons the strict gate (G1)"
+        );
+        assert!(narrowing.changed_content.contains(&new_file));
+        assert!(narrowing.changed_content.contains(&known));
+    }
+
+    /// #1058: a `Removed` content file is excluded from the lazy eager basis
+    /// (it runs the prune regime, not an eager render) and poisons the strict
+    /// gate. The Modified sibling still carries the basis.
+    #[test]
+    fn removed_content_excluded_from_lazy_basis() {
+        use zfb_watcher::ChangeKind;
+        let pipeline = CountingPipeline::default();
+        let applies = pipeline.applies.clone();
+        let orch = make_orch(pipeline);
+        let dist = tempfile::tempdir().unwrap();
+
+        let removed = PathBuf::from("/proj/content/other.md");
+        let edited = PathBuf::from("/proj/content/post.md"); // known: consumers c.tsx
+        orch.tick_with_kinds(
+            vec![
+                (edited.clone(), ChangeKind::Modified),
+                (removed.clone(), ChangeKind::Removed),
+            ],
+            &noop_ctx(dist.path()),
+            None,
+        )
+        .unwrap();
+
+        let plans = applies.lock().unwrap();
+        assert_eq!(plans.len(), 1);
+        let narrowing = plans[0]
+            .content_narrowing
+            .as_ref()
+            .expect("tick carries the lazy eager basis");
+        assert!(
+            !narrowing.fan_out_safe,
+            "a Removed change poisons the strict gate (G1)"
+        );
+        assert!(narrowing.changed_content.contains(&edited));
+        assert!(
+            !narrowing.changed_content.contains(&removed),
+            "a Removed content file is excluded from the lazy eager basis"
+        );
     }
 
     /// Regression for zfb#642 / #644 — `zfb dev` 404'd every route on a

--- a/crates/zfb-build/src/pipeline/dev.rs
+++ b/crates/zfb-build/src/pipeline/dev.rs
@@ -638,15 +638,27 @@ impl AssetPipeline for DevAssetPipeline {
         // already makes. CSS, islands, and plan prune paths still run.
         let mut renderer_refresh_skipped = false;
 
-        // Content-narrowing hint for the render callback (issue #958).
-        // Defensive G6: the hint must never coexist with a discovery-
-        // refreshed renderer (`renderer_fresh`) — the discovery regime
-        // implies created files, which the orchestrator never produces a
-        // hint for, but if both ever appear together the safe direction
-        // is full fan-out.
-        let mut narrowing: Option<&crate::ContentNarrowing> = plan.content_narrowing.as_ref();
+        // Content-narrowing hint for the render callback (issues #958 /
+        // #1058). G5/G6 historically dropped the hint to `None` because,
+        // under the old contract, a hint meant "narrow the eager fan-out" —
+        // unsafe when discovery refreshed the renderer (G6) or the route
+        // structure moved (G5), since narrowing could orphan a brand-new
+        // URL. The hint now ALSO carries the lazy eager basis (the edited
+        // entries' own routes), which is ALWAYS safe: it only ADDS eager
+        // renders for known routes and never restricts the fan-out. So
+        // instead of dropping the hint, clear only its `fan_out_safe` flag —
+        // the eager path falls back to the full fan-out (it gates on
+        // `fan_out_safe`) while the lazy path still eager-renders the edited
+        // entry's own route even when a co-changed Created file refreshed the
+        // renderer this tick (the #1058 mixed-tick failure).
+        //
+        // G6: a discovery-refreshed renderer (`renderer_fresh`) implies a
+        // created file in this tick → the fan-out is no longer safe to narrow.
+        let mut narrowing: Option<crate::ContentNarrowing> = plan.content_narrowing.clone();
         if plan.renderer_fresh {
-            narrowing = None;
+            if let Some(n) = narrowing.as_mut() {
+                n.fan_out_safe = false;
+            }
         }
 
         if !pages.is_empty() {
@@ -681,11 +693,15 @@ impl AssetPipeline for DevAssetPipeline {
                             // post-edit one — but if the refresh reports
                             // that any source's route-entry set changed
                             // (or any output path vanished), the route
-                            // structure moved this tick and narrowing
-                            // could orphan a brand-new URL. Render the
-                            // full selected set instead.
+                            // structure moved this tick and narrowing the
+                            // eager FAN-OUT could orphan a brand-new URL.
+                            // Clear `fan_out_safe` so the eager path renders
+                            // the full selected set, while the lazy eager
+                            // basis (own-route renders only) survives (#1058).
                             if !vanished.is_empty() || !changed_sources.is_empty() {
-                                narrowing = None;
+                                if let Some(n) = narrowing.as_mut() {
+                                    n.fan_out_safe = false;
+                                }
                             }
                             route_vanished.extend(vanished);
                         }
@@ -700,7 +716,7 @@ impl AssetPipeline for DevAssetPipeline {
         // stale-output candidates nor the live-dests bookkeeping run — an
         // unrendered URL can never be mistaken for a vanished one.
         if !pages.is_empty() && !renderer_refresh_skipped {
-            let rendered = (ctx.render_pages)(&pages, narrowing)?;
+            let rendered = (ctx.render_pages)(&pages, narrowing.as_ref())?;
             outcome.pages_rendered = rendered.len();
 
             // Collect prune candidates and the live dest set during the
@@ -1518,6 +1534,7 @@ mod tests {
         let mut plan = single_page_plan();
         plan.content_narrowing = Some(crate::ContentNarrowing {
             changed_content: vec![PathBuf::from("/proj/content/post.md")],
+            fan_out_safe: true,
         });
         plan
     }
@@ -1544,16 +1561,28 @@ mod tests {
             seen[0],
             Some(crate::ContentNarrowing {
                 changed_content: vec![PathBuf::from("/proj/content/post.md")],
+                fan_out_safe: true,
             }),
             "the hint must be forwarded when the route table did not move"
         );
     }
 
-    /// Fallback G5 (issue #958): a refresh that reports changed source
-    /// route sets disables narrowing for the tick — the render callback
-    /// must see `None`.
+    /// Helper: the narrowed hint with `fan_out_safe` cleared — what G5/G6
+    /// now forward (the eager fan-out is disabled, the lazy eager basis
+    /// survives). See issue #1058.
+    fn hint_with_fan_out_cleared() -> Option<crate::ContentNarrowing> {
+        Some(crate::ContentNarrowing {
+            changed_content: vec![PathBuf::from("/proj/content/post.md")],
+            fan_out_safe: false,
+        })
+    }
+
+    /// Fallback G5 (issues #958 / #1058): a refresh that reports changed
+    /// source route sets clears `fan_out_safe` (the eager path renders the
+    /// full fan-out) but PRESERVES the hint so the lazy path still
+    /// eager-renders the edited entry's own route.
     #[test]
-    fn refresh_changed_sources_disable_narrowing() {
+    fn refresh_changed_sources_clears_fan_out_safe() {
         let dir = tempdir().unwrap();
         let pipeline = DevAssetPipeline::new();
         let seen = Arc::new(Mutex::new(Vec::new()));
@@ -1569,15 +1598,16 @@ mod tests {
         let seen = seen.lock().unwrap();
         assert_eq!(seen.len(), 1);
         assert_eq!(
-            seen[0], None,
-            "non-empty changed_sources must force full fan-out (G5)"
+            seen[0],
+            hint_with_fan_out_cleared(),
+            "non-empty changed_sources clears fan_out_safe but keeps the lazy basis (G5)"
         );
     }
 
     /// Fallback G5, vanished arm: globally-vanished routes also mean the
-    /// route structure moved — no narrowing this tick.
+    /// route structure moved — clear `fan_out_safe`, keep the lazy basis.
     #[test]
-    fn refresh_vanished_routes_disable_narrowing() {
+    fn refresh_vanished_routes_clears_fan_out_safe() {
         let dir = tempdir().unwrap();
         let pipeline = DevAssetPipeline::new();
         let seen = Arc::new(Mutex::new(Vec::new()));
@@ -1593,15 +1623,18 @@ mod tests {
         let seen = seen.lock().unwrap();
         assert_eq!(seen.len(), 1);
         assert_eq!(
-            seen[0], None,
-            "non-empty vanished must force full fan-out (G5)"
+            seen[0],
+            hint_with_fan_out_cleared(),
+            "non-empty vanished clears fan_out_safe but keeps the lazy basis (G5)"
         );
     }
 
-    /// Fallback G6 (defensive): a hint must never survive on a
-    /// renderer-fresh tick (discovery regime) — the callback sees `None`.
+    /// Fallback G6 (issues #958 / #1058): a renderer-fresh tick (discovery
+    /// regime) clears `fan_out_safe` — the eager path renders the full
+    /// fan-out — but the lazy eager basis survives so a co-changed in-place
+    /// content edit still eager-renders its own route.
     #[test]
-    fn renderer_fresh_tick_drops_narrowing_hint() {
+    fn renderer_fresh_tick_clears_fan_out_safe() {
         let dir = tempdir().unwrap();
         let pipeline = DevAssetPipeline::new();
         let seen = Arc::new(Mutex::new(Vec::new()));
@@ -1619,8 +1652,9 @@ mod tests {
         let seen = seen.lock().unwrap();
         assert_eq!(seen.len(), 1);
         assert_eq!(
-            seen[0], None,
-            "renderer_fresh must drop the narrowing hint (G6)"
+            seen[0],
+            hint_with_fan_out_cleared(),
+            "renderer_fresh clears fan_out_safe but keeps the lazy basis (G6)"
         );
     }
 

--- a/crates/zfb-build/src/plan.rs
+++ b/crates/zfb-build/src/plan.rs
@@ -13,19 +13,36 @@ use std::path::PathBuf;
 
 use zfb_graph::{DirtySet, PageId};
 
-/// Hint that this tick was caused exclusively by in-place edits
-/// (`ChangeKind::Modified`) to content-collection files
-/// (`PathClass::Content`). Carries the changed paths so the dev render
-/// callback can narrow each dynamic source's fan-out to the routes
-/// derived from these entries (issue #958). `None` = no narrowing
-/// (render every selected page fully — today's behaviour). Purely
+/// The tick's directly-edited content-collection files
+/// (`PathClass::Content`), carried so the dev render callback can act on
+/// the changed entries' own routes. Two consumers, two strictness levels:
+///
+/// - The #958 **eager** fan-out narrowing requires the STRICT gate
+///   (`fan_out_safe`): narrow each dynamic source's fan-out to the routes
+///   derived from these entries ONLY when the whole tick was in-place
+///   `Modified` content edits — a co-changed module/component can affect
+///   every page, so narrowing a mixed tick would under-render.
+/// - The #1025 **lazy** eager-set derivation does NOT require it: it only
+///   ADDS eager renders for the edited entries' own routes and leaves the
+///   rest stale (never under-rendered), so it consumes `changed_content`
+///   even when `fan_out_safe` is `false`.
+///
+/// `None` = nothing was directly content-edited this tick. Purely
 /// advisory: must not affect `is_noop()`/merge logic.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContentNarrowing {
-    /// Paths of the Modified content files exactly as the watcher
-    /// delivered them (absolute; same representation recorded in
-    /// [`RebuildPlan::triggers`]).
+    /// Paths of the edited content files exactly as the watcher delivered
+    /// them (absolute; same representation recorded in
+    /// [`RebuildPlan::triggers`]). Populated permissively for the lazy
+    /// eager basis (issue #1058): a file edited as `Modified` OR `Created`
+    /// (an in-place edit of an existing file can arrive as `Created` under
+    /// FSEvents coalescing). Genuinely-new files carry no routes yet, so
+    /// the downstream route-table match renders nothing eager for them.
     pub changed_content: Vec<PathBuf>,
+    /// `true` only when the ENTIRE tick was in-place `Modified` content
+    /// edits — the strict #958 gate. The eager fan-out narrowing keys on
+    /// this; the lazy eager-set derivation ignores it (issue #1058).
+    pub fan_out_safe: bool,
 }
 
 /// What the orchestrator wants the asset pipeline to do for the next
@@ -246,6 +263,7 @@ mod tests {
         let mut plan = RebuildPlan::empty();
         plan.content_narrowing = Some(ContentNarrowing {
             changed_content: vec![PathBuf::from("/proj/content/post.md")],
+            fan_out_safe: true,
         });
         assert!(plan.is_noop());
     }

--- a/crates/zfb-watcher/src/lib.rs
+++ b/crates/zfb-watcher/src/lib.rs
@@ -360,20 +360,48 @@ fn merge_kind(existing: Option<ChangeKind>, incoming: ChangeKind) -> ChangeKind 
 ///   deletion would be lost and `tick_with_kinds` would skip its prune path.
 /// - Otherwise pass the kind through unchanged.
 ///
-/// `try_exists().unwrap_or(false)` is the conservative default in both
-/// directions: an I/O error is treated as "absent", which biases toward
-/// emitting `Removed` — the change we can least afford to drop.
+/// The existence probe is authoritative only for a **definitive** answer.
+/// A transient `Err` from `try_exists()` — e.g. `EIO`/`ENFILE` while an
+/// arm64 macOS host is under heavy IO load (issue #1058) — proves nothing
+/// about the file's state, so it must not be allowed to rewrite a write
+/// event into a deletion. The reconciliation is split into the pure
+/// [`reconcile_emit_kind`] so that transient-error branch is unit-testable
+/// without provoking real filesystem IO errors.
 fn resolve_emit_kind(path: &Path, kind: ChangeKind) -> ChangeKind {
-    let exists = path.try_exists().unwrap_or(false);
+    reconcile_emit_kind(kind, path.try_exists())
+}
+
+/// Pure existence-reconciliation step (see [`resolve_emit_kind`]). `exists`
+/// is the raw `try_exists()` outcome: `Ok(true)` present, `Ok(false)`
+/// genuinely absent, `Err` an IO error that tells us nothing.
+///
+/// - Incoming `Removed`: keep biasing to `Removed` on `Err` — we can least
+///   afford to *drop* a delete, so an unknown state still surfaces as a
+///   deletion (unchanged from the original behaviour). A definitive
+///   `Ok(true)` means the file was restored → upgrade to `Modified` (#823).
+/// - Incoming `Created`/`Modified`: a definitive `Ok(false)` still emits
+///   `Removed` (a backend can deliver a trailing `Modify` for an
+///   already-deleted path; without this the prune path is skipped). But on
+///   a transient `Err`, PASS THE KIND THROUGH rather than downgrading to
+///   `Removed` (issue #1058): the event source already told us the file was
+///   written, and a phantom deletion would route a live content edit to the
+///   prune regime and skip its eager re-render.
+fn reconcile_emit_kind(kind: ChangeKind, exists: std::io::Result<bool>) -> ChangeKind {
     match (kind, exists) {
+        // Removed boundary — a definitive on-disk answer is authoritative.
         // Accepted trade-off: a bare-Remove from a git-restore of a
         // brand-new route upgrades to Modified (never Created), so the
         // orchestrator's watch-ADD discovery hook does not fire for that
         // restored route on this tick.
-        (ChangeKind::Removed, true) => ChangeKind::Modified,
-        (ChangeKind::Removed, false) => ChangeKind::Removed,
-        (_, true) => kind,
-        (_, false) => ChangeKind::Removed,
+        (ChangeKind::Removed, Ok(true)) => ChangeKind::Modified,
+        (ChangeKind::Removed, Ok(false)) => ChangeKind::Removed,
+        (ChangeKind::Removed, Err(_)) => ChangeKind::Removed,
+        // Non-removed (Created/Modified): definitive "absent" → the file
+        // really is gone, emit Removed so the prune path runs.
+        (other, Ok(true)) => other,
+        (_, Ok(false)) => ChangeKind::Removed,
+        // Transient stat miss on a write/create event → do NOT downgrade.
+        (other, Err(_)) => other,
     }
 }
 
@@ -699,6 +727,71 @@ mod tests {
             resolve_emit_kind(&file, ChangeKind::Created),
             ChangeKind::Removed,
             "Created for a missing path is a genuine deletion",
+        );
+    }
+
+    // ---------------------------------------------------------------------------
+    // Transient stat-miss reconciliation (`reconcile_emit_kind`) — issue #1058.
+    // Under heavy IO load on arm64 macOS, `try_exists()` can return an `Err`
+    // (transient EIO/ENFILE) for a file that was just written. That unknown
+    // state must NOT downgrade a live write event to a phantom deletion, or the
+    // edit is routed to the prune regime and never eagerly re-rendered.
+    // ---------------------------------------------------------------------------
+
+    fn transient_err() -> std::io::Result<bool> {
+        Err(std::io::Error::other("transient stat miss"))
+    }
+
+    #[test]
+    fn reconcile_emit_kind_write_event_with_io_error_passes_through() {
+        assert_eq!(
+            reconcile_emit_kind(ChangeKind::Modified, transient_err()),
+            ChangeKind::Modified,
+            "a transient stat miss must not turn a Modified into a deletion (#1058)",
+        );
+        assert_eq!(
+            reconcile_emit_kind(ChangeKind::Created, transient_err()),
+            ChangeKind::Created,
+            "a transient stat miss must not turn a Created into a deletion (#1058)",
+        );
+    }
+
+    #[test]
+    fn reconcile_emit_kind_removed_with_io_error_stays_removed() {
+        // A delete is the change we can least afford to drop, so an unknown
+        // state for an incoming Removed still surfaces as Removed.
+        assert_eq!(
+            reconcile_emit_kind(ChangeKind::Removed, transient_err()),
+            ChangeKind::Removed,
+        );
+    }
+
+    #[test]
+    fn reconcile_emit_kind_definitive_answers_match_legacy_matrix() {
+        // Every definitive (Ok) answer preserves the pre-#1058 behaviour.
+        assert_eq!(
+            reconcile_emit_kind(ChangeKind::Removed, Ok(true)),
+            ChangeKind::Modified,
+        );
+        assert_eq!(
+            reconcile_emit_kind(ChangeKind::Removed, Ok(false)),
+            ChangeKind::Removed,
+        );
+        assert_eq!(
+            reconcile_emit_kind(ChangeKind::Modified, Ok(true)),
+            ChangeKind::Modified
+        );
+        assert_eq!(
+            reconcile_emit_kind(ChangeKind::Created, Ok(true)),
+            ChangeKind::Created
+        );
+        assert_eq!(
+            reconcile_emit_kind(ChangeKind::Modified, Ok(false)),
+            ChangeKind::Removed
+        );
+        assert_eq!(
+            reconcile_emit_kind(ChangeKind::Created, Ok(false)),
+            ChangeKind::Removed
         );
     }
 

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -3889,8 +3889,16 @@ fn make_render_callback(session: DevRenderSession, dist_dir: PathBuf) -> PageRen
         // Issue #958 — one narrowing decision per tick; per-page filters
         // fall out of the per-source map. The V8-off path has no
         // collection configs to match against, so it never narrows.
+        //
+        // Issue #1058 — the hint is now populated permissively (mixed /
+        // Created ticks carry the edited content for the lazy eager basis),
+        // so the EAGER fan-out narrowing must gate on the strict
+        // `fan_out_safe` flag: a co-changed module can affect every page, so
+        // a non-fan-out-safe tick falls back to the full fan-out exactly as
+        // before. (The lazy path above intentionally consumes the hint
+        // regardless of `fan_out_safe`.)
         #[cfg(feature = "embed_v8")]
-        let tick_narrowing = compute_tick_narrowing(&session, narrowing);
+        let tick_narrowing = compute_tick_narrowing(&session, narrowing.filter(|n| n.fan_out_safe));
         #[cfg(not(feature = "embed_v8"))]
         let tick_narrowing = {
             let _ = narrowing;
@@ -4717,6 +4725,11 @@ mod tests {
         fn hint_for(paths: &[PathBuf]) -> zfb_build::ContentNarrowing {
             zfb_build::ContentNarrowing {
                 changed_content: paths.to_vec(),
+                // These unit tests exercise `compute_tick_narrowing` /
+                // `compute_lazy_eager_sets` directly; neither reads
+                // `fan_out_safe` (the eager-path gate lives in
+                // `make_render_callback`). Value is immaterial here.
+                fan_out_safe: true,
             }
         }
 


### PR DESCRIPTION
See linked issue #1058 for the full writeup.

## Summary
Fixes the `dev_e2e_edit_to_serve_loop` scenario-2 flake (#1058) — green on CI, deterministic fail on a loaded arm64 Mac. Under IO load FSEvents delivers an in-place edit of an existing content file as `Created` and/or coalesces it into a mixed tick with a new file's discovery, defeating the lazy dev server's eager re-render of the edited entry's own route. Mechanism **confirmed** by new `ZFB_DEV_TIMING` tick instrumentation reproducing `a.md:Created narrowing=false`.

## Three coordinated fixes
1. orchestrator: normalize a spurious `Created` for an already-known content source back to `Modified` (routes through the edit regime, not discovery).
2. `ContentNarrowing.fan_out_safe` — populate the hint permissively (Modified OR Created content) as the lazy eager basis; the strict #958 eager fan-out narrowing keys on `fan_out_safe` (eager path byte-identical).
3. pipeline G5/G6 — clear `fan_out_safe` instead of dropping the hint, so the lazy basis survives a discovery refresh / structure move.

Plus `resolve_emit_kind` transient-stat hardening + env-gated `ZFB_DEV_TIMING` trace.

## Contract change (review)
`ContentNarrowing` gains `fan_out_safe` and is now populated in mixed/Created ticks; tests asserting `None` there were updated to the dual-role semantics.

## Verification
e2e under the moderate load that originally failed: pre-fix reliably failed; normalization-only 5/8; **all three fixes 12/12**. Unit: 21 watcher + 335 zfb-build + 452 zfb; clippy/fmt clean. Test stays un-quarantined. Blind spot: a load race can't be proven absent by sampling; deterministic unit tests pin each fix.