### PR TITLE
chore(deps): bump @takazudo/* in docs to latest published versions

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -13,10 +13,10 @@
     "b4push": "pnpm check && pnpm build"
   },
   "dependencies": {
-    "@takazudo/zfb": "0.1.0-next.53",
-    "@takazudo/zfb-runtime": "0.1.0-next.53",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.53",
-    "@takazudo/zudo-doc": "^0.2.15",
+    "@takazudo/zfb": "0.1.0-next.57",
+    "@takazudo/zfb-runtime": "0.1.0-next.57",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.57",
+    "@takazudo/zudo-doc": "^0.2.19",
     "zod": "^4.0.0",
     "preact": "^10.29.1",
     "preact-render-to-string": "^6.6.6",
@@ -31,7 +31,7 @@
     "katex": "^0.16.38",
     "minisearch": "^7.2.0",
     "diff": "^8.0.3",
-    "@takazudo/zudo-doc-history-server": "^0.2.15"
+    "@takazudo/zudo-doc-history-server": "^0.2.19"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,20 +47,20 @@ importers:
         specifier: ^4.0.0
         version: 4.0.2
       '@takazudo/zfb':
-        specifier: 0.1.0-next.53
-        version: 0.1.0-next.53
+        specifier: 0.1.0-next.57
+        version: 0.1.0-next.57(react@19.2.6)
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.53
-        version: 0.1.0-next.53
+        specifier: 0.1.0-next.57
+        version: 0.1.0-next.57
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.53
-        version: 0.1.0-next.53(@takazudo/zfb@0.1.0-next.53)
+        specifier: 0.1.0-next.57
+        version: 0.1.0-next.57(@takazudo/zfb@0.1.0-next.57(react@19.2.6))(react@19.2.6)
       '@takazudo/zudo-doc':
-        specifier: ^0.2.15
-        version: 0.2.15(@takazudo/zfb-runtime@0.1.0-next.53(@takazudo/zfb@0.1.0-next.53))(@takazudo/zfb@0.1.0-next.53)(@takazudo/zudo-doc-history-server@0.2.15)(preact@10.29.1)(shiki@4.2.0)
+        specifier: ^0.2.19
+        version: 0.2.19(@takazudo/zfb-runtime@0.1.0-next.57(@takazudo/zfb@0.1.0-next.57(react@19.2.6))(react@19.2.6))(@takazudo/zfb@0.1.0-next.57(react@19.2.6))(@takazudo/zudo-doc-history-server@0.2.19)(preact@10.29.1)(shiki@4.2.0)
       '@takazudo/zudo-doc-history-server':
-        specifier: ^0.2.15
-        version: 0.2.15
+        specifier: ^0.2.19
+        version: 0.2.19
       clsx:
         specifier: ^2.1.0
         version: 2.1.1
@@ -1415,57 +1415,66 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.53':
-    resolution: {integrity: sha512-OCcil6XTYLQgO/8djT3WvLPzhgm2FbA1RT9vYePFIKTnz8BNx61oxiCUWrkWmwX8ac6K5f3rQL5xpsXTQR3CzQ==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.57':
+    resolution: {integrity: sha512-s9sTBi+T9WjhxZraO6vNlb1sphR0qVMY2YSrzztGHkkX/rIVq6JfVO08WG9EmdidLYW5KN3+KJ+aTXkABGf5rw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.53':
-    resolution: {integrity: sha512-UZMEukrgfHeQ5+y14xrXXAPOAq6QI1LI6y+dNxPNmmZSJIjrzRAFU0TjPAQiltl2ZdUsszv17udqc2scemc4lA==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.57':
+    resolution: {integrity: sha512-T/vYGwwv3XL7J1x+Hr4rio7MjpYKblxsKgZuxLXQrCqoopw6LbNCREiK7mwxJkGkdpgF++fEQA6yTHi4cq/peQ==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.53':
-    resolution: {integrity: sha512-2HUkqqs+XrJLLw18OCv7Ky6EEXegIOhd7R8Xrqr8w+GbVv6Nw4TxHLLhjb9Qr97FlwMJ9mVewPYlBLYiDJjTqw==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.57':
+    resolution: {integrity: sha512-9LJaMCitmff70yAZwmewMKWVHRW7re7HNcwlkNT0a0loGWKAnQ3PDGXvprju3SKRFIvmlLFvZ3dO7O1jgqjZww==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.53':
-    resolution: {integrity: sha512-RixlNp1m7DBGqq9PWGMYtxmgg3GIbvYeI13zzMGez47UMRSpglH93Gg3LgSwpBs5c8oaPgLFQHn3pDDJDN9yog==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.57':
+    resolution: {integrity: sha512-m+kKO/7RH/P0Uy6W2+wN9zEhw0vmG08pmr71lngIkr8/+78Qcn8YIEUwFCju+i7SbPzQrxCXIVXRhZF69NUD0w==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.53':
-    resolution: {integrity: sha512-xyCvdL97WkhdBwxIagVq/xZuAzCaypwNUNDaQ7itxq/tfbBt2oyVv5H7vcEW/oG0RXRTFJMABJH2G+Y/9VZkbQ==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.57':
+    resolution: {integrity: sha512-UhOShcv4GQmWn3dZfx8r+cnbk6KJHO2xjS55RyvB7+PD1P5Dh+KYSEKmVSjEqo0+fWZpOD5Z98yAlMW6He2aMg==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.53':
-    resolution: {integrity: sha512-5i7+VjHr8P0o1R9fnCmU/mp6fadg1CZm42GqH9njomwAj+41pz1MQ+T0iQru8PCiTtLG9B+Inbv/dXdGTKWvLA==}
+  '@takazudo/zfb-runtime@0.1.0-next.57':
+    resolution: {integrity: sha512-6kLRpr9UQ/1OtPIrG0kL8wDM/e7dxR07C+cmOctqn8TLZi6hpt/taI7pHpuXUu3YePYgI7W++RZQZmZAcQFKjw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.53
+      '@takazudo/zfb': 0.1.0-next.57
+      react: ^19.2.3
+    peerDependenciesMeta:
+      react:
+        optional: true
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.53':
-    resolution: {integrity: sha512-F3AgrTycPsA9/eQm8E141EvWkc+oBaDwI4m1H/kGfuwQJiX8vcrFqZTLy33FfYKxfKqA3TLaRu4rwoO7t2g6vA==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.57':
+    resolution: {integrity: sha512-GrmRMqX26Y114J9PoyrOXjxED/7m0ZJY4sQKFTUDdzDBCO0cIRFFIrB9N5xFCmTYGQ8a/NJnsDCH0knHf4JsyQ==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.53':
-    resolution: {integrity: sha512-iwed5oRyMWyvE6VB6H0jE6qyIQ24R1M4uUzIeN38VJf1xqKJiCglNwP1J8dduhDEX0F1jtsWrBexfHxnp6K/vw==}
+  '@takazudo/zfb@0.1.0-next.57':
+    resolution: {integrity: sha512-DL02nzWhxn3cgn2UHzQIgwAkWQlfkZK4BHpe/+ieLdp+GXMl7ZDDpHAh4phTBYFdKmVfGREdBAPc1P9MJ9YblQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
+    peerDependencies:
+      react: ^19.2.3
+    peerDependenciesMeta:
+      react:
+        optional: true
 
-  '@takazudo/zudo-doc-history-server@0.2.15':
-    resolution: {integrity: sha512-IKrXOMJCBDzpcZVYiv2b1bPGeEIIxaSIepvIiRjySD6uBPF+tAzHfoKkpxQDJGn4f3crWdNEnuUCLO/sGYpP/A==}
+  '@takazudo/zudo-doc-history-server@0.2.19':
+    resolution: {integrity: sha512-ZlAKVUW+kecikJImbgbWhRgG0R693O5lBzFa899Jt7x/y/zoDpGedtgq6UlIqD+aGyFk+GfkNrsfca9EM9AT9w==}
     hasBin: true
 
-  '@takazudo/zudo-doc@0.2.15':
-    resolution: {integrity: sha512-f5k0BJFfYzArvyR4tErPltc3i3OpQIWM+Ybd935c7lRT/6I60G9Yag2dtCQ+vx8iZkYkWle1BtUHOfitIXyO7g==}
+  '@takazudo/zudo-doc@0.2.19':
+    resolution: {integrity: sha512-FZ/AGerj5flPqy4Wa662owgW7I1lI/kkrcnjCxsgj2fIbvy5bdzCfw+J+BTz9/J0RljjHSZgcGbtg7nMr97zVA==}
     peerDependencies:
       '@takazudo/zdtp': ^0.2.3
-      '@takazudo/zfb': ^0.1.0-next.53
-      '@takazudo/zfb-runtime': ^0.1.0-next.53
+      '@takazudo/zfb': ^0.1.0-next.57
+      '@takazudo/zfb-runtime': ^0.1.0-next.57
       '@takazudo/zudo-doc-history-server': ^0.2.15
       preact: ^10.29.1
       shiki: ^4.0.2
@@ -3584,46 +3593,49 @@ snapshots:
       tailwindcss: 4.2.4
       vite: 7.3.5(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.4)
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.53': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.57': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.53':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.57':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.53':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.57':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.53':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.57':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.53':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.57':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.53(@takazudo/zfb@0.1.0-next.53)':
+  '@takazudo/zfb-runtime@0.1.0-next.57(@takazudo/zfb@0.1.0-next.57(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.53
+      '@takazudo/zfb': 0.1.0-next.57(react@19.2.6)
       hono: 4.12.25
+    optionalDependencies:
+      react: 19.2.6
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.53':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.57':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.53':
+  '@takazudo/zfb@0.1.0-next.57(react@19.2.6)':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.53
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.53
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.53
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.53
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.53
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.57
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.57
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.57
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.57
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.57
+      react: 19.2.6
 
-  '@takazudo/zudo-doc-history-server@0.2.15': {}
+  '@takazudo/zudo-doc-history-server@0.2.19': {}
 
-  '@takazudo/zudo-doc@0.2.15(@takazudo/zfb-runtime@0.1.0-next.53(@takazudo/zfb@0.1.0-next.53))(@takazudo/zfb@0.1.0-next.53)(@takazudo/zudo-doc-history-server@0.2.15)(preact@10.29.1)(shiki@4.2.0)':
+  '@takazudo/zudo-doc@0.2.19(@takazudo/zfb-runtime@0.1.0-next.57(@takazudo/zfb@0.1.0-next.57(react@19.2.6))(react@19.2.6))(@takazudo/zfb@0.1.0-next.57(react@19.2.6))(@takazudo/zudo-doc-history-server@0.2.19)(preact@10.29.1)(shiki@4.2.0)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.53
-      '@takazudo/zfb-runtime': 0.1.0-next.53(@takazudo/zfb@0.1.0-next.53)
+      '@takazudo/zfb': 0.1.0-next.57(react@19.2.6)
+      '@takazudo/zfb-runtime': 0.1.0-next.57(@takazudo/zfb@0.1.0-next.57(react@19.2.6))(react@19.2.6)
       gray-matter: 4.0.3
       preact: 10.29.1
     optionalDependencies:
-      '@takazudo/zudo-doc-history-server': 0.2.15
+      '@takazudo/zudo-doc-history-server': 0.2.19
       shiki: 4.2.0
 
   '@types/d3-array@3.2.2': {}


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1159
    - https://github.com/Takazudo/zudo-front-builder/issues/1158 (epic)

---

## Summary

Bring the published `@takazudo/*` versions pinned by the `docs/` site current with the engine the
repo now ships. `docs/` is the only published-version consumer of `@takazudo/*` in this repo (all
other refs use the `workspace:` protocol).

| dep | from | to |
|---|---|---|
| `@takazudo/zfb` | `0.1.0-next.53` | `0.1.0-next.57` |
| `@takazudo/zfb-runtime` | `0.1.0-next.53` | `0.1.0-next.57` |
| `@takazudo/zfb-adapter-cloudflare` | `0.1.0-next.53` | `0.1.0-next.57` |
| `@takazudo/zudo-doc` | `^0.2.15` | `^0.2.19` |
| `@takazudo/zudo-doc-history-server` | `^0.2.15` | `^0.2.19` |

## Changes

- `docs/package.json` — five `@takazudo/*` deps bumped (range style preserved: exact pins for the
  zfb-stack, `^` for the zudo-doc pair).
- `pnpm-lock.yaml` — refreshed; version-only diff plus benign published-package metadata.

## Verification

- `pnpm docs:check` — ✅ no errors.
- `pnpm docs:build` — ✅ 275 pages built.
- Lockfile confirmed: docs's `@takazudo/zfb*` still resolves from the **npm registry**
  (integrity hash), not a workspace `link:` — the dogfood-the-published-artifact intent is
  preserved (pnpm 11 `linkWorkspacePackages` default false; no override in the repo).

## Notes

- `zudo-doc@0.2.19` tightened its zfb peer range to `^0.1.0-next.57`; the lockstep zfb bump
  satisfies it (bumping zudo-doc alone would have caused a peer mismatch).
- The optional `react@19.2.6` peer that appears in the lockfile flows from the published package
  (an optional peer added in next.54), not repo churn — harmless for the Preact docs.
- Pre-existing benign build warnings unchanged: `_category_.json` "unsupported data-file"
  notices (documented in `docs/CLAUDE.md`) and the `ThemeToggle` island-marker collision, where
  the docs site's own `src/components/theme-toggle.tsx` intentionally overrides the one shipped by
  `@takazudo/zudo-doc` (the build keeps the docs component, which is the desired behavior).

## Out of scope (verified)

- `@takazudo/mdx-formatter@1.2.1` dlx pins (root `package.json`) — `latest` dist-tag is still
  `1.2.1`; already current.
- `workspace:`-protocol `@takazudo/*` refs in `packages/*` / `crates/*` — release-managed, not deps.

Resolves #1159.

---
_Generated by [Claude Code](https://claude.ai/code/session_011Eg5wv8nfkmrgd242y2XRx)_