### PR TITLE
Markdown Fixes: container directives + close the test-utils CI gap

### DIFF
--- a/.github/workflows/health.yml
+++ b/.github/workflows/health.yml
@@ -155,6 +155,19 @@ jobs:
       # preact/jsx-runtime islands alias guards — were local-only (issue #638).
       - run: cargo test --workspace
 
+      # Run the zfb-md-extras integration suite gated behind the `test-utils`
+      # feature (issue #1091). The `test-utils` feature is not in the default
+      # feature set, so `cargo test --workspace` above silently skips every
+      # [[test]] target carrying `required-features = ["test-utils"]`. Using the
+      # scoped `-p zfb-md-extras` form because `test-utils` exists only on this
+      # crate — `--workspace --features test-utils` would error on other members
+      # that have no such feature.
+      - run: cargo test -p zfb-md-extras --features test-utils
+
+      # Lint the test-utils-gated targets (they are excluded from the workspace
+      # clippy step above for the same reason as cargo test).
+      - run: cargo clippy -p zfb-md-extras --features test-utils --all-targets -- -D warnings
+
       - name: actionlint
         uses: docker://rhysd/actionlint:1.7.12
 

--- a/crates/zfb-build/tests/migration_fixes_integration_confirm.rs
+++ b/crates/zfb-build/tests/migration_fixes_integration_confirm.rs
@@ -156,31 +156,26 @@ fn directive_label_becomes_title_attribute() {
 }
 
 // ---------------------------------------------------------------------------
-// 2. Un-blank-lined directive → blank-line diagnostic
+// 2. Un-blank-lined directive → now transforms to a component
 //
-// The blank-line diagnostic is emitted by `DirectiveRegistry` when it
-// detects that a `:::note\nbody\n:::` block was merged into a single
-// paragraph (no surrounding blank lines).  We test this at the
-// `zfb-content` pipeline level — below the bundler — so this assertion
-// always runs even without an esbuild binary.
+// HISTORY: this test originally asserted the OPPOSITE — that a `:::note`
+// written without surrounding blank lines (which the markdown parser
+// collapses into a single multi-line paragraph) was left as raw text and
+// emitted a "missing blank lines" diagnostic. That was a BUG (#1085): the
+// reporter's real-world admonitions are written without blank fences and
+// silently rendered as literal `:::note` text. Issue #1090 fixed the
+// container-directive matcher to transform the collapsed single-paragraph
+// form, matching how `githubAlerts` already behaves end-to-end.
 //
-// The diagnostic is accessible via `DirectiveRegistry::take_diagnostics()`
-// which is exposed through `zfb_content::plugins::DirectiveRegistry`.
-// We drive the registry standalone (not through `Pipeline`) so we can
-// call `take_diagnostics()` after the visit.
-//
-// NOTE: The `markdown::mdast` crate is an internal dep of `zfb-content`
-// but not of `zfb-build`.  We avoid importing it directly here by using
-// `zfb_content::pipeline::Pipeline` with a custom mdast visitor — but
-// since `Pipeline` boxes visitors and doesn't expose the registry's
-// diagnostic drain, we use a different approach: we verify that the
-// bad source does NOT produce a recognized `<Note>` element in the
-// serialized HTML (because the directive was left as a raw paragraph),
-// which is the observable effect of the missing-blank-lines path.
+// This test is updated (assertion flipped, not deleted) to confirm the
+// corrected behavior at the `zfb-build` boundary: an un-blank-lined
+// `:::note` now DOES compile to a `<Note>` JSX element. The companion
+// `merged_container_transforms_to_jsx` test in `zfb-content` guards the
+// same change at the mdast-transform level.
 // ---------------------------------------------------------------------------
 
 #[test]
