### PR TITLE
fix(docs): make bare `zfb/config` carry types via re-export shim (#1073)

### DIFF
--- a/docs/src/content/docs-ja/api/define-config.mdx
+++ b/docs/src/content/docs-ja/api/define-config.mdx
@@ -12,6 +12,21 @@ defineConfig(config: ZfbConfig): ZfbConfig
 
 `defineConfig` は `zfb/config` からエクスポートされます。このヘルパーは identity 型で、受け取った引数をそのまま返します。唯一の役割は、エディタに `ZfbConfig` 形状に対する IntelliSense と型チェックを提供することです。実際のスキーマは設定ロード時に Rust の serde によって検証されるため、設定を TypeScript で書いても JSON で書いても同じルールが適用されます。
 
+## `zfb/config` インポートの型付け
+
+`zfb.config.ts` は **ベア** specifier の `zfb/config` から `defineConfig` をインポートします。zfb は設定ロード時にそのインポートをランタイム専用のスタブにエイリアスし（そのため `@takazudo/zfb` パッケージを入れていなくても設定をパースできます）、`node_modules` に実体としての `zfb/config` モジュールは存在しません。公開されている型は **スコープ付き** のサブパス `@takazudo/zfb/config` 配下にあります。そのため素の `tsc --noEmit`（`zfb check` が実行するもの）にはベアインポートを型付けする対象がなく、`Cannot find module 'zfb/config'` を報告します。
+
+両者を橋渡しするには、スコープ付きパッケージの型を **再エクスポート** する 1 行の ambient 宣言を使います。プロジェクトルートに `zfb-shim.d.ts` を追加してください（`tsconfig` が拾う `.d.ts` ならどれでも構いません）。
+
+```ts
+// zfb-shim.d.ts — ベアの `zfb/config` specifier を型付けする。
+declare module "zfb/config" {
+  export * from "@takazudo/zfb/config";
+}
+```
+
+必ず再エクスポートにしてください — `ZfbConfig` の形状をシムに手書きでコピーしては **いけません**。手で写したフィールドリストは静かにエンジンから遅れていきます。新しい設定フィールドが追加されるたびに手で足さない限り、`zfb check` が妥当なフィールドを `TS2353: Object literal may only specify known properties` で拒否します。`export *` は公開されている `@takazudo/zfb/config` を自動的に追従するため、シムが遅れることはありません。
+
 ## 設定の形状
 
 すべてのキーは camelCase です。形状は Rust の serde デシリアライザ（`crates/zfb/src/config.rs`）によって強制されます。`packages/zfb/src/config.ts` の TypeScript 型は、エディタの IntelliSense のためにそれを反映しています。
@@ -44,7 +59,7 @@ defineConfig(config: ZfbConfig): ZfbConfig
 - `emitRoutesManifest?: boolean` — `zfb build` がビルド後のルートマニフェストを `<outDir>/__zfb/routes.json` に書き出すかどうか。デフォルト: `true`（書き出す）。`false` を設定すると抑制します。
 - `extraWatchPaths?: string[]` — プロジェクト内のソースルートに加えて、dev ウォッチャーが追跡する追加の絶対ファイルシステムパス。[プロジェクトルート外のパスを監視する](#プロジェクトルート外のパスを監視する) を参照してください。
 
-以下のキーは Rust の設定ローダーが受け付けますが、TypeScript 型では無視されます（これらは `zfb` が JS の dev ツールではなく Rust バイナリとして動作するときにのみ適用されます）。
+以下のキーも同じ `ZfbConfig` 型の一部で、`defineConfig` や `zfb check` は他のフィールドと同様に型チェックします。これらは Rust エンジンのコードレンダリングとプラグインの挙動を設定します。
 
 - `codeHighlight` — syntect の構文ハイライトテーマオプション。[構文ハイライトのガイド](../guides/syntax-highlighting.mdx)を参照してください。フィールド:
   - `theme?: string` — シングルテーマモード。syntect の組み込み、またはユーザーが読み込んだテーマ名（例: `"InspiredGitHub"`、`"Solarized (dark)"`）。デフォルトは `"base16-ocean.dark"`。トークンはインラインの `color:` で着色されます。`themeLight` / `themeDark` とは排他です。これらは Shiki（`"dracula"` など）ではなく **syntect** のテーマ名です。

--- a/docs/src/content/docs/api/define-config.mdx
+++ b/docs/src/content/docs/api/define-config.mdx
@@ -12,6 +12,21 @@ defineConfig(config: ZfbConfig): ZfbConfig
 
 `defineConfig` is exported from `zfb/config`. The helper is identity-typed: it returns its argument unchanged. Its only job is to give your editor IntelliSense and type-checking against the `ZfbConfig` shape. The actual schema is enforced by Rust serde at config-load time, so the same rules apply whether you author your config in TypeScript or JSON.
 
+## Typing the `zfb/config` import
+
+`zfb.config.ts` imports `defineConfig` from the **bare** specifier `zfb/config`. At config-load time zfb aliases that import to a runtime-only stub (so your config parses without the `@takazudo/zfb` package installed), and no real `zfb/config` module exists in `node_modules` — the published types live under the **scoped** subpath `@takazudo/zfb/config`. So a plain `tsc --noEmit` (what `zfb check` runs) has nothing to type the bare import against and reports `Cannot find module 'zfb/config'`.
+
+Bridge the two with a one-line ambient declaration that **re-exports** the scoped package's types. Add a `zfb-shim.d.ts` at your project root (any `.d.ts` your `tsconfig` includes works):
+
+```ts
+// zfb-shim.d.ts — types the bare `zfb/config` specifier.
+declare module "zfb/config" {
+  export * from "@takazudo/zfb/config";
+}
+```
+
+Re-export — do **not** hand-copy the `ZfbConfig` shape into the shim. A hand-mirrored field list silently lags the engine: every new config field has to be re-added by hand, or `zfb check` rejects a perfectly valid field with `TS2353: Object literal may only specify known properties`. `export *` tracks the published `@takazudo/zfb/config` automatically, so the shim can never fall behind.
+
 ## Config shape
 
 All keys are camelCase. The shape is enforced by the Rust serde deserializer (`crates/zfb/src/config.rs`) — the TypeScript type in `packages/zfb/src/config.ts` mirrors it for editor IntelliSense.
@@ -45,7 +60,7 @@ All keys are camelCase. The shape is enforced by the Rust serde deserializer (`c
 - `emitRoutesManifest?: boolean` — whether `zfb build` writes the post-build route manifest to `<outDir>/__zfb/routes.json`. Default: `true` (emit). Set `false` to suppress.
 - `extraWatchPaths?: string[]` — extra absolute filesystem paths the dev watcher follows in addition to the in-project source roots. See [Watching paths outside the project root](#watching-paths-outside-the-project-root).
 
-The following keys are accepted by the Rust config loader and ignored by the TypeScript type (they apply only when `zfb` runs as a Rust binary, not the JS dev tooling):
+The following keys are part of the same `ZfbConfig` type — `defineConfig` and `zfb check` type-check them like any other field. They configure the Rust engine's code-rendering and plugin behaviour:
 
 - `codeHighlight` — syntect syntax-highlight theme options. See the [syntax-highlighting guide](../guides/syntax-highlighting.mdx). Fields:
   - `theme?: string` — single-theme mode. A syntect built-in or user-loaded theme name (e.g. `"InspiredGitHub"`, `"Solarized (dark)"`); defaults to `"base16-ocean.dark"`. Tokens get an inline `color:`. Mutually exclusive with `themeLight` / `themeDark`. These are **syntect** theme names, not Shiki names like `"dracula"`.

--- a/docs/zfb-shim.d.ts
+++ b/docs/zfb-shim.d.ts
@@ -9,175 +9,23 @@
 // No real file backs `zfb/config` in `node_modules`, so this ambient
 // declaration is what supplies the `ZfbConfig` type to `zfb.config.ts`.
 //
-// IMPORTANT — this block is the source of truth for the type `zfb check`
-// (plain `tsc --noEmit`) binds against the config. An ambient `declare
-// module` wins over node resolution AND over tsconfig `paths`, so it must
-// be kept in sync BY HAND with the published `@takazudo/zfb/config`
-// (`dist/config.d.ts`). When it lags the engine, valid config fields fail
-// `pnpm check` with TS2353 (see Takazudo/zudo-front-builder#678 +
-// zudolab/zudo-doc#1834 — `bundle` was missing here, blocking next.22's
-// `bundle.exclude`).
+// IMPORTANT — DO NOT hand-mirror `ZfbConfig` here. This block must stay a
+// thin RE-EXPORT of the published `@takazudo/zfb/config` types. Earlier
+// versions of this file copied the `ZfbConfig` shape field-by-field, which
+// silently lagged the engine: every new config field had to be hand-added
+// here or `zfb check` (plain `tsc --noEmit`) rejected a perfectly valid
+// field with TS2353. That recurred twice — next.22 `bundle.exclude`
+// (Takazudo/zudo-front-builder#678) and next.47 `codeHighlight.themeLight`
+// / `themeDark` (#1073). Re-exporting the scoped package's types removes
+// the hand-maintained field list entirely, so the shim can no longer fall
+// behind — the whole "TS2353 on a newly-added valid field" class is closed.
+//
+// An ambient `declare module` wins over node resolution AND over tsconfig
+// `paths`, so this declaration (not the package's own export map) is what
+// `zfb check` binds `zfb/config` against. `export *` re-exports every named
+// export of `@takazudo/zfb/config` — including the `defineConfig` value and
+// the `ZfbConfig` type — into the bare specifier.
 
 declare module "zfb/config" {
-  /** JSX framework runtime. */
-  export type Framework = "preact" | "react";
-
-  /** A content collection registered with the zfb engine. */
-  export interface CollectionDef {
-    /** Identifier used at the call site (e.g. `"docs"`). */
-    name: string;
-    /** Directory (relative to the project root) holding the entries. */
-    path: string;
-    /**
-     * Optional schema. Reserved for v1.1 — accepted but not enforced
-     * today. Authored as zod and converted to JSON Schema via
-     * `z.toJSONSchema()` at the boundary.
-     */
-    schema?: Record<string, unknown>;
-  }
-
-  /** Tailwind options; absent = defaults. */
-  export interface TailwindConfig {
-    enabled?: boolean;
-  }
-
-  /** User-supplied plugin configuration entry. */
-  export interface PluginConfig {
-    name: string;
-    options?: Record<string, unknown>;
-  }
-
-  /**
-   * Bundler options. Mirrors `BundleConfig` in crates/zfb/src/config.rs
-   * and the published `@takazudo/zfb/config` (`dist/config.d.ts`). Added
-   * in next.22 (`bundle.exclude`, #664) and extended in next.23
-   * (`mainFields` / `external`, #676).
-   */
-  export interface BundleConfig {
-    /**
-     * Project-relative, gitignore-style globs for source files the bundler
-     * must NOT pull into the esbuild graph (e.g. test fixtures or
-     * `*.stories.tsx`). Matched files are skipped from the shadow-tree walk
-     * and dropped from any eager `import.meta.glob(...)` expansion.
-     */
-    exclude?: string[];
-    /**
-     * Explicit esbuild `main-fields` for the `--platform=neutral` page/SSR
-     * pass (empty by default under `neutral`), letting CJS-`main`-only deps
-     * resolve. Mirrors `BundleConfig::main_fields`.
-     */
-    mainFields?: string[];
-    /**
-     * Bare specifiers to mark external in the `--platform=neutral` pass so
-     * esbuild leaves them unbundled. Mirrors `BundleConfig::external`.
-     */
-    external?: string[];
-  }
-
-  /** Mirrors the Rust `Config` struct one-for-one. */
-  export interface ZfbConfig {
-    outDir?: string;
-    publicDir?: string;
-    host?: string;
-    port?: number;
-    framework?: Framework;
-    collections?: CollectionDef[];
-    tailwind?: TailwindConfig;
-    /**
-     * Bundler options. `bundle.exclude` keeps project-relative globs out of
-     * the esbuild graph — used here to skip `packages/md-plugins/__fixtures__/**`
-     * so the MDX link resolver no longer walks the test fixtures (silences
-     * ~15 pre-existing broken-link warnings). Mirrors `Config::bundle`.
-     */
-    bundle?: BundleConfig;
-    plugins?: PluginConfig[];
-    adapter?: string;
-    /**
-     * When `false`, public/ assets are flat-copied to the dist root
-     * instead of under `<outDir>/<base>/`. Mirrors
-     * `Config::copy_public_with_base` in crates/zfb/src/config.rs
-     * (shipped in @takazudo/zfb 0.1.0-next.37; #932 / #946).
-     */
-    copyPublicWithBase?: boolean;
-    /**
-     * Strip `.md` / `.mdx` from in-page `<a href>` paths and append a
-     * trailing `/` so author-written `[label](other.mdx)` references
-     * resolve to the rendered route URL. Mirrors Config::strip_md_ext
-     * in crates/zfb/src/config.rs (zudolab/zfb#131).
-     */
-    stripMdExt?: boolean;
-    /**
-     * Site base path. Prefixed onto stable HTML asset URLs (CSS / JS
-     * `<link>` and `<script>` tags). Normalised to start AND end with
-     * `/`; `undefined` / `""` / `"/"` all behave identically (no
-     * prefix). Mirrors Config::base in crates/zfb/src/config.rs
-     * (Takazudo/zudo-front-builder#154).
-     */
-    base?: string;
-    /**
-     * Configures the syntect-based syntax highlighter shipped with zfb.
-     * Mirrors `code_highlight` in crates/zfb/src/config.rs (Takazudo/zudo-front-builder#188 / sub #194; landed in commit 339e30f).
-     * When omitted, the engine falls back to the hardcoded default theme `base16-ocean.dark`.
-     *
-     * Single-theme mode: set `theme` (or omit for the default) — tokens get an
-     * inline `color:`. Dual-theme mode: set both `themeLight` and `themeDark`
-     * (mutually exclusive with `theme`) — tokens get `--shiki-light`/`--shiki-dark`
-     * custom props on `<pre class="syntect-dual">`, resolved via a `light-dark()`
-     * rule. Dual-theme fields shipped in @takazudo/zfb 0.1.0-next.47; kept in sync
-     * by hand with the published `@takazudo/zfb/config` `CodeHighlightConfig`.
-     */
-    codeHighlight?: {
-      theme?: string;
-      themesDir?: string;
-      themeLight?: string;
-      themeDark?: string;
-    };
-    /**
-     * Markdown link resolver (port of `remarkResolveMarkdownLinks`).
-     * Mirrors `Config::resolve_markdown_links` in crates/zfb/src/config.rs
-     * (Takazudo/zudo-front-builder PR #234 / zudolab/zudo-doc#1577).
-     * When `enabled: true`, the build appends `ResolveLinksPlugin` to the
-     * mdast pipeline so author-written `[label](./other.mdx)` links are
-     * rewritten to the corresponding rendered route URL — bypassing the
-     * file→directory transformation that breaks relative paths in dist
-     * HTML when `foo.mdx` becomes `foo/index.html`.
-     */
-    resolveMarkdownLinks?: {
-      enabled?: boolean;
-      docsDir?: string;
-      dirs?: Array<{ dir: string; routePrefix: string }>;
-      onBrokenLinks?: "warn" | "error" | "ignore";
-    };
-    /**
-     * Whether the basePath rewriter should append a trailing `/` to
-     * extensionless absolute hrefs. Mirrors `Config::trailing_slash` in
-     * crates/zfb/src/config.rs (Takazudo/zudo-front-builder PR #234 /
-     * zudolab/zudo-doc#1579). Off by default — preserves byte-for-byte
-     * parity with the pre-`trailingSlash` build for projects that
-     * haven't opted in.
-     */
-    trailingSlash?: boolean;
-    /**
-     * Markdown / MDX pipeline options. Mirrors `Config::markdown` →
-     * `MarkdownConfig` in crates/zfb/src/config.rs. zfb next.12 moved the
-     * former-Core features under `markdown.features` and next.13 ships the
-     * rest as opt-in; zudo-doc uses `markdown.features` to opt back into the
-     * former-Core four plus the additional opt-in features (#1804). Each
-     * `features` value is per-feature: `true` for boolean-shorthand features,
-     * or an options object for object-typed features.
-     */
-    markdown?: {
-      gfm?: boolean | Record<string, boolean>;
-      toc?: Record<string, unknown>;
-      externalLinks?: Record<string, unknown>;
-      cjkFriendly?: boolean;
-      features?: Record<string, boolean | Record<string, unknown>>;
-    };
-  }
-
-  /**
-   * Identity helper: returns the supplied config as-is, but typed
-   * against `ZfbConfig`. Use as the default export of `zfb.config.ts`.
-   */
-  export function defineConfig(config: ZfbConfig): ZfbConfig;
+  export * from "@takazudo/zfb/config";
 }


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1073

---

## Summary

Closes the recurring **TS2353** class (#1073, a recurrence of #678) where `zfb check` rejects a valid `zfb.config.ts` field because the consumer's hand-maintained `declare module "zfb/config"` shim lags the engine.

**Root cause:** `zfb.config.ts` imports the *bare* specifier `zfb/config`, which zfb aliases to a runtime-only stub at parse time (no types). The published types live under the *scoped* subpath `@takazudo/zfb/config`. To type the bare import, `docs/zfb-shim.d.ts` hand-mirrored the entire `ZfbConfig` shape — and that hand-copied field list silently fell behind the engine on every new field (next.22 `bundle.exclude` → #678; next.47 `codeHighlight.themeLight`/`themeDark` → this issue). An audit found **7 more** fields already missing from the hand-mirror.

**Fix (issue's Option B):** make the shim a thin **re-export** of the published types — `export * from "@takazudo/zfb/config"`. A re-export has no field list to lag, so the entire "TS2353 on a newly-added valid field" class is closed structurally.

## Changes

- **`docs/zfb-shim.d.ts`** — replace the hand-mirrored `declare module "zfb/config"` body (Framework / CollectionDef / BundleConfig / ZfbConfig / … duplicated by hand) with a one-line re-export of `@takazudo/zfb/config`. Header comment rewritten to explain the recurrence history and warn against ever reverting to hand-mirroring.
- **`docs/src/content/docs/api/define-config.mdx`** + **JA mirror** — add a "Typing the `zfb/config` import" section documenting the recommended self-maintaining re-export shim (so other consumers stop hand-mirroring), and fix the stale claim that `codeHighlight` / `pluginHookTimeoutSecs` are "ignored by the TypeScript type" (both are in the published `ZfbConfig` and type-check under `defineConfig` / `zfb check`).

## Test Plan

- `zfb check` (= `pnpm docs:check`) passes after the rewrite — regression guard against the dual-theme config that triggered #1073.
- All 7 previously-missing fields (`allowedHosts`, `prefetch`, `site`, `extraWatchPaths`, `emitRoutesManifest`, `pluginHookTimeoutSecs`, `output`) now type-check via the re-export (verified with a throwaway `tsc --noEmit`).
- Negative control: a bogus field still errors with `TS2353 … 'ZfbConfig'`, proving the shim binds the real published type (not `any`).
- `pnpm format:check` (prettier + mdx-formatter) passes.

**Not tested / blind spot:** `zfb check` / `docs:check` is *not* a CI gate in this repo, so the type-check verification above is local-only. The re-export shim is structurally lag-proof (no field list), so recurrence is prevented by construction rather than by a CI test.