### PR TITLE
fix(zfb-content): reject unknown single codeHighlight.theme at build start

### DIFF
--- a/crates/zfb-content/src/pipeline.rs
+++ b/crates/zfb-content/src/pipeline.rs
@@ -1686,18 +1686,26 @@ impl Pipeline {
         if let Some(dir) = themes_dir {
             highlighter.load_themes_from_dir(dir)?;
         }
-        // Build-start validation for dual mode: a misspelled or unloaded
-        // `themeLight`/`themeDark` must surface the documented `UnknownTheme`
-        // error here rather than silently rendering unhighlighted blocks —
-        // the per-block `highlight_lines_dual` call's `Err` is swallowed by
-        // `SyntectPlugin` (mirroring the single-theme path), so the only place
-        // a dual name can be rejected loudly is at construction, after any
-        // `themesDir` themes are loaded. (config.rs only validates that the
-        // pair is *present*; theme-name existence depends on `themesDir`,
-        // which is not known until here.)
-        if let Some((light, dark)) = dual {
+        // Build-start validation (dual #1067, single #1070): a misspelled or
+        // unloaded theme name — the single `theme`, or either of the dual
+        // `themeLight`/`themeDark` — must surface the documented `UnknownTheme`
+        // error here rather than silently rendering unhighlighted blocks. Both
+        // the single `highlight_lines` and the dual `highlight_lines_dual`
+        // per-block calls swallow their `Err` inside `SyntectPlugin`, so the
+        // only place a bad name can be rejected loudly is at construction,
+        // after any `themesDir` themes are loaded. This enforces the
+        // `CodeHighlightConfig` doc promise — "unknown theme names are rejected
+        // with a clear error rather than silently falling back" — for BOTH
+        // modes. (config.rs only validates name *presence* / dual-pair
+        // completeness; theme-name existence depends on `themesDir`, which is
+        // not known until here.)
+        let required_themes: Vec<&str> = match dual {
+            Some((light, dark)) => vec![light, dark],
+            None => theme.into_iter().collect(),
+        };
+        if !required_themes.is_empty() {
             let names = highlighter.theme_names();
-            for name in [light, dark] {
+            for name in required_themes {
                 if !names.iter().any(|n| n == name) {
                     return Err(crate::syntect_highlight::HighlightError::UnknownTheme(
                         name.to_string(),

--- a/crates/zfb-content/tests/dual_theme_pipeline.rs
+++ b/crates/zfb-content/tests/dual_theme_pipeline.rs
@@ -143,6 +143,56 @@ fn pipeline_spec_dual_unknown_theme_errors() {
     );
 }
 
+// ── Single-theme build-start validation (#1070) ──────────────────────────────
+
+/// Build-start validation for the SINGLE-theme path (#1070): a misspelled or
+/// unloaded `theme` name must surface `HighlightError::UnknownTheme` at pipeline
+/// CONSTRUCTION — same guarantee the dual path already gives (#1067). The
+/// per-block `highlight_lines` error is swallowed by `SyntectPlugin::rewrite_single`
+/// (it would silently leave the block unhighlighted), so construction is the only
+/// place a bad single name can be rejected loudly — honouring the documented
+/// `CodeHighlightConfig` build-start error promise for the single path too.
+#[test]
+fn single_unknown_theme_name_errors_at_construction() {
+    use zfb_content::syntect_highlight::HighlightError;
+
+    // `Pipeline` is not `Debug`, so match on the Result instead of `expect_err`.
+    let err = match Pipeline::with_defaults_and_full_config(
+        Some("NoSuchSingleTheme"),
+        ResolvedGfmConstructs::CONSERVATIVE,
+        None,
+        true,
+        false,
+        None,
+    ) {
+        Ok(_) => panic!("unknown single theme must error at construction"),
+        Err(e) => e,
+    };
+    assert!(
+        matches!(&err, HighlightError::UnknownTheme(n) if n == "NoSuchSingleTheme"),
+        "expected UnknownTheme(NoSuchSingleTheme), got: {err:?}"
+    );
+}
+
+/// The same single-name validation must fire through `PipelineSpec::build_pipeline`
+/// — the path the bundler and snapshot walker actually use.
+#[test]
+fn pipeline_spec_single_unknown_theme_errors() {
+    let spec = PipelineSpec {
+        code_highlight_theme: Some("NoSuchSingleTheme".to_string()),
+        ..PipelineSpec::default()
+    };
+    let err = match spec.build_pipeline() {
+        Ok(_) => panic!("unknown single theme must fail build_pipeline"),
+        Err(e) => e,
+    };
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("NoSuchSingleTheme"),
+        "build_pipeline error must name the unknown theme: {msg}"
+    );
+}
+
 /// The `<span class="line">` wrapper structure must be identical to the
 /// single-theme path — each line is a mutable Element.
 #[test]


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1070

---

## Summary

Closes #1070. The single `codeHighlight.theme` path silently swallowed unknown/misspelled theme names: `SyntectPlugin::rewrite_single` (syntect_plugin.rs) discards `HighlightError::UnknownTheme` from `highlight_lines` and leaves the block unhighlighted. This contradicted the `CodeHighlightConfig` doc promise (config.rs) that *"unknown theme names are rejected with a clear error rather than silently falling back."*

The **dual** `themeLight`/`themeDark` path (#1067) already validated theme names at pipeline construction. This change extends that same build-start validation to the **single** `theme` name, so the documented promise is now actually enforced for both modes.

This is a deliberate behavior change for the single path (silent fallback → hard error at build start), consistent with the dual path and the existing doc — see #1070's "Why deferred" note.

## Changes

- `crates/zfb-content/src/pipeline.rs` — in `with_defaults_and_full_config_inner`, generalized the dual-only build-start validation block into a unified `required_themes` check that validates the single `theme` name (when `Some`) **and** the dual pair against `highlighter.theme_names()` after any `themesDir` load, returning `HighlightError::UnknownTheme`. The no-explicit-theme default path (both `None`) is unaffected.
- `crates/zfb-content/tests/dual_theme_pipeline.rs` — two regression tests mirroring the dual ones:
  - `single_unknown_theme_name_errors_at_construction` — direct constructor rejects an unknown single theme.
  - `pipeline_spec_single_unknown_theme_errors` — the `PipelineSpec::build_pipeline` path (used by bundler/snapshot) rejects it too.

## Test Plan

- `cargo test -p zfb-content` — full crate suite green (435 lib unit tests + all integration tests, including the 2 new ones and the existing dual validation tests).
- `cargo clippy -p zfb-content --all-targets` — clean, no warnings.
- No existing test relied on the old silent-fallback behavior for a single theme (verified by search), so the behavior change breaks nothing.