-fn un_blank_lined_directive_does_not_produce_note_element() {
+fn un_blank_lined_directive_produces_note_element() {
     use zfb_content::mdx_to_jsx_module_with_pipeline;
     use zfb_content::pipeline::Pipeline;
     use zfb_content::MdxJsxOptions;
@@ -189,35 +184,31 @@ fn un_blank_lined_directive_does_not_produce_note_element() {
     //   :::note
     //   body text
     //   :::
-    // The markdown parser collapses this into a single merged paragraph
-    // (the `:::` tokens have no special meaning without the surrounding
-    // blank lines that let the directive parser see them as block fences).
-    // The DirectiveRegistry detects the merge via `paragraph_text_looks_merged`,
-    // emits a diagnostic, and leaves the paragraph intact — so no `<Note>`
-    // JSX element is emitted.
-    let bad_src = ":::note\nbody text without blank lines\n:::\n";
+    // The markdown parser collapses this into a single merged paragraph.
+    // Post-#1090 the DirectiveRegistry detects the collapsed form, strips
+    // the opener/closer fence lines, and emits the registered `<Note>`
+    // component — no diagnostic, no raw `:::` left behind.
+    let src = ":::note\nbody text without blank lines\n:::\n";
 
-    // `note → Note` is registered, so a well-formed `:::note` WOULD transform;
-    // this test proves the merged (no-blank-lines) form does NOT.
     let features = note_directive_features();
     let mut pipeline = Pipeline::with_defaults_and_features(&features);
-    let jsx = mdx_to_jsx_module_with_pipeline(bad_src, MdxJsxOptions::default(), &mut pipeline)
-        .expect("pipeline must not hard-error on bad-blank-line source");
+    let jsx = mdx_to_jsx_module_with_pipeline(src, MdxJsxOptions::default(), &mut pipeline)
+        .expect("pipeline must not hard-error on un-blank-lined directive source");
 
-    // The compiled JSX must NOT contain a `<Note` opening tag — the directive
-    // was left unrecognised (merged paragraph, no blank lines).
+    // The compiled JSX MUST contain a `<Note` opening tag — the collapsed
+    // directive is now recognised and transformed (#1090).
     assert!(
-        !jsx.contains("<Note"),
-        "un-blank-lined :::note must not produce a <Note> JSX element.\
+        jsx.contains("<Note"),
+        "un-blank-lined :::note must now produce a <Note> JSX element (#1090).\
          \nJSX excerpt: {}",
         &jsx[..jsx.len().min(1200)]
     );
 
-    // The raw `:::` fence markers (as string literals) must be visible in the
-    // JSX output, confirming the paragraph was NOT consumed by the registry.
+    // The raw `:::` fence markers must NOT survive — the paragraph was
+    // consumed by the registry and rewritten to the component.
     assert!(
-        jsx.contains(":::"),
-        "un-blank-lined directive source must survive as raw text in the JSX.\
+        !jsx.contains(":::"),
+        "un-blank-lined directive fences must be consumed, not left as raw text (#1090).\
          \nJSX excerpt: {}",
         &jsx[..jsx.len().min(1200)]
     );

--- a/crates/zfb-content/src/mdx_jsx_emit.rs
+++ b/crates/zfb-content/src/mdx_jsx_emit.rs
@@ -354,6 +354,13 @@ fn mdx_to_jsx_module_inner(
         if let (Some(reg), Some(src)) =
             (ctx.heading_registry.as_deref_mut(), ctx.source_path.clone())
         {
+            // Mark the file tracked before seeding individual headings so a
+            // document with zero headings still gets a `Some(&[])` entry —
+            // `LinkValidationPlugin` then validates its bare `#anchor` links
+            // as broken instead of silently skipping (zfb#1093). Mirrors the
+            // `HeadingLinksPlugin::visit_with_context` mark on the
+            // run_with_context path; keeps both compile paths in lockstep.
+            reg.mark_tracked(src.clone());
             let mut channel_entries: Vec<RegistryHeadingEntry> = Vec::new();
             for h in &headings {
                 if !h.slug.is_empty() {

--- a/crates/zfb-content/src/plugins/directives.rs
+++ b/crates/zfb-content/src/plugins/directives.rs
@@ -166,26 +166,25 @@ impl DirectiveRegistry {
                             i += 1;
                             continue;
                         }
-                        // A registered container name was found but no
-                        // separate closing `:::` paragraph exists.  Check
-                        // whether the opener and body were merged into a
-                        // single paragraph because the author forgot the
-                        // surrounding blank lines and emit a helpful
-                        // diagnostic.
-                        if paragraph_text_looks_merged(&children[i]) {
+                        // No separate closing `:::` paragraph exists. In
+                        // real markdown, when the fences are NOT surrounded
+                        // by blank lines, `markdown::to_mdast` collapses the
+                        // opener, body, and closing `:::` into a SINGLE
+                        // multi-line Paragraph (the opener is the first line
+                        // of the first Text child and the `:::` closer is the
+                        // last line of the last Text child). This is the
+                        // common real-world shape (issue #1090) — detect it
+                        // and transform the collapsed paragraph just like the
+                        // blank-line-separated form, matching what
+                        // `githubAlerts` does end-to-end.
+                        if let Some(inner) = collapsed_container_body(&children[i]) {
                             let (line, column) = paragraph_line_col(&children[i]);
-                            self.diagnostics.push(DirectiveDiagnostic {
-                                message: format!(
-                                    "admonition `:::{}` looks like it is missing blank lines \
-                                     around the fences — the opening `:::{name}` and closing \
-                                     `:::` must each be on their own paragraph (separated by \
-                                     blank lines) for the directive to be recognised",
-                                    parsed.name,
-                                    name = parsed.name,
-                                ),
-                                line,
-                                column,
-                            });
+                            let validated_opt = self.run_validation(&def, &parsed, line, column);
+                            let jsx =
+                                build_flow_jsx(&def, &parsed, inner, validated_opt.as_ref());
+                            children[i] = jsx;
+                            i += 1;
+                            continue;
                         }
                     }
                 } else {
@@ -645,28 +644,129 @@ fn paragraph_line_col(node: &MdastNode) -> (Option<usize>, Option<usize>) {
     (None, None)
 }
 
-/// Returns true when `node` is a paragraph whose text begins with a
-/// `:::name` directive opener AND contains a newline — indicating that
-/// the opener, body, and (optional) closing `:::` all collapsed into a
-/// single paragraph because blank lines were omitted.  This is the
-/// primary signal for the blank-line diagnostic.
-///
-/// Only inspects the first Text child; non-Text paragraphs return false
-/// so that arbitrary rich paragraphs are not misidentified.
-fn paragraph_text_looks_merged(node: &MdastNode) -> bool {
-    let MdastNode::Paragraph(p) = node else {
-        return false;
-    };
-    let Some(MdastNode::Text(t)) = p.children.first() else {
-        return false;
-    };
-    // Must have a newline (i.e. multi-line → merged).
-    if !t.value.contains('\n') {
-        return false;
+/// Strip a leading directive-opener line (and the `\n`/`\r\n` that
+/// follows it) from `value`. The opener line is the substring up to the
+/// first newline. Returns the remaining body text.
+fn strip_opener_line(value: &str) -> &str {
+    match value.find('\n') {
+        // Everything after the first `\n` is the body. Any trailing `\r`
+        // (CRLF input) belonged to the opener line, so nothing extra to
+        // strip here.
+        Some(nl) => &value[nl + 1..],
+        // No newline: the whole value was the opener — no body.
+        None => "",
     }
-    // First line must look like a container opener (`:::[a-z]…`).
-    let first = first_line(&t.value).trim_end();
-    parse_directive_line(first, 3).is_some()
+}
+
+/// Strip a trailing standalone `:::` line (and the `\n`/`\r\n` before it)
+/// from `value`. Returns `Some(remaining)` when the last line trims to
+/// exactly `:::`, else `None`.
+fn strip_closer_line(value: &str) -> Option<&str> {
+    let last_nl = value.rfind('\n');
+    match last_nl {
+        Some(nl) => {
+            let last = &value[nl + 1..];
+            if last.trim() == ":::" {
+                // Drop the `\n` and a preceding `\r` (CRLF) too.
+                let before = &value[..nl];
+                Some(before.strip_suffix('\r').unwrap_or(before))
+            } else {
+                None
+            }
+        }
+        None => {
+            // Single line: it must itself be the closer.
+            if value.trim() == ":::" {
+                Some("")
+            } else {
+                None
+            }
+        }
+    }
+}
+
+/// When `node` is a single Paragraph that collapsed a container directive
+/// (`:::name[...]` … `:::` written WITHOUT surrounding blank lines, so the
+/// markdown parser merged the opener, body, and closing `:::` into one
+/// multi-line Paragraph — issue #1090), return the directive body wrapped
+/// as JSX flow children: a `Vec` holding one body `Paragraph` (or empty
+/// when the body is blank), matching the shape the blank-line-separated
+/// form and `githubAlerts` produce. Returns `None` when `node` is not a
+/// collapsed container.
+///
+/// Detection: the FIRST child is a Text whose first line parses as a
+/// `:::name` opener, the value spans multiple lines, and the LAST child is
+/// a Text whose last line is exactly `:::`.
+fn collapsed_container_body(node: &MdastNode) -> Option<Vec<MdastNode>> {
+    let MdastNode::Paragraph(p) = node else {
+        return None;
+    };
+    // First child: Text whose first line is a `:::name` opener.
+    let MdastNode::Text(first) = p.children.first()? else {
+        return None;
+    };
+    // Must be multi-line (i.e. the parser merged the fences in).
+    if !first.value.contains('\n') {
+        return None;
+    }
+    let opener_line = first_line(&first.value).trim_end();
+    parse_directive_line(opener_line, 3)?;
+    // Last child must be a Text whose last line is exactly `:::`.
+    let MdastNode::Text(last) = p.children.last()? else {
+        return None;
+    };
+    let last_line = last.value.rsplit('\n').next().unwrap_or(&last.value);
+    if last_line.trim() != ":::" {
+        return None;
+    }
+
+    // Build the body inline nodes: clone the paragraph children, strip the
+    // opener line from the first Text and the closing `:::` line from the
+    // last Text. When first and last are the same node (single Text child),
+    // strip both from that one node.
+    let mut inline: Vec<MdastNode> = p.children.clone();
+    let n = inline.len();
+    if n == 1 {
+        if let MdastNode::Text(t) = &mut inline[0] {
+            let body = strip_opener_line(&t.value);
+            let body = strip_closer_line(body).unwrap_or(body);
+            t.value = body.to_string();
+        }
+    } else {
+        if let MdastNode::Text(t) = &mut inline[0] {
+            t.value = strip_opener_line(&t.value).to_string();
+        }
+        if let MdastNode::Text(t) = &mut inline[n - 1] {
+            if let Some(stripped) = strip_closer_line(&t.value) {
+                t.value = stripped.to_string();
+            }
+        }
+    }
+
+    // Drop leading/trailing empty Text nodes left after stripping so the
+    // body paragraph has no stray empty text runs.
+    if let Some(MdastNode::Text(t)) = inline.first() {
+        if t.value.is_empty() {
+            inline.remove(0);
+        }
+    }
+    if let Some(MdastNode::Text(t)) = inline.last() {
+        if t.value.is_empty() {
+            inline.pop();
+        }
+    }
+
+    if inline.is_empty() {
+        // Body was blank (e.g. `:::note\n:::`) — no children.
+        return Some(Vec::new());
+    }
+
+    // Wrap the remaining inline content in a Paragraph, matching the
+    // blank-line-separated form where the body is its own Paragraph node.
+    Some(vec![MdastNode::Paragraph(markdown::mdast::Paragraph {
+        children: inline,
+        position: None,
+    })])
 }
 
 // -- JSX construction ---------------------------------------------------
@@ -897,6 +997,149 @@ mod tests {
             }
         }
         None
+    }
+
+    // ---- real-parser container tests (Sub #1090) ----
+
+    /// Parse `input` with the real markdown parser, run a registry that
+    /// transforms it, and return the resulting top-level nodes. This
+    /// exercises the SAME `markdown::to_mdast` → DirectiveRegistry path a
+    /// real build uses — NOT hand-built mdast — so it reproduces the
+    /// collapsed-paragraph shape that hand-built fixtures never hit.
+    fn run_real_parser(reg: &mut DirectiveRegistry, input: &str) -> Vec<MdastNode> {
+        let mut root = markdown::to_mdast(input, &markdown::ParseOptions::mdx())
+            .expect("markdown-rs should parse the sample");
+        reg.visit(&mut root);
+        let MdastNode::Root(Root { children, .. }) = root else {
+            unreachable!("to_mdast always yields a Root")
+        };
+        children
+    }
+
+    #[test]
+    fn real_parser_transforms_container_directives_without_blank_lines() {
+        // Issue #1090 / #1085 repro: the reporter's exact markdown with NO
+        // blank lines around the fences. `markdown::to_mdast` collapses each
+        // `:::name … :::` block into a single multi-line Paragraph; before
+        // the fix the registry left them as literal `<p>:::note…</p>` text.
+        //
+        // This is the guard test: it MUST fail before the fix and pass
+        // after. It covers both the bracket title form (`:::tip[Title]`) and
+        // the space-after-name title form (`:::tip title="…"`) — the issue
+        // calls out both. (The documented title semantics are bracket-label
+        // → `title`; the space form carries the title as an explicit
+        // `title="…"` attribute, exactly like the legacy `:::details
+        // title="Click me"` form. There is no bare-word space-to-title
+        // promotion in the engine, so this test does not assert one.)
+        let mut r = registry_with_admonitions();
+        let input = "\
+:::note
+plain note body
+:::
+
+:::tip[Bracket Title]
+tip body
+:::
+
+:::tip title=\"Space Title\"
+another tip
+:::
+";
+        let out = run_real_parser(&mut r, input);
+        // Three directive blocks → three JSX flow elements (no literal text).
+        assert_eq!(
+            out.len(),
+            3,
+            "expected 3 transformed directives, got {out:#?}"
+        );
+
+        // 1. :::note → <Note> with the plain body.
+        let note = flow(&out[0]);
+        assert_eq!(note.name.as_deref(), Some("Note"));
+        let MdastNode::Paragraph(body) = &note.children[0] else {
+            unreachable!("note body should be a Paragraph, got {:?}", note.children[0]);
+        };
+        let MdastNode::Text(t) = &body.children[0] else {
+            unreachable!("note body text expected");
+        };
+        assert_eq!(t.value, "plain note body");
+
+        // 2. :::tip[Bracket Title] → <Tip title="Bracket Title">.
+        let tip_bracket = flow(&out[1]);
+        assert_eq!(tip_bracket.name.as_deref(), Some("Tip"));
+        assert_eq!(
+            attr(tip_bracket, "title").as_deref(),
+            Some("Bracket Title"),
+            "bracket label promoted to title attr"
+        );
+
+        // 3. :::tip title="Space Title" → <Tip title="Space Title"> (space
+        //    form carries the title as an explicit attribute).
+        let tip_space = flow(&out[2]);
+        assert_eq!(tip_space.name.as_deref(), Some("Tip"));
+        assert_eq!(
+            attr(tip_space, "title").as_deref(),
+            Some("Space Title"),
+            "space-form title attribute preserved"
+        );
+
+        // No diagnostics — every block is recognised and transformed.
+        assert!(
+            r.take_diagnostics().is_empty(),
+            "no diagnostics expected for well-formed collapsed directives"
+        );
+    }
+
+    #[test]
+    fn real_parser_collapsed_container_bare_space_form_transforms() {
+        // A bare space form (`:::tip heads up`) still TRANSFORMS to <Tip>
+        // (no longer literal text) — the bug was that it stayed as a
+        // `<p>:::tip…</p>` paragraph. The trailing words parse as boolean
+        // attributes (engine semantics; not a title), but the key acceptance
+        // is that the directive is recognised at all.
+        let mut r = registry_with_admonitions();
+        let out = run_real_parser(&mut r, ":::tip heads up\nbody\n:::\n");
+        assert_eq!(out.len(), 1, "got {out:#?}");
+        let tip = flow(&out[0]);
+        assert_eq!(tip.name.as_deref(), Some("Tip"));
+    }
+
+    #[test]
+    fn real_parser_blank_line_separated_form_still_transforms() {
+        // The blank-line-separated form parses to SEPARATE paragraphs (the
+        // shape the hand-built fixtures simulate). It must keep working
+        // through the real parser too.
+        let mut r = registry_with_admonitions();
+        let input = "\
+:::note
+
+separated body
+
+:::
+";
+        let out = run_real_parser(&mut r, input);
+        assert_eq!(out.len(), 1, "got {out:#?}");
+        let note = flow(&out[0]);
+        assert_eq!(note.name.as_deref(), Some("Note"));
+        assert!(r.take_diagnostics().is_empty());
+    }
+
+    #[test]
+    fn real_parser_unknown_collapsed_container_left_alone_and_warned() {
+        // A collapsed `:::unknown` block whose name is NOT registered must
+        // stay as literal text and earn an unknown-directive warning — the
+        // pre-existing unknown-directive behaviour is preserved.
+        let mut r = registry_with_admonitions();
+        let input = ":::nope\nbody\n:::\n";
+        let out = run_real_parser(&mut r, input);
+        assert_eq!(out.len(), 1);
+        assert!(
+            matches!(out[0], MdastNode::Paragraph(_)),
+            "unknown directive preserved as paragraph"
+        );
+        let diags = r.take_diagnostics();
+        assert_eq!(diags.len(), 1, "unknown-directive warning expected");
+        assert!(diags[0].message.contains("nope"));
     }
 
     // ---- container tests ----
@@ -1292,14 +1535,23 @@ mod tests {
         );
     }
 
-    // ---- blank-line diagnostic (Sub #185 Gap 2) ----
+    // ---- merged (collapsed) container transform (Sub #1090) ----
 
     #[test]
-    fn merged_container_emits_blank_line_diagnostic() {
-        // When :::note\nbody\n::: is written without blank lines, the
-        // markdown parser collapses them into a single paragraph.  The
-        // registry should emit a diagnostic suggesting the author add
-        // blank lines.
+    fn merged_container_transforms_to_jsx() {
+        // CHANGED for #1090 (was `merged_container_emits_blank_line_diagnostic`).
+        //
+        // Previously a merged `:::note\nbody\n:::` (written WITHOUT blank
+        // lines around the fences — the shape `markdown::to_mdast` actually
+        // produces for real input) was left untransformed and only earned a
+        // "missing blank lines" diagnostic. That diverged from `githubAlerts`,
+        // which transforms the same no-blank-line shape end-to-end, and meant
+        // every container directive in a real build rendered as literal text.
+        //
+        // After the fix the collapsed single-Paragraph form TRANSFORMS, so
+        // this test asserts the new behaviour (transform, no diagnostic)
+        // instead of the old diagnostic. The assertion is updated, not
+        // deleted: the merged form is now handled, not flagged.
         let mut r = registry_with_admonitions();
         // Simulate the merged paragraph: first Text child has the full
         // un-blank-lined content as a single multi-line value.
@@ -1311,25 +1563,23 @@ mod tests {
             position: None,
         });
         let out = run_with_registry(&mut r, vec![merged_para]);
-        // Source is preserved (not converted — no separate close para).
+        // The collapsed paragraph is now rewritten to a <Note> flow element.
         assert_eq!(out.len(), 1);
-        assert!(matches!(out[0], MdastNode::Paragraph(_)));
-        // A diagnostic must be emitted.
-        let diags = r.take_diagnostics();
-        assert_eq!(
-            diags.len(),
-            1,
-            "expected exactly one diagnostic, got {diags:?}"
-        );
+        let j = flow(&out[0]);
+        assert_eq!(j.name.as_deref(), Some("Note"));
+        // The body becomes a single paragraph child.
+        assert_eq!(j.children.len(), 1, "body wrapped in one paragraph");
+        let MdastNode::Paragraph(body) = &j.children[0] else {
+            unreachable!("expected body Paragraph, got {:?}", j.children[0]);
+        };
+        let MdastNode::Text(t) = &body.children[0] else {
+            unreachable!("expected body Text, got {:?}", body.children[0]);
+        };
+        assert_eq!(t.value, "body text");
+        // No diagnostic — the form is handled, not flagged.
         assert!(
-            diags[0].message.contains("blank lines"),
-            "diagnostic should mention blank lines, got: {:?}",
-            diags[0].message
-        );
-        assert!(
-            diags[0].message.contains("note"),
-            "diagnostic should mention directive name, got: {:?}",
-            diags[0].message
+            r.take_diagnostics().is_empty(),
+            "merged container now transforms; no diagnostic expected"
         );
     }
 

--- a/crates/zfb-content/src/plugins/directives.rs
+++ b/crates/zfb-content/src/plugins/directives.rs
@@ -180,8 +180,7 @@ impl DirectiveRegistry {
                         if let Some(inner) = collapsed_container_body(&children[i]) {
                             let (line, column) = paragraph_line_col(&children[i]);
                             let validated_opt = self.run_validation(&def, &parsed, line, column);
-                            let jsx =
-                                build_flow_jsx(&def, &parsed, inner, validated_opt.as_ref());
+                            let jsx = build_flow_jsx(&def, &parsed, inner, validated_opt.as_ref());
                             children[i] = jsx;
                             i += 1;
                             continue;
@@ -1057,7 +1056,10 @@ another tip
         let note = flow(&out[0]);
         assert_eq!(note.name.as_deref(), Some("Note"));
         let MdastNode::Paragraph(body) = &note.children[0] else {
-            unreachable!("note body should be a Paragraph, got {:?}", note.children[0]);
+            unreachable!(
+                "note body should be a Paragraph, got {:?}",
+                note.children[0]
+            );
         };
         let MdastNode::Text(t) = &body.children[0] else {
             unreachable!("note body text expected");

--- a/crates/zfb-content/src/plugins/heading_links.rs
+++ b/crates/zfb-content/src/plugins/heading_links.rs
@@ -172,6 +172,17 @@ impl HastVisitor for HeadingLinksPlugin {
     /// Zero-cost when `ctx.heading_registry` is `None` — no registry writes
     /// are performed.
     fn visit_with_context(&mut self, node: &mut HastNode, ctx: &mut BuildContext<'_>) {
+        // Mark this file as tracked up front so a document with zero
+        // `h2`–`h6` headings still produces a `Some(&[])` registry entry.
+        // Without this, `LinkValidationPlugin` cannot tell "processed, no
+        // headings" from "never tracked" and silently skips bare `#anchor`
+        // validation in headingless files (zfb#1093 — a transcluded snippet
+        // whose only content is a broken anchor link).
+        if let (Some(reg), Some(path)) =
+            (ctx.heading_registry.as_deref_mut(), ctx.source_path.clone())
+        {
+            reg.mark_tracked(path);
+        }
         self.visit_node(
             node,
             ctx.heading_registry.as_deref_mut(),

--- a/crates/zfb-md-ast/src/heading_registry.rs
+++ b/crates/zfb-md-ast/src/heading_registry.rs
@@ -51,6 +51,20 @@ impl HeadingRegistry {
         self.entries.entry(source_path).or_default().push(entry);
     }
 
+    /// Mark a source file as **tracked** without recording any heading.
+    ///
+    /// Ensures `get(source_path)` returns `Some(&[])` (an empty slice) rather
+    /// than `None` for a file that `HeadingLinksPlugin` processed but which
+    /// contained zero `h2`–`h6` headings. This is what lets
+    /// `LinkValidationPlugin` distinguish "file processed, has no headings"
+    /// (a bare `#anchor` is then definitively broken) from "file never
+    /// tracked" (registry unaware — skip to avoid false positives, e.g. the
+    /// JSX-emit cache-hit path where `HeadingLinksPlugin` never runs).
+    /// Idempotent and never clears existing entries.
+    pub fn mark_tracked(&mut self, source_path: PathBuf) {
+        self.entries.entry(source_path).or_default();
+    }
+
     /// Look up all headings recorded for the given source file.
     ///
     /// Returns `None` if no headings have been registered for that path yet.
@@ -121,5 +135,38 @@ mod tests {
         assert!(reg
             .get(std::path::Path::new("/does/not/exist.md"))
             .is_none());
+    }
+
+    #[test]
+    fn mark_tracked_makes_get_return_empty_slice_not_none() {
+        // A file processed with zero headings must be distinguishable from a
+        // never-tracked file: `get` returns `Some(&[])`, not `None` (zfb#1093).
+        let mut reg = HeadingRegistry::new();
+        let path = PathBuf::from("/docs/headingless.md");
+        assert!(reg.get(&path).is_none());
+        reg.mark_tracked(path.clone());
+        assert_eq!(reg.get(&path), Some(&[][..]));
+        // No headings were recorded, so the registry is still empty by count.
+        assert!(reg.is_empty());
+        assert_eq!(reg.len(), 0);
+    }
+
+    #[test]
+    fn mark_tracked_is_idempotent_and_preserves_entries() {
+        let mut reg = HeadingRegistry::new();
+        let path = PathBuf::from("/docs/guide.md");
+        reg.insert(
+            path.clone(),
+            HeadingEntry {
+                id: "intro".to_string(),
+                text: "Intro".to_string(),
+                depth: 2,
+            },
+        );
+        // Marking an already-populated file must not clear its entries.
+        reg.mark_tracked(path.clone());
+        let entries = reg.get(&path).expect("entries must survive mark_tracked");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].id, "intro");
     }
 }

--- a/crates/zfb-md-extras/src/image_dimensions.rs
+++ b/crates/zfb-md-extras/src/image_dimensions.rs
@@ -217,16 +217,23 @@ fn try_inject_dimensions(
 
     // Containment guard: reject paths that escape the expected root directory.
     // Absolute `/…` srcs are resolved into `public_dir`; relative srcs into
-    // `project_root`. Lexically normalize to collapse any `..` components
-    // injected via crafted src values (e.g. `../../etc/hosts`).
+    // `project_root`. Lexically normalize BOTH sides to collapse any `..`/`.`
+    // components — both those injected via crafted src values (e.g.
+    // `../../etc/hosts`) AND any `..` carried by the configured root itself
+    // (e.g. `project_root = <fixtures>/..`). Comparing in normalized form is
+    // what keeps the guard correct: a candidate that lexically resolves
+    // outside the normalized root is still rejected; the normalization only
+    // prevents a legitimately-contained candidate from being wrongly skipped
+    // because the un-normalized root carried a `..`.
     let is_absolute_src = src.starts_with('/');
     let expected_root = if is_absolute_src {
         &ctx.public_dir
     } else {
         &ctx.project_root
     };
+    let normalized_root = normalize_path_lexical(expected_root);
     let normalized = normalize_path_lexical(&abs_path);
-    if !normalized.starts_with(expected_root) {
+    if !normalized.starts_with(&normalized_root) {
         emit_warning(
             ctx,
             format!(

--- a/crates/zfb-md-extras/tests/cross_feature_integration.rs
+++ b/crates/zfb-md-extras/tests/cross_feature_integration.rs
@@ -49,8 +49,8 @@ use zfb_md_ast::{
     heading_registry::HeadingRegistry,
     BuildContext, CodeEnrichmentConfig, DirectiveFullSpec, DirectiveSpec, DirectiveSpecKind,
     FeatureToggle, GithubAutolinksConfig, HeadingMarkerTocFeature, ImageDimensionsConfig,
-    LinkValidationConfig, MarkdownFeaturesConfig, ReadingTimeFeature,
-    TocConfig, TocExportConfig, TranscludeConfig,
+    LinkValidationConfig, MarkdownFeaturesConfig, ReadingTimeFeature, TocConfig, TocExportConfig,
+    TranscludeConfig,
 };
 
 // ── Case 1: transclude + link_validation ────────────────────────────────────

--- a/crates/zfb-md-extras/tests/cross_feature_integration.rs
+++ b/crates/zfb-md-extras/tests/cross_feature_integration.rs
@@ -49,7 +49,8 @@ use zfb_md_ast::{
     heading_registry::HeadingRegistry,
     BuildContext, CodeEnrichmentConfig, DirectiveFullSpec, DirectiveSpec, DirectiveSpecKind,
     FeatureToggle, GithubAutolinksConfig, HeadingMarkerTocFeature, ImageDimensionsConfig,
-    LinkValidationConfig, MarkdownFeaturesConfig, TocConfig, TocExportConfig, TranscludeConfig,
+    LinkValidationConfig, MarkdownFeaturesConfig, ReadingTimeFeature,
+    TocConfig, TocExportConfig, TranscludeConfig,
 };
 
 // ── Case 1: transclude + link_validation ────────────────────────────────────
@@ -515,7 +516,7 @@ fn all_features_on_does_not_crash() {
             max_depth: 2,
         })),
         github_alerts: Some(FeatureToggle::Bool(true)),
-        reading_time: Some(FeatureToggle::Bool(true)),
+        reading_time: Some(ReadingTimeFeature::Bool(true)),
         github_autolinks: Some(GithubAutolinksConfig {
             repo: Some("owner/repo".to_string()),
         }),
@@ -526,6 +527,7 @@ fn all_features_on_does_not_crash() {
         image_dimensions: Some(ImageDimensionsConfig::default()),
         link_validation: Some(LinkValidationConfig::default()),
         transclude: Some(TranscludeConfig::default()),
+        heading_ids: None,
     };
 
     let mut pipeline = Pipeline::with_defaults_and_features(&features);

--- a/crates/zfb-md-extras/tests/image_dimensions.rs
+++ b/crates/zfb-md-extras/tests/image_dimensions.rs
@@ -707,7 +707,11 @@ fn absolute_traversal_outside_public_dir_rejected() {
     plugin.visit_with_context(&mut tree, &mut ctx);
 
     let diags = sink.take();
-    assert_eq!(diags.len(), 1, "absolute traversal src must emit one warning");
+    assert_eq!(
+        diags.len(),
+        1,
+        "absolute traversal src must emit one warning"
+    );
     assert_eq!(diags[0].severity(), DiagnosticSeverity::Warning);
     assert!(
         diag_message(&diags[0]).contains("resolves outside the expected root"),

--- a/crates/zfb-md-extras/tests/image_dimensions.rs
+++ b/crates/zfb-md-extras/tests/image_dimensions.rs
@@ -15,7 +15,7 @@
 
 use std::path::PathBuf;
 
-use zfb_md_ast::diagnostics::{CollectingSink, DiagnosticSeverity};
+use zfb_md_ast::diagnostics::{CollectingSink, DiagnosticSeverity, MarkdownDiagnostic};
 use zfb_md_ast::{BuildContext, HastNode, HastVisitor, ImageDimensionsConfig};
 use zfb_md_extras::image_dimensions::ImageDimensionsPlugin;
 
@@ -61,6 +61,16 @@ fn get_attr<'a>(node: &'a HastNode, name: &str) -> Option<&'a str> {
         .iter()
         .find(|(k, _)| k == name)
         .map(|(_, v)| v.as_str())
+}
+
+/// Extract the human-readable message from a generic diagnostic (the only
+/// variant the image-dimensions plugin emits). Panics on any other variant so
+/// a test that gets an unexpected diagnostic shape fails loudly.
+fn diag_message(d: &MarkdownDiagnostic) -> &str {
+    match d {
+        MarkdownDiagnostic::Generic { message, .. } => message,
+        other => panic!("expected a Generic diagnostic, got {other:?}"),
+    }
 }
 
 fn first_img(root: &HastNode) -> &HastNode {
@@ -621,6 +631,138 @@ fn svg_cache_hit_on_second_reference() {
         assert_eq!(get_attr(child, "width"), Some("120"), "img[{i}] width");
         assert_eq!(get_attr(child, "height"), Some("80"), "img[{i}] height");
     }
+}
+
+// ── security: path-traversal containment guard (#1089) ────────────────────────
+//
+// The containment guard normalizes BOTH the candidate path and the configured
+// root before comparing, so a `..` carried by the root no longer wrongly
+// rejects a legitimately-contained image — see
+// `injects_dimensions_relative_src_via_source_dir` above, whose `project_root`
+// is `<fixtures>/..`. These tests assert the OTHER half of the contract: a
+// crafted `src` that lexically resolves OUTSIDE the normalized root is still
+// rejected with the existing warning and no dimensions injected.
+
+/// A relative `src` escaping the project root via `../../` must be skipped with
+/// a containment warning and must NOT inject width/height.
+#[test]
+fn relative_traversal_outside_root_rejected() {
+    let fixtures = fixtures_path();
+    let mut plugin = ImageDimensionsPlugin::new(ImageDimensionsConfig::default());
+    // source dir = <fixtures>, project_root = <fixtures>. The src joins onto
+    // the source dir as <fixtures>/../../etc/hosts, which normalizes to a path
+    // well above <fixtures> — outside the (normalized) root, so it is rejected
+    // before any disk probe.
+    let mut tree = root_with_img("../../etc/hosts");
+    let mut sink = CollectingSink::new();
+    let mut ctx = BuildContext {
+        source_path: Some(fixtures.join("fake-doc.mdx")),
+        project_root: fixtures.clone(),
+        public_dir: fixtures.clone(),
+        heading_registry: None,
+        diagnostics: Some(&mut sink),
+        cross_file_links: None,
+    };
+    plugin.visit_with_context(&mut tree, &mut ctx);
+
+    let diags = sink.take();
+    assert_eq!(diags.len(), 1, "traversal src must emit one warning");
+    assert_eq!(diags[0].severity(), DiagnosticSeverity::Warning);
+    assert!(
+        diag_message(&diags[0]).contains("resolves outside the expected root"),
+        "warning must be the containment warning: {:?}",
+        diag_message(&diags[0])
+    );
+
+    let img = first_img(&tree);
+    assert_eq!(
+        get_attr(img, "width"),
+        None,
+        "traversal src must not inject width"
+    );
+    assert_eq!(
+        get_attr(img, "height"),
+        None,
+        "traversal src must not inject height"
+    );
+}
+
+/// An absolute `src` escaping `public_dir` via `/../../` must be skipped — the
+/// candidate normalizes to `/etc/hosts`, which is not under the normalized
+/// public_dir.
+#[test]
+fn absolute_traversal_outside_public_dir_rejected() {
+    let fixtures = fixtures_path();
+    let mut plugin = ImageDimensionsPlugin::new(ImageDimensionsConfig::default());
+    let mut tree = root_with_img("/../../etc/hosts");
+    let mut sink = CollectingSink::new();
+    let mut ctx = BuildContext {
+        source_path: Some(fixtures.join("fake-doc.mdx")),
+        project_root: fixtures.clone(),
+        public_dir: fixtures.clone(),
+        heading_registry: None,
+        diagnostics: Some(&mut sink),
+        cross_file_links: None,
+    };
+    plugin.visit_with_context(&mut tree, &mut ctx);
+
+    let diags = sink.take();
+    assert_eq!(diags.len(), 1, "absolute traversal src must emit one warning");
+    assert_eq!(diags[0].severity(), DiagnosticSeverity::Warning);
+    assert!(
+        diag_message(&diags[0]).contains("resolves outside the expected root"),
+        "warning must be the containment warning: {:?}",
+        diag_message(&diags[0])
+    );
+
+    let img = first_img(&tree);
+    assert_eq!(
+        get_attr(img, "width"),
+        None,
+        "absolute traversal src must not inject width"
+    );
+}
+
+/// Regression-pair for #1089: even when the configured root itself carries a
+/// `..` (the scenario that wrongly rejected a contained image), a crafted `src`
+/// that escapes the *normalized* root is STILL rejected. This proves the fix
+/// (normalize both sides) did not weaken the traversal guard.
+#[test]
+fn traversal_still_rejected_when_root_has_dotdot() {
+    let fixtures = fixtures_path();
+    let mut plugin = ImageDimensionsPlugin::new(ImageDimensionsConfig::default());
+    // project_root = <fixtures>/.. (normalizes to the parent of fixtures).
+    // The src then climbs further out, escaping even the normalized root.
+    let mut tree = root_with_img("../../../../../../etc/hosts");
+    let mut sink = CollectingSink::new();
+    let mut ctx = BuildContext {
+        source_path: Some(fixtures.join("fake-doc.mdx")),
+        project_root: fixtures.join(".."),
+        public_dir: fixtures.join("../public"),
+        heading_registry: None,
+        diagnostics: Some(&mut sink),
+        cross_file_links: None,
+    };
+    plugin.visit_with_context(&mut tree, &mut ctx);
+
+    let diags = sink.take();
+    assert_eq!(
+        diags.len(),
+        1,
+        "traversal must still warn even when root carries a .."
+    );
+    assert!(
+        diag_message(&diags[0]).contains("resolves outside the expected root"),
+        "warning must be the containment warning: {:?}",
+        diag_message(&diags[0])
+    );
+
+    let img = first_img(&tree);
+    assert_eq!(
+        get_attr(img, "width"),
+        None,
+        "traversal src must not inject width even with a ..-root"
+    );
 }
 
 // ── feature-disabled smoke test ───────────────────────────────────────────────

--- a/crates/zfb-md-extras/tests/link_validation.rs
+++ b/crates/zfb-md-extras/tests/link_validation.rs
@@ -492,26 +492,57 @@ fn cross_file_fragment_without_target_entry_degrades_to_existence_only() {
     );
 }
 
-// ── Fixture 14: bare fragment skipped when source has no registry entry ───────
+// ── Fixture 14: bare fragment skipped when the file was never tracked ─────────
 
-/// Registry `Some` but no entry for the source file; `[x](#anything)` → no
-/// diagnostic.
+/// Registry `Some` but **no entry at all** for the source file — the
+/// genuinely-untracked / cache-hit shape where `HeadingLinksPlugin` never ran
+/// (a compile-cache hit replays output without re-running the hast chain, see
+/// the registry contract in `pipeline.rs`). Entry-presence gating must degrade
+/// to skip here so a replayed file does not produce a spurious diagnostic.
+///
+/// This drives `LinkValidationPlugin` directly (NOT through the full pipeline):
+/// on the `run_with_context` path `HeadingLinksPlugin` now marks every compiled
+/// file tracked (`Some(&[])`), so a "no entry" source is unreachable there —
+/// that headingless-but-compiled case is the one #1093 fixes and is covered by
+/// `transclude_link_validation_broken_link_in_snippet` in
+/// `cross_feature_integration.rs`. The skip-on-`None` branch this fixture
+/// guards only fires when the file was never tracked at all.
 #[test]
 fn bare_fragment_without_source_entry_skipped() {
+    use zfb_content::pipeline::{HastNode, HastVisitor};
+    use zfb_md_extras::link_validation::LinkValidationPlugin;
+
     let source = PathBuf::from("/project/docs/page.md");
+    // Registry has NO entry for source — file was never tracked.
     let mut registry = HeadingRegistry::new();
-    // No entry for source — entry-presence gating must skip.
-    let md = "[x](#anything)\n";
-    let diags = run(
-        md,
-        source,
-        PathBuf::from("/project"),
-        &mut registry,
-        LinkValidationConfig::default(),
-    );
+    let mut sink = CollectingSink::new();
+
+    // A minimal hast tree: <a href="#anything">x</a>.
+    let mut tree = HastNode::Root {
+        children: vec![HastNode::Element {
+            tag: "a".to_string(),
+            attrs: vec![("href".to_string(), "#anything".to_string())],
+            children: vec![HastNode::Text("x".to_string())],
+            void: false,
+        }],
+    };
+
+    let mut ctx = BuildContext {
+        source_path: Some(source),
+        project_root: PathBuf::from("/project"),
+        public_dir: PathBuf::from("/project/public"),
+        heading_registry: Some(&mut registry),
+        diagnostics: Some(&mut sink),
+        cross_file_links: None,
+    };
+
+    let mut plugin = LinkValidationPlugin::new(LinkValidationConfig::default());
+    plugin.visit_with_context(&mut tree, &mut ctx);
+
+    let diags = sink.take();
     assert!(
         diags.is_empty(),
-        "bare fragment with no source entry must not emit diagnostic: {diags:?}"
+        "bare fragment in a never-tracked file must not emit diagnostic: {diags:?}"
     );
 }
 

--- a/crates/zfb-md-extras/tests/reading_time.rs
+++ b/crates/zfb-md-extras/tests/reading_time.rs
@@ -110,7 +110,7 @@ fn enabled_injects_export_in_mdast() {
     use zfb_md_ast::MdastVisitor;
     use zfb_md_extras::reading_time::ReadingTimePlugin;
 
-    let words: String = std::iter::repeat("word ").take(200).collect();
+    let words: String = "word ".repeat(200);
     let mut node = to_mdast(&words, &markdown::ParseOptions::default()).unwrap();
     ReadingTimePlugin::new().visit(&mut node);
 
@@ -142,7 +142,7 @@ fn jsx_module_contains_reading_time_export() {
     use zfb_md_ast::ReadingTimeFeature;
     use zfb_md_extras::MarkdownFeaturesConfig;
 
-    let words: String = std::iter::repeat("word ").take(200).collect();
+    let words: String = "word ".repeat(200);
     let features = MarkdownFeaturesConfig {
         reading_time: Some(ReadingTimeFeature::Bool(true)),
         ..Default::default()

--- a/crates/zfb-md-extras/tests/reading_time.rs
+++ b/crates/zfb-md-extras/tests/reading_time.rs
@@ -88,11 +88,11 @@ fn short_article_minimum_1_minute() {
 #[test]
 fn disabled_does_not_append_esm_node() {
     use zfb_content::pipeline::Pipeline;
-    use zfb_md_ast::FeatureToggle;
+    use zfb_md_ast::ReadingTimeFeature;
     use zfb_md_extras::MarkdownFeaturesConfig;
 
     let features = MarkdownFeaturesConfig {
-        reading_time: Some(FeatureToggle::Bool(false)),
+        reading_time: Some(ReadingTimeFeature::Bool(false)),
         ..Default::default()
     };
     let mut p = Pipeline::with_defaults_and_features(&features);
@@ -139,12 +139,12 @@ fn enabled_injects_export_in_mdast() {
 fn jsx_module_contains_reading_time_export() {
     use zfb_content::mdx_jsx_emit::{mdx_to_jsx_module_with_pipeline, MdxJsxOptions};
     use zfb_content::pipeline::Pipeline;
-    use zfb_md_ast::FeatureToggle;
+    use zfb_md_ast::ReadingTimeFeature;
     use zfb_md_extras::MarkdownFeaturesConfig;
 
     let words: String = std::iter::repeat("word ").take(200).collect();
     let features = MarkdownFeaturesConfig {
-        reading_time: Some(FeatureToggle::Bool(true)),
+        reading_time: Some(ReadingTimeFeature::Bool(true)),
         ..Default::default()
     };
     let mut pipeline = Pipeline::with_defaults_and_features(&features);


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1087 (epic)

---

## Summary

Two markdown-pipeline bugfixes from epic #1087, sharing one root theme — **tests that did not actually guard behavior**.

### #1085 — container directives (`:::name`) not transformed
`:::note` / `:::tip[Title]` written without blank lines around the fences were left as literal text (`<p>:::note…</p>`) instead of compiling to `<Note>` / `<Tip title="…">`. Root cause: the real markdown parser collapses such a block into a single multi-line `Paragraph`, and the matcher's `is_container_close` only scanned *sibling* nodes for the closing `:::`. Every directive test hand-built mdast with separate paragraphs, so the bug was invisible. Fixed the matcher to handle the collapsed form + added real-parser tests.

### #1086 — `zfb-md-extras` `test-utils` integration suite excluded from CI
The 10 `required-features = ["test-utils"]` integration tests were never built/linted/tested (the gate never enabled the feature), so the suite rotted. Enabled it in `health.yml` and fixed every broken test it surfaced.

## Changes

| Area | Change |
|---|---|
| `zfb-content/src/plugins/directives.rs` | Transform container directives in collapsed (blank-line-less) paragraphs; real-parser tests; updated the stale `merged_*` diagnostic test (#1090) |
| `zfb-md-extras/src/image_dimensions.rs` | Normalize `expected_root` before the `starts_with` containment check; 3 new traversal-rejection tests (security guard not weakened) (#1089) |
| `zfb-md-ast` + `zfb-content` (heading_links, mdx_jsx_emit) | `mark_tracked()` so headingless compiled files are link-validated — catches broken anchors in transcluded snippets (#1093, the hidden 4th broken test) |
| `zfb-md-extras/tests/{reading_time,cross_feature_integration}.rs` | Compile fixes: `FeatureToggle` → `ReadingTimeFeature`, add `heading_ids` (#1088) |
| `zfb-build/tests/migration_fixes_integration_confirm.rs` | Flip the stale regression-confirm test to assert the corrected directive behavior (#1090) |
| `.github/workflows/health.yml` | Run `cargo test -p zfb-md-extras --features test-utils` + matching clippy in the PR gate (#1091) |

The `required-features` gap is isolated to `zfb-md-extras` (grep confirmed — no other crate gates targets behind a feature).

## Closes
Closes #1085, #1086, #1088, #1089, #1090, #1091, #1093.

## Review / follow-ups
Deep-reviewed (2× Opus): security guard verified intact, no replay false-positives, no weakened tests. Two deliberate trade-offs tracked as follow-ups: #1094 (nested directives in one blank-line-less paragraph), #1095 (headingless-file anchor validation surface).