### PR TITLE
fix(zfb-content): terminate GFM autolink path at CJK boundaries — zfb#1105

### DIFF
--- a/crates/zfb-content/src/pipeline.rs
+++ b/crates/zfb-content/src/pipeline.rs
@@ -30,9 +30,10 @@ use zfb_md_ast::{CrossFileLinkCandidate, FileHeadings, HeadingIdStrategy, ReadRe
 use crate::dep_manifest::DependencyManifest;
 use crate::path_norm::normalize_path_lexically;
 use crate::plugins::{
-    BrokenLinkDiagnostic, CjkFriendlyPlugin, CodeTitlePlugin, ExternalLinksConfig,
-    ExternalLinksPlugin, HardBreaksPlugin, HeadingLinksPlugin, MermaidPlugin, ResolveLinksPlugin,
-    ResolveMarkdownLinksOptions, StripMdExtensionPlugin, SyntectPlugin, TocConfig, TocPlugin,
+    BrokenLinkDiagnostic, CjkAutolinkBoundaryPlugin, CjkFriendlyPlugin, CodeTitlePlugin,
+    ExternalLinksConfig, ExternalLinksPlugin, HardBreaksPlugin, HeadingLinksPlugin, MermaidPlugin,
+    ResolveLinksPlugin, ResolveMarkdownLinksOptions, StripMdExtensionPlugin, SyntectPlugin,
+    TocConfig, TocPlugin,
 };
 use crate::syntect_highlight::Highlighter;
 
@@ -1473,6 +1474,14 @@ impl Pipeline {
         // `push_config_derived_mdast_visitor`).
         if cjk_friendly {
             p.push_config_derived_mdast_visitor(Box::new(CjkFriendlyPlugin::new()));
+            // GFM autolink-literal CJK boundary fix (zfb#1105). Only fires when
+            // bare-URL autolinking is on (otherwise there are no autolink Link
+            // nodes to split, and gating on it keeps explicit links untouched).
+            // Both `cjk_friendly` and `autolink_literal` are already in the
+            // config fingerprint, so this wiring stays non-invalidating.
+            if resolved.autolink_literal {
+                p.push_config_derived_mdast_visitor(Box::new(CjkAutolinkBoundaryPlugin::new()));
+            }
         }
         // No directive registry here: core seeds zero directive names. Callers
         // that want `:::name` → `<Component>` go through
@@ -1721,6 +1730,11 @@ impl Pipeline {
         // `push_config_derived_mdast_visitor`).
         if cjk_friendly {
             p.push_config_derived_mdast_visitor(Box::new(CjkFriendlyPlugin::new()));
+            // GFM autolink-literal CJK boundary fix (zfb#1105) — see the twin
+            // wiring in `build_defaults` for the gating/fingerprint rationale.
+            if resolved.autolink_literal {
+                p.push_config_derived_mdast_visitor(Box::new(CjkAutolinkBoundaryPlugin::new()));
+            }
         }
         // HardBreaksPlugin runs AFTER CjkFriendlyPlugin so CJK emphasis
         // re-tokenisation sees intact Text nodes first (emphasis markers are

--- a/crates/zfb-content/src/pipeline.rs
+++ b/crates/zfb-content/src/pipeline.rs
@@ -1473,15 +1473,20 @@ impl Pipeline {
         // non-invalidating helpers (invalidation rule — see
         // `push_config_derived_mdast_visitor`).
         if cjk_friendly {
-            p.push_config_derived_mdast_visitor(Box::new(CjkFriendlyPlugin::new()));
-            // GFM autolink-literal CJK boundary fix (zfb#1105). Only fires when
-            // bare-URL autolinking is on (otherwise there are no autolink Link
-            // nodes to split, and gating on it keeps explicit links untouched).
-            // Both `cjk_friendly` and `autolink_literal` are already in the
-            // config fingerprint, so this wiring stays non-invalidating.
+            // GFM autolink-literal CJK boundary fix (zfb#1105). Runs BEFORE
+            // CjkFriendlyPlugin so it sees the single-Text-child autolink
+            // shape — emphasis retokenisation would otherwise split markers
+            // inside an over-consumed autolink's text (e.g.
+            // `https://x.com**重要。**`) and hide it from the boundary pass.
+            // Only fires when bare-URL autolinking is on (no autolink Link
+            // nodes exist otherwise, and gating on it keeps explicit links
+            // untouched). Both `cjk_friendly` and `autolink_literal` are
+            // already in the config fingerprint, so this stays
+            // non-invalidating.
             if resolved.autolink_literal {
                 p.push_config_derived_mdast_visitor(Box::new(CjkAutolinkBoundaryPlugin::new()));
             }
+            p.push_config_derived_mdast_visitor(Box::new(CjkFriendlyPlugin::new()));
         }
         // No directive registry here: core seeds zero directive names. Callers
         // that want `:::name` → `<Component>` go through
@@ -1729,12 +1734,13 @@ impl Pipeline {
         // the non-invalidating helpers (invalidation rule — see
         // `push_config_derived_mdast_visitor`).
         if cjk_friendly {
-            p.push_config_derived_mdast_visitor(Box::new(CjkFriendlyPlugin::new()));
-            // GFM autolink-literal CJK boundary fix (zfb#1105) — see the twin
-            // wiring in `build_defaults` for the gating/fingerprint rationale.
+            // GFM autolink-literal CJK boundary fix (zfb#1105) — runs BEFORE
+            // CjkFriendlyPlugin; see the twin wiring in `build_defaults` for
+            // the ordering / gating / fingerprint rationale.
             if resolved.autolink_literal {
                 p.push_config_derived_mdast_visitor(Box::new(CjkAutolinkBoundaryPlugin::new()));
             }
+            p.push_config_derived_mdast_visitor(Box::new(CjkFriendlyPlugin::new()));
         }
         // HardBreaksPlugin runs AFTER CjkFriendlyPlugin so CJK emphasis
         // re-tokenisation sees intact Text nodes first (emphasis markers are

--- a/crates/zfb-content/src/plugins.rs
+++ b/crates/zfb-content/src/plugins.rs
@@ -7,6 +7,7 @@
 //! [`MdastVisitor`]: crate::pipeline::MdastVisitor
 //! [`HastVisitor`]: crate::pipeline::HastVisitor
 
+pub mod cjk_autolink;
 pub mod cjk_friendly;
 pub mod code_title;
 pub mod directives;
@@ -20,6 +21,7 @@ pub mod syntect_plugin;
 pub mod toc;
 pub mod util;
 
+pub use cjk_autolink::CjkAutolinkBoundaryPlugin;
 pub use cjk_friendly::CjkFriendlyPlugin;
 pub use code_title::CodeTitlePlugin;
 pub use directives::{

--- a/crates/zfb-content/src/plugins/cjk_autolink.rs
+++ b/crates/zfb-content/src/plugins/cjk_autolink.rs
@@ -1,0 +1,419 @@
+//! GFM autolink-literal CJK boundary fixup (zfb#1105).
+//!
+//! GFM's extended-URL autolink **path** grammar terminates only on ASCII
+//! whitespace / EOL (`path ::= 1*( … | byte - eof - eol - space_or_tab )`),
+//! so a bare URL written flush against Japanese/Chinese/Korean text —
+//! `詳細はhttps://example.com参照してください。` — has its trailing CJK run
+//! swallowed into both the `href` and the visible link text. The domain
+//! rule already terminates on Unicode whitespace; only the path rule is
+//! affected (cmark-gfm spec issue #650).
+//!
+//! `markdown-rs` (the `markdown` crate) is a plain crates.io dependency —
+//! its tokeniser is not configurable from outside — so, exactly like
+//! [`CjkFriendlyPlugin`](super::cjk_friendly::CjkFriendlyPlugin) does for
+//! emphasis flanking, the cleanest fix is a post-parse mdast pass: find the
+//! `Link` node markdown-rs already produced for an over-consuming autolink
+//! literal and split it at the first CJK character, moving the CJK run out
+//! into a following `Text` sibling.
+//!
+//! A GFM autolink literal materialises as
+//! `Link { title: None, children: [Text(visible)], url }` where `url`
+//! either equals `visible` (the `http://` / `https://` / `ftp://` forms,
+//! whose scheme is part of the visible text) or is `visible` with `http://`
+//! prepended (the `www.` form). Email autolinks (`mailto:` URLs) already
+//! terminate before CJK in markdown-rs, so they never over-consume and are
+//! naturally skipped here.
+//!
+//! We only ever touch a `Link` whose truncated `url` reconstructs to the
+//! exact autolink markdown-rs would have built (Guard A) and still has a
+//! real host (Guard B, ≥2 dot-separated labels — rejects degenerate IDN
+//! cuts like `https://www.日本語.com参照` that would otherwise yield a
+//! hostless/partial `https://www`). Ordinary `[label](dest)` links fail
+//! these guards. The pass is also only registered when `gfm.autolinkLiteral`
+//! is on (and `markdown.cjkFriendly` is on), so a pipeline that never
+//! produces autolink literals never runs it. The one ambiguity that cannot
+//! be resolved in mdast — an author hand-writing
+//! `[https://x.com参照](https://x.com参照)`, byte-identical to an autolink —
+//! is only reachable once bare-URL autolinking is enabled, which is the
+//! same surface that produces the bug.
+
+use markdown::mdast::{Link, Node as MdastNode, Text};
+
+use super::cjk_friendly::is_cjk;
+use crate::pipeline::MdastVisitor;
+
+/// Horizontal ellipsis. Not a CJK codepoint (so it stays out of the global
+/// [`is_cjk`] table, which also governs emphasis flanking), but in CJK prose
+/// it is a sentence-internal boundary — `…ADDAC127` in the real-world repro.
+/// Treated as an autolink terminator only within this plugin.
+const HORIZONTAL_ELLIPSIS: char = '\u{2026}';
+
+/// True for a character that should terminate a GFM autolink path in CJK
+/// text: any CJK character (incl. full-width punctuation like `）` U+FF09 and
+/// `。` U+3002) plus the horizontal ellipsis.
+fn is_autolink_boundary(c: char) -> bool {
+    is_cjk(c) || c == HORIZONTAL_ELLIPSIS
+}
+
+/// GFM trailing-punctuation set. After the CJK cut, any of these left at the
+/// new end of the URL are not part of the link — GFM trims a trailing
+/// `?!.,:*_~` from an autolink (the `)` paren-balance rule is intentionally
+/// NOT re-applied: markdown-rs already balanced parens over the full run, so
+/// a `)` surviving the cut is path data, not trailing punctuation).
+fn is_gfm_trailing_punct(c: char) -> bool {
+    matches!(c, '?' | '!' | '.' | ',' | ':' | '*' | '_' | '~')
+}
+
+/// URL schemes whose host follows a `scheme://host` shape. Used by
+/// [`has_host`] to peel the scheme before validating the host. `mailto:` is
+/// intentionally absent — email autolinks never reach the split.
+const HOST_SCHEMES: [&str; 3] = ["https://", "http://", "ftp://"];
+
+/// Visitor that splits over-consuming GFM autolink-literal `Link` nodes at
+/// the first CJK character. Stateless.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct CjkAutolinkBoundaryPlugin;
+
+impl CjkAutolinkBoundaryPlugin {
+    /// New visitor; stateless.
+    #[must_use]
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl MdastVisitor for CjkAutolinkBoundaryPlugin {
+    fn visit(&mut self, node: &mut MdastNode) {
+        rewrite(node);
+    }
+}
+
+/// Walk `node`: split over-consuming autolink `Link`s in its children list,
+/// then recurse. Stops at no-recurse boundaries (verbatim / author-owned
+/// content) — mirrors [`CjkFriendlyPlugin`](super::cjk_friendly).
+fn rewrite(node: &mut MdastNode) {
+    if is_no_recurse(node) {
+        return;
+    }
+    if let Some(children) = node.children_mut() {
+        let split = split_autolinks(std::mem::take(children));
+        *children = split;
+    }
+    if let Some(children) = node.children_mut() {
+        for child in children {
+            rewrite(child);
+        }
+    }
+}
+
+/// Nodes whose subtree must NOT be touched: verbatim code, raw HTML, and
+/// MDX JSX / expression bodies (author-controlled). Same set as
+/// [`CjkFriendlyPlugin`](super::cjk_friendly).
+fn is_no_recurse(node: &MdastNode) -> bool {
+    matches!(
+        node,
+        MdastNode::Code(_)
+            | MdastNode::InlineCode(_)
+            | MdastNode::Html(_)
+            | MdastNode::MdxJsxFlowElement(_)
+            | MdastNode::MdxJsxTextElement(_)
+            | MdastNode::MdxFlowExpression(_)
+            | MdastNode::MdxTextExpression(_)
+    )
+}
+
+/// Replace each over-consuming autolink `Link` in `children` with a
+/// truncated `Link` followed by a `Text` carrying the CJK remainder. Every
+/// other child passes through untouched.
+fn split_autolinks(children: Vec<MdastNode>) -> Vec<MdastNode> {
+    let mut out = Vec::with_capacity(children.len());
+    for child in children {
+        match child {
+            MdastNode::Link(link) => match analyze(&link) {
+                Some(plan) => {
+                    out.push(MdastNode::Link(Link {
+                        url: plan.new_url,
+                        title: None,
+                        children: vec![text_node(plan.before)],
+                        position: None,
+                    }));
+                    out.push(text_node(plan.remainder));
+                }
+                None => out.push(MdastNode::Link(link)),
+            },
+            other => out.push(other),
+        }
+    }
+    out
+}
+
+/// The result of deciding to split a `Link`.
+struct SplitPlan {
+    /// Truncated `href` (and visible text) of the kept autolink.
+    new_url: String,
+    /// Kept visible text — equals `new_url` minus any scheme prefix.
+    before: String,
+    /// CJK run (plus any re-trimmed trailing punctuation) moved out into a
+    /// following `Text` sibling.
+    remainder: String,
+}
+
+/// Decide whether `link` is an over-consuming GFM autolink literal and, if
+/// so, where to cut it. Returns `None` to leave the `Link` untouched.
+fn analyze(link: &Link) -> Option<SplitPlan> {
+    // Autolink literals never carry a title and always have a single Text
+    // child. An explicit `[label](dest "title")` or a label with inline
+    // markup fails here.
+    if link.title.is_some() {
+        return None;
+    }
+    let visible = match link.children.as_slice() {
+        [MdastNode::Text(t)] => t.value.as_str(),
+        _ => return None,
+    };
+
+    // First CJK/ellipsis boundary. `k == 0` means the visible text *starts*
+    // with CJK — that is an explicit link label, never a bare URL.
+    let k = visible
+        .char_indices()
+        .find(|&(_, c)| is_autolink_boundary(c))
+        .map(|(i, _)| i)?;
+    if k == 0 {
+        return None;
+    }
+    let after0 = &visible[k..];
+
+    let before0 = &visible[..k];
+    // Re-apply GFM trailing-punctuation trimming: the cut can expose ASCII
+    // punctuation that GFM would not have considered part of the link.
+    let before = before0.trim_end_matches(is_gfm_trailing_punct);
+    if before.is_empty() {
+        return None;
+    }
+    let trimmed_tail = &before0[before.len()..];
+
+    // Peel `(CJK run) + (moved trailing punct)` off the URL's end with
+    // strip_suffix (no length arithmetic). A genuine autolink's `url` is
+    // `scheme_prefix + visible == scheme_prefix + before + trimmed_tail +
+    // after0`, so both suffixes peel cleanly; an explicit `[これは詳細](url)`
+    // whose `url` does not end with the label's CJK run fails the first
+    // strip and returns `None`.
+    let new_url = link
+        .url
+        .strip_suffix(after0)
+        .and_then(|u| u.strip_suffix(trimmed_tail))?;
+
+    // Guard A — reconstruction: the truncated URL must be exactly the
+    // autolink markdown-rs would have built for `before` — either `before`
+    // verbatim (the scheme is inside the visible text: `http(s)://`,
+    // `ftp://`) or `before` with `http://` prepended (the `www.` form). This
+    // rejects explicit links whose label merely *contains* a CJK run
+    // unrelated to the destination.
+    let is_reconstructable =
+        new_url == before || new_url.strip_prefix("http://").is_some_and(|h| h == before);
+    if !is_reconstructable {
+        return None;
+    }
+    // Guard B — real host: reject cuts that leave a scheme without a proper
+    // host (`https://日本語.com参照` → `https://`; `https://www.日本語.com参照`
+    // → `https://www`). Such inputs stay as-is rather than autolinking a
+    // partial host.
+    if !has_host(new_url) {
+        return None;
+    }
+
+    let remainder = &visible[before.len()..];
+    Some(SplitPlan {
+        new_url: new_url.to_string(),
+        before: before.to_string(),
+        remainder: remainder.to_string(),
+    })
+}
+
+/// True when `url`'s host is a real domain: at least two non-empty
+/// dot-separated labels (`example.com`, `www.example.com`) made of ASCII
+/// host characters. The host is the run after any recognised scheme up to
+/// the first `/`, `?`, or `#`. Rejects scheme-only (`https://`) and
+/// single-label (`https://www`) truncations.
+fn has_host(url: &str) -> bool {
+    let rest = HOST_SCHEMES
+        .iter()
+        .find_map(|scheme| url.strip_prefix(scheme))
+        .unwrap_or(url);
+    let host = rest.split(['/', '?', '#']).next().unwrap_or(rest);
+    let labels: Vec<&str> = host.split('.').collect();
+    labels.len() >= 2
+        && labels.iter().all(|label| {
+            !label.is_empty() && label.chars().all(|c| c.is_ascii_alphanumeric() || c == '-')
+        })
+}
+
+/// Build a position-less `Text` node (matching `CjkFriendlyPlugin`, which
+/// also drops positions on synthesised nodes).
+fn text_node(value: String) -> MdastNode {
+    MdastNode::Text(Text {
+        value,
+        position: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Parse with GFM autolink-literal ON, run the plugin, and render the
+    /// first paragraph's children to a compact, assertable string:
+    /// `Text` → its value verbatim; an autolink `Link` →
+    /// `[A href=<url> text=<visible>]`.
+    fn dump(input: &str) -> String {
+        let opts = markdown::ParseOptions {
+            constructs: markdown::Constructs {
+                gfm_autolink_literal: true,
+                ..markdown::Constructs::mdx()
+            },
+            ..markdown::ParseOptions::mdx()
+        };
+        let mut mdast = markdown::to_mdast(input, &opts).expect("markdown-rs parses fixture");
+        CjkAutolinkBoundaryPlugin::new().visit(&mut mdast);
+
+        let MdastNode::Root(root) = &mdast else {
+            unreachable!("expected Root, got {mdast:?}")
+        };
+        let MdastNode::Paragraph(p) = &root.children[0] else {
+            unreachable!("expected Paragraph, got {:?}", root.children[0])
+        };
+        let mut out = String::new();
+        for child in &p.children {
+            match child {
+                MdastNode::Text(t) => out.push_str(&t.value),
+                MdastNode::Link(l) => {
+                    let text = match l.children.as_slice() {
+                        [MdastNode::Text(t)] => t.value.as_str(),
+                        _ => "<non-text>",
+                    };
+                    out.push_str(&format!("[A href={} text={}]", l.url, text));
+                }
+                other => out.push_str(&format!("{other:?}")),
+            }
+        }
+        out
+    }
+
+    // --- The two issue #1105 repro cases. ---
+
+    #[test]
+    fn https_url_before_cjk_run_is_split() {
+        assert_eq!(
+            dump("詳細はhttps://example.com参照してください。"),
+            "詳細は[A href=https://example.com text=https://example.com]参照してください。"
+        );
+    }
+
+    #[test]
+    fn fullwidth_paren_terminates_the_path() {
+        // The real-world hit: `）` (U+FF09) is the first boundary, so the
+        // whole `）が施されており…ADDAC127` run drops out of the link.
+        assert_eq!(
+            dump("（https://ebow.com/diy-mods）が施されており…ADDAC127"),
+            "（[A href=https://ebow.com/diy-mods text=https://ebow.com/diy-mods]）が施されており…ADDAC127"
+        );
+    }
+
+    // --- Scheme variants. ---
+
+    #[test]
+    fn www_form_keeps_prepended_http_scheme() {
+        assert_eq!(
+            dump("www.example.com参照"),
+            "[A href=http://www.example.com text=www.example.com]参照"
+        );
+    }
+
+    // --- Boundary / trimming rules. ---
+
+    #[test]
+    fn cjk_full_stop_terminates() {
+        assert_eq!(
+            dump("https://example.com。"),
+            "[A href=https://example.com text=https://example.com]。"
+        );
+    }
+
+    #[test]
+    fn trailing_ascii_punct_is_re_trimmed_into_remainder() {
+        // The interior `,` becomes trailing once the path is cut at `参`,
+        // so GFM trimming moves it out of the href.
+        assert_eq!(
+            dump("https://example.com/path,参照"),
+            "[A href=https://example.com/path text=https://example.com/path],参照"
+        );
+    }
+
+    #[test]
+    fn ellipsis_is_a_boundary() {
+        assert_eq!(
+            dump("https://example.com…参照"),
+            "[A href=https://example.com text=https://example.com]…参照"
+        );
+    }
+
+    #[test]
+    fn multiple_autolinks_each_split() {
+        assert_eq!(
+            dump("https://a.com参照 https://b.com確認"),
+            "[A href=https://a.com text=https://a.com]参照 [A href=https://b.com text=https://b.com]確認"
+        );
+    }
+
+    // --- Cases that must be left UNCHANGED. ---
+
+    #[test]
+    fn ascii_terminated_autolink_unchanged() {
+        assert_eq!(
+            dump("see https://example.com for details"),
+            "see [A href=https://example.com text=https://example.com] for details"
+        );
+    }
+
+    #[test]
+    fn no_cjk_anywhere_unchanged() {
+        assert_eq!(
+            dump("https://example.com/a/b/c"),
+            "[A href=https://example.com/a/b/c text=https://example.com/a/b/c]"
+        );
+    }
+
+    #[test]
+    fn idn_cjk_in_host_left_unchanged() {
+        // First CJK is inside the host (right after the scheme) — there is no
+        // clean ASCII host to truncate to, so we leave it as markdown-rs
+        // produced it rather than emit a hostless `https://`.
+        assert_eq!(
+            dump("https://日本語.com参照"),
+            "[A href=https://日本語.com参照 text=https://日本語.com参照]"
+        );
+    }
+
+    #[test]
+    fn www_with_cjk_in_host_left_unchanged() {
+        // Guard B: truncating before `日` would leave `https://www` (a single
+        // label, no TLD) — rejected, link untouched.
+        assert_eq!(
+            dump("https://www.日本語.com参照"),
+            "[A href=https://www.日本語.com参照 text=https://www.日本語.com参照]"
+        );
+    }
+
+    #[test]
+    fn explicit_link_with_cjk_label_unchanged() {
+        // `[詳細](https://example.com)` — the label is CJK but the url is not
+        // derived from it, so the strip_suffix reconstruction fails and the
+        // explicit link is left alone. (The pathological collision
+        // `[https://x参照](https://x参照)` is byte-identical to an autolink in
+        // mdast and is intentionally NOT covered — see module docs.)
+        assert_eq!(
+            dump("[詳細](https://example.com)参照"),
+            "[A href=https://example.com text=詳細]参照"
+        );
+    }
+}

--- a/crates/zfb-content/src/plugins/cjk_autolink.rs
+++ b/crates/zfb-content/src/plugins/cjk_autolink.rs
@@ -25,17 +25,29 @@
 //! naturally skipped here.
 //!
 //! We only ever touch a `Link` whose truncated `url` reconstructs to the
-//! exact autolink markdown-rs would have built (Guard A) and still has a
-//! real host (Guard B, ≥2 dot-separated labels — rejects degenerate IDN
-//! cuts like `https://www.日本語.com参照` that would otherwise yield a
-//! hostless/partial `https://www`). Ordinary `[label](dest)` links fail
-//! these guards. The pass is also only registered when `gfm.autolinkLiteral`
-//! is on (and `markdown.cjkFriendly` is on), so a pipeline that never
-//! produces autolink literals never runs it. The one ambiguity that cannot
-//! be resolved in mdast — an author hand-writing
-//! `[https://x.com参照](https://x.com参照)`, byte-identical to an autolink —
-//! is only reachable once bare-URL autolinking is enabled, which is the
+//! exact autolink markdown-rs would have built (Guard A — the kept URL must
+//! carry a real `http(s)://`/`ftp://` scheme, or be a `www.` host with
+//! `http://` prepended) and still has a real host (Guard B — ≥2 dot-separated
+//! labels, ignoring an optional `:port`; rejects degenerate IDN cuts like
+//! `https://www.日本語.com参照` that would otherwise yield a hostless/partial
+//! `https://www`). Ordinary `[label](dest)` links — including schemeless ones
+//! like `[example.com参照](example.com参照)` — fail these guards. The truncated
+//! URL is re-trimmed with GFM's own autolink end rules (trailing `?!.,:*_~`
+//! punctuation plus the unmatched-`)` paren-balance rule), so a cut that
+//! exposes a stray `)` (`(https://example.com)参照`) drops it from the href.
+//!
+//! This pass runs in the mdast phase **before** [`CjkFriendlyPlugin`]: that
+//! plugin re-tokenises emphasis markers inside `Text` nodes (including a
+//! `Link`'s text child), which would split an over-consumed autolink's single
+//! `Text` child apart and hide it from the boundary check. It is only
+//! registered when `gfm.autolinkLiteral` is on (and `markdown.cjkFriendly` is
+//! on), so a pipeline that never produces autolink literals never runs it.
+//! The one ambiguity that cannot be resolved in mdast — an author
+//! hand-writing `[https://x.com参照](https://x.com参照)`, byte-identical to an
+//! autolink — is only reachable once bare-URL autolinking is enabled, the
 //! same surface that produces the bug.
+//!
+//! [`CjkFriendlyPlugin`]: super::cjk_friendly::CjkFriendlyPlugin
 
 use markdown::mdast::{Link, Node as MdastNode, Text};
 
@@ -55,13 +67,38 @@ fn is_autolink_boundary(c: char) -> bool {
     is_cjk(c) || c == HORIZONTAL_ELLIPSIS
 }
 
-/// GFM trailing-punctuation set. After the CJK cut, any of these left at the
-/// new end of the URL are not part of the link — GFM trims a trailing
-/// `?!.,:*_~` from an autolink (the `)` paren-balance rule is intentionally
-/// NOT re-applied: markdown-rs already balanced parens over the full run, so
-/// a `)` surviving the cut is path data, not trailing punctuation).
+/// GFM trailing-punctuation set: `?!.,:*_~` are never part of an autolink's
+/// tail (though they may appear in its interior).
 fn is_gfm_trailing_punct(c: char) -> bool {
     matches!(c, '?' | '!' | '.' | ',' | ':' | '*' | '_' | '~')
+}
+
+/// Re-apply GFM's autolink end-trimming to `url` after the CJK cut and return
+/// the kept prefix. The cut can expose tail characters that GFM would not
+/// have treated as part of the link: trailing `?!.,:*_~` punctuation, and a
+/// trailing `)` that has no matching `(` inside the link (the paren-balance
+/// rule that lets a bare URL sit inside parentheses — `(https://example.com)`).
+/// markdown-rs applied this to the *whole* over-consumed run, which ended in
+/// CJK; once we cut before the CJK, the rule must run again on the new tail.
+/// Iterates because trimming a `)` can expose more punctuation and vice versa,
+/// mirroring cmark-gfm's backward scan.
+fn trim_gfm_url_end(url: &str) -> &str {
+    let mut end = url.len();
+    loop {
+        let s = &url[..end];
+        let after_punct = s.trim_end_matches(is_gfm_trailing_punct);
+        if after_punct.len() != end {
+            end = after_punct.len();
+            continue;
+        }
+        // Trailing `)` is dropped only when the link holds more `)` than `(`.
+        if s.ends_with(')') && s.matches(')').count() > s.matches('(').count() {
+            end -= 1; // ')' is one byte
+            continue;
+        }
+        break;
+    }
+    &url[..end]
 }
 
 /// URL schemes whose host follows a `scheme://host` shape. Used by
@@ -184,33 +221,38 @@ fn analyze(link: &Link) -> Option<SplitPlan> {
     let after0 = &visible[k..];
 
     let before0 = &visible[..k];
-    // Re-apply GFM trailing-punctuation trimming: the cut can expose ASCII
-    // punctuation that GFM would not have considered part of the link.
-    let before = before0.trim_end_matches(is_gfm_trailing_punct);
+    // Re-apply GFM autolink end-trimming (trailing punctuation + unmatched
+    // `)`): the cut can expose tail characters GFM would not treat as part of
+    // the link.
+    let before = trim_gfm_url_end(before0);
     if before.is_empty() {
         return None;
     }
     let trimmed_tail = &before0[before.len()..];
 
-    // Peel `(CJK run) + (moved trailing punct)` off the URL's end with
-    // strip_suffix (no length arithmetic). A genuine autolink's `url` is
-    // `scheme_prefix + visible == scheme_prefix + before + trimmed_tail +
-    // after0`, so both suffixes peel cleanly; an explicit `[これは詳細](url)`
-    // whose `url` does not end with the label's CJK run fails the first
-    // strip and returns `None`.
+    // Peel `(CJK run) + (moved tail)` off the URL's end with strip_suffix (no
+    // length arithmetic). A genuine autolink's `url` is `scheme_prefix +
+    // visible == scheme_prefix + before + trimmed_tail + after0`, so both
+    // suffixes peel cleanly; an explicit `[これは詳細](url)` whose `url` does
+    // not end with the label's CJK run fails the first strip and returns
+    // `None`.
     let new_url = link
         .url
         .strip_suffix(after0)
         .and_then(|u| u.strip_suffix(trimmed_tail))?;
 
-    // Guard A — reconstruction: the truncated URL must be exactly the
-    // autolink markdown-rs would have built for `before` — either `before`
-    // verbatim (the scheme is inside the visible text: `http(s)://`,
-    // `ftp://`) or `before` with `http://` prepended (the `www.` form). This
-    // rejects explicit links whose label merely *contains* a CJK run
-    // unrelated to the destination.
-    let is_reconstructable =
-        new_url == before || new_url.strip_prefix("http://").is_some_and(|h| h == before);
+    // Guard A — reconstruction: the truncated URL must be exactly the autolink
+    // markdown-rs would have built for `before`. markdown-rs only emits an
+    // autolink-literal `Link` whose visible text either carries its own scheme
+    // (`http://`, `https://`, `ftp://` — then `url == visible`) or is a `www.`
+    // host with `http://` prepended. Requiring the scheme / `www.` prefix here
+    // rejects ordinary explicit links such as `[example.com参照](example.com参照)`
+    // or `[ex.com参照](http://ex.com参照)`, which are reachable because this
+    // visitor also runs over explicit `Link` nodes.
+    let is_reconstructable = (new_url == before && starts_with_url_scheme(before))
+        || new_url
+            .strip_prefix("http://")
+            .is_some_and(|h| h == before && before.starts_with("www."));
     if !is_reconstructable {
         return None;
     }
@@ -230,17 +272,30 @@ fn analyze(link: &Link) -> Option<SplitPlan> {
     })
 }
 
+/// True when `url` begins with a literal autolink scheme (`http://`,
+/// `https://`, `ftp://`) — i.e. the scheme is part of the visible text.
+fn starts_with_url_scheme(url: &str) -> bool {
+    HOST_SCHEMES.iter().any(|scheme| url.starts_with(scheme))
+}
+
 /// True when `url`'s host is a real domain: at least two non-empty
 /// dot-separated labels (`example.com`, `www.example.com`) made of ASCII
 /// host characters. The host is the run after any recognised scheme up to
-/// the first `/`, `?`, or `#`. Rejects scheme-only (`https://`) and
-/// single-label (`https://www`) truncations.
+/// the first `/`, `?`, or `#`, with an optional `:port` stripped (so
+/// `https://example.com:8080/参照` validates on `example.com`). Rejects
+/// scheme-only (`https://`) and single-label (`https://www`) truncations.
 fn has_host(url: &str) -> bool {
     let rest = HOST_SCHEMES
         .iter()
         .find_map(|scheme| url.strip_prefix(scheme))
         .unwrap_or(url);
-    let host = rest.split(['/', '?', '#']).next().unwrap_or(rest);
+    let authority = rest.split(['/', '?', '#']).next().unwrap_or(rest);
+    // Strip a trailing `:port` (digits only) so the port colon doesn't break
+    // label validation.
+    let host = match authority.rsplit_once(':') {
+        Some((h, port)) if !port.is_empty() && port.chars().all(|c| c.is_ascii_digit()) => h,
+        _ => authority,
+    };
     let labels: Vec<&str> = host.split('.').collect();
     labels.len() >= 2
         && labels.iter().all(|label| {
@@ -414,6 +469,49 @@ mod tests {
         assert_eq!(
             dump("[詳細](https://example.com)参照"),
             "[A href=https://example.com text=詳細]参照"
+        );
+    }
+
+    #[test]
+    fn schemeless_explicit_link_unchanged() {
+        // `[example.com参照](example.com参照)` is an explicit link with no URL
+        // scheme — Guard A requires a real scheme (or `www.`), so it is not
+        // mistaken for an autolink and is left untouched.
+        assert_eq!(
+            dump("[example.com参照](example.com参照)"),
+            "[A href=example.com参照 text=example.com参照]"
+        );
+    }
+
+    // --- Re-applied GFM end-trimming after the cut. ---
+
+    #[test]
+    fn unbalanced_trailing_paren_is_rebalanced() {
+        // An ASCII `(` wraps the URL; markdown-rs kept the `)` because the run
+        // ended in CJK, not `)`. After the cut, the unmatched `)` is dropped
+        // from the href and moved into the remainder.
+        assert_eq!(
+            dump("(https://example.com)参照"),
+            "([A href=https://example.com text=https://example.com])参照"
+        );
+    }
+
+    #[test]
+    fn balanced_interior_paren_is_kept() {
+        // A balanced `(bar)` inside the path stays in the href.
+        assert_eq!(
+            dump("https://example.com/foo(bar)参照"),
+            "[A href=https://example.com/foo(bar) text=https://example.com/foo(bar)]参照"
+        );
+    }
+
+    #[test]
+    fn port_is_kept_in_host() {
+        // `:8080` is a port, not a malformed label — the host still validates
+        // and the cut lands after the port.
+        assert_eq!(
+            dump("https://example.com:8080参照"),
+            "[A href=https://example.com:8080 text=https://example.com:8080]参照"
         );
     }
 }

--- a/crates/zfb-content/tests/cjk.rs
+++ b/crates/zfb-content/tests/cjk.rs
@@ -273,3 +273,125 @@ fn bold_at_cjk_boundary_default() {
     let html = render(input);
     assert_contains(&html, "<strong>強調</strong>するテキスト", input);
 }
+
+// --- GFM autolink-literal CJK boundary fix (issue #1105). ---
+
+/// Render with GFM autolink-literal ENABLED (the surface where bare URLs
+/// become `<a>` and the over-consumption bug occurs). cjkFriendly stays on
+/// (default), so `CjkAutolinkBoundaryPlugin` is wired.
+fn render_autolink(input: &str) -> String {
+    use zfb_content::pipeline::ResolvedGfmConstructs;
+    let resolved = ResolvedGfmConstructs {
+        autolink_literal: true,
+        ..ResolvedGfmConstructs::CONSERVATIVE
+    };
+    let mut p = Pipeline::with_defaults_and_gfm(resolved);
+    let hast = p.run(input).expect("pipeline runs");
+    serialize(&hast)
+}
+
+/// Render with autolink-literal ON but cjkFriendly OFF — the strict-
+/// CommonMark escape hatch, where the boundary plugin is NOT wired.
+fn render_autolink_no_cjk(input: &str) -> String {
+    use zfb_content::pipeline::ResolvedGfmConstructs;
+    let resolved = ResolvedGfmConstructs {
+        autolink_literal: true,
+        ..ResolvedGfmConstructs::CONSERVATIVE
+    };
+    let mut p = Pipeline::with_defaults_and_theme_and_gfm_and_cjk(None, resolved, false);
+    let hast = p.run(input).expect("pipeline runs");
+    serialize(&hast)
+}
+
+/// The exact expected output from issue #1105: the link stops at the URL and
+/// the Japanese run becomes following text.
+#[test]
+fn autolink_cjk_boundary_matches_issue_expected() {
+    let input = "詳細はhttps://example.com参照してください。\n";
+    let html = render_autolink(input);
+    assert_contains(
+        &html,
+        "<p>詳細は<a href=\"https://example.com\">https://example.com</a>参照してください。</p>",
+        input,
+    );
+}
+
+/// Real-world hit: a full-width `）` terminates the path; the link no longer
+/// swallows the trailing sentences up to the first ASCII token.
+#[test]
+fn autolink_fullwidth_paren_terminates_path() {
+    let input = "（https://ebow.com/diy-mods）が施されており…ADDAC127\n";
+    let html = render_autolink(input);
+    assert_contains(
+        &html,
+        "<a href=\"https://ebow.com/diy-mods\">https://ebow.com/diy-mods</a>）が施されており",
+        input,
+    );
+    // The href must NOT contain any CJK.
+    assert_lacks(&html, "href=\"https://ebow.com/diy-mods）", input);
+}
+
+/// `www.` autolink keeps its prepended `http://` scheme after the cut.
+/// (markdown-rs only recognises a `www.` autolink at the start of a line or
+/// after whitespace / `*_~(`, so the bare URL leads the paragraph here.)
+#[test]
+fn autolink_www_form_split() {
+    let input = "www.example.com参照\n";
+    let html = render_autolink(input);
+    assert_contains(
+        &html,
+        "<a href=\"http://www.example.com\">www.example.com</a>参照",
+        input,
+    );
+}
+
+/// An ASCII-terminated autolink in CJK context is untouched.
+#[test]
+fn autolink_ascii_terminated_unchanged() {
+    let input = "詳細は https://example.com です\n";
+    let html = render_autolink(input);
+    assert_contains(
+        &html,
+        "<a href=\"https://example.com\">https://example.com</a>",
+        input,
+    );
+}
+
+/// The fix reaches autolinks inside headings (heading anchors are added on
+/// top, but the autolink href itself must already be clean).
+#[test]
+fn autolink_cjk_boundary_inside_heading() {
+    let input = "## 参考https://example.com詳細\n";
+    let html = render_autolink(input);
+    assert_contains(
+        &html,
+        "<a href=\"https://example.com\">https://example.com</a>詳細",
+        input,
+    );
+    assert_lacks(&html, "href=\"https://example.com詳細", input);
+}
+
+/// Gating: with autolink-literal OFF (the default), bare URLs are not
+/// autolinked at all, so the plugin has nothing to do and the URL stays
+/// literal text — no `<a>` tag, no behavior change.
+#[test]
+fn autolink_off_leaves_bare_url_as_text() {
+    let input = "詳細はhttps://example.com参照してください。\n";
+    let html = render(input);
+    assert_lacks(&html, "<a href", input);
+    assert_contains(&html, "https://example.com参照してください。", input);
+}
+
+/// Gating: with cjkFriendly OFF (strict-CommonMark escape hatch), the
+/// boundary plugin is not wired, so the stock markdown-rs over-consumption
+/// is preserved — documents the opt-out.
+#[test]
+fn autolink_cjk_friendly_false_preserves_overconsumption() {
+    let input = "詳細はhttps://example.com参照してください。\n";
+    let html = render_autolink_no_cjk(input);
+    assert_contains(
+        &html,
+        "<a href=\"https://example.com参照してください。\">",
+        input,
+    );
+}

--- a/crates/zfb-content/tests/cjk.rs
+++ b/crates/zfb-content/tests/cjk.rs
@@ -371,6 +371,25 @@ fn autolink_cjk_boundary_inside_heading() {
     assert_lacks(&html, "href=\"https://example.com詳細", input);
 }
 
+/// Over-consumed autolink whose swallowed CJK run contains emphasis markers.
+/// The boundary pass must run BEFORE CjkFriendlyPlugin: the link splits at the
+/// first CJK char (the trailing `**` is GFM trailing punctuation, trimmed into
+/// the remainder), then CjkFriendlyPlugin turns the remainder's `**重要。**`
+/// into `<strong>`.
+#[test]
+fn autolink_split_runs_before_cjk_emphasis_retokenisation() {
+    let input = "https://example.com**重要。**テスト\n";
+    let html = render_autolink(input);
+    assert_contains(
+        &html,
+        "<a href=\"https://example.com\">https://example.com</a>",
+        input,
+    );
+    assert_contains(&html, "<strong>重要。</strong>テスト", input);
+    // The href must not have swallowed the emphasis markers / CJK.
+    assert_lacks(&html, "example.com**", input);
+}
+
 /// Gating: with autolink-literal OFF (the default), bare URLs are not
 /// autolinked at all, so the plugin has nothing to do and the URL stays
 /// literal text — no `<a>` tag, no behavior change.

--- a/crates/zfb/src/config.rs
+++ b/crates/zfb/src/config.rs
@@ -987,19 +987,26 @@ pub struct MarkdownConfig {
     #[serde(default)]
     pub external_links: Option<ExternalLinksConfig>,
 
-    /// Enable CJK-friendly emphasis/strong re-tokenisation.
+    /// Enable CJK-friendly markdown handling.
+    ///
+    /// Governs two mdast post-processors that adapt CommonMark/GFM rules to
+    /// CJK text: [`CjkFriendlyPlugin`] (emphasis/strong flanking around CJK
+    /// punctuation) and [`CjkAutolinkBoundaryPlugin`] (terminating a GFM
+    /// autolink-literal path at the first CJK character — zfb#1105; only
+    /// active when `gfm.autolinkLiteral` is also on).
     ///
     /// - `None` (absent, default) — CJK-friendly is **on**. Preserves
     ///   today's behaviour so existing CJK-content sites are unaffected
     ///   by the new field.
     /// - `Some(true)` — explicit opt-in; identical to absent.
-    /// - `Some(false)` — opt-out. [`CjkFriendlyPlugin`] is NOT added to
-    ///   the mdast pipeline; emphasis markers adjacent to CJK characters
-    ///   follow base CommonMark flanking rules (rarely the right choice;
-    ///   provided as an escape hatch for projects that need strict
-    ///   CommonMark output).
+    /// - `Some(false)` — opt-out. Neither plugin is added to the mdast
+    ///   pipeline; emphasis markers and bare-URL autolinks adjacent to CJK
+    ///   characters follow base CommonMark/GFM rules (rarely the right
+    ///   choice; provided as an escape hatch for projects that need strict
+    ///   CommonMark/GFM output).
     ///
     /// [`CjkFriendlyPlugin`]: zfb_content::plugins::CjkFriendlyPlugin
+    /// [`CjkAutolinkBoundaryPlugin`]: zfb_content::plugins::CjkAutolinkBoundaryPlugin
     #[serde(default)]
     pub cjk_friendly: Option<bool>,
 

--- a/packages/zfb/src/config.ts
+++ b/packages/zfb/src/config.ts
@@ -664,25 +664,35 @@ export type MarkdownConfig = {
   externalLinks?: ExternalLinksConfig;
 
   /**
-   * Enable CJK-friendly emphasis/strong re-tokenisation.
+   * Enable CJK-friendly markdown handling.
    *
-   * CommonMark's left-/right-flanking delimiter-run rules treat CJK
-   * characters as non-whitespace non-punctuation, which causes `**foo**`
-   * adjacent to CJK text (e.g. `**テスト。**テスト`) to render as literal
-   * stars instead of `<strong>`. zfb's built-in `CjkFriendlyPlugin`
-   * corrects this post-parse.
+   * Governs two post-parse fixups that adapt CommonMark/GFM rules to CJK
+   * text:
    *
-   * - **absent / `true` (default):** CJK-friendly re-tokenisation is
-   *   on. Preserves today's behaviour — existing CJK-content sites are
+   * 1. **Emphasis/strong flanking** (`CjkFriendlyPlugin`). CommonMark's
+   *    left-/right-flanking delimiter-run rules treat CJK characters as
+   *    non-whitespace non-punctuation, which causes `**foo**` adjacent to
+   *    CJK text (e.g. `**テスト。**テスト`) to render as literal stars
+   *    instead of `<strong>`.
+   * 2. **Bare-URL autolink boundary** (`CjkAutolinkBoundaryPlugin`,
+   *    zfb#1105). The GFM autolink-literal path grammar terminates only on
+   *    ASCII whitespace, so a bare URL flush against CJK text
+   *    (`詳細はhttps://example.com参照`) swallows the trailing CJK run into
+   *    the `href`. This fixup terminates the link at the first CJK
+   *    character. Only active when `gfm.autolinkLiteral` is also on.
+   *
+   * - **absent / `true` (default):** CJK-friendly handling is on.
+   *   Preserves today's behaviour — existing CJK-content sites are
    *   unaffected.
-   * - **`false`:** opt-out. `CjkFriendlyPlugin` is NOT added to the
-   *   pipeline; emphasis markers adjacent to CJK characters follow base
-   *   CommonMark flanking rules. Rarely the right choice; provided as
-   *   an escape hatch for projects that need strict CommonMark output.
+   * - **`false`:** opt-out. Neither plugin is added to the pipeline;
+   *   emphasis markers and bare-URL autolinks adjacent to CJK characters
+   *   follow base CommonMark/GFM rules. Rarely the right choice; provided
+   *   as an escape hatch for projects that need strict CommonMark/GFM
+   *   output.
    *
    * **GFM strikethrough** (`~~foo~~`) at CJK boundaries is unaffected
    * by this toggle — it is handled by markdown-rs's GFM tokeniser, not
-   * by `CjkFriendlyPlugin`, and works correctly in both modes.
+   * by these plugins, and works correctly in both modes.
    *
    * Mirrors `MarkdownConfig::cjk_friendly` in crates/zfb/src/config.rs.
    */


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1105

---

## Summary

GFM's autolink-literal **path** grammar terminates only on ASCII whitespace/EOL, so a bare URL written flush against Japanese/Chinese/Korean text — `詳細はhttps://example.com参照してください。` — has its trailing CJK run swallowed into both the `href` and the visible link text (cmark-gfm spec issue #650; the domain rule already terminates on Unicode whitespace, only the path rule is affected). Fixes #1105.

`markdown-rs` (the `markdown` crate) is a plain crates.io dependency whose tokeniser is not configurable, so — mirroring the existing `CjkFriendlyPlugin` post-AST approach — this adds a new mdast visitor **`CjkAutolinkBoundaryPlugin`** that splits an over-consuming autolink `Link` at the first CJK character, moving the CJK run into a following `Text` sibling.

### Before / after

```html
<!-- before -->
<p>詳細は<a href="https://example.com参照してください。">https://example.com参照してください。</a></p>
<!-- after -->
<p>詳細は<a href="https://example.com">https://example.com</a>参照してください。</p>
```

## Changes

- **New plugin** `crates/zfb-content/src/plugins/cjk_autolink.rs`: walks the mdast (same no-recurse boundaries as `CjkFriendlyPlugin`), and for each over-consuming autolink-literal `Link` splits it at the first CJK boundary (CJK chars, full-width punctuation like `）`/`。`, and the `…` ellipsis). Guards keep ordinary `[label](dest)` links untouched:
  - **Guard A (reconstruction):** the truncated URL must be exactly what markdown-rs would build — a real `http(s)://`/`ftp://` literal, or a `www.` host with `http://` prepended. Rejects schemeless explicit links.
  - **Guard B (host):** ≥2 dot-separated labels (ignoring an optional `:port`). Rejects degenerate IDN cuts (`https://www.日本語.com参照`) that would yield a hostless `https://www`.
  - **GFM end re-trim:** trailing `?!.,:*_~` punctuation and the unmatched-`)` paren-balance rule are re-applied after the cut (`(https://example.com)参照` drops the stray `)`).
- **Pipeline wiring** (`pipeline.rs`): registered via the non-invalidating helper, gated on `cjk_friendly && gfm.autolinkLiteral`, and ordered **before** `CjkFriendlyPlugin` (so emphasis retokenisation doesn't fragment an over-consumed autolink's `Text` child first). Both flags are already in the config fingerprint → default pipelines stay byte-identical.
- **Config docs** (`config.rs`, `config.ts`): `cjkFriendly` now documents that it also governs the autolink boundary fix.

## Test Plan

- 16 unit tests (`cjk_autolink.rs`) + 9 integration tests (`tests/cjk.rs`, pipeline → HTML with `autolinkLiteral` on): issue repro, full-width paren, `www.`, trailing-punct re-trim, ellipsis boundary, multiple autolinks, paren rebalance, port, emphasis-in-overconsumed (ordering), plus unchanged cases (ASCII-terminated, IDN/host-degenerate, schemeless/explicit links) and gating (autolink-off, `cjkFriendly: false`).
- `cargo test -p zfb-content` (all green), `cargo clippy --all-targets` (clean), `cargo fmt --check`, `pnpm --filter @takazudo/zfb typecheck`.

## Review

Plan validated via codex 2nd-opinion (CJK boundary predicate, IDN/host guards); codex code-review then surfaced 4 correctness gaps (loose Guard A, plugin ordering, paren balancing, ports) — all fixed in the second commit with tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)