### PR TITLE
chore(docs): update to zudo-doc 0.2.8 / zfb next.47 + enable dual-theme code highlighting

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -13,10 +13,10 @@
     "b4push": "pnpm check && pnpm build"
   },
   "dependencies": {
-    "@takazudo/zfb": "0.1.0-next.38",
-    "@takazudo/zfb-runtime": "0.1.0-next.38",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.38",
-    "@takazudo/zudo-doc": "^0.2.1",
+    "@takazudo/zfb": "0.1.0-next.47",
+    "@takazudo/zfb-runtime": "0.1.0-next.47",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.47",
+    "@takazudo/zudo-doc": "^0.2.8",
     "zod": "^4.0.0",
     "preact": "^10.29.1",
     "preact-render-to-string": "^6.6.6",
@@ -31,7 +31,7 @@
     "katex": "^0.16.38",
     "minisearch": "^7.2.0",
     "diff": "^8.0.3",
-    "@takazudo/zudo-doc-history-server": "^0.2.1"
+    "@takazudo/zudo-doc-history-server": "^0.2.8"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.0",

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -719,16 +719,18 @@ pre[class^="syntect-"].word-wrap code {
  * Code-block syntax-highlight token color rule
  * ======================================== */
 
-/* Build-time: zfb's Rust pipeline runs SyntectPlugin and emits
- * <pre class="syntect-..."> with inline style="color:#hex" on every token
- * span. The inline hex is the desired token color — this rule must NOT
- * override it (so: NO !important on `color`).
+/* Build-time (dual-theme syntect — zfb codeHighlight.themeLight/themeDark,
+ * configured in zfb.config.ts): zfb's Rust pipeline emits
+ * <pre class="syntect-dual"> with per-token inline
+ * style="--shiki-light:#X;--shiki-dark:#Y" custom properties (and
+ * --shiki-*-bg on the <pre>) — NO inline `color` — so this rule resolves
+ * light-dark(var(--shiki-light), var(--shiki-dark)) to the active theme.
+ * (Single-theme mode would instead emit inline `color:#hex`, which this
+ * rule must not override; we run dual-theme, so there is no inline color.)
  *
  * Runtime (design-token-tweak panel, when enabled): Shiki re-highlights on
- * demand and emits spans with inline style="--shiki-light:#X;--shiki-dark:#Y"
- * — CSS custom properties only, no `color` declaration — depending on this
- * rule to resolve light-dark(var(--shiki-light), var(--shiki-dark)) to the
- * active theme. Shiki spans have no inline `color`, so the rule applies
+ * demand and emits the same --shiki-light/--shiki-dark custom properties.
+ * Both paths leave spans without an inline `color`, so the rule applies
  * without needing !important. */
 [data-theme] .shiki,
 [data-theme] .shiki span,

--- a/docs/zfb-shim.d.ts
+++ b/docs/zfb-shim.d.ts
@@ -118,10 +118,19 @@ declare module "zfb/config" {
      * Configures the syntect-based syntax highlighter shipped with zfb.
      * Mirrors `code_highlight` in crates/zfb/src/config.rs (Takazudo/zudo-front-builder#188 / sub #194; landed in commit 339e30f).
      * When omitted, the engine falls back to the hardcoded default theme `base16-ocean.dark`.
+     *
+     * Single-theme mode: set `theme` (or omit for the default) — tokens get an
+     * inline `color:`. Dual-theme mode: set both `themeLight` and `themeDark`
+     * (mutually exclusive with `theme`) — tokens get `--shiki-light`/`--shiki-dark`
+     * custom props on `<pre class="syntect-dual">`, resolved via a `light-dark()`
+     * rule. Dual-theme fields shipped in @takazudo/zfb 0.1.0-next.47; kept in sync
+     * by hand with the published `@takazudo/zfb/config` `CodeHighlightConfig`.
      */
     codeHighlight?: {
       theme?: string;
       themesDir?: string;
+      themeLight?: string;
+      themeDark?: string;
     };
     /**
      * Markdown link resolver (port of `remarkResolveMarkdownLinks`).

--- a/docs/zfb.config.ts
+++ b/docs/zfb.config.ts
@@ -154,6 +154,16 @@ export default defineConfig({
   },
   base: settings.base,
   trailingSlash: settings.trailingSlash,
+  // Dual-theme syntect highlighting (zfb next.47 / zudo-doc 0.2.8): emits
+  // per-token --shiki-light/--shiki-dark custom props (and --shiki-*-bg on the
+  // <pre class="syntect-dual">) instead of a single inline color, so code blocks
+  // follow the light/dark toggle with no client JS. The light-dark() resolution
+  // lives in src/styles/global.css ([data-theme] pre[class^="syntect-"]). Names
+  // are SYNTECT built-ins, not Shiki names.
+  codeHighlight: {
+    themeLight: "base16-ocean.light",
+    themeDark: "base16-ocean.dark",
+  },
   markdown: {
     features: {
       // Former-Core features (were always-on before zfb next.12).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,20 +43,20 @@ importers:
         specifier: ^4.0.0
         version: 4.0.2
       '@takazudo/zfb':
-        specifier: 0.1.0-next.38
-        version: 0.1.0-next.38
+        specifier: 0.1.0-next.47
+        version: 0.1.0-next.47
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.38
-        version: 0.1.0-next.38
+        specifier: 0.1.0-next.47
+        version: 0.1.0-next.47
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.38
-        version: 0.1.0-next.38(@takazudo/zfb@0.1.0-next.38)
+        specifier: 0.1.0-next.47
+        version: 0.1.0-next.47(@takazudo/zfb@0.1.0-next.47)
       '@takazudo/zudo-doc':
-        specifier: ^0.2.1
-        version: 0.2.1(@takazudo/zfb-runtime@0.1.0-next.38(@takazudo/zfb@0.1.0-next.38))(@takazudo/zfb@0.1.0-next.38)(@takazudo/zudo-doc-history-server@0.2.1)(preact@10.29.1)(shiki@4.2.0)
+        specifier: ^0.2.8
+        version: 0.2.8(@takazudo/zfb-runtime@0.1.0-next.47(@takazudo/zfb@0.1.0-next.47))(@takazudo/zfb@0.1.0-next.47)(@takazudo/zudo-doc-history-server@0.2.8)(preact@10.29.1)(shiki@4.2.0)
       '@takazudo/zudo-doc-history-server':
-        specifier: ^0.2.1
-        version: 0.2.1
+        specifier: ^0.2.8
+        version: 0.2.8
       clsx:
         specifier: ^2.1.0
         version: 2.1.1
@@ -1406,58 +1406,58 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.38':
-    resolution: {integrity: sha512-vIS8x/XAlKyiq8JAuMhgaIxcVkB5YiqWwN1QJbmSEJmdaM+T11Cp4jAdFLvhgq2KXkGJAC4kfc8rq7tGpiITyg==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.47':
+    resolution: {integrity: sha512-qbgPxyBvpVtghB9OZ2aUvBlKxbft1e/UdS1j3C2t+2yCtE6kyI60dermtlxl42Qs9rk7YE8tyZi79gCzbnY58Q==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.38':
-    resolution: {integrity: sha512-zwK0P62EP8Eq/4KI3GySuj8wDNAvD17oYDeGfh3QQSS09uFEppxeypKWbvtxRFcIHxJJwN3SWGcHUHAoOBE6HQ==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.47':
+    resolution: {integrity: sha512-+AsqqzzajEp2ml8Yf8hLfvIAK41CG5/Pg75n/MxwGS05je00XBqklY4mx2HytcWIbG9/9gusKuUhModrle8z5g==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.38':
-    resolution: {integrity: sha512-pGDMJej+NOJ8s7U6LEHTo0f+UTEiFCHdaubFNedFthGc3dDR0mBF3zQJwjeVwhjEM0ZPAeIl4hgcbAyqusDYBg==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.47':
+    resolution: {integrity: sha512-KX0L6ZbUQ1PfGG1ryF9yXrvz+wFU3WTB0FCVys+H4BAAL5VoDjSSyJUq8ewogtxVS1yW388xaKvPNtHJ5+nX9A==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.38':
-    resolution: {integrity: sha512-qev+gKHLFJVJVyY0jGePibhxrLu0c3XXByJl8tkMm8CTx8qZCAwQwX+mfAFAhR2bKp0eSDDcenXoACsZUyO6Ng==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.47':
+    resolution: {integrity: sha512-+Ox7NvP6HCCuK2BnWV7XfT3UJCGPM/AhAPtR1q4fgmRbx+3p2Acd+SZb9au9v5NlP2/caw5/vDFr4bn88XS6FA==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.38':
-    resolution: {integrity: sha512-Qs0X/jdAmucGx9NE5xp0skq1lU5mCtcNx/FxAUg0NSb2vt4jmNKQDDa89rm0iaX4qSPu+wajnU3W8jDK1TNmRg==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.47':
+    resolution: {integrity: sha512-RM0FSDq1Gyph25lIwMdxMYVLCrI3OVy8s2IYgIJqqaBHXTZIQm54N2JU1oMzPNp5+P7HjextLFNT54zA1xcB5g==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.38':
-    resolution: {integrity: sha512-yPyW7nixnY6YDi+icuWd7mPYrLU4szX7J8Y4+9Iu2tQIcOXv+kMqbfKTdFDJNRPnsu7hOBhRCQSNr8b7pCkJKQ==}
+  '@takazudo/zfb-runtime@0.1.0-next.47':
+    resolution: {integrity: sha512-02pliKgGHrhzkRzhrEwdPc46+vzOFFt0wx7Lijnmh+jcwMfvEHYGDsejaJQjj37qS7OZN8XJHbXVrNnzakKF8w==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.38
+      '@takazudo/zfb': 0.1.0-next.47
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.38':
-    resolution: {integrity: sha512-wj5gQNSmuOjPsfWorl+70ef/bnr+Rxb50BmHI85vIBbq4i6OwMFcSUdxtXK110SU/dIJt3X7ECAVWgo2t8IsHA==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.47':
+    resolution: {integrity: sha512-Ogi5BTESgAM6jqtMIRgxoRX9/0tfLJEys7XyCo8yQk5Ao2xTJxN85wG4V4IxGlaypWHygv28vbZfEtr6758ipA==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.38':
-    resolution: {integrity: sha512-+P/Kt8SeUWKNbMnp6daAb8ZD3Fu54lJRdgg9T4JFcbh6Up7HCDRi+Z7EOjBhcBGWMp3cPTFLTc0srxkpOtFkbQ==}
+  '@takazudo/zfb@0.1.0-next.47':
+    resolution: {integrity: sha512-4mL+AI//ZqM34wNBEwzpeAIXQrFIjvrMuNL6vj37ncjK8T2I+tj4oqlK7Ca8BnaJlTUYzvlKP5uKElu871Sz8w==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zudo-doc-history-server@0.2.1':
-    resolution: {integrity: sha512-mgxNHU9ikhLRImqcrPsn0H0xQ6xvXWJNQJo76cUAvKe3pN7hBR2v/dYNNO8aeGONSL+Oi1piO/VjyhLfhTh6BQ==}
+  '@takazudo/zudo-doc-history-server@0.2.8':
+    resolution: {integrity: sha512-LWEojQK3AZ01L8Gu7rYxx4KKagZRXT89T9PFvzarDkk0vvPt6SqGrgB0nKOVcxWvxpKgkEseFC7lG16CpXCe+A==}
     hasBin: true
 
-  '@takazudo/zudo-doc@0.2.1':
-    resolution: {integrity: sha512-ueC3B0aNBgLHoJAQssqo1ou9b5Lz/OvFaTnHOgN18E50PjKzp9oVgWQjDuPaHTqySQbneWuwyBkl75gn9ukt/w==}
+  '@takazudo/zudo-doc@0.2.8':
+    resolution: {integrity: sha512-0VWr2fBmv0XvNb45vnO9Em1etdc2TaCTtAmgMb3CjgyP/WXkLXY1fEqf20DzPqClF7KH7IudzxwQH/pV0kf80A==}
     peerDependencies:
-      '@takazudo/zdtp': ^0.2.0-next.2
-      '@takazudo/zfb': ^0.1.0-next.38
-      '@takazudo/zfb-runtime': ^0.1.0-next.38
-      '@takazudo/zudo-doc-history-server': ^0.2.1
+      '@takazudo/zdtp': ^0.2.3
+      '@takazudo/zfb': ^0.1.0-next.47
+      '@takazudo/zfb-runtime': ^0.1.0-next.47
+      '@takazudo/zudo-doc-history-server': ^0.2.8
       preact: ^10.29.1
       shiki: ^4.0.2
     peerDependenciesMeta:
@@ -3556,46 +3556,46 @@ snapshots:
       tailwindcss: 4.2.4
       vite: 7.3.5(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.38': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.47': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.38':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.47':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.38':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.47':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.38':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.47':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.38':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.47':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.38(@takazudo/zfb@0.1.0-next.38)':
+  '@takazudo/zfb-runtime@0.1.0-next.47(@takazudo/zfb@0.1.0-next.47)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.38
+      '@takazudo/zfb': 0.1.0-next.47
       hono: 4.12.23
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.38':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.47':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.38':
+  '@takazudo/zfb@0.1.0-next.47':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.38
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.38
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.38
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.38
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.38
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.47
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.47
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.47
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.47
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.47
 
-  '@takazudo/zudo-doc-history-server@0.2.1': {}
+  '@takazudo/zudo-doc-history-server@0.2.8': {}
 
-  '@takazudo/zudo-doc@0.2.1(@takazudo/zfb-runtime@0.1.0-next.38(@takazudo/zfb@0.1.0-next.38))(@takazudo/zfb@0.1.0-next.38)(@takazudo/zudo-doc-history-server@0.2.1)(preact@10.29.1)(shiki@4.2.0)':
+  '@takazudo/zudo-doc@0.2.8(@takazudo/zfb-runtime@0.1.0-next.47(@takazudo/zfb@0.1.0-next.47))(@takazudo/zfb@0.1.0-next.47)(@takazudo/zudo-doc-history-server@0.2.8)(preact@10.29.1)(shiki@4.2.0)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.38
-      '@takazudo/zfb-runtime': 0.1.0-next.38(@takazudo/zfb@0.1.0-next.38)
+      '@takazudo/zfb': 0.1.0-next.47
+      '@takazudo/zfb-runtime': 0.1.0-next.47(@takazudo/zfb@0.1.0-next.47)
       gray-matter: 4.0.3
       preact: 10.29.1
     optionalDependencies:
-      '@takazudo/zudo-doc-history-server': 0.2.1
+      '@takazudo/zudo-doc-history-server': 0.2.8
       shiki: 4.2.0
 
   '@types/d3-array@3.2.2': {}


### PR DESCRIPTION
## Summary

Updates the `docs/` site to the latest **zudo-doc 0.2.8** and the **zfb family next.47** (required by zudo-doc 0.2.8's peer deps), and enables the headline **dual-theme syntect code highlighting** that ships in this version — fixing the previously near-invisible code on the light theme.

## Changes

**Dependency bumps** (`docs/package.json` + `pnpm-lock.yaml`)
- `@takazudo/zudo-doc` `^0.2.1` → `^0.2.8`
- `@takazudo/zudo-doc-history-server` `^0.2.1` → `^0.2.8`
- `@takazudo/zfb`, `@takazudo/zfb-runtime`, `@takazudo/zfb-adapter-cloudflare` `0.1.0-next.38` → `0.1.0-next.47`
- `@takazudo/zdtp` intentionally **not** added — it's an optional peer of zudo-doc and the docs site doesn't use the design-token-tweak panel.

**Enable dual-theme code highlighting** (`docs/zfb.config.ts`)
- Set `codeHighlight.themeLight = "base16-ocean.light"` / `themeDark = "base16-ocean.dark"`. The build now emits `<pre class="syntect-dual">` with per-token `--shiki-light`/`--shiki-dark` custom properties (and `--shiki-*-bg` on the `<pre>`), resolved by the existing `light-dark()` rule in `global.css` — so code blocks follow the light/dark toggle with no client JS.

**Type shim sync** (`docs/zfb-shim.d.ts`)
- Added `themeLight`/`themeDark` to the hand-maintained `CodeHighlightConfig` so `zfb check` (tsc) passes. (The bare `zfb/config` specifier resolves to this ambient shim, which lags the engine — see follow-up below.)

**Comment** (`docs/src/styles/global.css`)
- Updated the build-time syntax-highlight comment to describe the dual-theme output.

## Verification

- `pnpm --filter docs check` — passes (tsc, 2 collections)
- `pnpm --filter docs build` — 255 pages; dual-theme output confirmed (653 `syntect-dual` blocks, **0** leftover single-theme inline-`color:#hex` spans)
- **Browser computed-style check, both themes**: a foreground token resolves to `#c0c5ce` (dark) vs `#4f5b66` (light); default code text `rgb(184,184,184)` (dark) vs `rgb(48,48,48)` (light) — code is readable in both themes.
- `pnpm format:check` — passes
- Multi-dimensional + adversarial review — clean; no in-scope issues.

## Follow-ups (filed upstream, not blocking)

- Takazudo/zudo-front-builder#1073 — bare `zfb/config` is typeless, forcing the hand-maintained `zfb-shim.d.ts` that recurringly drifts (recurrence of #678; 7 more fields currently missing). Proposes making `zfb/config` carry types.
- zudolab/zudo-doc#2164 — zudo-doc 0.2.8's scanner-visible `ThemeToggle` island collides (benignly) with the docs' local `ThemeToggle` under next.47 island scanning.