### PR TITLE
Dual Syntect Themes: light/dark codeHighlight (CSS custom properties)

### DIFF
--- a/crates/zfb-content/src/pipeline.rs
+++ b/crates/zfb-content/src/pipeline.rs
@@ -1591,6 +1591,15 @@ impl Pipeline {
     /// [`Pipeline::with_defaults_and_theme_and_gfm_and_themes_dir`] (and
     /// `zfb::config::resolve_hard_breaks`). Returns `Err` only when
     /// `themes_dir` is `Some` and a `.tmTheme` file fails to load.
+    ///
+    /// `dual` — when `Some((light, dark))`, constructs [`SyntectPlugin`] in
+    /// dual-theme mode via [`SyntectPlugin::with_dual_themes`] and overrides
+    /// `theme`. Both names must be SYNTECT theme names (e.g.
+    /// `"base16-ocean.light"`, `"base16-ocean.dark"`), NOT Shiki names like
+    /// `"dracula"`. When `None`, the single-theme path is used (with the
+    /// `theme` param as usual). The fingerprint encodes the mode explicitly
+    /// (`code_highlight=single(theme=…)` vs `code_highlight=dual(light=…,dark=…)`)
+    /// so single/dual configs can never alias a compile-cache entry.
     pub fn with_defaults_and_full_config(
         theme: Option<&str>,
         resolved: ResolvedGfmConstructs,
@@ -1598,6 +1607,55 @@ impl Pipeline {
         cjk_friendly: bool,
         hard_breaks: bool,
         features: Option<&zfb_md_extras::MarkdownFeaturesConfig>,
+    ) -> Result<Self, crate::syntect_highlight::HighlightError> {
+        Self::with_defaults_and_full_config_inner(
+            theme,
+            resolved,
+            themes_dir,
+            cjk_friendly,
+            hard_breaks,
+            features,
+            None,
+        )
+    }
+
+    /// Like [`Pipeline::with_defaults_and_full_config`] but with an explicit
+    /// dual-theme pair.
+    ///
+    /// When `dual` is `Some((light, dark))`, the `SyntectPlugin` is constructed
+    /// in dual-theme mode (CSS custom properties `--shiki-light`/`--shiki-dark`
+    /// instead of inline `color:`). The `theme` parameter is ignored in this case.
+    ///
+    /// Both theme names must be SYNTECT names — NOT Shiki names like `"dracula"`.
+    pub fn with_defaults_and_full_config_dual(
+        resolved: ResolvedGfmConstructs,
+        themes_dir: Option<&Path>,
+        cjk_friendly: bool,
+        hard_breaks: bool,
+        features: Option<&zfb_md_extras::MarkdownFeaturesConfig>,
+        theme_light: &str,
+        theme_dark: &str,
+    ) -> Result<Self, crate::syntect_highlight::HighlightError> {
+        Self::with_defaults_and_full_config_inner(
+            None,
+            resolved,
+            themes_dir,
+            cjk_friendly,
+            hard_breaks,
+            features,
+            Some((theme_light, theme_dark)),
+        )
+    }
+
+    /// Internal shared builder for both single and dual full-config constructors.
+    fn with_defaults_and_full_config_inner(
+        theme: Option<&str>,
+        resolved: ResolvedGfmConstructs,
+        themes_dir: Option<&Path>,
+        cjk_friendly: bool,
+        hard_breaks: bool,
+        features: Option<&zfb_md_extras::MarkdownFeaturesConfig>,
+        dual: Option<(&str, &str)>,
     ) -> Result<Self, crate::syntect_highlight::HighlightError> {
         // `markdown.features` absent → empty feature set (post-epic opt-in
         // default, #583 / #586): the former-Core framework features
@@ -1679,7 +1737,13 @@ impl Pipeline {
         register_features_config_derived(&mut p, features, read_recorder.as_ref());
         // SyntectPlugin MUST be added AFTER register_features so pre-syntect
         // extras visitors (mermaid, …) run first.
-        let syntect = if let Some(t) = theme {
+        //
+        // Dual mode: when `dual` is `Some((light, dark))` the plugin is
+        // constructed via `with_dual_themes`; the `theme` param is ignored.
+        // Single mode: mirrors the pre-dual logic.
+        let syntect = if let Some((light, dark)) = dual {
+            SyntectPlugin::new(highlighter).with_dual_themes(light, dark)
+        } else if let Some(t) = theme {
             SyntectPlugin::new(highlighter).with_theme(t)
         } else {
             SyntectPlugin::new(highlighter)
@@ -1704,12 +1768,26 @@ impl Pipeline {
         // reads as a `DependencyManifest` with every entry and re-probes
         // them before honouring a hit, so a cached entry can no longer go
         // stale when a referenced file changes between dev ticks.
+        //
+        // The mode is encoded EXPLICITLY in the fingerprint segment
+        // (`code_highlight=single(theme=…)` vs `code_highlight=dual(light=…,dark=…)`)
+        // so a single-theme config can never alias a dual-theme entry in the
+        // compile cache, regardless of how the theme names compare (codex #5).
+        // IMPORTANT: the single-mode segment must be BYTE-IDENTICAL to the
+        // pre-dual form so existing warm caches are not invalidated on upgrade.
+        let code_highlight_seg = if let Some((light, dark)) = dual {
+            format!("code_highlight=dual(light={light:?},dark={dark:?})")
+        } else {
+            // Single mode: reproduce the exact pre-dual descriptor string so
+            // fingerprints are unchanged for all existing single-theme configs.
+            format!("theme={theme:?}")
+        };
         let base = match (
             themes_dir_fingerprint_segment(themes_dir),
             features_fingerprint_segment(features),
         ) {
             (Some(themes_seg), Some(features_seg)) => Some(format!(
-                "{FINGERPRINT_VERSION};full;theme={theme:?};{gfm};{themes_seg};cjk={cjk_friendly};hard_breaks={hard_breaks};{features_seg}",
+                "{FINGERPRINT_VERSION};full;{code_highlight_seg};{gfm};{themes_seg};cjk={cjk_friendly};hard_breaks={hard_breaks};{features_seg}",
                 gfm = gfm_fingerprint_segment(resolved),
             )),
             _ => None,

--- a/crates/zfb-content/src/pipeline.rs
+++ b/crates/zfb-content/src/pipeline.rs
@@ -1686,6 +1686,25 @@ impl Pipeline {
         if let Some(dir) = themes_dir {
             highlighter.load_themes_from_dir(dir)?;
         }
+        // Build-start validation for dual mode: a misspelled or unloaded
+        // `themeLight`/`themeDark` must surface the documented `UnknownTheme`
+        // error here rather than silently rendering unhighlighted blocks —
+        // the per-block `highlight_lines_dual` call's `Err` is swallowed by
+        // `SyntectPlugin` (mirroring the single-theme path), so the only place
+        // a dual name can be rejected loudly is at construction, after any
+        // `themesDir` themes are loaded. (config.rs only validates that the
+        // pair is *present*; theme-name existence depends on `themesDir`,
+        // which is not known until here.)
+        if let Some((light, dark)) = dual {
+            let names = highlighter.theme_names();
+            for name in [light, dark] {
+                if !names.iter().any(|n| n == name) {
+                    return Err(crate::syntect_highlight::HighlightError::UnknownTheme(
+                        name.to_string(),
+                    ));
+                }
+            }
+        }
         let highlighter = Arc::new(highlighter);
         let mut p = Self::with_resolved_gfm_constructs(resolved);
         // mdast phase — CjkFriendlyPlugin honours the cjk_friendly toggle.

--- a/crates/zfb-content/src/pipeline_spec.rs
+++ b/crates/zfb-content/src/pipeline_spec.rs
@@ -70,14 +70,42 @@ pub struct PipelineSpec {
     /// `None` keeps the built-in default theme (`base16-ocean.dark`).
     /// Custom themes are loaded via [`Self::code_highlight_themes_dir`].
     /// Mirrors `codeHighlight.theme` in `zfb.config.ts`.
+    ///
+    /// Mutually exclusive with [`Self::code_highlight_theme_light`] /
+    /// [`Self::code_highlight_theme_dark`] — set only one mode per build.
+    /// These are SYNTECT theme names (e.g. `"InspiredGitHub"`,
+    /// `"Solarized (dark)"`), NOT Shiki names like `"dracula"`.
     pub code_highlight_theme: Option<String>,
     /// Optional absolute path to a directory of `.tmTheme` files, loaded
     /// before the syntect plugin is constructed so custom themes become
-    /// addressable by name in [`Self::code_highlight_theme`]. `None`
-    /// keeps syntect's bundled themes only. Mirrors
+    /// addressable by name in [`Self::code_highlight_theme`] (or the dual
+    /// pair). `None` keeps syntect's bundled themes only. Mirrors
     /// `codeHighlight.themesDir` in `zfb.config.ts` (resolved to an
     /// absolute path by the command layer before being stored here).
+    ///
+    /// Applies to both single-theme and dual-theme mode.
     pub code_highlight_themes_dir: Option<PathBuf>,
+    /// Light-mode syntect theme name for dual-theme highlighting.
+    ///
+    /// Active iff BOTH `code_highlight_theme_light` AND
+    /// `code_highlight_theme_dark` are `Some`. When the dual pair is
+    /// active, every fenced code block is highlighted twice and per-token
+    /// colors are emitted as CSS custom properties (`--shiki-light` /
+    /// `--shiki-dark`) instead of inline `color:`. The `<pre>` element
+    /// carries `class="syntect-dual"` and `--shiki-*-bg` vars in its
+    /// `style` attribute.
+    ///
+    /// Mutually exclusive with [`Self::code_highlight_theme`].
+    /// Must be a SYNTECT theme name (e.g. `"base16-ocean.light"`),
+    /// NOT a Shiki name like `"dracula"`.
+    /// Mirrors `codeHighlight.themeLight` in `zfb.config.ts`.
+    pub code_highlight_theme_light: Option<String>,
+    /// Dark-mode syntect theme name for dual-theme highlighting.
+    ///
+    /// See [`Self::code_highlight_theme_light`] for the full dual-mode
+    /// contract. Must be a SYNTECT theme name (e.g. `"base16-ocean.dark"`),
+    /// NOT a Shiki name. Mirrors `codeHighlight.themeDark` in `zfb.config.ts`.
+    pub code_highlight_theme_dark: Option<String>,
     /// When `true`, append [`Pipeline::add_strip_md_ext`] so internal
     /// `[link](other.md)` style hrefs are rewritten to `other/`. Mirrors
     /// the opt-in `stripMdExt` flag in `zfb.config.ts` (zfb#127 / #129).
@@ -155,6 +183,8 @@ impl Default for PipelineSpec {
         Self {
             code_highlight_theme: None,
             code_highlight_themes_dir: None,
+            code_highlight_theme_light: None,
+            code_highlight_theme_dark: None,
             strip_md_ext: false,
             resolve_source_map: None,
             gfm_constructs: ResolvedGfmConstructs::default(),
@@ -197,6 +227,8 @@ impl PipelineSpec {
         let Self {
             code_highlight_theme,
             code_highlight_themes_dir,
+            code_highlight_theme_light,
+            code_highlight_theme_dark,
             strip_md_ext,
             resolve_source_map,
             gfm_constructs,
@@ -208,17 +240,38 @@ impl PipelineSpec {
             build_context_roots,
         } = self;
 
-        // Single feature-aware entry point. `features = None` is an empty
-        // feature set: the former-Core framework features are off (the
+        // Dual mode is active iff BOTH light and dark are Some.
+        let dual_pair = match (
+            code_highlight_theme_light.as_deref(),
+            code_highlight_theme_dark.as_deref(),
+        ) {
+            (Some(light), Some(dark)) => Some((light, dark)),
+            _ => None,
+        };
+
+        // Single or dual feature-aware entry point. `features = None` is an
+        // empty feature set: the former-Core framework features are off (the
         // post-epic opt-in default, #583 / #586).
-        let mut pipeline = Pipeline::with_defaults_and_full_config(
-            code_highlight_theme.as_deref(),
-            *gfm_constructs,
-            code_highlight_themes_dir.as_deref(),
-            *cjk_friendly,
-            *hard_breaks,
-            features.as_ref(),
-        )
+        let mut pipeline = if let Some((light, dark)) = dual_pair {
+            Pipeline::with_defaults_and_full_config_dual(
+                *gfm_constructs,
+                code_highlight_themes_dir.as_deref(),
+                *cjk_friendly,
+                *hard_breaks,
+                features.as_ref(),
+                light,
+                dark,
+            )
+        } else {
+            Pipeline::with_defaults_and_full_config(
+                code_highlight_theme.as_deref(),
+                *gfm_constructs,
+                code_highlight_themes_dir.as_deref(),
+                *cjk_friendly,
+                *hard_breaks,
+                features.as_ref(),
+            )
+        }
         .map_err(|cause| PipelineSpecError {
             // `Err` only occurs when `themes_dir` is `Some` (theme-file
             // load), so the `unwrap_or_default()` empty-string branch is

--- a/crates/zfb-content/src/plugins/syntect_plugin.rs
+++ b/crates/zfb-content/src/plugins/syntect_plugin.rs
@@ -6,11 +6,13 @@
 //!
 //! 1. Skips `mermaid` blocks — those are handled by
 //!    [`crate::plugins::MermaidPlugin`].
-//! 2. Calls `highlighter.highlight_lines(code, Some(lang), None)`.
+//! 2. Calls `highlighter.highlight_lines(code, Some(lang), None)` (single
+//!    mode) or `highlighter.highlight_lines_dual(...)` (dual mode).
 //! 3. Replaces the entire `<pre>` [`HastNode`] with a structured HAST
 //!    tree of the form:
 //!    ```text
-//!    Element<pre class="syntect-{slug}">
+//!    Element<pre class="syntect-{slug}">          (single mode)
+//!    Element<pre class="syntect-dual" style="…">  (dual mode)
 //!      Element<code>
 //!        Element<span class="line">  Raw(line_1_html)  </span>
 //!        Element<span class="line">  Raw(line_2_html)  </span>
@@ -34,28 +36,86 @@ use std::sync::Arc;
 use crate::pipeline::{HastNode, HastVisitor};
 use crate::syntect_highlight::Highlighter;
 
+/// Internal mode selector for [`SyntectPlugin`].
+///
+/// `Single` uses the existing single-theme path (inline `color:`).
+/// `Dual` calls `highlight_lines_dual` and emits `--shiki-light` /
+/// `--shiki-dark` custom properties instead of inline color.
+#[derive(Clone)]
+enum SyntectMode {
+    /// Single theme — forwards to `highlight_lines` with the optional
+    /// theme name override. `None` falls back to the highlighter default.
+    Single(Option<String>),
+    /// Dual light + dark theme — forwards to `highlight_lines_dual` and
+    /// emits `<pre class="syntect-dual" style="--shiki-light-bg:…;--shiki-dark-bg:…">`.
+    ///
+    /// Theme names are SYNTECT names (e.g. `"base16-ocean.light"`,
+    /// `"base16-ocean.dark"`), NOT Shiki names like `"dracula"`.
+    Dual {
+        /// Light-mode syntect theme name (e.g. `"base16-ocean.light"`).
+        light: String,
+        /// Dark-mode syntect theme name (e.g. `"base16-ocean.dark"`).
+        dark: String,
+    },
+}
+
 /// Visitor that swaps fenced code blocks for syntect HTML.
 #[derive(Clone)]
 pub struct SyntectPlugin {
     highlighter: Arc<Highlighter>,
-    theme: Option<String>,
+    mode: SyntectMode,
 }
 
 impl SyntectPlugin {
-    /// Construct with a shared highlighter.
+    /// Construct with a shared highlighter in single-theme mode.
+    ///
+    /// The theme defaults to the highlighter's configured default
+    /// (`base16-ocean.dark`). Use [`SyntectPlugin::with_theme`] to
+    /// override it, or [`SyntectPlugin::with_dual_themes`] for dual mode.
     #[must_use]
     pub fn new(highlighter: Arc<Highlighter>) -> Self {
         Self {
             highlighter,
-            theme: None,
+            mode: SyntectMode::Single(None),
         }
     }
 
     /// Override the theme passed to the highlighter (defaults to the
     /// highlighter's configured default).
+    ///
+    /// The name must be a SYNTECT built-in or user-loaded theme name
+    /// (e.g. `"InspiredGitHub"`, `"Solarized (dark)"`), NOT a Shiki
+    /// name like `"dracula"`.
     #[must_use]
     pub fn with_theme(mut self, theme: impl Into<String>) -> Self {
-        self.theme = Some(theme.into());
+        self.mode = SyntectMode::Single(Some(theme.into()));
+        self
+    }
+
+    /// Switch to dual light + dark theme mode.
+    ///
+    /// In dual mode every fenced code block is highlighted twice — once
+    /// with `theme_light` and once with `theme_dark` — and the per-token
+    /// colors are emitted as CSS custom properties (`--shiki-light` /
+    /// `--shiki-dark`) instead of inline `color:`. The `<pre>` element
+    /// gets `class="syntect-dual"` and carries `--shiki-light-bg` /
+    /// `--shiki-dark-bg` as inline `style` variables (omitted when the
+    /// theme has no background). The consumer resolves the active color
+    /// with a `light-dark()` CSS rule.
+    ///
+    /// Both names must be SYNTECT built-in or user-loaded theme names
+    /// (e.g. `"base16-ocean.light"`, `"base16-ocean.dark"`), NOT Shiki
+    /// names like `"dracula"`.
+    #[must_use]
+    pub fn with_dual_themes(
+        mut self,
+        theme_light: impl Into<String>,
+        theme_dark: impl Into<String>,
+    ) -> Self {
+        self.mode = SyntectMode::Dual {
+            light: theme_light.into(),
+            dark: theme_dark.into(),
+        };
         self
     }
 }
@@ -64,7 +124,7 @@ impl HastVisitor for SyntectPlugin {
     fn visit(&mut self, node: &mut HastNode) {
         match node {
             HastNode::Root { children } | HastNode::Element { children, .. } => {
-                rewrite_children(children, &self.highlighter, self.theme.as_deref());
+                rewrite_children(children, &self.highlighter, &self.mode);
                 for c in children {
                     self.visit(c);
                 }
@@ -74,54 +134,142 @@ impl HastVisitor for SyntectPlugin {
     }
 }
 
-fn rewrite_children(children: &mut [HastNode], highlighter: &Highlighter, theme: Option<&str>) {
+fn rewrite_children(children: &mut [HastNode], highlighter: &Highlighter, mode: &SyntectMode) {
     for child in children.iter_mut() {
         if let Some((lang, meta, code)) = lang_and_code(child) {
             if lang == "mermaid" {
                 continue;
             }
-            if let Ok(result) = highlighter.highlight_lines(&code, Some(&lang), theme) {
-                // Build structured HAST: <pre class="syntect-{slug}"><code>
-                //   <span class="line">Raw(line_html)</span>…
-                // </code></pre>
-                // The per-line Raw keeps token-span HTML verbatim; the
-                // <span class="line"> Element wrapper exposes each line to
-                // downstream visitors (wave-5 code-enrichment).
-                let line_spans: Vec<HastNode> = result
-                    .lines
-                    .into_iter()
-                    .map(|line_html| HastNode::Element {
-                        tag: "span".to_string(),
-                        attrs: vec![("class".to_string(), "line".to_string())],
-                        children: vec![HastNode::Raw(line_html)],
-                        void: false,
-                    })
-                    .collect();
-                // Preserve `data-meta` on the new <code> element so downstream
-                // hast visitors (e.g. wave-5 CodeEnrichmentPlugin) can read the
-                // fence info-string (e.g. `{1,3-5}` for line highlighting).
-                let mut code_attrs: Vec<(String, String)> = Vec::new();
-                if let Some(m) = meta {
-                    code_attrs.push(("data-meta".to_string(), m));
+            match mode {
+                SyntectMode::Single(theme) => {
+                    rewrite_single(child, highlighter, theme.as_deref(), &lang, meta, &code);
                 }
-                let code_el = HastNode::Element {
-                    tag: "code".to_string(),
-                    attrs: code_attrs,
-                    children: line_spans,
-                    void: false,
-                };
-                *child = HastNode::Element {
-                    tag: "pre".to_string(),
-                    attrs: vec![(
-                        "class".to_string(),
-                        format!("syntect-{}", result.theme_slug),
-                    )],
-                    children: vec![code_el],
-                    void: false,
-                };
+                SyntectMode::Dual { light, dark } => {
+                    rewrite_dual(child, highlighter, light, dark, &lang, meta, &code);
+                }
             }
         }
     }
+}
+
+/// Rewrite `child` using the single-theme path. Mirrors the pre-dual logic.
+fn rewrite_single(
+    child: &mut HastNode,
+    highlighter: &Highlighter,
+    theme: Option<&str>,
+    lang: &str,
+    meta: Option<String>,
+    code: &str,
+) {
+    if let Ok(result) = highlighter.highlight_lines(code, Some(lang), theme) {
+        // Build structured HAST: <pre class="syntect-{slug}"><code>
+        //   <span class="line">Raw(line_html)</span>…
+        // </code></pre>
+        // The per-line Raw keeps token-span HTML verbatim; the
+        // <span class="line"> Element wrapper exposes each line to
+        // downstream visitors (wave-5 code-enrichment).
+        let line_spans = build_line_spans(result.lines);
+        // Preserve `data-meta` on the new <code> element so downstream
+        // hast visitors (e.g. wave-5 CodeEnrichmentPlugin) can read the
+        // fence info-string (e.g. `{1,3-5}` for line highlighting).
+        let code_el = build_code_el(line_spans, meta);
+        *child = HastNode::Element {
+            tag: "pre".to_string(),
+            attrs: vec![(
+                "class".to_string(),
+                format!("syntect-{}", result.theme_slug),
+            )],
+            children: vec![code_el],
+            void: false,
+        };
+    }
+}
+
+/// Rewrite `child` using the dual light/dark theme path.
+///
+/// Calls `highlight_lines_dual` and emits:
+/// ```html
+/// <pre class="syntect-dual" style="--shiki-light-bg:#…;--shiki-dark-bg:#…">
+///   <code>
+///     <span class="line">Raw(dual_line_html)</span>…
+///   </code>
+/// </pre>
+/// ```
+///
+/// Per-token spans carry `--shiki-light:#…;--shiki-dark:#…` custom
+/// properties (NO inline `color:`). The `--shiki-*-bg` vars are emitted
+/// only when the corresponding theme provides a background color; if
+/// BOTH themes lack a background the `style` attribute is omitted
+/// entirely.
+fn rewrite_dual(
+    child: &mut HastNode,
+    highlighter: &Highlighter,
+    theme_light: &str,
+    theme_dark: &str,
+    lang: &str,
+    meta: Option<String>,
+    code: &str,
+) {
+    if let Ok(result) = highlighter.highlight_lines_dual(code, Some(lang), theme_light, theme_dark)
+    {
+        let line_spans = build_line_spans(result.lines);
+        let code_el = build_code_el(line_spans, meta);
+
+        // Build the style attribute carrying the --shiki-*-bg variables.
+        // Omit a given *-bg var when its Option is None (colour-only theme);
+        // omit the style attr entirely when both are None.
+        let mut style_parts: Vec<String> = Vec::new();
+        if let Some(light_bg) = &result.light_bg {
+            style_parts.push(format!("--shiki-light-bg:{light_bg}"));
+        }
+        if let Some(dark_bg) = &result.dark_bg {
+            style_parts.push(format!("--shiki-dark-bg:{dark_bg}"));
+        }
+
+        let mut attrs: Vec<(String, String)> =
+            vec![("class".to_string(), "syntect-dual".to_string())];
+        if !style_parts.is_empty() {
+            attrs.push(("style".to_string(), style_parts.join(";")));
+        }
+
+        *child = HastNode::Element {
+            tag: "pre".to_string(),
+            attrs,
+            children: vec![code_el],
+            void: false,
+        };
+    }
+}
+
+/// Build a `<code>` element wrapping the given line spans.
+///
+/// Preserves `data-meta` when the fence carried a meta string so
+/// downstream hast visitors (e.g. wave-5 `CodeEnrichmentPlugin`) can
+/// read the fence info-string (e.g. `{1,3-5}` for line highlighting).
+fn build_code_el(line_spans: Vec<HastNode>, meta: Option<String>) -> HastNode {
+    let mut code_attrs: Vec<(String, String)> = Vec::new();
+    if let Some(m) = meta {
+        code_attrs.push(("data-meta".to_string(), m));
+    }
+    HastNode::Element {
+        tag: "code".to_string(),
+        attrs: code_attrs,
+        children: line_spans,
+        void: false,
+    }
+}
+
+/// Wrap each per-line HTML fragment in `<span class="line">Raw(…)</span>`.
+fn build_line_spans(lines: Vec<String>) -> Vec<HastNode> {
+    lines
+        .into_iter()
+        .map(|line_html| HastNode::Element {
+            tag: "span".to_string(),
+            attrs: vec![("class".to_string(), "line".to_string())],
+            children: vec![HastNode::Raw(line_html)],
+            void: false,
+        })
+        .collect()
 }
 
 /// If `node` is `<pre><code data-lang="…">TEXT</code></pre>`, return
@@ -307,6 +455,131 @@ mod tests {
             "expected themed wrapper for unknown lang: {html}"
         );
         assert!(html.contains("hello"), "code content missing: {html}");
+    }
+
+    // ── Dual-theme mode (with_dual_themes) ────────────────────────────────
+
+    /// Acceptance: dual mode emits `<pre class="syntect-dual">` with
+    /// `--shiki-light-bg`/`--shiki-dark-bg` in the `style` attribute, and
+    /// per-token spans carry `--shiki-light`/`--shiki-dark` with NO inline
+    /// `color:`.
+    #[test]
+    fn dual_mode_emits_syntect_dual_class_and_bg_vars() {
+        let h = Arc::new(Highlighter::new());
+        let mut plugin =
+            SyntectPlugin::new(h).with_dual_themes("base16-ocean.light", "base16-ocean.dark");
+        let mut tree = HastNode::Root {
+            children: vec![pre_code(Some("rust"), "fn main() {}\n")],
+        };
+        plugin.visit(&mut tree);
+
+        let HastNode::Root { children } = &tree else {
+            unreachable!("expected Root")
+        };
+        let HastNode::Element {
+            tag,
+            attrs,
+            children: pre_children,
+            ..
+        } = &children[0]
+        else {
+            panic!("expected Element<pre>, got {:?}", children[0])
+        };
+        assert_eq!(tag, "pre");
+        // class must be "syntect-dual"
+        assert!(
+            attrs
+                .iter()
+                .any(|(k, v)| k == "class" && v == "syntect-dual"),
+            "pre must have class=\"syntect-dual\": {attrs:?}"
+        );
+        // style must carry both --shiki-light-bg and --shiki-dark-bg
+        let style = attrs
+            .iter()
+            .find(|(k, _)| k == "style")
+            .map(|(_, v)| v.as_str())
+            .unwrap_or("");
+        assert!(
+            style.contains("--shiki-light-bg:"),
+            "style must contain --shiki-light-bg: {style}"
+        );
+        assert!(
+            style.contains("--shiki-dark-bg:"),
+            "style must contain --shiki-dark-bg: {style}"
+        );
+
+        // Serialize the whole tree and check token properties.
+        use crate::serializer::serialize;
+        let html = serialize(&children[0]);
+        assert!(
+            html.contains("--shiki-light:#"),
+            "must contain --shiki-light: {html}"
+        );
+        assert!(
+            html.contains("--shiki-dark:#"),
+            "must contain --shiki-dark: {html}"
+        );
+        // The whole point: no inline `color:` in dual mode.
+        assert!(
+            !html.contains("color:#"),
+            "dual mode must NOT emit inline color: {html}"
+        );
+
+        // <code> must still be present, with <span class="line"> children.
+        let code_el = pre_children.first().expect("pre must have <code>");
+        let HastNode::Element {
+            tag: code_tag,
+            children: code_children,
+            ..
+        } = code_el
+        else {
+            panic!("expected Element<code>");
+        };
+        assert_eq!(code_tag, "code");
+        assert!(
+            !code_children.is_empty(),
+            "code must have line span children"
+        );
+    }
+
+    /// Byte-identity: single mode must still emit inline `color:` and
+    /// NO `--shiki-*` vars (the pre-dual output is unchanged).
+    #[test]
+    fn single_mode_still_emits_inline_color_not_shiki_vars() {
+        let h = Arc::new(Highlighter::new());
+        let mut plugin = SyntectPlugin::new(h);
+        let mut tree = HastNode::Root {
+            children: vec![pre_code(Some("rust"), "fn main() {}\n")],
+        };
+        plugin.visit(&mut tree);
+
+        let HastNode::Root { children } = &tree else {
+            unreachable!("expected Root")
+        };
+        use crate::serializer::serialize;
+        let html = serialize(&children[0]);
+        assert!(
+            html.contains("color:#"),
+            "single mode must still emit inline color: {html}"
+        );
+        assert!(
+            !html.contains("--shiki-"),
+            "single mode must NOT emit --shiki- vars: {html}"
+        );
+    }
+
+    /// Dual mode mermaid blocks are skipped (same as single mode).
+    #[test]
+    fn dual_mode_skips_mermaid_block() {
+        let h = Arc::new(Highlighter::new());
+        let mut plugin =
+            SyntectPlugin::new(h).with_dual_themes("base16-ocean.light", "base16-ocean.dark");
+        let mut tree = HastNode::Root {
+            children: vec![pre_code(Some("mermaid"), "graph TD;")],
+        };
+        let original = tree.clone();
+        plugin.visit(&mut tree);
+        assert_eq!(tree, original, "dual mode must also skip mermaid blocks");
     }
 
     /// New acceptance criterion (issue #571): a 3-line `<pre>` produces

--- a/crates/zfb-content/src/syntect_highlight.rs
+++ b/crates/zfb-content/src/syntect_highlight.rs
@@ -359,9 +359,17 @@ impl Highlighter {
             for ((light_style, text), (dark_style, _)) in
                 light_regions.iter().zip(dark_regions.iter())
             {
+                // Spec (#1066): a dual span carries ONLY `--shiki-light` /
+                // `--shiki-dark` color vars — the sole difference vs the single
+                // path is those vars replacing `color:`. Syntect font styles
+                // (bold/italic/underline) are intentionally NOT emitted here:
+                // the two themes could disagree on style and there is no dual
+                // custom-property convention for it in this primitive. Wiring
+                // font styles is out of scope for this engine sub-issue.
+                //
                 // Escape with the SAME escaper syntect uses for text nodes so the
-                // only difference vs the single path is `--shiki-*` replacing
-                // `color:`. (Verified equal to syntect's `Escape` in tests.)
+                // escaped output is byte-identical to the single path's token
+                // text. (Verified equal to syntect's `Escape` in tests.)
                 let escaped = escape_html(text);
                 line_html.push_str("<span style=\"--shiki-light:");
                 line_html.push_str(&color_to_hex(light_style.foreground));

--- a/crates/zfb-content/src/syntect_highlight.rs
+++ b/crates/zfb-content/src/syntect_highlight.rs
@@ -21,7 +21,7 @@ use std::path::Path;
 use std::sync::{Arc, LazyLock};
 
 use syntect::easy::HighlightLines;
-use syntect::highlighting::{Theme, ThemeSet};
+use syntect::highlighting::{Color, Theme, ThemeSet};
 use syntect::html::{styled_line_to_highlighted_html, IncludeBackground};
 use syntect::parsing::SyntaxSet;
 use syntect::util::LinesWithEndings;
@@ -256,6 +256,131 @@ impl Highlighter {
             fallback: false,
         })
     }
+
+    /// Highlight a code block **twice** (a light theme and a dark theme) and
+    /// emit per-token CSS *custom properties* (`--shiki-light` / `--shiki-dark`)
+    /// instead of an inline `color:`.
+    ///
+    /// This is the engine primitive for dual-theme (light + dark) rendering: a
+    /// single HTML payload carries both colours per token, and CSS picks which
+    /// custom property to apply based on the active colour scheme. The variable
+    /// names mirror Shiki's dual-theme convention so downstream CSS is familiar.
+    ///
+    /// * `code` - raw source code (no surrounding HTML).
+    /// * `lang` - language identifier from the markdown fence.
+    /// * `theme_light` / `theme_dark` - theme names; BOTH must resolve or the
+    ///   call returns [`HighlightError::UnknownTheme`] (same path as the
+    ///   single-theme method).
+    ///
+    /// Returns a [`DualHighlightedLines`] carrying:
+    /// - `lines`: one HTML fragment per source line. On the highlighted path each
+    ///   token is `<span style="--shiki-light:#…;--shiki-dark:#…">{escaped}</span>`.
+    ///   On the fallback path each entry is the HTML-escaped source line with no
+    ///   colour vars.
+    /// - `light_bg` / `dark_bg`: each theme's background as `#rrggbb`, or `None`
+    ///   when that theme defines no `settings.background` (colour-only `.tmTheme`).
+    /// - `fallback`: `true` when the themed-fallback path was used (unknown lang,
+    ///   tokenization error, or a per-line region-alignment mismatch).
+    ///
+    /// ## Region-alignment guard
+    ///
+    /// Tokenization is syntax/scope-driven, not theme-driven, so highlighting the
+    /// same syntax under two themes yields region lists whose text slices
+    /// concatenate to identical per-line text. This is *asserted* per line: on any
+    /// mismatch the method degrades to the escaped fallback rather than zipping
+    /// misaligned spans.
+    pub fn highlight_lines_dual(
+        &self,
+        code: &str,
+        lang: Option<&str>,
+        theme_light: &str,
+        theme_dark: &str,
+    ) -> Result<DualHighlightedLines, HighlightError> {
+        // Resolve BOTH themes up front, mirroring `highlight_lines`'
+        // UnknownTheme path. Unknown lang degrades to fallback (not an error),
+        // but an unknown theme name is always an error.
+        let light_obj: &Theme = self
+            .theme_set
+            .themes
+            .get(theme_light)
+            .ok_or_else(|| HighlightError::UnknownTheme(theme_light.to_string()))?;
+        let dark_obj: &Theme = self
+            .theme_set
+            .themes
+            .get(theme_dark)
+            .ok_or_else(|| HighlightError::UnknownTheme(theme_dark.to_string()))?;
+
+        // Background vars are emitted whenever the theme defines one; a
+        // colour-only theme (no `settings.background`) yields `None` and the
+        // corresponding `--shiki-*-bg` var is simply omitted downstream.
+        let light_bg = light_obj.settings.background.map(color_to_hex);
+        let dark_bg = dark_obj.settings.background.map(color_to_hex);
+
+        let syntax = lang.filter(|s| !s.is_empty()).and_then(|l| {
+            self.syntax_set.find_syntax_by_token(l).or_else(|| {
+                resolve_alias(l)
+                    .iter()
+                    .find_map(|name| self.syntax_set.find_syntax_by_name(name))
+            })
+        });
+
+        let Some(syntax) = syntax else {
+            return Ok(dual_fallback_lines(code, light_bg, dark_bg));
+        };
+
+        // Two highlighters over the SAME resolved syntax — only the theme
+        // differs, so per-line region *text* is identical between them.
+        let mut h_light = HighlightLines::new(syntax, light_obj);
+        let mut h_dark = HighlightLines::new(syntax, dark_obj);
+        let mut lines: Vec<String> = Vec::new();
+        for line in LinesWithEndings::from(code) {
+            let light_regions = match h_light.highlight_line(line, &self.syntax_set) {
+                Ok(r) => r,
+                Err(_) => return Ok(dual_fallback_lines(code, light_bg, dark_bg)),
+            };
+            let dark_regions = match h_dark.highlight_line(line, &self.syntax_set) {
+                Ok(r) => r,
+                Err(_) => return Ok(dual_fallback_lines(code, light_bg, dark_bg)),
+            };
+
+            // Region-zip guard: the two themes must produce the same token
+            // boundaries (same count, same text per token). If they don't, the
+            // zip would emit misaligned spans — degrade to fallback instead.
+            let aligned = light_regions.len() == dark_regions.len()
+                && light_regions
+                    .iter()
+                    .zip(dark_regions.iter())
+                    .all(|((_, lt), (_, dt))| lt == dt);
+            if !aligned {
+                return Ok(dual_fallback_lines(code, light_bg, dark_bg));
+            }
+
+            let mut line_html = String::new();
+            for ((light_style, text), (dark_style, _)) in
+                light_regions.iter().zip(dark_regions.iter())
+            {
+                // Escape with the SAME escaper syntect uses for text nodes so the
+                // only difference vs the single path is `--shiki-*` replacing
+                // `color:`. (Verified equal to syntect's `Escape` in tests.)
+                let escaped = escape_html(text);
+                line_html.push_str("<span style=\"--shiki-light:");
+                line_html.push_str(&color_to_hex(light_style.foreground));
+                line_html.push_str(";--shiki-dark:");
+                line_html.push_str(&color_to_hex(dark_style.foreground));
+                line_html.push_str("\">");
+                line_html.push_str(&escaped);
+                line_html.push_str("</span>");
+            }
+            lines.push(line_html);
+        }
+
+        Ok(DualHighlightedLines {
+            lines,
+            light_bg,
+            dark_bg,
+            fallback: false,
+        })
+    }
 }
 
 /// Per-line highlighting result returned by [`Highlighter::highlight_lines`].
@@ -268,6 +393,31 @@ pub struct HighlightedLines {
     pub lines: Vec<String>,
     /// `true` when the output used the themed-fallback path (unknown lang or
     /// tokenization error) rather than per-token syntect highlighting.
+    pub fallback: bool,
+}
+
+/// Per-line dual-theme highlighting result returned by
+/// [`Highlighter::highlight_lines_dual`].
+///
+/// Each token carries both a light and a dark colour as CSS custom properties
+/// (`--shiki-light` / `--shiki-dark`) so a single payload renders correctly
+/// under either colour scheme. The two `*_bg` fields are the per-theme
+/// backgrounds (each `Option`: `None` when a theme defines no background).
+#[derive(Debug, Clone)]
+pub struct DualHighlightedLines {
+    /// One HTML fragment per source line. On the highlighted path each token is
+    /// `<span style="--shiki-light:#…;--shiki-dark:#…">{escaped}</span>`; on the
+    /// fallback path each entry is the HTML-escaped source line (no colour vars).
+    pub lines: Vec<String>,
+    /// Light theme background as `#rrggbb`, or `None` when the theme defines no
+    /// `settings.background` (the `--shiki-light-bg` var is then omitted).
+    pub light_bg: Option<String>,
+    /// Dark theme background as `#rrggbb`, or `None` when the theme defines no
+    /// `settings.background` (the `--shiki-dark-bg` var is then omitted).
+    pub dark_bg: Option<String>,
+    /// `true` when the output used the themed-fallback path (unknown lang,
+    /// tokenization error, or a per-line region-alignment mismatch) rather than
+    /// per-token dual highlighting.
     pub fallback: bool,
 }
 
@@ -337,6 +487,35 @@ fn fallback_lines(code: &str, slug: &str) -> HighlightedLines {
     HighlightedLines {
         theme_slug: slug.to_string(),
         lines,
+        fallback: true,
+    }
+}
+
+/// Format a syntect [`Color`] as a lowercase `#rrggbb` string, dropping alpha.
+///
+/// Matches the RGB branch of syntect's own `write_css_color`
+/// (`#{:02x}{:02x}{:02x}`) so the colours emitted in `--shiki-*` vars are
+/// byte-identical to what the single `color:` path would emit — minus the alpha
+/// channel, which is intentionally dropped for the dual custom-property form.
+fn color_to_hex(c: Color) -> String {
+    format!("#{:02x}{:02x}{:02x}", c.r, c.g, c.b)
+}
+
+/// Build a [`DualHighlightedLines`] for the dual fallback path (unknown lang,
+/// tokenization error, or region-alignment mismatch). Splits `code` on
+/// `LinesWithEndings` so the per-line vector matches the normal path's
+/// granularity; each line is HTML-escaped with no colour vars. Background vars
+/// are preserved (the themes resolved fine; only tokenization fell back).
+fn dual_fallback_lines(
+    code: &str,
+    light_bg: Option<String>,
+    dark_bg: Option<String>,
+) -> DualHighlightedLines {
+    let lines: Vec<String> = LinesWithEndings::from(code).map(escape_html).collect();
+    DualHighlightedLines {
+        lines,
+        light_bg,
+        dark_bg,
         fallback: true,
     }
 }
@@ -775,5 +954,264 @@ mod tests {
             h.theme_names().iter().any(|n| n == "My Custom Theme"),
             "custom theme present after mixed-dir load"
         );
+    }
+
+    // ── Dual-theme highlighting (highlight_lines_dual) ─────────────────────
+
+    #[test]
+    fn dual_highlight_rust_emits_shiki_vars_no_color() {
+        let h = Highlighter::new();
+        let result = h
+            .highlight_lines_dual(
+                "fn main() {}\n",
+                Some("rust"),
+                "base16-ocean.light",
+                "base16-ocean.dark",
+            )
+            .expect("dual highlight ok");
+        assert!(
+            !result.fallback,
+            "should be the highlighted path, not fallback"
+        );
+        let html = result.lines.concat();
+        assert!(
+            html.contains("--shiki-light:#"),
+            "missing --shiki-light var: {html}"
+        );
+        assert!(
+            html.contains("--shiki-dark:#"),
+            "missing --shiki-dark var: {html}"
+        );
+        // The whole point: no inline `color:` — dual mode uses custom props.
+        assert!(
+            !html.contains("color:#"),
+            "dual path must not emit inline color: {html}"
+        );
+    }
+
+    #[test]
+    fn dual_highlight_backgrounds_present_and_differ() {
+        let h = Highlighter::new();
+        let result = h
+            .highlight_lines_dual(
+                "fn main() {}\n",
+                Some("rust"),
+                "base16-ocean.light",
+                "base16-ocean.dark",
+            )
+            .expect("dual highlight ok");
+        let light = result.light_bg.expect("light bg present");
+        let dark = result.dark_bg.expect("dark bg present");
+        assert!(
+            light.starts_with('#') && light.len() == 7,
+            "light bg not #rrggbb: {light}"
+        );
+        assert!(
+            dark.starts_with('#') && dark.len() == 7,
+            "dark bg not #rrggbb: {dark}"
+        );
+        assert_ne!(light, dark, "light and dark backgrounds must differ");
+    }
+
+    /// Region-alignment guard: highlighting the same syntax under two themes
+    /// yields region lists whose text slices concatenate to identical per-line
+    /// text, and whose token count + text match the single path's regions.
+    #[test]
+    fn dual_region_text_aligns_and_matches_single_path() {
+        let h = Highlighter::new();
+        let code = "let x: i32 = 1 + 2;\nfn f() {}\n";
+        let syntax = h
+            .syntax_set
+            .find_syntax_by_name("Rust")
+            .expect("Rust syntax present");
+
+        let mut h_single = HighlightLines::new(syntax, &h.theme_set.themes["base16-ocean.dark"]);
+        let mut h_light = HighlightLines::new(syntax, &h.theme_set.themes["base16-ocean.light"]);
+        let mut h_dark = HighlightLines::new(syntax, &h.theme_set.themes["base16-ocean.dark"]);
+
+        for line in LinesWithEndings::from(code) {
+            let single = h_single.highlight_line(line, &h.syntax_set).unwrap();
+            let light = h_light.highlight_line(line, &h.syntax_set).unwrap();
+            let dark = h_dark.highlight_line(line, &h.syntax_set).unwrap();
+
+            // light/dark region text slices concatenate to identical text.
+            let light_text: String = light.iter().map(|(_, t)| *t).collect();
+            let dark_text: String = dark.iter().map(|(_, t)| *t).collect();
+            assert_eq!(
+                light_text, dark_text,
+                "light/dark per-line region text must be identical"
+            );
+
+            // token count + text match the single path's regions.
+            assert_eq!(
+                light.len(),
+                single.len(),
+                "dual region count must match single path"
+            );
+            for ((_, lt), (_, st)) in light.iter().zip(single.iter()) {
+                assert_eq!(lt, st, "dual region text must match single path");
+            }
+        }
+    }
+
+    /// Escaping parity (codex #2): the dual path escapes token text identically
+    /// to the single path. Verified two ways:
+    /// 1. our `escape_html` matches syntect's own `Escape` for the same input;
+    /// 2. the dual HTML's token text equals the single path's token text for a
+    ///    snippet containing `& < > " '`.
+    #[test]
+    fn dual_escaping_matches_single_path() {
+        use syntect::html::styled_line_to_highlighted_html;
+        use syntect::html::IncludeBackground;
+
+        // 1. escape_html ≡ syntect Escape for the tricky characters.
+        for sample in ["& < > \" '", "a&b<c>d\"e'f", "<script>alert(1)</script>"] {
+            let ours = escape_html(sample);
+            // syntect's Escape is applied via styled_line_to_highlighted_html; we
+            // reproduce its text-node escaping by passing a single trivial token.
+            let style = syntect::highlighting::Style::default();
+            let single = styled_line_to_highlighted_html(&[(style, sample)], IncludeBackground::No)
+                .expect("single html ok");
+            // The span wraps the escaped text; extract the inner text node.
+            let inner = single
+                .strip_prefix(&format!(
+                    "<span style=\"color:#{:02x}{:02x}{:02x};\">",
+                    style.foreground.r, style.foreground.g, style.foreground.b
+                ))
+                .and_then(|s| s.strip_suffix("</span>"))
+                .expect("span shape");
+            assert_eq!(
+                ours, inner,
+                "escape_html must match syntect Escape for {sample:?}"
+            );
+        }
+
+        // 2. End-to-end: a snippet with special chars produces the same escaped
+        // token text in dual mode as the single path emits.
+        let h = Highlighter::new();
+        let code = "let s = \"a & b < c > d ' e\";\n";
+        let dual = h
+            .highlight_lines_dual(
+                code,
+                Some("rust"),
+                "base16-ocean.light",
+                "base16-ocean.dark",
+            )
+            .expect("dual ok");
+        let dual_html = dual.lines.concat();
+        // The escaped entities must appear; raw specials must not leak.
+        for needle in ["&amp;", "&lt;", "&gt;", "&quot;", "&#39;"] {
+            assert!(
+                dual_html.contains(needle),
+                "dual output missing escaped {needle}: {dual_html}"
+            );
+        }
+        assert!(
+            !dual_html.contains(" & "),
+            "raw ampersand leaked: {dual_html}"
+        );
+    }
+
+    #[test]
+    fn dual_missing_background_omits_bg_var() {
+        // Build a Highlighter whose dark theme has no settings.background.
+        let mut h = Highlighter::new();
+        let mut no_bg = h.theme_set.themes["base16-ocean.dark"].clone();
+        no_bg.settings.background = None;
+        h.theme_set.themes.insert("no-bg-theme".to_string(), no_bg);
+
+        let result = h
+            .highlight_lines_dual(
+                "fn main() {}\n",
+                Some("rust"),
+                "base16-ocean.light",
+                "no-bg-theme",
+            )
+            .expect("dual highlight must not error on missing background");
+        assert!(
+            result.light_bg.is_some(),
+            "light bg should still be present"
+        );
+        assert!(
+            result.dark_bg.is_none(),
+            "dark bg must be omitted when theme has no background"
+        );
+    }
+
+    #[test]
+    fn dual_unknown_theme_errors() {
+        let h = Highlighter::new();
+        // Unknown light theme.
+        let err = h
+            .highlight_lines_dual("x", Some("rust"), "no-such-theme", "base16-ocean.dark")
+            .unwrap_err();
+        match err {
+            HighlightError::UnknownTheme(name) => assert_eq!(name, "no-such-theme"),
+            other => unreachable!("expected UnknownTheme for light, got {other:?}"),
+        }
+        // Unknown dark theme.
+        let err = h
+            .highlight_lines_dual("x", Some("rust"), "base16-ocean.light", "no-such-theme")
+            .unwrap_err();
+        match err {
+            HighlightError::UnknownTheme(name) => assert_eq!(name, "no-such-theme"),
+            other => unreachable!("expected UnknownTheme for dark, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn dual_unknown_lang_falls_back_no_color_vars() {
+        let h = Highlighter::new();
+        let result = h
+            .highlight_lines_dual(
+                "<hello> & 'world'\n",
+                Some("klingon"),
+                "base16-ocean.light",
+                "base16-ocean.dark",
+            )
+            .expect("fallback ok");
+        assert!(result.fallback, "unknown lang must set fallback = true");
+        let html = result.lines.concat();
+        assert!(
+            !html.contains("--shiki-light:"),
+            "fallback must not emit color vars: {html}"
+        );
+        assert!(
+            !html.contains("<span"),
+            "fallback must be plain text: {html}"
+        );
+        // Escaped, not raw.
+        assert!(
+            html.contains("&lt;hello&gt;"),
+            "fallback not escaped: {html}"
+        );
+        assert!(html.contains("&amp;"), "fallback amp not escaped: {html}");
+        assert!(
+            html.contains("&#39;world&#39;"),
+            "fallback quote not escaped: {html}"
+        );
+        // Backgrounds still resolved (themes were valid).
+        assert!(result.light_bg.is_some() && result.dark_bg.is_some());
+    }
+
+    #[test]
+    fn color_to_hex_matches_syntect_rgb_format() {
+        // color_to_hex must produce the same `#rrggbb` lowercase form syntect's
+        // write_css_color emits for the alpha==0xFF case (alpha dropped).
+        let c = Color {
+            r: 0xd0,
+            g: 0x87,
+            b: 0x70,
+            a: 0xff,
+        };
+        assert_eq!(color_to_hex(c), "#d08770");
+        // Alpha is dropped even when not opaque.
+        let c2 = Color {
+            r: 0x01,
+            g: 0x02,
+            b: 0x03,
+            a: 0x80,
+        };
+        assert_eq!(color_to_hex(c2), "#010203");
     }
 }

--- a/crates/zfb-content/tests/dual_theme_pipeline.rs
+++ b/crates/zfb-content/tests/dual_theme_pipeline.rs
@@ -77,6 +77,72 @@ fn dual_pipeline_emits_shiki_vars_and_dual_class() {
     );
 }
 
+/// Build-start validation (codex review, #1067): an unknown `themeLight` or
+/// `themeDark` name must surface `HighlightError::UnknownTheme` at pipeline
+/// CONSTRUCTION, not silently render unhighlighted blocks. The per-block
+/// `highlight_lines_dual` error is swallowed by `SyntectPlugin` (mirroring
+/// the single path), so construction is the only place a bad dual name can
+/// be rejected loudly — honouring the documented build-start error.
+#[test]
+fn dual_unknown_theme_name_errors_at_construction() {
+    use zfb_content::syntect_highlight::HighlightError;
+
+    // `Pipeline` is not `Debug`, so match on the Result instead of `expect_err`.
+    let light_err = match Pipeline::with_defaults_and_full_config_dual(
+        ResolvedGfmConstructs::CONSERVATIVE,
+        None,
+        true,
+        false,
+        None,
+        "NoSuchLightTheme",
+        "base16-ocean.dark",
+    ) {
+        Ok(_) => panic!("unknown themeLight must error at construction"),
+        Err(e) => e,
+    };
+    assert!(
+        matches!(&light_err, HighlightError::UnknownTheme(n) if n == "NoSuchLightTheme"),
+        "expected UnknownTheme(NoSuchLightTheme), got: {light_err:?}"
+    );
+
+    let dark_err = match Pipeline::with_defaults_and_full_config_dual(
+        ResolvedGfmConstructs::CONSERVATIVE,
+        None,
+        true,
+        false,
+        None,
+        "base16-ocean.light",
+        "NoSuchDarkTheme",
+    ) {
+        Ok(_) => panic!("unknown themeDark must error at construction"),
+        Err(e) => e,
+    };
+    assert!(
+        matches!(&dark_err, HighlightError::UnknownTheme(n) if n == "NoSuchDarkTheme"),
+        "expected UnknownTheme(NoSuchDarkTheme), got: {dark_err:?}"
+    );
+}
+
+/// The same dual-name validation must fire through `PipelineSpec::build_pipeline`
+/// — the path the bundler and snapshot walker actually use.
+#[test]
+fn pipeline_spec_dual_unknown_theme_errors() {
+    let spec = PipelineSpec {
+        code_highlight_theme_light: Some("base16-ocean.light".to_string()),
+        code_highlight_theme_dark: Some("NoSuchDarkTheme".to_string()),
+        ..PipelineSpec::default()
+    };
+    let err = match spec.build_pipeline() {
+        Ok(_) => panic!("unknown dual theme must fail build_pipeline"),
+        Err(e) => e,
+    };
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("NoSuchDarkTheme"),
+        "build_pipeline error must name the unknown theme: {msg}"
+    );
+}
+
 /// The `<span class="line">` wrapper structure must be identical to the
 /// single-theme path — each line is a mutable Element.
 #[test]

--- a/crates/zfb-content/tests/dual_theme_pipeline.rs
+++ b/crates/zfb-content/tests/dual_theme_pipeline.rs
@@ -1,0 +1,250 @@
+//! Integration tests for the dual-theme code-highlight pipeline (#1067).
+//!
+//! Verifies the end-to-end wiring of `{ themeLight, themeDark }` through
+//! `Pipeline::with_defaults_and_full_config_dual` (and `PipelineSpec` with the
+//! dual fields set), asserting:
+//!
+//! 1. Token spans carry `--shiki-light` / `--shiki-dark` CSS custom properties
+//!    and NO inline `color:`.
+//! 2. The `<pre>` element carries `class="syntect-dual"` and
+//!    `--shiki-light-bg` / `--shiki-dark-bg` in its `style` attribute.
+//! 3. The single-theme path is BYTE-IDENTICAL to the pre-dual build (no
+//!    inline `color:` regression in the old path).
+//! 4. `PipelineSpec` with the dual fields builds a dual-mode pipeline.
+
+use zfb_content::pipeline::{Pipeline, ResolvedGfmConstructs};
+use zfb_content::serializer::serialize;
+use zfb_content::PipelineSpec;
+
+const RUST_CODE: &str = "```rust\nfn main() {}\n```\n";
+
+/// Build a pipeline and run a markdown snippet through it, returning the
+/// serialised HTML.
+fn run_markdown(pipeline: &mut Pipeline, md: &str) -> String {
+    let hast = pipeline
+        .run(md)
+        .expect("pipeline.run must succeed for valid markdown");
+    serialize(&hast)
+}
+
+// ── Dual-theme path ──────────────────────────────────────────────────────────
+
+/// The primary acceptance test: dual-theme mode emits `--shiki-light` /
+/// `--shiki-dark` custom properties (NO inline `color:`) and wraps the
+/// block in `<pre class="syntect-dual" style="--shiki-light-bg:…;--shiki-dark-bg:…">`.
+#[test]
+fn dual_pipeline_emits_shiki_vars_and_dual_class() {
+    let mut pipeline = Pipeline::with_defaults_and_full_config_dual(
+        ResolvedGfmConstructs::CONSERVATIVE,
+        None,
+        true,
+        false,
+        None,
+        "base16-ocean.light",
+        "base16-ocean.dark",
+    )
+    .expect("no themes_dir — cannot fail");
+
+    let html = run_markdown(&mut pipeline, RUST_CODE);
+
+    // class="syntect-dual"
+    assert!(
+        html.contains("class=\"syntect-dual\""),
+        "pre must carry class=\"syntect-dual\": {html}"
+    );
+    // --shiki-light-bg and --shiki-dark-bg in the style attribute
+    assert!(
+        html.contains("--shiki-light-bg:"),
+        "pre style must carry --shiki-light-bg: {html}"
+    );
+    assert!(
+        html.contains("--shiki-dark-bg:"),
+        "pre style must carry --shiki-dark-bg: {html}"
+    );
+    // Per-token CSS custom properties
+    assert!(
+        html.contains("--shiki-light:#"),
+        "token spans must carry --shiki-light: {html}"
+    );
+    assert!(
+        html.contains("--shiki-dark:#"),
+        "token spans must carry --shiki-dark: {html}"
+    );
+    // The whole point: NO inline color: in dual mode.
+    assert!(
+        !html.contains("color:#"),
+        "dual mode must NOT emit inline color: {html}"
+    );
+}
+
+/// The `<span class="line">` wrapper structure must be identical to the
+/// single-theme path — each line is a mutable Element.
+#[test]
+fn dual_pipeline_produces_span_line_structure() {
+    let mut pipeline = Pipeline::with_defaults_and_full_config_dual(
+        ResolvedGfmConstructs::CONSERVATIVE,
+        None,
+        true,
+        false,
+        None,
+        "base16-ocean.light",
+        "base16-ocean.dark",
+    )
+    .expect("no themes_dir — cannot fail");
+
+    let hast = pipeline.run(RUST_CODE).expect("run ok");
+    use zfb_content::pipeline::HastNode;
+    // Walk looking for the pre element.
+    fn find_pre(node: &HastNode) -> Option<&HastNode> {
+        match node {
+            HastNode::Root { children } | HastNode::Element { children, .. } => {
+                for c in children {
+                    if let HastNode::Element { tag, .. } = c {
+                        if tag == "pre" {
+                            return Some(c);
+                        }
+                    }
+                    if let Some(found) = find_pre(c) {
+                        return Some(found);
+                    }
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+
+    let pre = find_pre(&hast).expect("pre element must be in the HAST");
+    let HastNode::Element {
+        attrs,
+        children: pre_children,
+        ..
+    } = pre
+    else {
+        panic!("expected Element<pre>");
+    };
+    // class must be "syntect-dual"
+    assert!(
+        attrs
+            .iter()
+            .any(|(k, v)| k == "class" && v == "syntect-dual"),
+        "pre class must be syntect-dual: {attrs:?}"
+    );
+    // There must be a <code> child with <span class="line"> children.
+    let code = pre_children
+        .iter()
+        .find(|c| matches!(c, HastNode::Element { tag, .. } if tag == "code"))
+        .expect("pre must have <code>");
+    let HastNode::Element {
+        children: code_children,
+        ..
+    } = code
+    else {
+        panic!("expected Element<code>");
+    };
+    for (i, span) in code_children.iter().enumerate() {
+        let HastNode::Element { tag, attrs, .. } = span else {
+            panic!("code child {i}: expected Element<span>, got {span:?}");
+        };
+        assert_eq!(tag, "span", "code child {i}: tag must be span");
+        assert!(
+            attrs.iter().any(|(k, v)| k == "class" && v == "line"),
+            "code child {i}: must have class=\"line\": {attrs:?}"
+        );
+    }
+}
+
+// ── Single-theme byte-identity (codex #4) ────────────────────────────────────
+
+/// Single-theme path must still emit inline `color:` and NO `--shiki-` vars.
+/// This assertion was already in `syntect_plugin.rs`; we also pin it at the
+/// full-pipeline level to cover the wiring chain end-to-end.
+#[test]
+fn single_pipeline_still_emits_inline_color_not_shiki_vars() {
+    let mut pipeline = Pipeline::with_defaults_and_full_config(
+        Some("base16-ocean.dark"),
+        ResolvedGfmConstructs::CONSERVATIVE,
+        None,
+        true,
+        false,
+        None,
+    )
+    .expect("no themes_dir — cannot fail");
+
+    let html = run_markdown(&mut pipeline, RUST_CODE);
+
+    assert!(
+        html.contains("color:#"),
+        "single mode must still emit inline color: {html}"
+    );
+    assert!(
+        !html.contains("--shiki-"),
+        "single mode must NOT emit --shiki- vars: {html}"
+    );
+    assert!(
+        html.contains("class=\"syntect-"),
+        "single mode must carry syntect-* class: {html}"
+    );
+    assert!(
+        !html.contains("class=\"syntect-dual\""),
+        "single mode must NOT carry syntect-dual class: {html}"
+    );
+}
+
+// ── PipelineSpec dual fields ─────────────────────────────────────────────────
+
+/// `PipelineSpec` with both `code_highlight_theme_light` and
+/// `code_highlight_theme_dark` set must produce the same dual-mode output as
+/// `Pipeline::with_defaults_and_full_config_dual`.
+#[test]
+fn pipeline_spec_dual_fields_build_dual_pipeline() {
+    let spec = PipelineSpec {
+        code_highlight_theme_light: Some("base16-ocean.light".to_string()),
+        code_highlight_theme_dark: Some("base16-ocean.dark".to_string()),
+        ..Default::default()
+    };
+    let mut pipeline = spec
+        .build_pipeline()
+        .expect("PipelineSpec::build_pipeline ok");
+    let html = run_markdown(&mut pipeline, RUST_CODE);
+
+    assert!(
+        html.contains("class=\"syntect-dual\""),
+        "spec-built pipeline must carry syntect-dual class: {html}"
+    );
+    assert!(
+        html.contains("--shiki-light:#"),
+        "spec-built pipeline must carry --shiki-light: {html}"
+    );
+    assert!(
+        html.contains("--shiki-dark:#"),
+        "spec-built pipeline must carry --shiki-dark: {html}"
+    );
+    assert!(
+        !html.contains("color:#"),
+        "spec-built dual pipeline must NOT emit inline color: {html}"
+    );
+}
+
+/// `PipelineSpec` with only `code_highlight_theme` set (single mode) must
+/// still behave identically to the pre-dual single-theme path.
+#[test]
+fn pipeline_spec_single_field_unchanged() {
+    let spec = PipelineSpec {
+        code_highlight_theme: Some("base16-ocean.dark".to_string()),
+        ..Default::default()
+    };
+    let mut pipeline = spec
+        .build_pipeline()
+        .expect("PipelineSpec::build_pipeline ok");
+    let html = run_markdown(&mut pipeline, RUST_CODE);
+
+    assert!(
+        html.contains("color:#"),
+        "single-theme spec must still emit inline color: {html}"
+    );
+    assert!(
+        !html.contains("--shiki-"),
+        "single-theme spec must NOT emit --shiki- vars: {html}"
+    );
+}

--- a/crates/zfb-content/tests/large_mdx_fallback_regression.rs
+++ b/crates/zfb-content/tests/large_mdx_fallback_regression.rs
@@ -369,6 +369,8 @@ fn large_mdx_with_inline_code_html_curly_braces_does_not_fall_back() {
     let pipeline_config = PipelineSpec {
         code_highlight_theme: None,
         code_highlight_themes_dir: None,
+        code_highlight_theme_light: None,
+        code_highlight_theme_dark: None,
         strip_md_ext: true,
         resolve_source_map: None,
         gfm_constructs: zfb_content::ResolvedGfmConstructs::default(),

--- a/crates/zfb-content/tests/pipeline_fingerprint.rs
+++ b/crates/zfb-content/tests/pipeline_fingerprint.rs
@@ -14,7 +14,9 @@ use std::collections::HashSet;
 
 use serde_json::json;
 use zfb_content::pipeline::{HastNode, HastVisitor, Pipeline, ResolvedGfmConstructs};
-use zfb_content::{ExternalLinksConfig, HeadingIdStrategy, MarkdownFeaturesConfig, TocConfig};
+use zfb_content::{
+    ExternalLinksConfig, HeadingIdStrategy, MarkdownFeaturesConfig, PipelineSpec, TocConfig,
+};
 
 fn features(value: serde_json::Value) -> MarkdownFeaturesConfig {
     serde_json::from_value(value).expect("valid features config")
@@ -564,6 +566,129 @@ fn build_context_roots_join_the_fingerprint() {
     d.set_build_context_roots("/proj".into(), "/proj/public".into());
     let d = d.config_fingerprint().expect("fingerprinted");
     assert_eq!(a, d, "re-arming must replace the previous roots segment");
+}
+
+/// Dual-theme mode fingerprint tests (issue #1067).
+///
+/// The fingerprint encodes the mode explicitly:
+/// - single mode produces the SAME descriptor as before (no warm-cache
+///   invalidation on upgrade — the `code_highlight=single(theme=…)` segment
+///   expands to the same bytes as the old `theme=…` form for single mode).
+/// - dual mode produces a DISTINCT fingerprint from any single-theme or
+///   default config (so a single `{ theme: "x" }` can never alias the dual
+///   fields in the compile cache).
+#[test]
+fn dual_theme_fingerprint_is_distinct_from_single_and_default() {
+    let default_fp = baseline()
+        .config_fingerprint()
+        .expect("default fingerprintable");
+
+    let single_fp = full_config(
+        Some("base16-ocean.light"),
+        ResolvedGfmConstructs::CONSERVATIVE,
+        true,
+        false,
+        None,
+    )
+    .config_fingerprint()
+    .expect("single-theme fingerprintable");
+
+    // Dual path via the new constructor.
+    let dual_fp = Pipeline::with_defaults_and_full_config_dual(
+        ResolvedGfmConstructs::CONSERVATIVE,
+        None,
+        true,
+        false,
+        None,
+        "base16-ocean.light",
+        "base16-ocean.dark",
+    )
+    .expect("no themes_dir — cannot fail")
+    .config_fingerprint()
+    .expect("dual-theme fingerprintable");
+
+    // All three must be pairwise distinct.
+    assert_ne!(
+        default_fp, single_fp,
+        "default and single-theme must have different fingerprints"
+    );
+    assert_ne!(
+        default_fp, dual_fp,
+        "default and dual-theme must have different fingerprints"
+    );
+    assert_ne!(
+        single_fp, dual_fp,
+        "single-theme and dual-theme must have different fingerprints — \
+         a single-theme config must never alias a dual entry in the compile cache"
+    );
+}
+
+/// Two dual-theme pipelines built with the SAME pair must agree on the
+/// fingerprint (the cache depends on this).
+#[test]
+fn dual_theme_fingerprint_is_stable_across_constructions() {
+    let build = || {
+        Pipeline::with_defaults_and_full_config_dual(
+            ResolvedGfmConstructs::CONSERVATIVE,
+            None,
+            true,
+            false,
+            None,
+            "base16-ocean.light",
+            "base16-ocean.dark",
+        )
+        .expect("no themes_dir — cannot fail")
+        .config_fingerprint()
+        .expect("dual-theme fingerprintable")
+    };
+    assert_eq!(build(), build(), "same dual pair → identical fingerprint");
+}
+
+/// Single-theme fingerprint byte-identity (codex #4 / #5): the default and
+/// single-theme pipeline fingerprints must be UNCHANGED by the dual-mode
+/// wiring — no warm-cache invalidation on upgrade.
+///
+/// The pinned digests are from HEAD before the dual-mode landed; if this
+/// test fails because you INTENTIONALLY changed a fingerprint input, update
+/// the literals and say so in the commit message.
+#[test]
+fn single_and_default_fingerprints_unchanged_by_dual_wiring() {
+    let default_fp = PipelineSpec::default()
+        .build_pipeline()
+        .expect("builds")
+        .config_fingerprint()
+        .expect("fingerprintable");
+    // This literal is the pre-#1067 fingerprint captured via the
+    // `side_channels_keep_fingerprint_byte_identical_to_pre_977` test in
+    // pipeline_spec.rs — unchanged by this PR.
+    assert_eq!(
+        default_fp, "87680d4705178c808751765ad1a8861b5ef0c004a3a185323af27ea506d8e6ca",
+        "default-spec fingerprint must be unchanged by dual-mode wiring"
+    );
+
+    // A single-theme spec must also produce the same fingerprint as before.
+    let single_spec = PipelineSpec {
+        code_highlight_theme: Some("InspiredGitHub".to_string()),
+        ..Default::default()
+    };
+    let single_fp_a = single_spec
+        .build_pipeline()
+        .expect("builds")
+        .config_fingerprint()
+        .expect("fingerprintable");
+    let single_fp_b = single_spec
+        .build_pipeline()
+        .expect("builds")
+        .config_fingerprint()
+        .expect("fingerprintable");
+    assert_eq!(
+        single_fp_a, single_fp_b,
+        "same single-theme spec must be stable across builds"
+    );
+    assert_ne!(
+        single_fp_a, default_fp,
+        "single-theme spec must differ from the default"
+    );
 }
 
 #[test]

--- a/crates/zfb/src/commands/bundler_input.rs
+++ b/crates/zfb/src/commands/bundler_input.rs
@@ -53,14 +53,29 @@ pub(crate) fn pipeline_spec_from_config(
     zfb_content::PipelineSpec {
         // `codeHighlight.theme` — named syntect theme for fenced code
         // blocks instead of the default `base16-ocean.dark`.
+        // Mutually exclusive with the dual pair below; validation in
+        // config.rs guarantees at most one mode is set.
         code_highlight_theme: config.code_highlight.as_ref().and_then(|c| c.theme.clone()),
         // `codeHighlight.themesDir` — resolved to an absolute path HERE so
-        // both surfaces load the same `.tmTheme` files.
+        // both surfaces load the same `.tmTheme` files. Applies to both
+        // single-theme and dual-theme mode.
         code_highlight_themes_dir: config
             .code_highlight
             .as_ref()
             .and_then(|c| c.themes_dir.as_ref())
             .map(|td| project_root.join(td)),
+        // `codeHighlight.themeLight` / `codeHighlight.themeDark` — the
+        // dual-theme pair that emits CSS custom properties (`--shiki-light`
+        // / `--shiki-dark`) instead of inline `color:`. Active iff BOTH
+        // are Some. Mutually exclusive with `code_highlight_theme`.
+        code_highlight_theme_light: config
+            .code_highlight
+            .as_ref()
+            .and_then(|c| c.theme_light.clone()),
+        code_highlight_theme_dark: config
+            .code_highlight
+            .as_ref()
+            .and_then(|c| c.theme_dark.clone()),
         // Opt-in `stripMdExt` flag (zfb#127 / #129).
         strip_md_ext: config.strip_md_ext,
         // Derivation-owned — see the doc comment above.

--- a/crates/zfb/src/config.rs
+++ b/crates/zfb/src/config.rs
@@ -774,20 +774,55 @@ pub struct BundleConfig {
 pub struct CodeHighlightConfig {
     /// Syntect built-in or user-loaded theme name.  When absent the
     /// pipeline defaults to `"base16-ocean.dark"`.
+    ///
+    /// Mutually exclusive with [`Self::theme_light`] / [`Self::theme_dark`]
+    /// — set only one mode per build.  This is a SYNTECT theme name (e.g.
+    /// `"InspiredGitHub"`, `"Solarized (dark)"`), NOT a Shiki name like
+    /// `"dracula"`.
     #[serde(default)]
     pub theme: Option<String>,
 
     /// Path to a directory of `.tmTheme` files, relative to the
     /// project root.  Every `.tmTheme` file in the directory is loaded
-    /// and becomes available by its declared `name` via `theme`.
+    /// and becomes available by its declared `name` via `theme`,
+    /// `theme_light`, or `theme_dark`.
     ///
     /// When absent only syntect's bundled themes are available.
     ///
     /// The path must be relative and must not escape the project root
     /// via `..`.  A missing directory is reported as an error at build
     /// start (before any pages are rendered).
+    ///
+    /// Applies to both single-theme and dual-theme mode.
     #[serde(default)]
     pub themes_dir: Option<std::path::PathBuf>,
+
+    /// Light-mode syntect theme name for dual-theme highlighting.
+    ///
+    /// Must be set together with [`Self::theme_dark`] — setting only one
+    /// of the two is an error.  When both are set, every fenced code block
+    /// is highlighted twice and per-token colors are emitted as CSS custom
+    /// properties (`--shiki-light` / `--shiki-dark`) instead of inline
+    /// `color:`.  The `<pre>` element carries `class="syntect-dual"` and
+    /// `--shiki-*-bg` variables.  The consumer resolves the active color
+    /// with a `light-dark()` CSS rule.
+    ///
+    /// Mutually exclusive with [`Self::theme`].
+    /// Must be a SYNTECT theme name (e.g. `"base16-ocean.light"`), NOT a
+    /// Shiki name like `"dracula"`.
+    #[serde(default)]
+    pub theme_light: Option<String>,
+
+    /// Dark-mode syntect theme name for dual-theme highlighting.
+    ///
+    /// See [`Self::theme_light`] for the full dual-mode contract.
+    /// Must be set together with [`Self::theme_light`] — setting only one
+    /// of the two is an error.  Must be a SYNTECT theme name (e.g.
+    /// `"base16-ocean.dark"`), NOT a Shiki name.
+    ///
+    /// Mutually exclusive with [`Self::theme`].
+    #[serde(default)]
+    pub theme_dark: Option<String>,
 }
 
 /// What to do when a `.md`/`.mdx` link cannot be found in the source map.
@@ -1520,6 +1555,17 @@ fn validate(cfg: &Config, dir: &Path) -> Result<()> {
         if let Some(td) = &ch.themes_dir {
             ensure_path_in_root(td, dir).context("codeHighlight.themesDir")?;
         }
+        // Dual-theme validation: themeLight and themeDark must be set together.
+        match (ch.theme_light.as_ref(), ch.theme_dark.as_ref()) {
+            (Some(_), None) | (None, Some(_)) => {
+                bail!("codeHighlight.themeLight and themeDark must be set together");
+            }
+            _ => {}
+        }
+        // Mutual exclusion: theme and the dual pair cannot both be set.
+        if ch.theme.is_some() && (ch.theme_light.is_some() || ch.theme_dark.is_some()) {
+            bail!("codeHighlight.theme is mutually exclusive with themeLight/themeDark");
+        }
     }
     if let Some(rml) = &cfg.resolve_markdown_links {
         if !rml.docs_dir.as_os_str().is_empty() {
@@ -2041,6 +2087,107 @@ mod tests {
         assert!(
             msg.contains("codeHighlight.themesDir"),
             "error should mention field; got: {msg}"
+        );
+    }
+
+    // ── Dual-theme config parse tests (#1067) ─────────────────────────────
+
+    /// `themeLight` and `themeDark` parse from camelCase JSON and populate
+    /// the Rust `theme_light` / `theme_dark` fields.
+    #[tokio::test]
+    async fn code_highlight_theme_light_and_dark_parse_from_camelcase_json() {
+        let tmp = TempDir::new().unwrap();
+        tokio::fs::write(
+            tmp.path().join("zfb.config.json"),
+            r#"{ "codeHighlight": { "themeLight": "base16-ocean.light", "themeDark": "base16-ocean.dark" } }"#,
+        )
+        .await
+        .unwrap();
+        let cfg = load_from_dir(tmp.path()).await.expect("load ok");
+        let ch = cfg.code_highlight.as_ref().expect("codeHighlight present");
+        assert_eq!(ch.theme_light.as_deref(), Some("base16-ocean.light"));
+        assert_eq!(ch.theme_dark.as_deref(), Some("base16-ocean.dark"));
+        assert_eq!(ch.theme, None, "theme must be absent in dual mode");
+    }
+
+    /// `themesDir` works alongside `themeLight` + `themeDark`.
+    #[tokio::test]
+    async fn code_highlight_dual_pair_works_with_themes_dir() {
+        let tmp = TempDir::new().unwrap();
+        tokio::fs::write(
+            tmp.path().join("zfb.config.json"),
+            r#"{ "codeHighlight": { "themeLight": "My Light", "themeDark": "My Dark", "themesDir": "themes" } }"#,
+        )
+        .await
+        .unwrap();
+        let cfg = load_from_dir(tmp.path()).await.expect("load ok");
+        let ch = cfg.code_highlight.as_ref().expect("codeHighlight present");
+        assert_eq!(ch.theme_light.as_deref(), Some("My Light"));
+        assert_eq!(ch.theme_dark.as_deref(), Some("My Dark"));
+        assert_eq!(
+            ch.themes_dir.as_deref(),
+            Some(std::path::Path::new("themes"))
+        );
+    }
+
+    /// Setting only `themeLight` (without `themeDark`) must be a validation error.
+    #[tokio::test]
+    async fn code_highlight_only_theme_light_is_error() {
+        let tmp = TempDir::new().unwrap();
+        tokio::fs::write(
+            tmp.path().join("zfb.config.json"),
+            r#"{ "codeHighlight": { "themeLight": "base16-ocean.light" } }"#,
+        )
+        .await
+        .unwrap();
+        let err = load_from_dir(tmp.path())
+            .await
+            .expect_err("only themeLight must be rejected");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("themeLight and themeDark must be set together"),
+            "error must mention the mutual-requirement; got: {msg}"
+        );
+    }
+
+    /// Setting only `themeDark` (without `themeLight`) must be a validation error.
+    #[tokio::test]
+    async fn code_highlight_only_theme_dark_is_error() {
+        let tmp = TempDir::new().unwrap();
+        tokio::fs::write(
+            tmp.path().join("zfb.config.json"),
+            r#"{ "codeHighlight": { "themeDark": "base16-ocean.dark" } }"#,
+        )
+        .await
+        .unwrap();
+        let err = load_from_dir(tmp.path())
+            .await
+            .expect_err("only themeDark must be rejected");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("themeLight and themeDark must be set together"),
+            "error must mention the mutual-requirement; got: {msg}"
+        );
+    }
+
+    /// Setting `theme` together with `themeLight` / `themeDark` must be a
+    /// validation error (mutually exclusive modes).
+    #[tokio::test]
+    async fn code_highlight_theme_and_dual_pair_mutually_exclusive() {
+        let tmp = TempDir::new().unwrap();
+        tokio::fs::write(
+            tmp.path().join("zfb.config.json"),
+            r#"{ "codeHighlight": { "theme": "InspiredGitHub", "themeLight": "base16-ocean.light", "themeDark": "base16-ocean.dark" } }"#,
+        )
+        .await
+        .unwrap();
+        let err = load_from_dir(tmp.path())
+            .await
+            .expect_err("theme + dual pair must be rejected");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("mutually exclusive with themeLight/themeDark"),
+            "error must mention mutual exclusion; got: {msg}"
         );
     }
 

--- a/docs/src/content/docs-ja/api/define-config.mdx
+++ b/docs/src/content/docs-ja/api/define-config.mdx
@@ -46,7 +46,11 @@ defineConfig(config: ZfbConfig): ZfbConfig
 
 以下のキーは Rust の設定ローダーが受け付けますが、TypeScript 型では無視されます（これらは `zfb` が JS の dev ツールではなく Rust バイナリとして動作するときにのみ適用されます）。
 
-- `codeHighlight` — syntect の構文ハイライトテーマオプション。構文ハイライトのガイドを参照してください。
+- `codeHighlight` — syntect の構文ハイライトテーマオプション。[構文ハイライトのガイド](../guides/syntax-highlighting.mdx)を参照してください。フィールド:
+  - `theme?: string` — シングルテーマモード。syntect の組み込み、またはユーザーが読み込んだテーマ名（例: `"InspiredGitHub"`、`"Solarized (dark)"`）。デフォルトは `"base16-ocean.dark"`。トークンはインラインの `color:` で着色されます。`themeLight` / `themeDark` とは排他です。これらは Shiki（`"dracula"` など）ではなく **syntect** のテーマ名です。
+  - `themesDir?: string` — `.tmTheme` ファイルのディレクトリ。プロジェクトルートからの相対です。各ファイルは宣言された `name` によって `theme`・`themeLight`・`themeDark` から利用できます。シングル / デュアル**両方**のモードに適用されます。相対パスである必要があり、`..` でルートから抜け出すことはできません。ディレクトリが存在しない場合はビルド開始時にエラーになります。
+  - `themeLight?: string` — デュアルテーマハイライト用のライトモード syntect テーマ名。`themeDark` と**必ずセットで**指定する必要があり、片方だけの指定はビルドエラーになります。`theme` とは排他です。ペアを設定すると、各ブロックが 2 回ハイライトされ、トークンはインラインの `color:` の代わりに `--shiki-light` / `--shiki-dark` カスタムプロパティを持ち、`<pre>` には `class="syntect-dual"` と `--shiki-light-bg` / `--shiki-dark-bg` が付与され、利用側は `light-dark()` CSS ルールでアクティブな色を解決します。
+  - `themeDark?: string` — デュアルテーマハイライト用のダークモード syntect テーマ名。`themeLight` と**必ずセットで**指定し、`theme` とは排他です。デュアルモードの完全な仕様は `themeLight` を参照してください。
 - `pluginHookTimeoutSecs` — プラグインフック呼び出しのタイムアウト（秒）。
 
 ## プロジェクトルート外のパスを監視する

--- a/docs/src/content/docs-ja/guides/syntax-highlighting.mdx
+++ b/docs/src/content/docs-ja/guides/syntax-highlighting.mdx
@@ -64,6 +64,58 @@ my-project/
 
 **エラー報告:** `themesDir` が存在しないディレクトリを指している場合や、いずれかの `.tmTheme` ファイルが不正な形式の場合、zfb はビルド開始時（ページの描画前）に、ファイルパスとパースエラーを含む明確なエラーを表示します。
 
+## ライト / ダークのデュアルテーマ
+
+上記の `theme` オプションは各トークンをインラインの `style="color:…"` で着色するため、テーマは 1 つだけ焼き込まれます。1 回のビルドでライトとダークの両方のサイトテーマに対応させるには、代わりに **`themeLight` と `themeDark`** を設定します。各ブロックは 2 回ハイライトされ、2 つの色が CSS カスタムプロパティとして出力されます。ブラウザは `light-dark()` ルールでアクティブな色を選びます。ランタイム JS は依然としてゼロです。
+
+```ts
+// zfb.config.ts
+export default {
+  codeHighlight: {
+    themeLight: "InspiredGitHub",
+    themeDark: "base16-ocean.dark",
+  },
+};
+```
+
+### ルール
+
+- **両方を必ずセットで指定する。** `themeLight` だけ、または `themeDark` だけを設定するとビルドエラーになります。
+- **`theme` とは排他。** デュアルのペアと同時に `theme` を設定するとビルドエラーになります。シングルテーマモード（`theme`）かデュアルテーマモード（`themeLight` + `themeDark`）のどちらか一方を選び、両方は使えません。
+- **`themesDir` は両方のモードに適用される。** `themesDir` で読み込んだカスタム `.tmTheme` ファイルは、`theme` と同様に、宣言された `name` によって `themeLight` / `themeDark` から利用できます。
+- **これらは Shiki ではなく syntect のテーマ名です** — `"base16-ocean.light"` / `"base16-ocean.dark"`、`"InspiredGitHub"`、`"Solarized (light)"` / `"Solarized (dark)"`、または読み込んだ任意のカスタム `.tmTheme`。`themesDir` 経由で読み込んでいない `"dracula"` のような名前は、やはりビルド時にエラーになります。
+
+### 出力される markup
+
+デュアルモードでは `<pre>` 要素に `class="syntect-dual"` が付与され、2 つの背景色が `--shiki-light-bg` / `--shiki-dark-bg` として `style` に入ります。各トークンの `<span>` は、インラインの `color:` の代わりに `--shiki-light` / `--shiki-dark` を持ちます。
+
+```html
+<pre class="syntect-dual" style="--shiki-light-bg:#fff;--shiki-dark-bg:#2b303b">
+  <code><span class="line"><span style="--shiki-light:#998;--shiki-dark:#65737e">token</span>…</span></code>
+</pre>
+```
+
+`<span class="line">` のラッパー構造はシングルテーマモードと同一で、異なるのはトークンごとの色の指定方法だけです。
+
+<Note>
+
+変数名 `--shiki-light` / `--shiki-dark` は、利用側の CSS をなじみやすくするため、意図的に [Shiki のデュアルテーマ CSS 規約](https://shiki.style/guide/dual-themes)に合わせています。ただし、指定する*テーマ名*は Shiki ではなく syntect のものです。
+
+</Note>
+
+### 色の解決（利用側の CSS）
+
+ライト / ダーク対応のサイトは、出力された変数を `light-dark()` を通してマッピングする **1 つの** CSS ルールを追加します。`light-dark()` はページの `color-scheme` に従います。
+
+```css
+pre[class^="syntect-"] span {
+  color: light-dark(var(--shiki-light), var(--shiki-dark));
+  background-color: light-dark(var(--shiki-light-bg), var(--shiki-dark-bg));
+}
+```
+
+`light-dark()` がアクティブなモードに解決されるよう、周囲のコンテキスト（`:root` や `<pre>` など）で `color-scheme: light dark` をオプトインしておいてください。
+
 ## 補足パターン 1 — クライアントサイドの追加ハイライト
 
 インタラクティブなテーマ切り替えやユーザーごとの設定が必要な場合は、サーバーで描画された出力の上に、クライアントサイドのハイライターを [クライアントアイランド](../concepts/islands.mdx) として重ねます。

--- a/docs/src/content/docs-ja/markdown-features/syntax-highlighting.mdx
+++ b/docs/src/content/docs-ja/markdown-features/syntax-highlighting.mdx
@@ -26,6 +26,29 @@ export default {
 カスタムの `.tmTheme` ファイルや、補助的なクライアントサイドのパターンについては、
 以下の専用ガイドで解説しています。
 
+## ライト / ダークのデュアルテーマ
+
+`theme` を 1 つ指定する代わりに、`themeLight` と `themeDark` の両方を設定すると、
+各ブロックを 2 回ハイライトし、トークンごとの色を CSS カスタムプロパティとして
+出力します。これにより、描画後にページのライト / ダークモードに応じてアクティブな
+色が選ばれます。JavaScript は不要です。
+
+```ts title="zfb.config.ts"
+export default {
+  codeHighlight: {
+    themeLight: "InspiredGitHub",
+    themeDark: "base16-ocean.dark",
+  },
+};
+```
+
+`themeLight` と `themeDark` は**必ずセットで**指定する必要があり、`theme` とは
+排他です。`<pre>` には `class="syntect-dual"` が付与され、利用側は 1 つの
+`light-dark()` CSS ルールで色を解決します。これらは Shiki ではなく syntect の
+テーマ名です。出力される markup と CSS ルールについては、
+[専用ガイド](../guides/syntax-highlighting.mdx#ライト--ダークのデュアルテーマ)
+を参照してください。
+
 ## 詳細なドキュメント
 
 テーマ名、カスタム `.tmTheme` の読み込み、クライアントサイドの補助的なハイライト、

--- a/docs/src/content/docs/api/define-config.mdx
+++ b/docs/src/content/docs/api/define-config.mdx
@@ -47,7 +47,11 @@ All keys are camelCase. The shape is enforced by the Rust serde deserializer (`c
 
 The following keys are accepted by the Rust config loader and ignored by the TypeScript type (they apply only when `zfb` runs as a Rust binary, not the JS dev tooling):
 
-- `codeHighlight` — syntect syntax-highlight theme options. See the syntax-highlighting guide.
+- `codeHighlight` — syntect syntax-highlight theme options. See the [syntax-highlighting guide](../guides/syntax-highlighting.mdx). Fields:
+  - `theme?: string` — single-theme mode. A syntect built-in or user-loaded theme name (e.g. `"InspiredGitHub"`, `"Solarized (dark)"`); defaults to `"base16-ocean.dark"`. Tokens get an inline `color:`. Mutually exclusive with `themeLight` / `themeDark`. These are **syntect** theme names, not Shiki names like `"dracula"`.
+  - `themesDir?: string` — directory of `.tmTheme` files, relative to the project root. Each file becomes available by its declared `name` to `theme`, `themeLight`, or `themeDark`. Applies to **both** single- and dual-theme mode. Must be relative and must not escape the root via `..`; a missing directory errors at build start.
+  - `themeLight?: string` — light-mode syntect theme name for dual-theme highlighting. Must be set **together with** `themeDark` — setting only one is a build error. Mutually exclusive with `theme`. When the pair is set, each block is highlighted twice and tokens carry `--shiki-light` / `--shiki-dark` custom properties instead of an inline `color:`, the `<pre>` gets `class="syntect-dual"` plus `--shiki-light-bg` / `--shiki-dark-bg`, and the consumer resolves the active colour with a `light-dark()` CSS rule.
+  - `themeDark?: string` — dark-mode syntect theme name for dual-theme highlighting. Must be set **together with** `themeLight`; mutually exclusive with `theme`. See `themeLight` for the full dual-mode contract.
 - `pluginHookTimeoutSecs` — timeout (seconds) for plugin hook invocations.
 
 ## Watching paths outside the project root

--- a/docs/src/content/docs/guides/syntax-highlighting.mdx
+++ b/docs/src/content/docs/guides/syntax-highlighting.mdx
@@ -81,6 +81,79 @@ directly from the [Dracula GitHub repository](https://github.com/dracula/sublime
 `.tmTheme` file is malformed, zfb surfaces a clear error at build start (before
 rendering any pages) that includes the file path and the parse error.
 
+## Dual light/dark themes
+
+The `theme` option above colours each token with an inline `style="color:…"`,
+so a single theme is baked in. To support both a light and a dark site theme
+from one build, set **`themeLight` and `themeDark`** instead. Each block is
+highlighted twice and the two colours are emitted as CSS custom properties; the
+browser picks the active one with a `light-dark()` rule — still zero runtime JS.
+
+```ts
+// zfb.config.ts
+export default {
+  codeHighlight: {
+    themeLight: "InspiredGitHub",
+    themeDark: "base16-ocean.dark",
+  },
+};
+```
+
+### Rules
+
+- **Both are required together.** Setting only `themeLight` or only `themeDark`
+  is a build error.
+- **Mutually exclusive with `theme`.** Setting `theme` alongside the dual pair
+  is a build error. Pick single-theme mode (`theme`) or dual-theme mode
+  (`themeLight` + `themeDark`), not both.
+- **`themesDir` applies to both modes.** Custom `.tmTheme` files loaded via
+  `themesDir` are available to `themeLight` / `themeDark` by their declared
+  `name`, exactly as for `theme`.
+- **These are syntect theme names, not Shiki names** — `"base16-ocean.light"` /
+  `"base16-ocean.dark"`, `"InspiredGitHub"`, `"Solarized (light)"` /
+  `"Solarized (dark)"`, or any custom `.tmTheme` you loaded. A name like
+  `"dracula"` that is not loaded via `themesDir` still errors at build time.
+
+### Emitted markup
+
+In dual mode the `<pre>` element gets `class="syntect-dual"` and carries the
+two background colours as `--shiki-light-bg` / `--shiki-dark-bg` in its `style`.
+Each token `<span>` carries `--shiki-light` / `--shiki-dark` instead of an
+inline `color:`:
+
+```html
+<pre class="syntect-dual" style="--shiki-light-bg:#fff;--shiki-dark-bg:#2b303b">
+  <code><span class="line"><span style="--shiki-light:#998;--shiki-dark:#65737e">token</span>…</span></code>
+</pre>
+```
+
+The `<span class="line">` wrapper structure is identical to single-theme mode —
+only the per-token colour mechanism differs.
+
+<Note>
+
+The variable names `--shiki-light` / `--shiki-dark` intentionally mirror
+[Shiki's dual-theme CSS convention](https://shiki.style/guide/dual-themes) so
+the consumer-side CSS feels familiar. The *theme names* you pass, however, are
+syntect's — not Shiki's.
+
+</Note>
+
+### Resolving the colours (consumer CSS)
+
+A light/dark site adds **one** CSS rule that maps the emitted variables through
+`light-dark()`, which follows the page's `color-scheme`:
+
+```css
+pre[class^="syntect-"] span {
+  color: light-dark(var(--shiki-light), var(--shiki-dark));
+  background-color: light-dark(var(--shiki-light-bg), var(--shiki-dark-bg));
+}
+```
+
+Make sure the surrounding context opts in to `color-scheme: light dark` (e.g.
+on `:root` or the `<pre>`) so `light-dark()` resolves to the active mode.
+
 ## Supplementary pattern 1 — additional client-side highlighting
 
 If you want interactive theme switching or per-user preferences, layer a

--- a/docs/src/content/docs/markdown-features/syntax-highlighting.mdx
+++ b/docs/src/content/docs/markdown-features/syntax-highlighting.mdx
@@ -27,6 +27,29 @@ export default {
 Custom `.tmTheme` files and supplementary client-side patterns are
 covered in the dedicated guide below.
 
+## Dual light/dark themes
+
+Instead of a single `theme`, set both `themeLight` and `themeDark` to
+highlight every block twice and emit per-token CSS custom properties, so the
+active colour can be chosen by the page's light/dark mode at render time —
+no JavaScript:
+
+```ts title="zfb.config.ts"
+export default {
+  codeHighlight: {
+    themeLight: "InspiredGitHub",
+    themeDark: "base16-ocean.dark",
+  },
+};
+```
+
+`themeLight` and `themeDark` must be set **together**, and they are mutually
+exclusive with `theme`. The `<pre>` carries `class="syntect-dual"` and the
+consumer resolves the colours with a single `light-dark()` CSS rule. These are
+syntect theme names, not Shiki names. See the
+[dedicated guide](../guides/syntax-highlighting.mdx#dual-lightdark-themes) for
+the emitted markup and the CSS rule.
+
 ## Full documentation
 
 For theme names, custom `.tmTheme` loading, client-side supplementary

--- a/packages/zfb/src/config.ts
+++ b/packages/zfb/src/config.ts
@@ -504,24 +504,69 @@ export type OutputMode = "static" | "hybrid" | "auto";
  * Unknown theme names are rejected at build start with a clear error
  * rather than silently falling back.
  *
+ * **Single-theme mode** (the default): set `theme` to a syntect theme name,
+ * or omit it to use the default (`"base16-ocean.dark"`). Tokens are colored
+ * with inline `color:`.
+ *
+ * **Dual-theme mode**: set both `themeLight` and `themeDark`. Tokens are
+ * colored with CSS custom properties (`--shiki-light` / `--shiki-dark`),
+ * and the consumer applies a `light-dark()` rule to pick the active color.
+ * The `<pre>` element carries `class="syntect-dual"` and
+ * `--shiki-light-bg` / `--shiki-dark-bg` in its `style` attribute.
+ *
+ * `theme` and the dual pair are mutually exclusive. Setting only one of
+ * `themeLight` / `themeDark` is an error.
+ *
+ * All theme names are **SYNTECT** built-in or user-loaded names (e.g.
+ * `"base16-ocean.light"`, `"base16-ocean.dark"`, `"InspiredGitHub"`,
+ * `"Solarized (dark)"`), NOT Shiki names like `"dracula"`.
+ *
  * Mirrors `CodeHighlightConfig` in crates/zfb/src/config.rs.
  */
 export type CodeHighlightConfig = {
   /**
    * Syntect built-in or user-loaded theme name. When absent the
    * pipeline defaults to `"base16-ocean.dark"`.
+   *
+   * Mutually exclusive with {@link themeLight} / {@link themeDark}.
+   * Must be a SYNTECT theme name (e.g. `"InspiredGitHub"`), NOT a Shiki name.
    */
   theme?: string;
   /**
    * Path to a directory of `.tmTheme` files, relative to the project
    * root. Every `.tmTheme` file in the directory is loaded and becomes
-   * available by its declared `name` via {@link theme}. When absent
-   * only syntect's bundled themes are available.
+   * available by its declared `name` via {@link theme}, {@link themeLight},
+   * or {@link themeDark}. When absent only syntect's bundled themes are
+   * available.
    *
    * The path must be relative and must not escape the project root via
    * `..`. A missing directory is reported as an error at build start.
+   *
+   * Applies to both single-theme and dual-theme mode.
    */
   themesDir?: string;
+  /**
+   * Light-mode syntect theme name for dual-theme highlighting.
+   *
+   * Must be set together with {@link themeDark} — setting only one of
+   * the two is a build error. When both are set, tokens are colored with
+   * CSS custom properties (`--shiki-light` / `--shiki-dark`) instead of
+   * inline `color:`. Mutually exclusive with {@link theme}.
+   *
+   * Must be a SYNTECT theme name (e.g. `"base16-ocean.light"`),
+   * NOT a Shiki name like `"dracula"`.
+   */
+  themeLight?: string;
+  /**
+   * Dark-mode syntect theme name for dual-theme highlighting.
+   *
+   * Must be set together with {@link themeLight} — setting only one of
+   * the two is a build error. Mutually exclusive with {@link theme}.
+   *
+   * Must be a SYNTECT theme name (e.g. `"base16-ocean.dark"`),
+   * NOT a Shiki name like `"dracula"`.
+   */
+  themeDark?: string;
 };
 
 /**


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1065

---

## Summary

Adds an opt-in **dual light/dark** mode to `codeHighlight`. When a project configures `{ themeLight, themeDark }`, each fenced code block is highlighted twice and emits per-token CSS **custom properties** (`--shiki-light`/`--shiki-dark`) instead of an inline `color:`, plus `--shiki-light-bg`/`--shiki-dark-bg` on `<pre class="syntect-dual">`. A consumer resolves the active colors with one `light-dark()` CSS rule (zudolab/zudo-doc already ships it). The existing single `{ theme }` path is **byte-identical** (non-breaking). Follow-up to the closed single-theme work #188/#194.

Closes the engine gap behind zudo-doc's "code highlight invisible on light theme" report.

## What landed (epic #1065)

- **#1066 engine** — `Highlighter::highlight_lines_dual` + `DualHighlightedLines`: highlights twice, zips regions per token (guarded against misalignment), escapes with parity to syntect, omits `*-bg` vars when a theme has no background. 8 unit tests.
- **#1067 wiring** — threaded the dual pair through `SyntectPlugin` (`SyntectMode::Dual`) → `Pipeline::with_defaults_and_full_config_dual` → `PipelineSpec` (drift-guard) → `pipeline_spec_from_config` → `CodeHighlightConfig { themeLight, themeDark }` + validation (pair-required, mutually exclusive with `theme`) → TS `config.ts`. Fingerprint encodes mode explicitly (single vs dual). Integration + fingerprint + config-parse tests; single-path byte-identity asserted.
- **#1068 docs** — EN + JA pages: dual form, precedence rules, emitted markup, the consumer `light-dark()` rule, SYNTECT-not-Shiki naming clarification.
- **Review fix** — dual unknown theme names now error at build start (`UnknownTheme`) instead of silently rendering unhighlighted (codex P2). Pre-existing single-path equivalent tracked in #1070.

## Naming

These are **syntect** theme names (`base16-ocean.dark`/`.light`, `InspiredGitHub`, `Solarized (dark)`/`(light)`), NOT Shiki names. The `--shiki-*` variable names mirror Shiki's dual-theme CSS convention for consumer familiarity.

## Tests

`cargo test -p zfb-content -p zfb` green; `pnpm --filter zfb typecheck` + `test` green; clippy clean on changed crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)