### PR TITLE
chore(docs): bump zudo-doc to 0.2.9 (zfb npm trio to next.49)

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -13,10 +13,10 @@
     "b4push": "pnpm check && pnpm build"
   },
   "dependencies": {
-    "@takazudo/zfb": "0.1.0-next.47",
-    "@takazudo/zfb-runtime": "0.1.0-next.47",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.47",
-    "@takazudo/zudo-doc": "^0.2.8",
+    "@takazudo/zfb": "0.1.0-next.49",
+    "@takazudo/zfb-runtime": "0.1.0-next.49",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.49",
+    "@takazudo/zudo-doc": "^0.2.9",
     "zod": "^4.0.0",
     "preact": "^10.29.1",
     "preact-render-to-string": "^6.6.6",
@@ -31,7 +31,7 @@
     "katex": "^0.16.38",
     "minisearch": "^7.2.0",
     "diff": "^8.0.3",
-    "@takazudo/zudo-doc-history-server": "^0.2.8"
+    "@takazudo/zudo-doc-history-server": "^0.2.9"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.0",

--- a/docs/zfb.config.ts
+++ b/docs/zfb.config.ts
@@ -154,7 +154,7 @@ export default defineConfig({
   },
   base: settings.base,
   trailingSlash: settings.trailingSlash,
-  // Dual-theme syntect highlighting (zfb next.47 / zudo-doc 0.2.8): emits
+  // Dual-theme syntect highlighting (zfb next.49 / zudo-doc 0.2.9): emits
   // per-token --shiki-light/--shiki-dark custom props (and --shiki-*-bg on the
   // <pre class="syntect-dual">) instead of a single inline color, so code blocks
   // follow the light/dark toggle with no client JS. The light-dark() resolution

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,20 +46,20 @@ importers:
         specifier: ^4.0.0
         version: 4.0.2
       '@takazudo/zfb':
-        specifier: 0.1.0-next.47
-        version: 0.1.0-next.47
+        specifier: 0.1.0-next.49
+        version: 0.1.0-next.49
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.47
-        version: 0.1.0-next.47
+        specifier: 0.1.0-next.49
+        version: 0.1.0-next.49
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.47
-        version: 0.1.0-next.47(@takazudo/zfb@0.1.0-next.47)
+        specifier: 0.1.0-next.49
+        version: 0.1.0-next.49(@takazudo/zfb@0.1.0-next.49)
       '@takazudo/zudo-doc':
-        specifier: ^0.2.8
-        version: 0.2.8(@takazudo/zfb-runtime@0.1.0-next.47(@takazudo/zfb@0.1.0-next.47))(@takazudo/zfb@0.1.0-next.47)(@takazudo/zudo-doc-history-server@0.2.8)(preact@10.29.1)(shiki@4.2.0)
+        specifier: ^0.2.9
+        version: 0.2.9(@takazudo/zfb-runtime@0.1.0-next.49(@takazudo/zfb@0.1.0-next.49))(@takazudo/zfb@0.1.0-next.49)(@takazudo/zudo-doc-history-server@0.2.9)(preact@10.29.1)(shiki@4.2.0)
       '@takazudo/zudo-doc-history-server':
-        specifier: ^0.2.8
-        version: 0.2.8
+        specifier: ^0.2.9
+        version: 0.2.9
       clsx:
         specifier: ^2.1.0
         version: 2.1.1
@@ -1414,58 +1414,58 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.47':
-    resolution: {integrity: sha512-qbgPxyBvpVtghB9OZ2aUvBlKxbft1e/UdS1j3C2t+2yCtE6kyI60dermtlxl42Qs9rk7YE8tyZi79gCzbnY58Q==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.49':
+    resolution: {integrity: sha512-1ilAvfQcTUHa4nmV0XU8zHPjIzfr0hUdJJACtklYYHkWVyemh1k9hoRUZm2MAKYVwye6BZV/p5x1zkxCYn3P2g==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.47':
-    resolution: {integrity: sha512-+AsqqzzajEp2ml8Yf8hLfvIAK41CG5/Pg75n/MxwGS05je00XBqklY4mx2HytcWIbG9/9gusKuUhModrle8z5g==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.49':
+    resolution: {integrity: sha512-pUDptGa4L4mxfn7vThzpYDjszkuhvfLHwDuBBvZ/qC1Uz32/nqJJOxl8ZdwkzpfzYGkna1I9OzUUnx9QBv2Qiw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.47':
-    resolution: {integrity: sha512-KX0L6ZbUQ1PfGG1ryF9yXrvz+wFU3WTB0FCVys+H4BAAL5VoDjSSyJUq8ewogtxVS1yW388xaKvPNtHJ5+nX9A==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.49':
+    resolution: {integrity: sha512-iJrktID8Momn3CHBzMjU31F6NzlnV89QM/v/iMiZGnEtLote6HJcXDstm5xoghbX2i6RynCJ0CTiUNu4meEAKQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.47':
-    resolution: {integrity: sha512-+Ox7NvP6HCCuK2BnWV7XfT3UJCGPM/AhAPtR1q4fgmRbx+3p2Acd+SZb9au9v5NlP2/caw5/vDFr4bn88XS6FA==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.49':
+    resolution: {integrity: sha512-m0DsadTcMVAztEqnWhW21NYMGtE+78LRErYVi2eoLIrLD2VhwGeIl7dxx8qUBw2DS3Y/QiIkXC9WZbvhSQ68Mw==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.47':
-    resolution: {integrity: sha512-RM0FSDq1Gyph25lIwMdxMYVLCrI3OVy8s2IYgIJqqaBHXTZIQm54N2JU1oMzPNp5+P7HjextLFNT54zA1xcB5g==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.49':
+    resolution: {integrity: sha512-aQYxEYIufy5DL9/J8uuCGsZATmmvT28x/TWrft4YzkCToEgGSbQgCE6p7XGOTvJWsQpSGq8nVwHbIjHb7os0dg==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.47':
-    resolution: {integrity: sha512-02pliKgGHrhzkRzhrEwdPc46+vzOFFt0wx7Lijnmh+jcwMfvEHYGDsejaJQjj37qS7OZN8XJHbXVrNnzakKF8w==}
+  '@takazudo/zfb-runtime@0.1.0-next.49':
+    resolution: {integrity: sha512-5sg3EEOQbwe5FSP0dH/8eDNODlhJlWzc5sXGNSe9tnwy3EZeIV36zWy0nqhgEyjuaSnfgQPdkO1V/xX84IG/TQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.47
+      '@takazudo/zfb': 0.1.0-next.49
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.47':
-    resolution: {integrity: sha512-Ogi5BTESgAM6jqtMIRgxoRX9/0tfLJEys7XyCo8yQk5Ao2xTJxN85wG4V4IxGlaypWHygv28vbZfEtr6758ipA==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.49':
+    resolution: {integrity: sha512-GMucMsaD3e2WYs4q8zK844CvAq88NPJRm7BnO6+AEsVB/Mfec/wD2oBbp94Q7eDr6PoJCTEFXO0o44fvgT6zrg==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.47':
-    resolution: {integrity: sha512-4mL+AI//ZqM34wNBEwzpeAIXQrFIjvrMuNL6vj37ncjK8T2I+tj4oqlK7Ca8BnaJlTUYzvlKP5uKElu871Sz8w==}
+  '@takazudo/zfb@0.1.0-next.49':
+    resolution: {integrity: sha512-IyZqXSjsS5mAleErx74LeNq/7ZvxJfBOqlUwl3Sz+0HcOAWj811Worevh+TZUiRo23MRgeoLFn83VJk185ftcg==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zudo-doc-history-server@0.2.8':
-    resolution: {integrity: sha512-LWEojQK3AZ01L8Gu7rYxx4KKagZRXT89T9PFvzarDkk0vvPt6SqGrgB0nKOVcxWvxpKgkEseFC7lG16CpXCe+A==}
+  '@takazudo/zudo-doc-history-server@0.2.9':
+    resolution: {integrity: sha512-JF+fWItfOPNIdz6I1xOZS3nSLuvsimobOVbsqr8slWYj/lYq0EXkAmvFwIqI3ecx2pPa9/rJvqz23WgtVYbslQ==}
     hasBin: true
 
-  '@takazudo/zudo-doc@0.2.8':
-    resolution: {integrity: sha512-0VWr2fBmv0XvNb45vnO9Em1etdc2TaCTtAmgMb3CjgyP/WXkLXY1fEqf20DzPqClF7KH7IudzxwQH/pV0kf80A==}
+  '@takazudo/zudo-doc@0.2.9':
+    resolution: {integrity: sha512-A/ZhWL4Ux2E+Ba1G5nqWz9YakUw+D+CBLPAV+xEv6mdRzeGSOhAkmfYoeRzJdLWWVW2gxM74Hazq6sEPrvRn3g==}
     peerDependencies:
       '@takazudo/zdtp': ^0.2.3
-      '@takazudo/zfb': ^0.1.0-next.47
-      '@takazudo/zfb-runtime': ^0.1.0-next.47
-      '@takazudo/zudo-doc-history-server': ^0.2.8
+      '@takazudo/zfb': ^0.1.0-next.49
+      '@takazudo/zfb-runtime': ^0.1.0-next.49
+      '@takazudo/zudo-doc-history-server': ^0.2.9
       preact: ^10.29.1
       shiki: ^4.0.2
     peerDependenciesMeta:
@@ -3583,46 +3583,46 @@ snapshots:
       tailwindcss: 4.2.4
       vite: 7.3.5(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.47': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.49': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.47':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.49':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.47':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.49':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.47':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.49':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.47':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.49':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.47(@takazudo/zfb@0.1.0-next.47)':
+  '@takazudo/zfb-runtime@0.1.0-next.49(@takazudo/zfb@0.1.0-next.49)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.47
+      '@takazudo/zfb': 0.1.0-next.49
       hono: 4.12.23
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.47':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.49':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.47':
+  '@takazudo/zfb@0.1.0-next.49':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.47
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.47
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.47
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.47
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.47
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.49
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.49
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.49
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.49
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.49
 
-  '@takazudo/zudo-doc-history-server@0.2.8': {}
+  '@takazudo/zudo-doc-history-server@0.2.9': {}
 
-  '@takazudo/zudo-doc@0.2.8(@takazudo/zfb-runtime@0.1.0-next.47(@takazudo/zfb@0.1.0-next.47))(@takazudo/zfb@0.1.0-next.47)(@takazudo/zudo-doc-history-server@0.2.8)(preact@10.29.1)(shiki@4.2.0)':
+  '@takazudo/zudo-doc@0.2.9(@takazudo/zfb-runtime@0.1.0-next.49(@takazudo/zfb@0.1.0-next.49))(@takazudo/zfb@0.1.0-next.49)(@takazudo/zudo-doc-history-server@0.2.9)(preact@10.29.1)(shiki@4.2.0)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.47
-      '@takazudo/zfb-runtime': 0.1.0-next.47(@takazudo/zfb@0.1.0-next.47)
+      '@takazudo/zfb': 0.1.0-next.49
+      '@takazudo/zfb-runtime': 0.1.0-next.49(@takazudo/zfb@0.1.0-next.49)
       gray-matter: 4.0.3
       preact: 10.29.1
     optionalDependencies:
-      '@takazudo/zudo-doc-history-server': 0.2.8
+      '@takazudo/zudo-doc-history-server': 0.2.9
       shiki: 4.2.0
 
   '@types/d3-array@3.2.2': {}


### PR DESCRIPTION
## What

Bump the docs site's `@takazudo/zudo-doc` (+ `@takazudo/zudo-doc-history-server`) from `^0.2.8` to `^0.2.9`.

## Why the zfb trio moves too

zudo-doc 0.2.9 raises its peer deps to `@takazudo/zfb` / `@takazudo/zfb-runtime` `^0.1.0-next.49`. To satisfy them, the docs site's zfb npm trio (`zfb`, `zfb-runtime`, `zfb-adapter-cloudflare`) moves `0.1.0-next.47` → `0.1.0-next.49` in lockstep (latest published, matches the repo's own current release).

## Verification (local)

- `pnpm install` — resolves with **no unmet peer warnings** (`zdtp`/`history-server`/`shiki` peers are optional).
- `pnpm --filter docs check` — ✓ tsc, no errors.
- `pnpm --filter docs build` — ✓ 259 pages built.

## Notes

- zudo-doc 0.2.9 is a maintenance release (scaffold-only zdtp gating, pnpm-trust fix, theme-toggle doc tweak); **no breaking changes**.
- The `ThemeToggle island marker collision` build warning is **pre-existing and benign** — it's the docs site's intentional local-`ThemeToggle` override, tracked upstream at zudolab/zudo-doc#2164 (closed as completed). Not introduced by this bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)