### PR TITLE
fix(zfb-runtime): give client-router timers explicit lifecycle ownership (#1063)

### DIFF
--- a/packages/zfb-runtime/src/__tests__/client-router/router.test.ts
+++ b/packages/zfb-runtime/src/__tests__/client-router/router.test.ts
@@ -558,3 +558,83 @@ describe("island lifecycle ordering during navigate()", () => {
     expect(unmountIdx).toBeLessThan(mountIdx);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Route announcer — timer lifecycle ownership (#1063)
+// ---------------------------------------------------------------------------
+//
+// Covers the announce() changes from #1063: exactly one announcer element
+// (fresh per navigation, never reused or accumulated) and a cancellable 60ms
+// timer that a superseding navigation clears.
+//
+// NOT covered here (documented blind spot): the scroll-position polling
+// setInterval guard (router.ts, the `else` branch when `onscrollend` is
+// absent). Per #1063's own investigation, happy-dom reports
+// `"onscrollend" in window === false` (so the router takes the setInterval
+// branch) but `window.scrollTo()` dispatches no `scroll` event, and the
+// interval is only ever started from inside the `scroll` listener — so the
+// interval never starts in this environment and cannot be driven through the
+// public API. Its teardown guard is defensive-only (a real browser always has
+// the globals it reads). Re-announce *reliability* of the aria-live region is
+// likewise a screen-reader behavior happy-dom cannot observe (Level 5/6).
+describe("route announcer — timer lifecycle (#1063)", () => {
+  // Flush pending microtasks WITHOUT advancing real time, so announce() (which
+  // runs in the post-swap `updateCallbackDone.finally` continuation) has run but
+  // its 60ms timer is still pending. Avoids setTimeout so it doesn't perturb the
+  // timer spies below.
+  const flushMicrotasks = async () => {
+    for (let i = 0; i < 12; i++) await Promise.resolve();
+  };
+
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: RequestInfo) => {
+        const slug = String(url).split("/").pop() || "page";
+        return htmlResponse(pageHtml(`Title-${slug}`, `content-${slug}`));
+      }),
+    );
+  });
+
+  it("appends exactly one announcer, fresh per navigation (no reuse, no accumulation)", async () => {
+    await navigate("/ann-a");
+    await flushMicrotasks();
+    const first = document.querySelector(".zfb-route-announcer");
+    expect(first).not.toBeNull();
+    // The aria-live contract the announcer is created with.
+    expect(first?.getAttribute("aria-live")).toBe("assertive");
+    expect(first?.getAttribute("aria-atomic")).toBe("true");
+
+    await navigate("/ann-b");
+    await flushMicrotasks();
+    const announcers = document.querySelectorAll(".zfb-route-announcer");
+    // Exactly one announcer ever exists ...
+    expect(announcers).toHaveLength(1);
+    // ... and it is a FRESH element, not the prior instance reused. A reused
+    // live region re-entering the a11y tree is an unreliable SR trigger (#1063).
+    expect(announcers[0]).not.toBe(first);
+  });
+
+  it("cancels the prior pending announce timer when a newer navigation supersedes it", async () => {
+    const setTimeoutSpy = vi.spyOn(window, "setTimeout");
+    const clearTimeoutSpy = vi.spyOn(window, "clearTimeout");
+    try {
+      await navigate("/sup-a");
+      await flushMicrotasks();
+      // announce() schedules the only 60ms setTimeout in the navigation pipeline.
+      const idx = setTimeoutSpy.mock.calls.findIndex((c) => c[1] === 60);
+      expect(idx).toBeGreaterThanOrEqual(0);
+      const firstTimerId = setTimeoutSpy.mock.results[idx]!.value;
+
+      await navigate("/sup-b");
+      await flushMicrotasks();
+
+      // The second navigation's announce() must clear the first's still-pending
+      // 60ms timer before scheduling its own — the supersede guarantee.
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(firstTimerId);
+    } finally {
+      setTimeoutSpy.mockRestore();
+      clearTimeoutSpy.mockRestore();
+    }
+  });
+});

