### PR TITLE
fix(deps): bump hono to >=4.12.25 (GHSA-88fw-hqm2-52qc)

### DIFF
--- a/crates/zfb/build.rs
+++ b/crates/zfb/build.rs
@@ -75,7 +75,7 @@ const PREACT_VERSION: &str = "10.29.1";
 const PREACT_RTS_VERSION: &str = "6.6.7";
 
 /// Pinned `hono` version (transitive dep of `@takazudo/zfb-runtime`).
-const HONO_VERSION: &str = "4.12.23";
+const HONO_VERSION: &str = "4.12.25";
 
 // ---------------------------------------------------------------------------
 // SHA-256 constants — esbuild 0.25.12 (from the npm package binary)

--- a/packages/zfb-runtime/package.json
+++ b/packages/zfb-runtime/package.json
@@ -80,7 +80,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "hono": "^4.12.23"
+    "hono": "^4.12.25"
   },
   "peerDependencies": {
     "@takazudo/zfb": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   devalue: ^5.8.1
+  hono: '>=4.12.25'
 
 importers:
 
@@ -194,8 +195,8 @@ importers:
   packages/zfb-runtime:
     dependencies:
       hono:
-        specifier: ^4.12.23
-        version: 4.12.23
+        specifier: '>=4.12.25'
+        version: 4.12.25
     devDependencies:
       '@takazudo/zfb':
         specifier: workspace:*
@@ -2033,8 +2034,8 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
-  hono@4.12.23:
-    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
+  hono@4.12.25:
+    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
     engines: {node: '>=16.9.0'}
 
   html-validate@10.17.0:
@@ -3600,7 +3601,7 @@ snapshots:
   '@takazudo/zfb-runtime@0.1.0-next.49(@takazudo/zfb@0.1.0-next.49)':
     dependencies:
       '@takazudo/zfb': 0.1.0-next.49
-      hono: 4.12.23
+      hono: 4.12.25
 
   '@takazudo/zfb-win32-x64-msvc@0.1.0-next.49':
     optional: true
@@ -4304,7 +4305,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
-  hono@4.12.23: {}
+  hono@4.12.25: {}
 
   html-validate@10.17.0(vitest@2.1.9(@types/node@22.19.17)(happy-dom@15.11.7)(lightningcss@1.32.0)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -28,6 +28,11 @@ minimumReleaseAge: 0
 
 overrides:
   devalue: "^5.8.1"
+  # Force hono to the patched version across the whole tree. The transitively
+  # pulled published @takazudo/zfb-runtime still requests an older hono, which
+  # carries the GHSA-88fw-hqm2-52qc CORS advisory (vulnerable <4.12.25). The
+  # override patches every path so `pnpm audit --prod --audit-level=high` passes.
+  hono: ">=4.12.25"
 
 # pnpm 11 replaces the legacy `onlyBuiltDependencies` list with `allowBuilds`,
 # a per-package true/false map. Each entry is a deliberate decision to allow


### PR DESCRIPTION
## Summary

The PR-gate `pnpm audit (prod)` check (`pnpm audit --prod --audit-level=high`) is red across the repo on the **hono CORS advisory** [GHSA-88fw-hqm2-52qc](https://github.com/advisories/GHSA-88fw-hqm2-52qc) — "CORS Middleware reflects any Origin with credentials when `origin` defaults to the wildcard", vulnerable `<4.12.25`, patched `>=4.12.25`. This is unrelated to any feature work; it blocks every PR until `hono` is bumped. Surfaced while completing #1101.

## Root cause

`hono` was resolved at `4.12.23` via two paths:
- `packages/zfb-runtime` (workspace) → declared `hono: ^4.12.23`
- the **published** `@takazudo/zfb-runtime@0.1.0-next.49`, pulled transitively through the external `@takazudo/zudo-doc` into the docs site → also requested an older `hono`

Bumping only the workspace package left the transitive published-runtime path on `4.12.23`, so the advisory persisted.

## Changes

- `packages/zfb-runtime/package.json`: `hono ^4.12.23 → ^4.12.25` (honest spec bump so the published package declares the patched floor).
- `pnpm-workspace.yaml`: add `overrides: hono: ">=4.12.25"` to force the transitively-pulled published runtime onto the patched version too. Overrides live here because pnpm 11 ignores `pnpm.*` in `package.json` (as the file's own comments document).
- `pnpm-lock.yaml`: regenerated — `hono` deduped to a single `4.12.25`.

## Test Plan

- `pnpm audit --prod --audit-level=high` → exit 0 (0 high advisories; remaining findings are low/moderate, below the gate threshold).
- `prettier --check` on changed files → clean.
- Lockfile: only `hono@4.12.25` remains; override recorded.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SB29BszsRG9iouozqdKzAJ)_