### PR TITLE
Markdown edge cases: anchor-id link validation + recursive collapsed-directive transform

### DIFF
--- a/crates/zfb-content/src/plugins/directives.rs
+++ b/crates/zfb-content/src/plugins/directives.rs
@@ -148,6 +148,32 @@ impl DirectiveRegistry {
         // First pass: container + leaf at block level.
         let mut i = 0;
         while i < children.len() {
+            // Collapsed-run entry (issues #1090 + #1094). When the fences are
+            // written with NO blank lines, `markdown::to_mdast` merges the
+            // opener, body, inner fences, and closers into ONE multi-line
+            // Paragraph with a single Text child. The block-level scan below
+            // (which inspects whole paragraph nodes and exactly-3-colon
+            // openers) cannot see sibling/nested directives buried as mid-text
+            // LINES, nor a >3-colon outer opener. Route any single-text
+            // collapsed paragraph whose first line is a `:::+name` opener
+            // (>=3 colons) through the line-level re-segmenter, which emits one
+            // JSX flow element per top-level directive run and recurses for
+            // nested ones. This must run BEFORE the 3-colon `parse_block_open`
+            // check so a `:::::note` (5-colon) outer opener is handled too.
+            if let Some((text_value, base_col)) = single_text_collapsed_value(&children[i]) {
+                if first_line_is_container_opener(&text_value) {
+                    let line_no = single_text_collapsed_line_col(&children[i]).unwrap_or(1);
+                    if let Some(replacement) =
+                        self.transform_collapsed_run(&text_value, line_no, base_col, false)
+                    {
+                        let n = replacement.len();
+                        children.splice(i..=i, replacement);
+                        i += n;
+                        continue;
+                    }
+                }
+            }
+
             // Try container open.
             if let Some(parsed) = self.parse_block_open(&children[i], 3) {
                 if let Some(def) = self.defs.get(&parsed.name).cloned() {
@@ -166,17 +192,14 @@ impl DirectiveRegistry {
                             i += 1;
                             continue;
                         }
-                        // No separate closing `:::` paragraph exists. In
-                        // real markdown, when the fences are NOT surrounded
-                        // by blank lines, `markdown::to_mdast` collapses the
-                        // opener, body, and closing `:::` into a SINGLE
-                        // multi-line Paragraph (the opener is the first line
-                        // of the first Text child and the `:::` closer is the
-                        // last line of the last Text child). This is the
-                        // common real-world shape (issue #1090) — detect it
-                        // and transform the collapsed paragraph just like the
-                        // blank-line-separated form, matching what
-                        // `githubAlerts` does end-to-end.
+                        // No separate closing `:::` paragraph exists. The
+                        // single-text collapsed form (one multi-line Text
+                        // child) was already handled by the collapsed-run entry
+                        // at the top of the loop. What remains here is the rare
+                        // MULTI-inline-child collapsed paragraph (e.g. the body
+                        // contained emphasis, so the parser split the value
+                        // across several inline children). Use the original
+                        // #1090 single-container handler for it.
                         if let Some(inner) = collapsed_container_body(&children[i]) {
                             let (line, column) = paragraph_line_col(&children[i]);
                             let validated_opt = self.run_validation(&def, &parsed, line, column);
@@ -219,6 +242,170 @@ impl DirectiveRegistry {
             }
 
             i += 1;
+        }
+    }
+
+    /// Transform a fully-collapsed directive paragraph by RE-SEGMENTING its
+    /// raw multi-line `Text` value at the line level.
+    ///
+    /// ## Why a separate line-level pass exists
+    ///
+    /// When `:::` fences are written with NO blank lines between them (the
+    /// common real-world shape), `markdown::to_mdast` collapses the opener,
+    /// body, inner fences, and closers into ONE multi-line `Paragraph` with a
+    /// single `Text` child. The inner / sibling `:::` markers are mid-text
+    /// LINES inside that one `Text` value — NOT separate block paragraphs —
+    /// so the block-level `transform_children` scan (which inspects whole
+    /// paragraph nodes) never sees them. The #1090 fix only rewrote the OUTER
+    /// container and left any sibling/nested directive as literal text. This
+    /// method splits the value into lines and re-discovers the directive runs.
+    ///
+    /// ## Fence-matching rule
+    ///
+    /// Openers and closers are matched by COLON COUNT, mirroring the
+    /// CommonMark-Directives convention that a nested container uses MORE
+    /// colons on its outer fence. A closer line of `k` colons closes the
+    /// most-recently-opened (innermost) fence whose opener colon-count is
+    /// `<= k`. This makes:
+    ///   - `:::note … ::: :::tip … :::` parse as two SIBLINGS, and
+    ///   - `:::::outer … :::inner … ::: :::::` parse as inner-then-outer
+    ///     (innermost-first), with the body of an outer run recursively
+    ///     re-segmented for its nested directives.
+    ///
+    /// ## Unbalanced / malformed handling
+    ///
+    /// If an opener never finds a matching closer, the opener line and the
+    /// remaining lines after the last successfully-matched run are emitted as
+    /// literal text (a Paragraph) — no panic, graceful fallback. Lines between
+    /// recognised runs that are plain prose are likewise re-parsed as markdown
+    /// and emitted verbatim.
+    ///
+    /// Returns `Some(replacement_nodes)` when at least one top-level directive
+    /// run was recognised and transformed; `None` when nothing matched (so the
+    /// caller falls through to other handlers / leaves the paragraph alone).
+    ///
+    /// `first_line`/`first_col` carry the source position of the paragraph's
+    /// opener for diagnostics.
+    ///
+    /// `is_body` distinguishes the TOP-LEVEL call (from `transform_children`,
+    /// `false`) from a recursive BODY re-segmentation (`true`). It controls
+    /// unknown-directive warning placement so each unknown is reported exactly
+    /// once (see the unknown branch below).
+    fn transform_collapsed_run(
+        &mut self,
+        value: &str,
+        first_line: usize,
+        first_col: usize,
+        is_body: bool,
+    ) -> Option<Vec<MdastNode>> {
+        let lines: Vec<&str> = value.split('\n').collect();
+        let mut out: Vec<MdastNode> = Vec::new();
+        let mut transformed_any = false;
+        let mut i = 0usize;
+        // Track plain (non-directive) lines so we can flush them as a prose
+        // block in source order between recognised runs.
+        let mut prose_start = 0usize;
+
+        while i < lines.len() {
+            let line = lines[i].trim_end_matches('\r');
+            if let Some(open_colons) = container_opener_colons(line) {
+                // Find the matching closer line by colon count.
+                if let Some(close_idx) = find_collapsed_closer(&lines, i + 1, open_colons) {
+                    // Flush any pending prose before this run.
+                    self.flush_prose(&lines, prose_start, i, &mut out);
+
+                    // Reconstruct the inner body (lines between opener and
+                    // closer) as a single text block for recursive handling.
+                    let body_lines = &lines[i + 1..close_idx];
+                    let opener = first_line_trim(line);
+                    if let Some(parsed) = parse_directive_line(opener, open_colons) {
+                        if let Some(def) = self.defs.get(&parsed.name).cloned() {
+                            if def.kind == DirectiveKind::Container {
+                                let (line_no, col_no) = if i == 0 {
+                                    (Some(first_line), Some(first_col))
+                                } else {
+                                    (None, None)
+                                };
+                                let validated_opt =
+                                    self.run_validation(&def, &parsed, line_no, col_no);
+                                let inner = self.build_collapsed_body(body_lines);
+                                let jsx =
+                                    build_flow_jsx(&def, &parsed, inner, validated_opt.as_ref());
+                                out.push(jsx);
+                                transformed_any = true;
+                                i = close_idx + 1;
+                                prose_start = i;
+                                continue;
+                            }
+                            // Registered but not a container: fall through and
+                            // treat as prose (leave literal).
+                        } else if is_body {
+                            // Unknown directive name BURIED in a container body.
+                            // The lines are emitted as prose (via
+                            // `flush_prose`/`reparse_block`) and re-parsed into a
+                            // paragraph nested inside the JSX element; the outer
+                            // `visit` re-walk does NOT re-discover a directive
+                            // buried mid-paragraph, so warn HERE — exactly once.
+                            self.diagnostics.push(DirectiveDiagnostic {
+                                message: format!("unknown directive `{}`", parsed.name),
+                                line: None,
+                                column: None,
+                            });
+                        }
+                        // Unknown directive at TOP level (`is_body == false`):
+                        // do NOT warn here. The whole run is emitted as a prose
+                        // paragraph and the outer `visit` re-walk's block scan
+                        // (`parse_block_open`) issues exactly one unknown-
+                        // directive warning for it (acceptance: warn ONCE).
+                    }
+                }
+                // No matching closer (or unknown / wrong kind): leave this
+                // line as prose; advance one line.
+            }
+            i += 1;
+        }
+
+        if !transformed_any {
+            return None;
+        }
+        // Flush trailing prose after the last recognised run.
+        self.flush_prose(&lines, prose_start, lines.len(), &mut out);
+        Some(out)
+    }
+
+    /// Re-parse the lines `lines[start..end]` as markdown and append the
+    /// resulting block nodes to `out`. Empty / whitespace-only ranges produce
+    /// nothing. Used to emit prose that sits between collapsed directive runs
+    /// (or unmatched/unknown fence lines) verbatim, including literal `:::`
+    /// markers that did not form a recognised directive.
+    fn flush_prose(&self, lines: &[&str], start: usize, end: usize, out: &mut Vec<MdastNode>) {
+        if start >= end {
+            return;
+        }
+        let text = lines[start..end].join("\n");
+        if text.trim().is_empty() {
+            return;
+        }
+        out.extend(reparse_block(&text));
+    }
+
+    /// Build the JSX children of a collapsed container from its raw body
+    /// lines. Recursively re-segments the body so nested collapsed directives
+    /// transform too, then emits any remaining prose as markdown blocks.
+    fn build_collapsed_body(&mut self, body_lines: &[&str]) -> Vec<MdastNode> {
+        if body_lines.is_empty() {
+            return Vec::new();
+        }
+        let body_text = body_lines.join("\n");
+        if body_text.trim().is_empty() {
+            return Vec::new();
+        }
+        // Recurse: a nested `:::tip … :::` inside the body is itself a
+        // collapsed run. `None` means "no directive in the body" — emit the
+        // body as plain markdown blocks.
+        match self.transform_collapsed_run(&body_text, 0, 0, true) {
+            Some(nodes) => nodes,
+            None => reparse_block(&body_text),
         }
     }
 
@@ -627,6 +814,131 @@ fn is_container_close(node: &MdastNode) -> bool {
         return false;
     };
     first_line(&t.value).trim() == ":::"
+}
+
+/// Trim a `\r` (CRLF input) off the end of a single re-segmented line.
+fn first_line_trim(line: &str) -> &str {
+    line.trim_end_matches('\r')
+}
+
+/// True when the first line of `value` is a container directive opener
+/// (`:::+name…`, >=3 colons followed by a name-start char).
+fn first_line_is_container_opener(value: &str) -> bool {
+    container_opener_colons(first_line(value).trim_end()).is_some()
+}
+
+/// If `line` is a container DIRECTIVE OPENER (`:::+name…`, i.e. ≥3 leading
+/// colons immediately followed by a name-start char), return its leading
+/// colon count. A bare `:::` (close fence) returns `None` because the byte
+/// after the colons is not a name start.
+fn container_opener_colons(line: &str) -> Option<usize> {
+    let bytes = line.trim_end().as_bytes();
+    let mut n = 0;
+    while n < bytes.len() && bytes[n] == b':' {
+        n += 1;
+    }
+    if n < 3 {
+        return None;
+    }
+    if n < bytes.len() && is_name_start(bytes[n]) {
+        Some(n)
+    } else {
+        None
+    }
+}
+
+/// If `line` is a bare container CLOSE fence (only colons, ≥3, no name),
+/// return its colon count, else `None`.
+fn container_close_colons(line: &str) -> Option<usize> {
+    let t = line.trim();
+    if t.len() >= 3 && t.bytes().all(|b| b == b':') {
+        Some(t.len())
+    } else {
+        None
+    }
+}
+
+/// Find the index in `lines` (searching from `from`) of the closer that
+/// matches an opener with `open_colons` colons, honouring NESTED openers of
+/// the same family. The matching rule: a close fence of `k` colons closes the
+/// innermost still-open fence whose opener colon-count is `<= k`. We start one
+/// fence deep (the opener the caller already consumed) and return the index of
+/// the closer that brings the depth back to zero. Returns `None` for an
+/// unbalanced run (no matching closer) — the caller leaves it as literal text.
+fn find_collapsed_closer(lines: &[&str], from: usize, open_colons: usize) -> Option<usize> {
+    // Stack of open fence colon-counts; seed with the opener we're matching.
+    let mut stack: Vec<usize> = vec![open_colons];
+    let mut j = from;
+    while j < lines.len() {
+        let line = first_line_trim(lines[j]);
+        if let Some(close_k) = container_close_colons(line) {
+            // A close fence of `close_k` colons closes the innermost open
+            // fence whose colon-count is <= close_k.
+            let &top = stack.last().expect("stack seeded with the opener");
+            if top > close_k {
+                // Closer too small for the innermost opener: it cannot close
+                // it — unbalanced, stop scanning (malformed).
+                return None;
+            }
+            stack.pop();
+            if stack.is_empty() {
+                // Closed back down to our opener — this is the match.
+                return Some(j);
+            }
+        } else if let Some(inner_colons) = container_opener_colons(line) {
+            // A nested opener pushes onto the stack.
+            stack.push(inner_colons);
+        }
+        j += 1;
+    }
+    None
+}
+
+/// Re-parse a body/prose text fragment with the real markdown parser and
+/// return its top-level block nodes. Used to materialise collapsed-directive
+/// bodies and inter-run prose as proper mdast (Paragraph/list/etc.), matching
+/// the shape the blank-line-separated form produces.
+fn reparse_block(text: &str) -> Vec<MdastNode> {
+    match markdown::to_mdast(text, &markdown::ParseOptions::mdx()) {
+        Ok(MdastNode::Root(root)) => root.children,
+        _ => vec![MdastNode::Paragraph(markdown::mdast::Paragraph {
+            children: vec![MdastNode::Text(Text {
+                value: text.to_string(),
+                position: None,
+            })],
+            position: None,
+        })],
+    }
+}
+
+/// When `node` is a Paragraph with exactly one multi-line `Text` child (the
+/// collapsed shape `markdown::to_mdast` produces for blank-line-less fences),
+/// return that Text's `value` plus the paragraph's start column for
+/// diagnostics. Returns `None` for the multi-inline-child case (which the
+/// #1090 `collapsed_container_body` fallback handles instead).
+fn single_text_collapsed_value(node: &MdastNode) -> Option<(String, usize)> {
+    let MdastNode::Paragraph(p) = node else {
+        return None;
+    };
+    if p.children.len() != 1 {
+        return None;
+    }
+    let MdastNode::Text(t) = &p.children[0] else {
+        return None;
+    };
+    if !t.value.contains('\n') {
+        return None;
+    }
+    let col = p.position.as_ref().map_or(1, |pos| pos.start.column);
+    Some((t.value.clone(), col))
+}
+
+/// Paragraph start line for a single-text collapsed paragraph (for diags).
+fn single_text_collapsed_line_col(node: &MdastNode) -> Option<usize> {
+    let MdastNode::Paragraph(p) = node else {
+        return None;
+    };
+    Some(p.position.as_ref().map_or(1, |pos| pos.start.line))
 }
 
 fn paragraph_position(node: &MdastNode) -> Option<markdown::unist::Position> {
@@ -1142,6 +1454,144 @@ separated body
         let diags = r.take_diagnostics();
         assert_eq!(diags.len(), 1, "unknown-directive warning expected");
         assert!(diags[0].message.contains("nope"));
+    }
+
+    // ---- recursive collapsed sibling/nested transform (Sub #1094) ----
+
+    #[test]
+    fn real_parser_collapsed_sibling_directives_both_transform() {
+        // Issue #1094: two SIBLING containers collapsed with NO blank line
+        // between them land in ONE multi-line Paragraph. Before the recursive
+        // fix only the OUTER (first) directive transformed and the second was
+        // left as literal text. Both must now become JSX flow elements.
+        let mut r = registry_with_admonitions();
+        let input = ":::note\nA\n:::\n:::tip\nB\n:::\n";
+        let out = run_real_parser(&mut r, input);
+        assert_eq!(out.len(), 2, "both siblings transform, got {out:#?}");
+
+        let note = flow(&out[0]);
+        assert_eq!(note.name.as_deref(), Some("Note"));
+        let MdastNode::Paragraph(nb) = &note.children[0] else {
+            unreachable!("note body Paragraph, got {:?}", note.children[0]);
+        };
+        let MdastNode::Text(nt) = &nb.children[0] else {
+            unreachable!("note body Text");
+        };
+        assert_eq!(nt.value, "A");
+
+        let tip = flow(&out[1]);
+        assert_eq!(tip.name.as_deref(), Some("Tip"));
+        let MdastNode::Paragraph(tb) = &tip.children[0] else {
+            unreachable!("tip body Paragraph, got {:?}", tip.children[0]);
+        };
+        let MdastNode::Text(tt) = &tb.children[0] else {
+            unreachable!("tip body Text");
+        };
+        assert_eq!(tt.value, "B");
+
+        assert!(
+            r.take_diagnostics().is_empty(),
+            "well-formed siblings produce no diagnostics"
+        );
+    }
+
+    #[test]
+    fn real_parser_collapsed_nested_directive_transforms() {
+        // A NESTED collapsed directive: the outer fence uses MORE colons
+        // (`:::::`) per the CommonMark-Directives nesting convention, the
+        // inner uses `:::`. The inner `:::tip` must transform into <Tip>
+        // (no longer literal text) and live inside the outer <Note>.
+        let mut r = registry_with_admonitions();
+        let input = ":::::note\nbefore\n:::tip\ninner\n:::\nafter\n:::::\n";
+        let out = run_real_parser(&mut r, input);
+        assert_eq!(out.len(), 1, "one outer directive, got {out:#?}");
+
+        let note = flow(&out[0]);
+        assert_eq!(note.name.as_deref(), Some("Note"));
+
+        // The outer body must contain a transformed <Tip> JSX element among
+        // its children — proof the inner directive was not left as literal
+        // text.
+        let has_tip = note.children.iter().any(
+            |c| matches!(c, MdastNode::MdxJsxFlowElement(j) if j.name.as_deref() == Some("Tip")),
+        );
+        assert!(
+            has_tip,
+            "nested <Tip> should be transformed inside <Note>, got {:#?}",
+            note.children
+        );
+
+        assert!(
+            r.take_diagnostics().is_empty(),
+            "well-formed nested directives produce no diagnostics"
+        );
+    }
+
+    #[test]
+    fn real_parser_collapsed_unbalanced_run_leaves_remainder_literal() {
+        // MALFORMED: a well-formed first directive followed by a second
+        // opener with NO closer. The first transforms; the unbalanced
+        // remainder is left as literal text — no panic, graceful fallback.
+        let mut r = registry_with_admonitions();
+        let input = ":::note\nA\n:::\n:::tip\nB\n";
+        let out = run_real_parser(&mut r, input);
+
+        // First directive transformed.
+        let note = flow(&out[0]);
+        assert_eq!(note.name.as_deref(), Some("Note"));
+
+        // The unbalanced `:::tip\nB` remainder survives as literal text
+        // somewhere in the output (not transformed into a <Tip>).
+        let literal: String = out
+            .iter()
+            .filter_map(|n| match n {
+                MdastNode::Paragraph(p) => Some(
+                    p.children
+                        .iter()
+                        .filter_map(|c| match c {
+                            MdastNode::Text(t) => Some(t.value.clone()),
+                            _ => None,
+                        })
+                        .collect::<String>(),
+                ),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            literal.contains(":::tip"),
+            "unbalanced opener left literal, got {out:#?}"
+        );
+        let has_tip = out.iter().any(
+            |c| matches!(c, MdastNode::MdxJsxFlowElement(j) if j.name.as_deref() == Some("Tip")),
+        );
+        assert!(!has_tip, "unbalanced tip must NOT transform");
+    }
+
+    #[test]
+    fn real_parser_collapsed_inner_unknown_warns_once_and_left_alone() {
+        // A KNOWN outer container with an UNKNOWN inner directive: the inner
+        // is left as literal text and earns EXACTLY ONE unknown-directive
+        // warning (no duplicate from the recursive pass + the outer re-walk).
+        let mut r = registry_with_admonitions();
+        let input = ":::::note\nbefore\n:::bogus\nx\n:::\nafter\n:::::\n";
+        let out = run_real_parser(&mut r, input);
+        assert_eq!(out.len(), 1);
+        let note = flow(&out[0]);
+        assert_eq!(note.name.as_deref(), Some("Note"));
+
+        // No <Bogus>/<bogus> transform happened.
+        let has_jsx_inner = note.children.iter().any(
+            |c| matches!(c, MdastNode::MdxJsxFlowElement(j) if j.name.as_deref() != Some("Tip")),
+        );
+        assert!(!has_jsx_inner, "unknown inner must stay literal");
+
+        let diags = r.take_diagnostics();
+        assert_eq!(
+            diags.len(),
+            1,
+            "exactly one unknown-directive warning, got {diags:#?}"
+        );
+        assert!(diags[0].message.contains("bogus"));
     }
 
     // ---- container tests ----

--- a/crates/zfb-content/src/plugins/directives.rs
+++ b/crates/zfb-content/src/plugins/directives.rs
@@ -160,17 +160,23 @@ impl DirectiveRegistry {
             // JSX flow element per top-level directive run and recurses for
             // nested ones. This must run BEFORE the 3-colon `parse_block_open`
             // check so a `:::::note` (5-colon) outer opener is handled too.
-            if let Some((text_value, base_col)) = single_text_collapsed_value(&children[i]) {
-                if first_line_is_container_opener(&text_value) {
-                    let line_no = single_text_collapsed_line_col(&children[i]).unwrap_or(1);
+            if let Some((text_value, line_no, base_col)) = single_text_collapsed(&children[i]) {
+                if container_opener_colons(first_line(&text_value).trim_end()).is_some() {
                     if let Some(replacement) =
-                        self.transform_collapsed_run(&text_value, line_no, base_col, false)
+                        self.transform_collapsed_run(&text_value, Some((line_no, base_col)))
                     {
+                        // `transform_collapsed_run` owns the paragraph: it has
+                        // transformed every recognised run and warned every
+                        // unknown exactly once. Splice in its result and skip
+                        // the block-level checks below (no double-warn).
                         let n = replacement.len();
                         children.splice(i..=i, replacement);
                         i += n;
                         continue;
                     }
+                    // First line looked like an opener but no fence run was
+                    // recognised (e.g. no closer) — fall through to the
+                    // block-level handlers below, which leave it alone.
                 }
             }
 
@@ -280,27 +286,32 @@ impl DirectiveRegistry {
     /// recognised runs that are plain prose are likewise re-parsed as markdown
     /// and emitted verbatim.
     ///
-    /// Returns `Some(replacement_nodes)` when at least one top-level directive
-    /// run was recognised and transformed; `None` when nothing matched (so the
-    /// caller falls through to other handlers / leaves the paragraph alone).
+    /// Returns `Some(replacement_nodes)` when at least one directive fence run
+    /// was recognised (transformed to JSX, or an unknown/unmatched run left as
+    /// re-parsed prose). In that case this method OWNS the paragraph and warns
+    /// every unknown directive exactly once, so the caller must splice the
+    /// result and NOT fall through to other warn paths. Returns `None` only
+    /// when no fence run was recognised at all (e.g. the first line looked
+    /// like an opener but had no closer and no other run matched), letting the
+    /// caller leave the paragraph alone.
     ///
-    /// `first_line`/`first_col` carry the source position of the paragraph's
-    /// opener for diagnostics.
+    /// Unknown directives are warned HERE (not by the caller's re-walk):
+    /// once a run is recognised, every unmatched/unknown line is folded into a
+    /// re-parsed prose Paragraph that the outer `visit` re-walk does NOT
+    /// re-block-scan (it only walks inline children), so this is the single
+    /// authoritative warn site for collapsed directives.
     ///
-    /// `is_body` distinguishes the TOP-LEVEL call (from `transform_children`,
-    /// `false`) from a recursive BODY re-segmentation (`true`). It controls
-    /// unknown-directive warning placement so each unknown is reported exactly
-    /// once (see the unknown branch below).
+    /// `first_pos` carries the `(line, column)` source position of the
+    /// paragraph's opener for diagnostics, or `None` when unknown (recursive
+    /// body re-segmentation has no reliable per-line position).
     fn transform_collapsed_run(
         &mut self,
         value: &str,
-        first_line: usize,
-        first_col: usize,
-        is_body: bool,
+        first_pos: Option<(usize, usize)>,
     ) -> Option<Vec<MdastNode>> {
         let lines: Vec<&str> = value.split('\n').collect();
         let mut out: Vec<MdastNode> = Vec::new();
-        let mut transformed_any = false;
+        let mut recognised_any = false;
         let mut i = 0usize;
         // Track plain (non-directive) lines so we can flush them as a prose
         // block in source order between recognised runs.
@@ -311,61 +322,59 @@ impl DirectiveRegistry {
             if let Some(open_colons) = container_opener_colons(line) {
                 // Find the matching closer line by colon count.
                 if let Some(close_idx) = find_collapsed_closer(&lines, i + 1, open_colons) {
-                    // Flush any pending prose before this run.
-                    self.flush_prose(&lines, prose_start, i, &mut out);
-
-                    // Reconstruct the inner body (lines between opener and
-                    // closer) as a single text block for recursive handling.
-                    let body_lines = &lines[i + 1..close_idx];
                     let opener = first_line_trim(line);
                     if let Some(parsed) = parse_directive_line(opener, open_colons) {
                         if let Some(def) = self.defs.get(&parsed.name).cloned() {
                             if def.kind == DirectiveKind::Container {
-                                let (line_no, col_no) = if i == 0 {
-                                    (Some(first_line), Some(first_col))
-                                } else {
-                                    (None, None)
+                                // Flush any pending prose before this run.
+                                self.flush_prose(&lines, prose_start, i, &mut out);
+                                // Only the very first opener line has a known
+                                // source position; later sibling/nested openers
+                                // have none (they are mid-text lines).
+                                let (line_no, col_no) = match (i, first_pos) {
+                                    (0, Some((l, c))) => (Some(l), Some(c)),
+                                    _ => (None, None),
                                 };
                                 let validated_opt =
                                     self.run_validation(&def, &parsed, line_no, col_no);
-                                let inner = self.build_collapsed_body(body_lines);
+                                // Body = lines between opener and its closer.
+                                let inner = self.build_collapsed_body(&lines[i + 1..close_idx]);
                                 let jsx =
                                     build_flow_jsx(&def, &parsed, inner, validated_opt.as_ref());
                                 out.push(jsx);
-                                transformed_any = true;
+                                recognised_any = true;
                                 i = close_idx + 1;
                                 prose_start = i;
                                 continue;
                             }
-                            // Registered but not a container: fall through and
-                            // treat as prose (leave literal).
-                        } else if is_body {
-                            // Unknown directive name BURIED in a container body.
-                            // The lines are emitted as prose (via
-                            // `flush_prose`/`reparse_block`) and re-parsed into a
-                            // paragraph nested inside the JSX element; the outer
-                            // `visit` re-walk does NOT re-discover a directive
-                            // buried mid-paragraph, so warn HERE — exactly once.
+                            // Registered but not a container: leave the run as
+                            // literal prose (no warn — known name, wrong kind).
+                        } else {
+                            // Unknown directive name. The opener..=closer lines
+                            // stay as literal prose; warn exactly once. (The
+                            // re-parsed prose is never re-block-scanned, so this
+                            // is the only place the warning can come from.)
+                            let (line_no, col_no) = match (i, first_pos) {
+                                (0, Some((l, c))) => (Some(l), Some(c)),
+                                _ => (None, None),
+                            };
                             self.diagnostics.push(DirectiveDiagnostic {
                                 message: format!("unknown directive `{}`", parsed.name),
-                                line: None,
-                                column: None,
+                                line: line_no,
+                                column: col_no,
                             });
+                            recognised_any = true;
+                            // Fall through: the lines remain part of prose_start
+                            // run and are flushed as literal text below.
                         }
-                        // Unknown directive at TOP level (`is_body == false`):
-                        // do NOT warn here. The whole run is emitted as a prose
-                        // paragraph and the outer `visit` re-walk's block scan
-                        // (`parse_block_open`) issues exactly one unknown-
-                        // directive warning for it (acceptance: warn ONCE).
                     }
                 }
-                // No matching closer (or unknown / wrong kind): leave this
-                // line as prose; advance one line.
+                // No matching closer: leave this line as prose; advance one.
             }
             i += 1;
         }
 
-        if !transformed_any {
+        if !recognised_any {
             return None;
         }
         // Flush trailing prose after the last recognised run.
@@ -403,7 +412,7 @@ impl DirectiveRegistry {
         // Recurse: a nested `:::tip … :::` inside the body is itself a
         // collapsed run. `None` means "no directive in the body" — emit the
         // body as plain markdown blocks.
-        match self.transform_collapsed_run(&body_text, 0, 0, true) {
+        match self.transform_collapsed_run(&body_text, None) {
             Some(nodes) => nodes,
             None => reparse_block(&body_text),
         }
@@ -821,12 +830,6 @@ fn first_line_trim(line: &str) -> &str {
     line.trim_end_matches('\r')
 }
 
-/// True when the first line of `value` is a container directive opener
-/// (`:::+name…`, >=3 colons followed by a name-start char).
-fn first_line_is_container_opener(value: &str) -> bool {
-    container_opener_colons(first_line(value).trim_end()).is_some()
-}
-
 /// If `line` is a container DIRECTIVE OPENER (`:::+name…`, i.e. ≥3 leading
 /// colons immediately followed by a name-start char), return its leading
 /// colon count. A bare `:::` (close fence) returns `None` because the byte
@@ -913,10 +916,11 @@ fn reparse_block(text: &str) -> Vec<MdastNode> {
 
 /// When `node` is a Paragraph with exactly one multi-line `Text` child (the
 /// collapsed shape `markdown::to_mdast` produces for blank-line-less fences),
-/// return that Text's `value` plus the paragraph's start column for
-/// diagnostics. Returns `None` for the multi-inline-child case (which the
-/// #1090 `collapsed_container_body` fallback handles instead).
-fn single_text_collapsed_value(node: &MdastNode) -> Option<(String, usize)> {
+/// return `(text_value, start_line, start_column)` — the Text's value plus the
+/// paragraph's start position (defaulting to 1:1 when absent) for diagnostics.
+/// Returns `None` for the multi-inline-child case (which the #1090
+/// `collapsed_container_body` fallback handles instead).
+fn single_text_collapsed(node: &MdastNode) -> Option<(String, usize, usize)> {
     let MdastNode::Paragraph(p) = node else {
         return None;
     };
@@ -929,16 +933,11 @@ fn single_text_collapsed_value(node: &MdastNode) -> Option<(String, usize)> {
     if !t.value.contains('\n') {
         return None;
     }
-    let col = p.position.as_ref().map_or(1, |pos| pos.start.column);
-    Some((t.value.clone(), col))
-}
-
-/// Paragraph start line for a single-text collapsed paragraph (for diags).
-fn single_text_collapsed_line_col(node: &MdastNode) -> Option<usize> {
-    let MdastNode::Paragraph(p) = node else {
-        return None;
-    };
-    Some(p.position.as_ref().map_or(1, |pos| pos.start.line))
+    let (line, col) = p
+        .position
+        .as_ref()
+        .map_or((1, 1), |pos| (pos.start.line, pos.start.column));
+    Some((t.value.clone(), line, col))
 }
 
 fn paragraph_position(node: &MdastNode) -> Option<markdown::unist::Position> {
@@ -1585,6 +1584,52 @@ separated body
         );
         assert!(!has_jsx_inner, "unknown inner must stay literal");
 
+        let diags = r.take_diagnostics();
+        assert_eq!(
+            diags.len(),
+            1,
+            "exactly one unknown-directive warning, got {diags:#?}"
+        );
+        assert!(diags[0].message.contains("bogus"));
+    }
+
+    #[test]
+    fn real_parser_collapsed_unknown_with_extra_colons_warns_once() {
+        // A top-level UNKNOWN collapsed container with MORE than 3 colons
+        // (`:::::bogus … :::::`) must still warn exactly once and be left as
+        // literal text — the exactly-3-colon block scan alone would miss it.
+        let mut r = registry_with_admonitions();
+        let out = run_real_parser(&mut r, ":::::bogus\nx\n:::::\n");
+        let has_jsx = out
+            .iter()
+            .any(|c| matches!(c, MdastNode::MdxJsxFlowElement(_)));
+        assert!(
+            !has_jsx,
+            "unknown directive must not transform, got {out:#?}"
+        );
+        let diags = r.take_diagnostics();
+        assert_eq!(diags.len(), 1, "exactly one warning, got {diags:#?}");
+        assert!(diags[0].message.contains("bogus"));
+    }
+
+    #[test]
+    fn real_parser_collapsed_known_then_unknown_sibling_warns_once() {
+        // A KNOWN sibling followed by an UNKNOWN sibling in one collapsed run:
+        // the known transforms, the unknown is left literal and warns exactly
+        // once (no duplicate, no lost warning).
+        let mut r = registry_with_admonitions();
+        let out = run_real_parser(&mut r, ":::note\nA\n:::\n:::bogus\nB\n:::\n");
+        let note_count = out
+            .iter()
+            .filter(
+                |c| matches!(c, MdastNode::MdxJsxFlowElement(j) if j.name.as_deref() == Some("Note")),
+            )
+            .count();
+        assert_eq!(note_count, 1, "known sibling transforms, got {out:#?}");
+        let has_other_jsx = out.iter().any(
+            |c| matches!(c, MdastNode::MdxJsxFlowElement(j) if j.name.as_deref() != Some("Note")),
+        );
+        assert!(!has_other_jsx, "unknown sibling must not transform");
         let diags = r.take_diagnostics();
         assert_eq!(
             diags.len(),

--- a/crates/zfb-content/src/plugins/directives.rs
+++ b/crates/zfb-content/src/plugins/directives.rs
@@ -347,8 +347,16 @@ impl DirectiveRegistry {
                                 prose_start = i;
                                 continue;
                             }
-                            // Registered but not a container: leave the run as
-                            // literal prose (no warn — known name, wrong kind).
+                            // Registered but not a container (wrong kind): keep
+                            // the ENTIRE opener..=closer run literal — skip past
+                            // the closer so a KNOWN directive nested inside the
+                            // wrong-kind wrapper is not re-scanned and leaked out
+                            // transformed mid-prose (zfb#1094 review C1). These
+                            // lines stay in the pending prose run and are flushed
+                            // verbatim (or the whole paragraph is left alone when
+                            // nothing else in it is recognised).
+                            i = close_idx + 1;
+                            continue;
                         } else {
                             // Unknown directive name. The opener..=closer lines
                             // stay as literal prose; warn exactly once. (The
@@ -364,8 +372,14 @@ impl DirectiveRegistry {
                                 column: col_no,
                             });
                             recognised_any = true;
-                            // Fall through: the lines remain part of prose_start
-                            // run and are flushed as literal text below.
+                            // Skip past the closer: the whole unknown run stays
+                            // literal prose. Without this, a KNOWN directive
+                            // nested inside the unknown wrapper would be
+                            // re-scanned and transformed mid-prose, splitting the
+                            // literal `:::::name`/`:::::` around it (zfb#1094
+                            // review C1).
+                            i = close_idx + 1;
+                            continue;
                         }
                     }
                 }
@@ -1637,6 +1651,51 @@ separated body
             "exactly one unknown-directive warning, got {diags:#?}"
         );
         assert!(diags[0].message.contains("bogus"));
+    }
+
+    #[test]
+    fn real_parser_collapsed_unknown_outer_keeps_known_inner_literal() {
+        // zfb#1094 review C1: an UNKNOWN outer fence wrapping a KNOWN inner
+        // directive must keep the WHOLE run literal — the inner `:::note` must
+        // NOT leak out transformed mid-prose (splitting the literal
+        // `:::::bogus`/`:::::` around a real <Note>). Before the fix the unknown
+        // branch fell through into the body and re-scanned the inner opener.
+        let mut r = registry_with_admonitions();
+        let out = run_real_parser(&mut r, ":::::bogus\n:::note\nA\n:::\n:::::\n");
+        let has_jsx = out
+            .iter()
+            .any(|c| matches!(c, MdastNode::MdxJsxFlowElement(_)));
+        assert!(
+            !has_jsx,
+            "inner known directive must stay literal inside an unknown wrapper, got {out:#?}"
+        );
+        let diags = r.take_diagnostics();
+        assert_eq!(
+            diags.len(),
+            1,
+            "exactly one unknown warning, got {diags:#?}"
+        );
+        assert!(diags[0].message.contains("bogus"));
+    }
+
+    #[test]
+    fn real_parser_collapsed_closer_with_more_colons_still_closes() {
+        // zfb#1094 review C2 (pin behavior): a closer with MORE colons than its
+        // opener still closes it — the colon-count rule is "a closer of k
+        // colons closes the innermost open fence whose opener colon-count
+        // <= k". This leniency is what makes nested fences (outer uses more
+        // colons) work, so `:::note\nA\n:::::` transforms to <Note> rather than
+        // being left literal. Documented + pinned so it is intended, not
+        // incidental.
+        let mut r = registry_with_admonitions();
+        let out = run_real_parser(&mut r, ":::note\nA\n:::::\n");
+        assert_eq!(out.len(), 1, "got {out:#?}");
+        let note = flow(&out[0]);
+        assert_eq!(note.name.as_deref(), Some("Note"));
+        assert!(
+            r.take_diagnostics().is_empty(),
+            "lenient closer is accepted without diagnostics"
+        );
     }
 
     // ---- container tests ----

--- a/crates/zfb-content/src/plugins/heading_links.rs
+++ b/crates/zfb-content/src/plugins/heading_links.rs
@@ -197,6 +197,15 @@ impl HeadingLinksPlugin {
     /// When `registry` and `source_path` are provided, a `HeadingEntry` is
     /// pushed for each heading processed. When `registry` is `None` the
     /// behaviour is identical to the pre-wave-6 `visit` method.
+    ///
+    /// KNOWN LIMITATION (#1095): raw-HTML elements authored as literal HTML
+    /// inside markdown (e.g. `<div id="x">`) arrive as `HastNode::Raw` (an
+    /// opaque string) at this walk — they are NOT structured `Element` nodes
+    /// and therefore cannot be recorded in the anchor-id store. GFM footnote
+    /// back-reference anchors (`id="user-content-fn-1"`) similarly degrade to
+    /// `HastNode::Raw("")` in `mdast_to_hast`. Both remain unrecorded and will
+    /// still trigger a `BrokenLink` if linked from the same file. A future fix
+    /// would require a raw-HTML parser pass before this walk.
     fn visit_node(
         &mut self,
         node: &mut HastNode,
@@ -232,6 +241,30 @@ impl HeadingLinksPlugin {
                         depth,
                     },
                 );
+            }
+        } else if let (Some(reg), Some(ref path)) = (registry.as_deref_mut(), &source_path) {
+            // For non-heading elements, record explicit `id` attributes and
+            // `<a name="…">` values in the anchor-id store so that bare
+            // `#anchor` links to non-heading targets (e.g. `<div id="foo">`,
+            // `<a name="foo">`) are not falsely flagged as broken in files
+            // that happen to have no headings (#1095).
+            if let HastNode::Element { tag, attrs, .. } = &*node {
+                // Any element with an `id` attribute — `<div id="x">`, `<section id="y">`, etc.
+                if let Some(id_val) = attrs.iter().find(|(k, _)| k == "id").map(|(_, v)| v) {
+                    if !id_val.is_empty() {
+                        reg.insert_anchor_id(path.clone(), id_val.clone());
+                    }
+                }
+                // `<a name="x">` — legacy named anchors (GitHub Flavored Markdown
+                // and hand-authored HTML that survived mdast parsing as Elements).
+                if tag == "a" {
+                    if let Some(name_val) = attrs.iter().find(|(k, _)| k == "name").map(|(_, v)| v)
+                    {
+                        if !name_val.is_empty() {
+                            reg.insert_anchor_id(path.clone(), name_val.clone());
+                        }
+                    }
+                }
             }
         }
 

--- a/crates/zfb-md-ast/src/heading_registry.rs
+++ b/crates/zfb-md-ast/src/heading_registry.rs
@@ -8,7 +8,7 @@
 //! Zero-cost for non-validating callers: when no registry is passed in the
 //! `BuildContext`, `HeadingLinksPlugin` makes no registry calls at all.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 /// A single heading entry recorded by `HeadingLinksPlugin`.
@@ -33,6 +33,16 @@ pub struct HeadingEntry {
 #[derive(Debug, Default)]
 pub struct HeadingRegistry {
     entries: HashMap<PathBuf, Vec<HeadingEntry>>,
+    /// Explicit (non-heading) anchor ids recorded per source file.
+    ///
+    /// Populated by `HeadingLinksPlugin` for every `Element` carrying an `id`
+    /// attribute (e.g. `<div id="foo">`) and every `<a name="…">` anchor. This
+    /// is a separate store from `entries` because it must be queryable even for
+    /// files that have zero headings — the `mark_tracked` / `get` contract on
+    /// `entries` only tells the validator whether the file was processed, while
+    /// `anchor_ids` independently tells it whether a specific non-heading id
+    /// exists. See issue #1095.
+    anchor_ids: HashMap<PathBuf, HashSet<String>>,
 }
 
 impl HeadingRegistry {
@@ -63,6 +73,39 @@ impl HeadingRegistry {
     /// Idempotent and never clears existing entries.
     pub fn mark_tracked(&mut self, source_path: PathBuf) {
         self.entries.entry(source_path).or_default();
+    }
+
+    /// Record a non-heading explicit anchor `id` for `source_path`.
+    ///
+    /// Called by `HeadingLinksPlugin` for every hast `Element` whose `id`
+    /// attribute was NOT set by heading-slug logic (all non-`h2`–`h6` elements
+    /// with an explicit `id`), and for every `<a name="…">` element. This lets
+    /// `LinkValidationPlugin` accept `#foo` in a headingless file when a
+    /// `<div id="foo">` or `<a name="foo">` is present, without reporting a
+    /// false-positive `BrokenLink`.
+    ///
+    /// The store is path-keyed and independent from `entries` so a file with
+    /// zero headings can still have anchor ids recorded. Idempotent for
+    /// duplicate ids within the same file.
+    ///
+    /// NOTE: Raw-HTML elements (`<div id="x">` written as literal HTML inside
+    /// markdown) and GFM footnote back-reference anchors (`id="user-content-fn-1"`)
+    /// arrive as `HastNode::Raw` (opaque strings) at the point `HeadingLinksPlugin`
+    /// walks — they are NOT structured `Element` nodes and therefore cannot be
+    /// recorded here. See the known limitation comment in `heading_links.rs`.
+    pub fn insert_anchor_id(&mut self, source_path: PathBuf, id: String) {
+        self.anchor_ids.entry(source_path).or_default().insert(id);
+    }
+
+    /// Return `true` if `id` was recorded as an explicit anchor in `source_path`.
+    ///
+    /// Returns `false` for unknown paths and unknown ids alike, so callers can
+    /// use a simple boolean gate rather than an `Option` chain.
+    #[must_use]
+    pub fn has_anchor(&self, source_path: &std::path::Path, id: &str) -> bool {
+        self.anchor_ids
+            .get(source_path)
+            .is_some_and(|ids| ids.contains(id))
     }
 
     /// Look up all headings recorded for the given source file.
@@ -149,6 +192,54 @@ mod tests {
         // No headings were recorded, so the registry is still empty by count.
         assert!(reg.is_empty());
         assert_eq!(reg.len(), 0);
+    }
+
+    // ── anchor_ids store ──────────────────────────────────────────────────────
+
+    #[test]
+    fn insert_anchor_id_and_has_anchor() {
+        let mut reg = HeadingRegistry::new();
+        let path = PathBuf::from("/docs/headingless.md");
+        // Unknown path + unknown id → false before any insert.
+        assert!(!reg.has_anchor(&path, "foo"));
+        reg.insert_anchor_id(path.clone(), "foo".to_string());
+        assert!(reg.has_anchor(&path, "foo"));
+        // Different id on the same path → still false.
+        assert!(!reg.has_anchor(&path, "bar"));
+        // Multiple ids on the same path.
+        reg.insert_anchor_id(path.clone(), "bar".to_string());
+        assert!(reg.has_anchor(&path, "bar"));
+    }
+
+    #[test]
+    fn has_anchor_unknown_path_returns_false() {
+        let reg = HeadingRegistry::new();
+        assert!(!reg.has_anchor(std::path::Path::new("/does/not/exist.md"), "any"));
+    }
+
+    #[test]
+    fn insert_anchor_id_is_idempotent() {
+        let mut reg = HeadingRegistry::new();
+        let path = PathBuf::from("/docs/page.md");
+        reg.insert_anchor_id(path.clone(), "foo".to_string());
+        reg.insert_anchor_id(path.clone(), "foo".to_string()); // duplicate — no panic
+        assert!(reg.has_anchor(&path, "foo"));
+    }
+
+    #[test]
+    fn anchor_ids_independent_from_heading_entries() {
+        // A file can have anchor ids without any heading entries (and vice versa).
+        let mut reg = HeadingRegistry::new();
+        let path = PathBuf::from("/docs/headingless.md");
+        reg.mark_tracked(path.clone());
+        reg.insert_anchor_id(path.clone(), "section".to_string());
+        // get() still returns Some(&[]) — no headings.
+        assert_eq!(reg.get(&path), Some(&[][..]));
+        // has_anchor correctly returns true for the registered id.
+        assert!(reg.has_anchor(&path, "section"));
+        // len() / is_empty() count only heading entries, unaffected.
+        assert_eq!(reg.len(), 0);
+        assert!(reg.is_empty());
     }
 
     #[test]

--- a/crates/zfb-md-extras/src/link_validation.rs
+++ b/crates/zfb-md-extras/src/link_validation.rs
@@ -353,12 +353,18 @@ fn validate_link(href: &str, env: &ValidationEnv<'_>, ctx: &mut BuildContext<'_>
     }
 }
 
-/// Validate a bare `#fragment` against the current file's heading registry.
+/// Validate a bare `#fragment` against the current file's heading registry
+/// and explicit-anchor-id store.
 ///
 /// No filesystem read happens here (zfb#944 audit): the fragment is
 /// checked against the in-memory registry, whose entries for the CURRENT
 /// file derive from the compile input itself — already covered by the
 /// compile cache's input hash — so there is nothing to record.
+///
+/// A `BrokenLink` is emitted only when BOTH the heading-id lookup AND the
+/// explicit-anchor-id lookup miss, so legitimate non-heading targets
+/// (e.g. `<div id="foo">`, `<a name="foo">`) recorded by
+/// `HeadingLinksPlugin` do not produce false positives (#1095).
 fn validate_fragment_in_file(
     raw_href: &str,
     fragment: &str,
@@ -377,9 +383,18 @@ fn validate_fragment_in_file(
         None => return, // no registry entry for this file → cannot distinguish
                         // "file has no headings" from "file not tracked" → skip
     };
-    if !entries.iter().any(|e| e.id == fragment) {
-        emit_broken_link(raw_href, env, ctx);
+    // Accept the fragment if it matches any heading id OR any explicit anchor id.
+    if entries.iter().any(|e| e.id == fragment) {
+        return;
     }
+    if ctx
+        .heading_registry
+        .as_ref()
+        .is_some_and(|r| r.has_anchor(env.source_path, fragment))
+    {
+        return;
+    }
+    emit_broken_link(raw_href, env, ctx);
 }
 
 /// Validate that a file-only reference (`./other.md`) exists on disk and

--- a/crates/zfb-md-extras/src/link_validation.rs
+++ b/crates/zfb-md-extras/src/link_validation.rs
@@ -501,9 +501,18 @@ fn validate_file_with_fragment(
             return;
         }
     };
-    if !entries.iter().any(|e| e.id == fragment) {
-        emit_broken_link(raw_href, env, ctx);
+    // Accept the fragment if it matches any heading id OR any explicit anchor id.
+    if entries.iter().any(|e| e.id == fragment) {
+        return;
     }
+    if ctx
+        .heading_registry
+        .as_ref()
+        .is_some_and(|r| r.has_anchor(&resolved, fragment))
+    {
+        return;
+    }
+    emit_broken_link(raw_href, env, ctx);
 }
 
 /// Emit a `BrokenLink` diagnostic through `ctx.diagnostics`.

--- a/crates/zfb-md-extras/src/link_validation.rs
+++ b/crates/zfb-md-extras/src/link_validation.rs
@@ -480,6 +480,14 @@ fn validate_file_with_fragment(
             // (mirrors the bare-anchor contract; kills the
             // `./other.md#frag` unwrap_or(false) false positive).
             //
+            // Note: a target compiled in THIS build is always `Some(..)` here
+            // (HeadingLinksPlugin calls `mark_tracked` for every file it
+            // walks, yielding `Some(&[])` even when headingless), so explicit
+            // anchor ids ARE consulted below for same-build targets. Only a
+            // not-yet-compiled target falls here, and its explicit anchor ids
+            // are settled by the post-compile cross-file check (#960/#977),
+            // not this in-compile path (#1095).
+            //
             // Cross-file candidate recording (#960 / #977): exactly the
             // links reaching this branch — FileWithFragment, non-img,
             // already past containment + existence — are the ones the

--- a/crates/zfb-md-extras/tests/link_validation.rs
+++ b/crates/zfb-md-extras/tests/link_validation.rs
@@ -602,3 +602,213 @@ fn query_string_file_link_validates_path_only() {
         "query-string file link with existing target must not emit diagnostic: {diags:?}"
     );
 }
+
+// ── Fixture 17: bare anchor to explicit element id (#1095) ───────────────────
+
+/// In a headingless file, `[x](#foo)` where the hast tree contains an element
+/// with `id="foo"` (e.g. a `<div id="foo">` produced by a MDX JSX element)
+/// must NOT emit a `BrokenLink` diagnostic.
+///
+/// The pipeline passes through `HeadingLinksPlugin` (which records the id in
+/// `anchor_ids`) before `LinkValidationPlugin` runs.
+#[test]
+fn bare_anchor_to_explicit_element_id_no_diagnostic() {
+    use zfb_content::pipeline::{BuildContext, HastNode, HastVisitor};
+    use zfb_content::plugins::heading_links::HeadingLinksPlugin;
+    use zfb_md_extras::link_validation::LinkValidationPlugin;
+
+    let source = PathBuf::from("/project/docs/headingless.md");
+    let mut registry = HeadingRegistry::new();
+    let mut sink = CollectingSink::new();
+
+    // Hast tree: <div id="foo">...</div> + <a href="#foo">link</a>
+    // The <div> is a non-heading element with an explicit id — simulates
+    // a MDX component or custom element that renders with an id attribute.
+    let mut tree = HastNode::Root {
+        children: vec![
+            HastNode::Element {
+                tag: "div".to_string(),
+                attrs: vec![("id".to_string(), "foo".to_string())],
+                children: vec![HastNode::Text("content".to_string())],
+                void: false,
+            },
+            HastNode::Element {
+                tag: "a".to_string(),
+                attrs: vec![("href".to_string(), "#foo".to_string())],
+                children: vec![HastNode::Text("link".to_string())],
+                void: false,
+            },
+        ],
+    };
+
+    let mut ctx = BuildContext {
+        source_path: Some(source.clone()),
+        project_root: PathBuf::from("/project"),
+        public_dir: PathBuf::from("/project/public"),
+        heading_registry: Some(&mut registry),
+        diagnostics: Some(&mut sink),
+        cross_file_links: None,
+    };
+
+    // Run HeadingLinksPlugin first (records anchor ids into the registry).
+    HeadingLinksPlugin::new().visit_with_context(&mut tree, &mut ctx);
+    // Then run LinkValidationPlugin (consults the registry).
+    let mut plugin = LinkValidationPlugin::new(LinkValidationConfig::default());
+    plugin.visit_with_context(&mut tree, &mut ctx);
+
+    let diags = sink.take();
+    assert!(
+        diags.is_empty(),
+        "bare anchor to explicit element id must not emit BrokenLink: {diags:?}"
+    );
+}
+
+// ── Fixture 18: genuinely broken bare anchor in headingless file (#1095) ─────
+
+/// A headingless file with `[x](#nonexistent)` where NO element has `id="nonexistent"`
+/// must STILL emit `BrokenLink` — the fix must not suppress valid diagnostics.
+#[test]
+fn bare_broken_anchor_in_headingless_file_emits_diagnostic() {
+    use zfb_content::pipeline::{BuildContext, HastNode, HastVisitor};
+    use zfb_content::plugins::heading_links::HeadingLinksPlugin;
+    use zfb_md_extras::link_validation::LinkValidationPlugin;
+
+    let source = PathBuf::from("/project/docs/headingless.md");
+    let mut registry = HeadingRegistry::new();
+    let mut sink = CollectingSink::new();
+
+    // The file has a div with a DIFFERENT id, plus a broken anchor.
+    let mut tree = HastNode::Root {
+        children: vec![
+            HastNode::Element {
+                tag: "div".to_string(),
+                attrs: vec![("id".to_string(), "other".to_string())],
+                children: vec![],
+                void: false,
+            },
+            HastNode::Element {
+                tag: "a".to_string(),
+                attrs: vec![("href".to_string(), "#nonexistent".to_string())],
+                children: vec![HastNode::Text("bad link".to_string())],
+                void: false,
+            },
+        ],
+    };
+
+    let mut ctx = BuildContext {
+        source_path: Some(source.clone()),
+        project_root: PathBuf::from("/project"),
+        public_dir: PathBuf::from("/project/public"),
+        heading_registry: Some(&mut registry),
+        diagnostics: Some(&mut sink),
+        cross_file_links: None,
+    };
+
+    HeadingLinksPlugin::new().visit_with_context(&mut tree, &mut ctx);
+    let mut plugin = LinkValidationPlugin::new(LinkValidationConfig::default());
+    plugin.visit_with_context(&mut tree, &mut ctx);
+
+    let diags = sink.take();
+    assert_eq!(
+        diags.len(),
+        1,
+        "genuinely broken bare anchor must still emit BrokenLink: {diags:?}"
+    );
+    assert!(
+        matches!(&diags[0], MarkdownDiagnostic::BrokenLink { url, .. } if url == "#nonexistent"),
+        "diagnostic url must be the raw href: {diags:?}"
+    );
+}
+
+// ── Fixture 19: bare anchor to `<a name="…">` (#1095) ────────────────────────
+
+/// An `<a name="section">` legacy named anchor in a headingless file:
+/// `[x](#section)` must NOT emit a `BrokenLink`.
+#[test]
+fn bare_anchor_to_a_name_no_diagnostic() {
+    use zfb_content::pipeline::{BuildContext, HastNode, HastVisitor};
+    use zfb_content::plugins::heading_links::HeadingLinksPlugin;
+    use zfb_md_extras::link_validation::LinkValidationPlugin;
+
+    let source = PathBuf::from("/project/docs/headingless.md");
+    let mut registry = HeadingRegistry::new();
+    let mut sink = CollectingSink::new();
+
+    // `<a name="section">` followed by a link to `#section`.
+    let mut tree = HastNode::Root {
+        children: vec![
+            HastNode::Element {
+                tag: "a".to_string(),
+                attrs: vec![("name".to_string(), "section".to_string())],
+                children: vec![],
+                void: false,
+            },
+            HastNode::Element {
+                tag: "a".to_string(),
+                attrs: vec![("href".to_string(), "#section".to_string())],
+                children: vec![HastNode::Text("link".to_string())],
+                void: false,
+            },
+        ],
+    };
+
+    let mut ctx = BuildContext {
+        source_path: Some(source.clone()),
+        project_root: PathBuf::from("/project"),
+        public_dir: PathBuf::from("/project/public"),
+        heading_registry: Some(&mut registry),
+        diagnostics: Some(&mut sink),
+        cross_file_links: None,
+    };
+
+    HeadingLinksPlugin::new().visit_with_context(&mut tree, &mut ctx);
+    let mut plugin = LinkValidationPlugin::new(LinkValidationConfig::default());
+    plugin.visit_with_context(&mut tree, &mut ctx);
+
+    let diags = sink.take();
+    assert!(
+        diags.is_empty(),
+        "bare anchor to <a name> must not emit BrokenLink: {diags:?}"
+    );
+}
+
+// ── Fixture 20: heading-bearing file unaffected (#1095) ──────────────────────
+
+/// A file WITH headings plus an explicit element id: both kinds of anchor
+/// should work, and broken ones should still fail. Ensures the #1095 fix
+/// does not alter behaviour for heading-bearing files.
+#[test]
+fn heading_file_with_element_id_both_accepted() {
+    let source = PathBuf::from("/project/docs/page.md");
+    let mut registry = HeadingRegistry::new();
+    // Pre-populate a heading entry for the source file.
+    registry.insert(
+        source.clone(),
+        HeadingEntry {
+            id: "introduction".to_string(),
+            text: "Introduction".to_string(),
+            depth: 2,
+        },
+    );
+    // Also record an explicit anchor id (as HeadingLinksPlugin would).
+    registry.insert_anchor_id(source.clone(), "custom-section".to_string());
+
+    // Both `#introduction` (heading) and `#custom-section` (explicit id) must pass.
+    let md = "[a](#introduction)\n\n[b](#custom-section)\n\n[c](#broken)\n";
+    let diags = run(
+        md,
+        source,
+        PathBuf::from("/project"),
+        &mut registry,
+        LinkValidationConfig::default(),
+    );
+    assert_eq!(
+        diags.len(),
+        1,
+        "only the genuinely broken anchor must produce a diagnostic: {diags:?}"
+    );
+    assert!(
+        matches!(&diags[0], MarkdownDiagnostic::BrokenLink { url, .. } if url == "#broken"),
+        "diagnostic url must be #broken: {diags:?}"
+    );
+}

--- a/crates/zfb-md-extras/tests/link_validation.rs
+++ b/crates/zfb-md-extras/tests/link_validation.rs
@@ -812,3 +812,72 @@ fn heading_file_with_element_id_both_accepted() {
         "diagnostic url must be #broken: {diags:?}"
     );
 }
+
+// ── Fixture 21: cross-file link to explicit element id (#1095) ───────────────
+
+/// `[x](./other.md#foo)` where `other.md` has `<div id="foo">` but NO headings
+/// must NOT emit `BrokenLink` — the fix must also cover cross-file fragment
+/// validation, not just bare same-file fragments.
+#[test]
+fn cross_file_link_to_explicit_element_id_no_diagnostic() {
+    let tmpdir = tempdir::TempDir::new("zfb-link-val-test").expect("tempdir");
+    let project_root = tmpdir.path().to_path_buf();
+    let source_path = tmpdir.path().join("page.md");
+    let other_path = tmpdir.path().join("other.md");
+    std::fs::write(&source_path, "").expect("write page.md");
+    std::fs::write(&other_path, "no headings here\n").expect("write other.md");
+
+    let mut registry = HeadingRegistry::new();
+    // Pre-populate the target file's anchor id (as HeadingLinksPlugin would
+    // have done when processing other.md with a <div id="foo"> element).
+    registry.mark_tracked(other_path.clone());
+    registry.insert_anchor_id(other_path.clone(), "foo".to_string());
+
+    let md = "[link](./other.md#foo)\n";
+    let diags = run(
+        md,
+        source_path,
+        project_root,
+        &mut registry,
+        LinkValidationConfig::default(),
+    );
+    assert!(
+        diags.is_empty(),
+        "cross-file link to explicit element id must not emit BrokenLink: {diags:?}"
+    );
+}
+
+/// Verify the regression contract: a cross-file link to a genuinely absent
+/// anchor in a headingless file must still emit `BrokenLink`.
+#[test]
+fn cross_file_link_broken_anchor_in_headingless_file_emits_diagnostic() {
+    let tmpdir = tempdir::TempDir::new("zfb-link-val-test").expect("tempdir");
+    let project_root = tmpdir.path().to_path_buf();
+    let source_path = tmpdir.path().join("page.md");
+    let other_path = tmpdir.path().join("other.md");
+    std::fs::write(&source_path, "").expect("write page.md");
+    std::fs::write(&other_path, "no headings here\n").expect("write other.md");
+
+    let mut registry = HeadingRegistry::new();
+    // Mark other.md as tracked with only one anchor id (not "missing").
+    registry.mark_tracked(other_path.clone());
+    registry.insert_anchor_id(other_path.clone(), "present".to_string());
+
+    let md = "[link](./other.md#missing)\n";
+    let diags = run(
+        md,
+        source_path,
+        project_root,
+        &mut registry,
+        LinkValidationConfig::default(),
+    );
+    assert_eq!(
+        diags.len(),
+        1,
+        "cross-file link to absent anchor must emit BrokenLink: {diags:?}"
+    );
+    assert!(
+        matches!(&diags[0], MarkdownDiagnostic::BrokenLink { url, .. } if url == "./other.md#missing"),
+        "diagnostic url must be the raw href: {diags:?}"
+    );
+}


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1096

---

## Summary

Epic #1096 — two independent markdown edge-case bug fixes (one wave, parallel subagents), plus deep-review fixes.

### #1097 — link_validation accepts explicit anchor ids (resolves #1095)
The #1093 fix registered headingless files so their bare `#anchor` links are validated against the heading registry, which only records `h2`–`h6` ids. Side effect: a bare `#anchor` to a legit non-heading target in a headingless file was flagged broken. Fix: `HeadingRegistry` now keeps a separate path-keyed explicit-anchor-id store; `HeadingLinksPlugin` records element `id` attributes and `<a name>` values during its existing walk; `validate_fragment_in_file` (and the cross-file path) emit `BrokenLink` only when **both** the heading-id and anchor-id lookups miss.
- **Known limitation:** raw-HTML `<div id>` / `<a name>` and GFM footnote ids arrive as `HastNode::Raw` (opaque strings) at walk time, so they're out of reach of an element walk — documented in code; a future fix needs a raw-HTML parse pass.

### #1098 — recursive transform of collapsed sibling/nested directives (resolves #1094)
When multiple/nested `:::` directives are collapsed into one blank-line-less paragraph, `markdown::to_mdast` merges them into a single multi-line `Text`, so only the outer block transformed. Fix: line-level re-segmentation of the collapsed body, feeding each opener/body/closer run through the existing parse → validate → `build_flow_jsx` path; nested bodies recurse. Fence matching is by colon count (outer fence uses more colons); unbalanced runs fall back to literal text without panicking; unknown directives warn exactly once.

### Deep-review fixes (this PR)
- **C1 (correctness):** an unknown/wrong-kind outer fence wrapping a known inner directive previously leaked the inner out transformed mid-prose — now the whole wrapper stays literal.
- **C2:** pinned the lenient mismatched-colon closer behavior with a test.
- **S1:** documented the cross-file `None`-branch anchor-id limitation.
- Maintainability cluster deferred to a follow-up `agent-found` issue.

## Tests
- `cargo test` green across `zfb-md-ast`, `zfb-content`, `zfb-md-extras` (447 + 23 + 3 unit + all integration suites); `clippy -D warnings` clean; `fmt` clean.
- New: registry anchor-id units; 6 link_validation integration fixtures (same-file element id, `<a name>`, broken-anchor regression, heading-bearing unaffected, cross-file valid+broken); directive real-parser tests for sibling/nested/unbalanced/inner-unknown/extra-colon/known-then-unknown plus the C1 and C2 cases.

🤖 Implemented in a limited (web) environment — Rust unit/integration coverage only; no Mac/visual verification needed (no UI).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QmbgcGk9scJwAJZR3KjRko)_