--- a/packages/zfb-runtime/src/client-router/router.ts
+++ b/packages/zfb-runtime/src/client-router/router.ts
@@ -24,7 +24,8 @@
 //   - `inBrowser` evaluates to `typeof document !== "undefined"` rather than relying
 //     on the SSR flag, because the runtime package serves both server- and client-side
 //     code; same observable behavior in browser and on SSR.
-//   - `announce()` is a TODO stub (W3C3 owns the route announcer).
+//   - `announce()` was a TODO stub at W1B port time; W3C3 implemented it and #1063 gave
+//     its 60ms timer explicit lifecycle ownership — see the route-announcer block below.
 //
 // W3C2 additions (this file):
 //   - `navigate()` public entry.
@@ -33,9 +34,10 @@
 //     from `history.state`, registers popstate / load / scrollend listeners, and
 //     marks already-executed scripts with `dataset["zfbExec"] = ""`).
 //
-// W3C1 deferred to W3C3:
-//   - `announce()` route-announcer implementation.
-//   - Click + form intercept.
+// W3C1 items deferred to — and since implemented in — W3C3:
+//   - `announce()` route-announcer implementation (see the route-announcer block below;
+//     timer lifecycle ownership hardened in #1063).
+//   - Click + form intercept (see `handleClick` / `handleSubmit` / `init()` below).
 
 import {
   doPreparation,

--- a/packages/zfb-runtime/src/client-router/router.ts
+++ b/packages/zfb-runtime/src/client-router/router.ts
@@ -94,31 +94,51 @@ let mostRecentTransition: Transition | undefined;
 // This variable tells us where we came from
 let originalLocation: URL;
 
-// Route announcer — ported from Astro's announce(). Creates (or reuses) a single
-// shared aria-live <div> per navigation, so screen readers announce the new page title.
+// Route announcer — ported from Astro's announce(). Each navigation appends a fresh
+// aria-live <div> (after removing any prior announcer, so exactly one ever exists) and
+// writes the new page title into it 60ms later, so screen readers announce the new page.
+//
+// zfb deviation from Astro / design decision for #1063 (timer lifecycle ownership):
+//   - The 60ms timer id is stored and cleared when a newer navigation supersedes a
+//     still-pending announcement, so a superseded page's title is never written to a
+//     now-detached announcer. (Astro leaves the timer fire-and-forget.)
+//   - The previous announcer is removed before a new one is appended, so they never
+//     accumulate. We deliberately do NOT *reuse* one element across navigations (which
+//     #1063 floated): a reused live region is detached and re-inserted into the a11y
+//     tree on every body swap, and a repeated title would be a no-op text write — both
+//     make re-announcement unreliable across screen readers. Creating a fresh empty
+//     element and writing text 60ms later is Astro's proven, reliable announce trigger.
+//
 // The 60ms delay is Astro's magic number: screen readers need to see the element change
 // and may miss it if it happens too quickly.
+let announceTimer: number | undefined;
+
 const announce = () => {
-  let div = document.createElement("div");
+  // A newer navigation supersedes any still-pending announcement: cancel the old
+  // timer so it can't write a now-stale title after this navigation's swap.
+  if (announceTimer !== undefined) window.clearTimeout(announceTimer);
+
+  // Keep exactly one announcer: drop any leftover from a prior navigation that the
+  // body swap did not already detach.
+  document.querySelector(".zfb-route-announcer")?.remove();
+  const div = document.createElement("div");
   div.setAttribute("aria-live", "assertive");
   div.setAttribute("aria-atomic", "true");
   div.className = "zfb-route-announcer";
   document.body.append(div);
-  setTimeout(
-    () => {
-      // This fire-and-forget timer can outlive its document context — a test
-      // env teardown (vitest/happy-dom) or a real page unload removes `document`
-      // (and `location`) before the 60ms elapses. `typeof` is safe even when the
-      // global is gone, so bail out instead of throwing an unhandled
-      // ReferenceError (#1061); the announcement is moot once the page is gone.
-      // Both globals the callback dereferences are checked, not just `document`.
-      if (typeof document === "undefined" || typeof location === "undefined") return;
-      let title = document.title || document.querySelector("h1")?.textContent || location.pathname;
-      div.textContent = title;
-    },
-    // Screen readers need to see the element change; 60ms is Astro's empirically chosen delay.
-    60,
-  );
+
+  announceTimer = window.setTimeout(() => {
+    announceTimer = undefined;
+    // This timer can outlive its document context — a test-env teardown
+    // (vitest/happy-dom) or a real page unload removes `document` (and
+    // `location`) before the 60ms elapses. `typeof` is safe even when the
+    // global is gone, so bail out instead of throwing an unhandled
+    // ReferenceError (#1061); the announcement is moot once the page is gone.
+    // Both globals the callback dereferences are checked, not just `document`.
+    if (typeof document === "undefined" || typeof location === "undefined") return;
+    const title = document.title || document.querySelector("h1")?.textContent || location.pathname;
+    div.textContent = title;
+  }, 60);
 };
 
 const PERSIST_ATTR = "data-zfb-transition-persist";
@@ -742,6 +762,17 @@ if (inBrowser) {
       // Keep track of state between intervals
       let intervalId: number | undefined, lastY: number, lastX: number, lastIndex: State["index"];
       const scrollInterval = () => {
+        // The interval can outlive its document context — a test-env teardown or a
+        // real page unload removes window/history before the 50ms tick. `typeof`
+        // never throws even when the global is gone: stop the interval and bail
+        // rather than dereferencing a torn-down global (the #1061 bug class; #1063).
+        // In a real browser these globals always exist, so this path is test-env
+        // only. clearInterval may itself be mid-teardown, so guard the call too.
+        if (typeof window === "undefined" || typeof history === "undefined") {
+          if (typeof clearInterval === "function") clearInterval(intervalId);
+          intervalId = undefined;
+          return;
+        }
         // Check the index to see if a popstate event was fired
         if (lastIndex !== history.state?.index) {
           clearInterval(intervalId);


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1063

---

## Summary

The client-router (`packages/zfb-runtime/src/client-router/router.ts`) scheduled two timers with no lifecycle cancellation (#1063). This PR gives both explicit lifecycle ownership.

## Changes

**`announce()` route announcer**
- Stores the 60ms `setTimeout` id and `clearTimeout`s it at the start of each call, so a navigation that supersedes a still-pending announcement can't write a now-stale title to a detached announcer.
- Removes any pre-existing `.zfb-route-announcer` before appending a fresh one, so announcers never accumulate (an improvement over upstream Astro, which appends one per navigation and never removes them).
- Keeps the `typeof document/location` teardown guard from #1062.
- **Design note:** the issue floated *reusing* one `<div>`, but we deliberately create a fresh element each navigation. A reused `aria-live` region that detaches and re-enters the a11y tree on every body swap — plus a no-op text write when consecutive pages share a title — is an unreliable screen-reader trigger. Fresh-empty-element-then-write-60ms-later is Astro's field-proven trigger; this PR keeps that and only adds the single-announcer + cancellable-timer hygiene. (SR re-announce reliability is a Level 5/6 concern happy-dom can't prove — it rests on Astro's proven design, not a test here.)

**Scroll-position polling `setInterval`**
- Added a `typeof window/history` teardown guard at the top of the callback that also `clearInterval`s (itself guarded by `typeof clearInterval === "function"`) and nulls `intervalId`, giving the 50ms poll deterministic teardown — the same #1061 bug class, currently latent because the interval never starts under happy-dom.

**Provenance**
- Reconciled the stale top-of-file "Named-cause deviations" notes (announce() was described as a TODO stub / deferred — both implemented in W3C3 and rewritten here).

## Test Plan

- New tests in `__tests__/client-router/router.test.ts`: assert a single, fresh `.zfb-route-announcer` per navigation, and that a superseding navigation `clearTimeout`s the prior pending announce timer (via a `setTimeout`/`clearTimeout` spy + microtask flush that keeps the 60ms timer pending).
- **Documented blind spot:** the `scrollInterval` teardown guard is defensive-only and cannot be driven through the public API under happy-dom (the interval never starts — `scrollTo` dispatches no `scroll` event). Noted in the test file.
- `pnpm --filter @takazudo/zfb-runtime test` → 125 passing; `typecheck` clean; `prettier --check` clean.

Closes #1063