### PR TITLE
fix(zfb-runtime): guard client-router announce() timer against torn-down document (#1061)

### DIFF
--- a/packages/zfb-runtime/src/client-router/router.ts
+++ b/packages/zfb-runtime/src/client-router/router.ts
@@ -106,6 +106,12 @@ const announce = () => {
   document.body.append(div);
   setTimeout(
     () => {
+      // This fire-and-forget timer can outlive its document context — a test
+      // env teardown (vitest/happy-dom) or a real page unload removes `document`
+      // before the 60ms elapses. `typeof` is safe even when the global is gone,
+      // so bail out instead of throwing an unhandled ReferenceError (#1061);
+      // the announcement is moot once the page is no longer there.
+      if (typeof document === "undefined") return;
       let title = document.title || document.querySelector("h1")?.textContent || location.pathname;
       div.textContent = title;
     },

--- a/packages/zfb-runtime/src/client-router/router.ts
+++ b/packages/zfb-runtime/src/client-router/router.ts
@@ -108,10 +108,11 @@ const announce = () => {
     () => {
       // This fire-and-forget timer can outlive its document context — a test
       // env teardown (vitest/happy-dom) or a real page unload removes `document`
-      // before the 60ms elapses. `typeof` is safe even when the global is gone,
-      // so bail out instead of throwing an unhandled ReferenceError (#1061);
-      // the announcement is moot once the page is no longer there.
-      if (typeof document === "undefined") return;
+      // (and `location`) before the 60ms elapses. `typeof` is safe even when the
+      // global is gone, so bail out instead of throwing an unhandled
+      // ReferenceError (#1061); the announcement is moot once the page is gone.
+      // Both globals the callback dereferences are checked, not just `document`.
+      if (typeof document === "undefined" || typeof location === "undefined") return;
       let title = document.title || document.querySelector("h1")?.textContent || location.pathname;
       div.textContent = title;
     },


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1061

---

## Summary

Fixes the intermittent `ReferenceError: document is not defined` flake in `packages/zfb-runtime` vitest runs (#1061).

The client-router's `announce()` route-announcer schedules a fire-and-forget 60ms `setTimeout` after every successful navigation (`router.ts:107`). Its callback dereferences `document` (and, as a fallback, `location`). When the happy-dom test environment is torn down before that timer fires, those globals are removed, so the callback threw an unhandled `ReferenceError` that failed the run. Classic timer-after-teardown flake (one of the 5 deflake root causes in CLAUDE.md §Flaky).

## Changes

- **`client-router/router.ts`** — guard the `announce()` timer callback with `if (typeof document === "undefined" || typeof location === "undefined") return;`. `typeof` never throws even when the global is gone, so a timer that outlives its document context (test teardown **or** real page unload) becomes a safe no-op instead of a crash. This makes **both** timing outcomes — fires-before-teardown vs. fires-after — safe, so the result is deterministic regardless of CI timing. Matches the file's existing `inBrowser = typeof document !== "undefined"` idiom.

## Why a guard (not cancellation)

The timer is fire-and-forget and uncancellable, matching upstream Astro's structure. Cancelling/owning the timer lifecycle is a larger architectural change — tracked separately in #1063 along with a same-class **latent** issue in the scroll-poll `setInterval` (which, per a happy-dom probe, never actually starts in the current suite because `scrollTo` does not dispatch a `scroll` event, so it cannot race teardown today).

## Test Plan

- `vitest run` for `@takazudo/zfb-runtime`, router test re-run 5×: 16/16 pass, no teardown errors.
- Full `zfb-runtime` suite re-run 3×: 123/123 pass across 7 files, clean.
- `tsc --noEmit` (package typecheck): clean.
- Reasoning-level proof: the only failure mode was the `ReferenceError` at the guarded derefs; the guard makes that line unreachable when the globals are absent.

## Not tested / blind spots

- No deterministic regression test asserting the post-teardown path (hard to simulate env teardown mid-timer); the change removes a crash rather than adding observable product behavior. Real-browser behavior is unchanged (globals are never undefined during a live page).

Fixes #1061