### PR TITLE
fix(dev): defer the eager islands build past TcpListener::bind (#1172)

### DIFF
--- a/crates/zfb-build/src/orchestrator.rs
+++ b/crates/zfb-build/src/orchestrator.rs
@@ -928,12 +928,14 @@ impl<P: AssetPipeline> BuildOrchestrator<P> {
     /// #644). `zfb build` was unaffected because it never goes through
     /// the orchestrator at all.
     ///
-    /// Pages-only by design: the dev command already bundles CSS and
-    /// islands eagerly at boot (the #494 / #377 wiring) before
-    /// constructing the orchestrator, so re-running those sub-pipelines
-    /// here would be redundant work. We force `PageSelection::All` (not a
-    /// change-derived plan) so the result does not depend on the graph's
-    /// reverse-edge state — the seeded page nodes are enough.
+    /// Pages-only by design: in dev, CSS is bundled eagerly at boot (the
+    /// #494 wiring), and the islands bundle is produced out-of-band by the
+    /// deferred boot task (the #377 / #1170 wiring — no longer before the
+    /// orchestrator, but it never flows through this `apply` either), so
+    /// re-running those sub-pipelines here would be redundant work. We force
+    /// `PageSelection::All` (not a change-derived plan) so the result does
+    /// not depend on the graph's reverse-edge state — the seeded page nodes
+    /// are enough.
     ///
     /// Returns `Ok(None)` only when the graph has zero pages (nothing to
     /// render); otherwise `Ok(Some(outcome))` whose `pages_rendered`
@@ -941,9 +943,12 @@ impl<P: AssetPipeline> BuildOrchestrator<P> {
     pub fn initial_build(&self, ctx: &BuildContext) -> Result<Option<BuildOutcome>> {
         let mut plan = RebuildPlan::empty();
         plan.mark_pages(PageSelection::All);
-        // The dev command bundles eagerly at boot right before this
-        // call — the renderer is already bound to a fresh bundle, so the
-        // pipeline must not re-bundle again for the initial render.
+        // The dev renderer's page bundle is built eagerly at boot
+        // (`boot_dev_renderer`, before the bind) — the renderer is already
+        // bound to a fresh bundle, so the pipeline must not re-bundle it
+        // again for the initial render. (This is the V8 page bundle, distinct
+        // from the islands bundle, which the deferred boot task builds
+        // out-of-band — issue #1170.)
         plan.mark_renderer_fresh();
         self.resolve_all(&mut plan);
         if plan.pages.is_empty() {

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -337,15 +337,16 @@ pub async fn run(args: &DevArgs) -> Result<()> {
 
     // 3. Build orchestrator setup.
     //
-    // Issue #1166 — the manifest-digest + persisted-graph load + graph
-    // seed + boot render are all DEFERRED past `TcpListener::bind` (see
-    // the deferred task in step 7 below). The cold-start hang #1161
-    // reports is `compute_manifest_digest`'s `WalkDir`+`metadata()` walk
-    // over the watched tree; running it before bind made the port's
-    // reachability scale with the static-asset / watched-tree SIZE.
-    // Binding first and doing this walk on a background task makes the
-    // server accept connections in O(1) regardless of tree size,
-    // completing #1057's "serve immediately" intent.
+    // Issues #1166, #1170 — the manifest-digest + persisted-graph load +
+    // graph seed + boot render + eager islands bundle are all DEFERRED past
+    // `TcpListener::bind` (see the deferred task in step 7 below). The
+    // cold-start hang #1161 reports is `compute_manifest_digest`'s
+    // `WalkDir`+`metadata()` walk over the watched tree; #1170's is the
+    // islands `"use client"` scan + esbuild bundle — both ran before bind
+    // and made the port's reachability scale with the watched-tree /
+    // dependency-tree SIZE. Binding first and doing this work on a
+    // background task makes the server accept connections in O(1) regardless
+    // of tree size, completing #1057's "serve immediately" intent.
     //
     // Cold-start optimisation (now performed inside the deferred task):
     // try to reuse a previously persisted graph from `.zfb/graph.bin`.
@@ -924,14 +925,17 @@ pub async fn run(args: &DevArgs) -> Result<()> {
         Err(e) => return Err(e),
     };
 
-    // 7b. Deferred boot task (issue #1166). Now that the listener is
-    //     bound and the server is about to accept connections, run the
+    // 7b. Deferred boot task (issues #1166, #1170). Now that the listener
+    //     is bound and the server is about to accept connections, run the
     //     work that used to block the bind:
     //       1. compute_manifest_digest (the size-bound walk we moved)
     //       2. load_persisted_graph (digest-gated cache reuse)
     //       3. seed the graph from session.page_ids()
     //       4. boot render (boot-lazy mark-stale vs eager initial_build)
-    //       5. orchestrator.run (the watcher loop)
+    //       5. eager islands bundle (issue #1170 — the other size-bound
+    //          step we moved; folded into the boot outcome so a tab loaded
+    //          during the pre-bundle window gets a livereload and hydrates)
+    //     then orchestrator.run drains the watcher loop.
     //     The digest is published into `manifest_digest_slot` so the
     //     shutdown persistence path (step 8) can read it; until it lands
     //     the slot stays `None` and an early Ctrl+C skips the save.
@@ -966,11 +970,11 @@ pub async fn run(args: &DevArgs) -> Result<()> {
             }
         }
 
-        // Steps 1-4 (digest walk, persisted-graph load, graph seed, boot
-        // render) now run inside a ONE-SHOT BOOT HOOK that
-        // `BuildOrchestrator::run_with_boot` invokes AFTER the notify watch
-        // is registered but BEFORE the drain loop consumes events (issue
-        // #1166 startup-race fixes):
+        // Steps 1-5 (digest walk, persisted-graph load, graph seed, boot
+        // render, and the eager islands bundle — issue #1170) now run inside
+        // a ONE-SHOT BOOT HOOK that `BuildOrchestrator::run_with_boot`
+        // invokes AFTER the notify watch is registered but BEFORE the drain
+        // loop consumes events (issue #1166 startup-race fixes):
         //
         //   - Finding 2 (missed-edit window): registering `watch()` first
         //     means a source edit saved during the digest walk / boot
@@ -1132,8 +1136,9 @@ pub async fn run(args: &DevArgs) -> Result<()> {
             }
         };
 
-        // 5. Orchestrator watcher loop — registers the watch, runs the boot
-        //    hook above, then drains change events until aborted on shutdown.
+        // Orchestrator watcher loop — registers the watch, runs the boot
+        // hook above (steps 1-5), then drains change events until aborted on
+        // shutdown.
         if let Err(err) = orchestrator
             .run_with_boot(ctx, discover_hook, on_outcome, Some(boot))
             .await

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -472,92 +472,17 @@ pub async fn run(args: &DevArgs) -> Result<()> {
     // next rebundle tick can delete stale ones (issue #809).
     let live_chunk_filenames: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
 
-    // Eager initial bundle. Failures are non-fatal — we warn and let the
-    // dev server boot anyway. The hot-rebuild path will retry on the next
-    // file change so a transient esbuild hiccup at boot doesn't strand the
-    // user.
-    // Unlike the production path (which only emits a hashed file), the dev
-    // server must write the stable `dist/assets/islands.js` explicitly so
-    // `ServeDir` can serve `GET /assets/islands.js` (mirrors the CSS path
-    // below — the bundler carries bytes in memory only; disk writes belong
-    // to the caller).
-    // Small helper closure to translate a stable_url into the prefixed
-    // form the dev server actually serves it at (`/assets/islands.js`
-    // for no-base, `/foo/assets/islands.js` for `base: "/foo/"`, plain
-    // `/assets/islands.js` for absolute-URL bases). Captures by clone
-    // so the run_islands callback below can own its own copy.
-    let prefix_for_init = dev_islands_url_prefix.clone();
-    let prefixed_islands_url = move |stable: String| -> String {
-        if prefix_for_init.is_empty() {
-            stable
-        } else {
-            format!("{prefix_for_init}{stable}")
-        }
-    };
-    match crate::commands::build::build_default_islands_payload(
-        &project_root,
-        &dist_root,
-        cfg.framework,
-        &islands_plugin_config,
-    ) {
-        Ok((Some(payload), _marker_names)) => {
-            // Write the stable `islands.js` bytes to disk so the dev
-            // server's `ServeDir` can handle `GET /assets/islands.js`.
-            // The bundler no longer writes to disk itself — the caller
-            // owns the disk write (same pattern as the CSS path below).
-            // Only publish the bundle URL when the write succeeded —
-            // setting it on a failed write would inject a `<script>` tag
-            // pointing at a file that 404s (mirrors the pre-change
-            // behaviour where a bundler write failure produced no URL).
-            let assets_dir = dist_root.join(zfb_types::DIST_ASSETS_DIR);
-            let islands_out_path = assets_dir.join(zfb_types::STABLE_ISLANDS_FILENAME);
-            if let Some(parent) = islands_out_path.parent() {
-                let _ = std::fs::create_dir_all(parent);
-            }
-            match std::fs::write(&islands_out_path, &payload.bytes) {
-                Ok(()) => {
-                    let url = prefixed_islands_url(payload.stable_url);
-                    if let Ok(mut guard) = islands_bundle_url_handle.write() {
-                        *guard = Some(url);
-                    }
-                }
-                Err(e) => {
-                    output::warn(format!(
-                        "initial islands bundle write failed (no <script \
-                         type=\"module\"> will be injected until the next \
-                         successful rebuild): {e:#}"
-                    ));
-                }
-            }
-            // Write chunk companions alongside islands.js and seed the
-            // live-chunk tracker. Boot failures here are non-fatal —
-            // the server still comes up; the next successful rebuild
-            // will retry.
-            match refresh_dev_island_chunks(&assets_dir, &payload.companions, &HashSet::new()) {
-                Ok(names) => {
-                    if let Ok(mut guard) = live_chunk_filenames.lock() {
-                        *guard = names;
-                    }
-                }
-                Err(e) => {
-                    output::warn(format!(
-                        "initial islands chunks write failed (chunks may 404 \
-                         until the next rebuild): {e:#}"
-                    ));
-                }
-            }
-        }
-        Ok((None, _marker_names)) => {
-            // No `"use client"` islands in the project. Leave the handle
-            // at `None` so the server skips head injection entirely.
-        }
-        Err(err) => {
-            output::warn(format!(
-                "initial islands bundle failed (no <script type=\"module\"> \
-                 will be injected until the next successful rebuild): {err:#}"
-            ));
-        }
-    }
+    // Issue #1170 — the eager initial islands bundle used to run HERE,
+    // synchronously, before `TcpListener::bind`. On a large-dependency
+    // consumer its `"use client"` scan + esbuild bundle was the dominant
+    // pre-bind cost (the last size-bound step #1166 had not yet moved). It
+    // now runs in the deferred boot task (step 7b) via `rebundle_islands`,
+    // publishing the bundle URL late through `islands_bundle_url_handle`
+    // and folding the result into the boot `BuildOutcome` so a browser that
+    // loaded during the pre-bundle window gets a `ReloadEvent::Islands` and
+    // hydrates. Until the bundle lands the handle stays `None` and the
+    // server simply omits the `<script type="module">` (the same contract
+    // the project-has-no-islands path already ships).
 
     let run_islands: Option<IslandsRunner> = {
         let project_root = project_root.clone();
@@ -567,116 +492,23 @@ pub async fn run(args: &DevArgs) -> Result<()> {
         let url_prefix = dev_islands_url_prefix.clone();
         let url_handle = Arc::clone(&islands_bundle_url_handle);
         let chunk_names = Arc::clone(&live_chunk_filenames);
+        // The watcher tick and the deferred boot build (issue #1170) share
+        // ONE implementation — `rebundle_islands` — so the boot-time bundle
+        // and every rebundle tick write islands.js, prune chunks, and
+        // publish the shared URL handle identically (no drift). The watcher
+        // path propagates the `Err` (an esbuild / disk failure on a tick
+        // should fail loudly); the boot path catches it and warns-and-
+        // continues (see step 7b).
         Some(Arc::new(move || -> Result<Option<IslandsBundleInfo>> {
-            // Marker names are only needed by the production build pass; dev
-            // mode already surfaces unknown-marker warnings in the browser
-            // console via the runtime.ts warn path.
-            let (payload, _marker_names) = crate::commands::build::build_default_islands_payload(
+            rebundle_islands(
                 &project_root,
                 &dist_root_for_islands,
                 framework,
                 &plugin_cfg,
-            )?;
-            // Rewrite the shared handle so the next initial GET (a fresh
-            // browser tab, or a page that has not yet hydrated) sees the
-            // current bundle URL. The dev server holds the same Arc, so
-            // this is visible without re-routing through ServeOpts.
-            //
-            // Treat lock poisoning as a soft event: a writer panic should
-            // not abort the watcher loop. Recover the inner and continue.
-            let mut guard = url_handle.write().unwrap_or_else(|p| {
-                tracing::warn!(
-                    site = "dev.run_islands.url_handle",
-                    "rwlock poisoned, recovered"
-                );
-                p.into_inner()
-            });
-            let Some(payload) = payload else {
-                // The project produced no islands bundle this tick. Clear
-                // the shared URL so the next served HTML response does
-                // NOT keep injecting a stale `<script type="module">`
-                // tag — without this, removing the last `"use client"`
-                // component would leave the previously-emitted bundle URL
-                // visible on every page until the dev server restarts.
-                *guard = None;
-                // Also prune any chunks that were part of the last bundle
-                // — with no islands bundle at all, none of the chunk files
-                // should be served either.
-                {
-                    let mut prev = chunk_names.lock().unwrap_or_else(|p| {
-                        tracing::warn!(
-                            site = "dev.run_islands.chunk_names (clear)",
-                            "mutex poisoned, recovered"
-                        );
-                        p.into_inner()
-                    });
-                    let assets_dir = dist_root_for_islands.join(zfb_types::DIST_ASSETS_DIR);
-                    if let Err(e) = refresh_dev_island_chunks(&assets_dir, &[], &prev) {
-                        tracing::warn!(
-                            error = %e,
-                            "dev islands: failed to prune stale chunks after no-bundle tick (ignored)"
-                        );
-                    }
-                    *prev = HashSet::new();
-                }
-                return Ok(None);
-            };
-            // Write the stable `islands.js` bytes to disk so ServeDir can
-            // serve `GET /assets/islands.js`. The bundler carries bytes in
-            // memory only — the dev caller owns the disk write (same
-            // pattern as the CSS path).
-            {
-                let assets_dir = dist_root_for_islands.join(zfb_types::DIST_ASSETS_DIR);
-                let islands_out_path = assets_dir.join(zfb_types::STABLE_ISLANDS_FILENAME);
-                if let Some(parent) = islands_out_path.parent() {
-                    let _ = std::fs::create_dir_all(parent);
-                }
-                if let Err(e) = std::fs::write(&islands_out_path, &payload.bytes) {
-                    return Err(anyhow::anyhow!(
-                        "dev islands: failed to write islands.js to disk: {e:#}"
-                    ));
-                }
-            }
-            let bundle_url = if url_prefix.is_empty() {
-                payload.stable_url
-            } else {
-                format!("{url_prefix}{}", payload.stable_url)
-            };
-            // Write / prune chunk files for this generation.
-            {
-                let mut prev = chunk_names.lock().unwrap_or_else(|p| {
-                    tracing::warn!(
-                        site = "dev.run_islands.chunk_names",
-                        "mutex poisoned, recovered"
-                    );
-                    p.into_inner()
-                });
-                let assets_dir = dist_root_for_islands.join(zfb_types::DIST_ASSETS_DIR);
-                match refresh_dev_island_chunks(&assets_dir, &payload.companions, &prev) {
-                    Ok(names) => *prev = names,
-                    Err(e) => {
-                        return Err(e.context("dev islands: failed to refresh chunk files"));
-                    }
-                }
-            }
-            // The bundler does not currently surface a "bytes-changed" bit
-            // back through `build_default_islands_payload` — the URL stays
-            // stable (`/assets/islands.js`) on every rebuild, the bytes on
-            // disk update in place. Report `changed = true` so the SSE
-            // layer always emits a reload event after a successful
-            // re-bundle; the browser then re-imports the URL with a
-            // cache-busting `?v=…` query that picks up the new bytes.
-            // `components` is empty because the build-side payload doesn't
-            // carry per-island names; the livereload client's empty-
-            // component path handles "unknown components" by reloading the
-            // whole bundle.
-            let info = IslandsBundleInfo {
-                changed: true,
-                bundle_url: bundle_url.clone(),
-                components: Vec::new(),
-            };
-            *guard = Some(bundle_url);
-            Ok(Some(info))
+                &url_prefix,
+                &url_handle,
+                &chunk_names,
+            )
         }))
     };
 
@@ -979,6 +811,17 @@ pub async fn run(args: &DevArgs) -> Result<()> {
     let graph_cache_path_for_boot = graph_cache_path.clone();
     let manifest_digest_slot_for_boot = Arc::clone(&manifest_digest_slot);
     let dist_root_for_boot = dist_root.clone();
+    // Issue #1170 — the deferred boot task also runs the eager islands
+    // bundle (the last size-bound step that used to gate the bind). Clone
+    // its inputs now, before `ServeOpts` / `run_islands` consume the
+    // originals: `rebundle_islands` needs the project + dist roots, the
+    // framework, the islands plugin config, the URL prefix, the shared
+    // bundle-URL handle, and the live-chunk tracker.
+    let islands_url_handle_for_boot = Arc::clone(&islands_bundle_url_handle);
+    let islands_chunk_names_for_boot = Arc::clone(&live_chunk_filenames);
+    let islands_plugin_config_for_boot = islands_plugin_config.clone();
+    let islands_url_prefix_for_boot = dev_islands_url_prefix.clone();
+    let framework_for_boot = cfg.framework;
 
     // 6. Build the serve options and announce readiness.
     //
@@ -1201,14 +1044,92 @@ pub async fn run(args: &DevArgs) -> Result<()> {
 
             // 4. Boot render — eager by default (zfb#642 / #644), opt-in
             //    boot-lazy (#1057). Returns the eager outcome (or `None` for
-            //    boot-lazy / no-pages) so `run_with_boot` can broadcast a
-            //    reload after the render lands. See `run_boot_render`.
-            run_boot_render(
+            //    boot-lazy / no-pages / render error) so `run_with_boot` can
+            //    broadcast a reload after the render lands. See
+            //    `run_boot_render`.
+            let render_outcome = run_boot_render(
                 orchestrator,
                 ctx,
                 dev_session_for_boot.as_ref(),
                 &dist_root_for_boot,
-            )
+            );
+
+            // 5. Eager islands bundle (issue #1170). This is the last
+            //    size-bound step that used to run synchronously before
+            //    `TcpListener::bind`; on a large-dependency consumer its
+            //    `"use client"` scan + esbuild bundle was the dominant
+            //    pre-bind cost. Running it HERE (post-bind, on the deferred
+            //    boot task) keeps cold-start reachability O(1) in the
+            //    consumer's dependency-tree size.
+            //
+            //    Test-only slow-step injection (issue #1170 regression
+            //    guard): `ZFB_DEV_TEST_SLOW_ISLANDS_MS` sleeps right before
+            //    the islands build, so a test can prove the port accepts
+            //    connections / answers HTTP while this slow step is still in
+            //    flight. Reverting the deferral (building islands before the
+            //    bind) makes that assertion fail. Blocking `std::thread::sleep`
+            //    is fine for the same reason the boot-render slow-step above
+            //    is: request handling runs on other multi-thread runtime
+            //    workers. Independent of the digest / boot-render slow-steps.
+            if let Ok(raw) = std::env::var("ZFB_DEV_TEST_SLOW_ISLANDS_MS") {
+                if let Ok(ms) = raw.trim().parse::<u64>() {
+                    if ms > 0 {
+                        std::thread::sleep(std::time::Duration::from_millis(ms));
+                    }
+                }
+            }
+            let islands_info = match rebundle_islands(
+                &project_root_for_boot,
+                &dist_root_for_boot,
+                framework_for_boot,
+                &islands_plugin_config_for_boot,
+                &islands_url_prefix_for_boot,
+                &islands_url_handle_for_boot,
+                &islands_chunk_names_for_boot,
+            ) {
+                Ok(info) => info,
+                Err(e) => {
+                    // Same contract as the pre-#1170 eager build's Err /
+                    // write-fail arms: warn and continue. The server stays
+                    // up, the bundle-URL handle stays `None` (no
+                    // `<script type="module">` injected), and the next
+                    // successful watcher rebuild retries.
+                    output::warn(format!(
+                        "initial islands bundle failed (no <script \
+                         type=\"module\"> will be injected until the next \
+                         successful rebuild): {e:#}"
+                    ));
+                    None
+                }
+            };
+
+            // 6. Fold the islands bundle into the boot outcome so
+            //    `run_with_boot` broadcasts a `ReloadEvent::Islands` (via
+            //    `outcome_to_events`) — a browser that loaded a page during
+            //    the pre-bundle window then re-imports the bundle and
+            //    hydrates. CRITICAL: `run_boot_render` returns `None` on
+            //    boot-lazy / no-pages / render-error, but the islands reload
+            //    must STILL fire on those paths — otherwise a pre-bundle tab
+            //    never hydrates. So when the render produced no outcome we
+            //    synthesise a `BuildOutcome` carrying only the islands info.
+            //    A single merged outcome is returned (one broadcast), never
+            //    two.
+            match (render_outcome, islands_info) {
+                (Some(mut outcome), Some(info)) => {
+                    outcome.islands_rerun = true;
+                    outcome.islands_changed = info.changed;
+                    outcome.islands_bundle = Some(info);
+                    Some(outcome)
+                }
+                (Some(outcome), None) => Some(outcome),
+                (None, Some(info)) => Some(BuildOutcome {
+                    islands_rerun: true,
+                    islands_changed: info.changed,
+                    islands_bundle: Some(info),
+                    ..BuildOutcome::default()
+                }),
+                (None, None) => None,
+            }
         };
 
         // 5. Orchestrator watcher loop — registers the watch, runs the boot
@@ -1281,6 +1202,137 @@ pub async fn run(args: &DevArgs) -> Result<()> {
     }
 
     result
+}
+
+/// Re-bundle the project's `"use client"` islands once and publish the
+/// result: build the payload, write the stable `dist/assets/islands.js`,
+/// refresh / prune the chunk companions, and rewrite the shared bundle-URL
+/// handle. Returns `Some(IslandsBundleInfo { changed: true, .. })` when a
+/// bundle was produced (so `outcome_to_events` emits a
+/// `ReloadEvent::Islands`), or `None` when the project has no `"use client"`
+/// components this run — in which case the handle is cleared and stale
+/// chunks are pruned so no `<script type="module">` and no dead chunk files
+/// keep being served.
+///
+/// Shared by the watcher-tick `run_islands` callback and the deferred boot
+/// build (issue #1170) so both write disk, prune chunks, and publish the URL
+/// IDENTICALLY — the two paths cannot drift. Lock poisoning is recovered (a
+/// writer panic must not strand the watcher loop). Disk / chunk-write
+/// failures are returned as `Err`: the watcher path propagates it (a tick
+/// failure is loud), the boot path warns-and-continues (issue #1170).
+fn rebundle_islands(
+    project_root: &Path,
+    dist_root: &Path,
+    framework: crate::config::Framework,
+    plugin_config: &crate::commands::build::IslandsPluginConfig,
+    url_prefix: &str,
+    url_handle: &zfb_server::IslandsBundleUrl,
+    chunk_names: &Arc<Mutex<HashSet<String>>>,
+) -> anyhow::Result<Option<IslandsBundleInfo>> {
+    // Marker names are only needed by the production build pass; dev mode
+    // already surfaces unknown-marker warnings in the browser console via
+    // the runtime.ts warn path.
+    let (payload, _marker_names) = crate::commands::build::build_default_islands_payload(
+        project_root,
+        dist_root,
+        framework,
+        plugin_config,
+    )?;
+    // Rewrite the shared handle so the next initial GET (a fresh browser
+    // tab, or a page that has not yet hydrated) sees the current bundle URL.
+    // The dev server holds the same Arc, so this is visible without
+    // re-routing through ServeOpts.
+    //
+    // Treat lock poisoning as a soft event: a writer panic should not abort
+    // the watcher loop. Recover the inner and continue.
+    let mut guard = url_handle.write().unwrap_or_else(|p| {
+        tracing::warn!(
+            site = "dev.rebundle_islands.url_handle",
+            "rwlock poisoned, recovered"
+        );
+        p.into_inner()
+    });
+    let Some(payload) = payload else {
+        // The project produced no islands bundle this run. Clear the shared
+        // URL so the next served HTML response does NOT keep injecting a
+        // stale `<script type="module">` tag — without this, removing the
+        // last `"use client"` component would leave the previously-emitted
+        // bundle URL visible on every page until the dev server restarts.
+        *guard = None;
+        // Also prune any chunks that were part of the last bundle — with no
+        // islands bundle at all, none of the chunk files should be served.
+        {
+            let mut prev = chunk_names.lock().unwrap_or_else(|p| {
+                tracing::warn!(
+                    site = "dev.rebundle_islands.chunk_names (clear)",
+                    "mutex poisoned, recovered"
+                );
+                p.into_inner()
+            });
+            let assets_dir = dist_root.join(zfb_types::DIST_ASSETS_DIR);
+            if let Err(e) = refresh_dev_island_chunks(&assets_dir, &[], &prev) {
+                tracing::warn!(
+                    error = %e,
+                    "dev islands: failed to prune stale chunks after no-bundle tick (ignored)"
+                );
+            }
+            *prev = HashSet::new();
+        }
+        return Ok(None);
+    };
+    // Write the stable `islands.js` bytes to disk so ServeDir can serve
+    // `GET /assets/islands.js`. The bundler carries bytes in memory only —
+    // the dev caller owns the disk write (same pattern as the CSS path).
+    {
+        let assets_dir = dist_root.join(zfb_types::DIST_ASSETS_DIR);
+        let islands_out_path = assets_dir.join(zfb_types::STABLE_ISLANDS_FILENAME);
+        if let Some(parent) = islands_out_path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        if let Err(e) = std::fs::write(&islands_out_path, &payload.bytes) {
+            return Err(anyhow::anyhow!(
+                "dev islands: failed to write islands.js to disk: {e:#}"
+            ));
+        }
+    }
+    let bundle_url = if url_prefix.is_empty() {
+        payload.stable_url
+    } else {
+        format!("{url_prefix}{}", payload.stable_url)
+    };
+    // Write / prune chunk files for this generation.
+    {
+        let mut prev = chunk_names.lock().unwrap_or_else(|p| {
+            tracing::warn!(
+                site = "dev.rebundle_islands.chunk_names",
+                "mutex poisoned, recovered"
+            );
+            p.into_inner()
+        });
+        let assets_dir = dist_root.join(zfb_types::DIST_ASSETS_DIR);
+        match refresh_dev_island_chunks(&assets_dir, &payload.companions, &prev) {
+            Ok(names) => *prev = names,
+            Err(e) => {
+                return Err(e.context("dev islands: failed to refresh chunk files"));
+            }
+        }
+    }
+    // The bundler does not currently surface a "bytes-changed" bit back
+    // through `build_default_islands_payload` — the URL stays stable
+    // (`/assets/islands.js`) on every rebuild, the bytes on disk update in
+    // place. Report `changed = true` so the SSE layer always emits a reload
+    // event after a successful re-bundle; the browser then re-imports the
+    // URL with a cache-busting `?v=…` query that picks up the new bytes.
+    // `components` is empty because the build-side payload doesn't carry
+    // per-island names; the livereload client's empty-component path handles
+    // "unknown components" by reloading the whole bundle.
+    let info = IslandsBundleInfo {
+        changed: true,
+        bundle_url: bundle_url.clone(),
+        components: Vec::new(),
+    };
+    *guard = Some(bundle_url);
+    Ok(Some(info))
 }
 
 /// Boot render — eager by default (zfb#642 / #644), opt-in boot-lazy

--- a/crates/zfb/tests/dev_bind_before_walk_e2e.rs
+++ b/crates/zfb/tests/dev_bind_before_walk_e2e.rs
@@ -43,6 +43,12 @@
 //!    deferred-state correctness: if the dev server is killed BEFORE the
 //!    deferred digest completes, NO `.zfb/graph.bin` is written (never a
 //!    graph tagged with an absent / wrong digest).
+//! 4. `dev_binds_and_serves_before_slow_islands_step` — the
+//!    bind-before-islands guard (issue #1170). The eager initial islands
+//!    bundle used to run synchronously before the bind; it now runs on the
+//!    deferred boot task. Uses the same strategy with a co-located
+//!    `ZFB_DEV_TEST_SLOW_ISLANDS_MS` slow step, independent of the digest
+//!    one, so it specifically pins the islands build's position past bind.
 //!
 //! ## Spawn / teardown discipline (from `dev_serve_e2e.rs` /
 //! `build_terminates.rs`)
@@ -216,7 +222,8 @@ fn spawn_dev(tmp: &tempfile::TempDir, esbuild: &Path, extra_env: &[(&str, &str)]
     cmd.env_remove("ZFB_DEV_EAGER")
         .env_remove("ZFB_LAZY_DEV_RENDER")
         .env_remove("ZFB_DEV_BOOT_LAZY")
-        .env_remove("ZFB_DEV_TEST_SLOW_DIGEST_MS");
+        .env_remove("ZFB_DEV_TEST_SLOW_DIGEST_MS")
+        .env_remove("ZFB_DEV_TEST_SLOW_ISLANDS_MS");
     for (k, v) in extra_env {
         cmd.env(k, v);
     }
@@ -570,4 +577,100 @@ async fn early_shutdown_before_digest_skips_graph_save() {
         graph_path.display(),
         session.logs(),
     );
+}
+
+// ---------------------------------------------------------------------------
+// Test 4 — bind-before-islands guard (issue #1170).
+// ---------------------------------------------------------------------------
+
+/// Issue #1170 — the eager initial islands bundle
+/// (`build_default_islands_payload`) used to run SYNCHRONOUSLY before
+/// `TcpListener::bind`. On a large-dependency consumer its `"use client"`
+/// scan + esbuild bundle was the dominant pre-bind cost (the last size-bound
+/// step #1166 had not yet moved). It now runs on the deferred boot task.
+///
+/// The dev binary reads a TEST-ONLY env var `ZFB_DEV_TEST_SLOW_ISLANDS_MS`
+/// and sleeps that long right before the deferred islands build. With a long
+/// sleep the server must STILL bind and answer an HTTP request well before it
+/// elapses — proving the listener binds BEFORE the islands build.
+///
+/// Falsifiability: the slow step is co-located with the islands build, so
+/// moving the build back ahead of the bind moves the sleep with it — the bind
+/// would then be delayed by `SLOW_MS` and the `< FIRST_RESPONSE_DEADLINE`
+/// assertion fails. This is independent of `ZFB_DEV_TEST_SLOW_DIGEST_MS`
+/// (which pins the digest's position); this pins the islands build's.
+///
+/// The `dev-loop-basic` fixture ships no `"use client"` islands, so the build
+/// itself produces no bundle — but the injected sleep runs unconditionally
+/// right before it, so the guard holds regardless of whether the project has
+/// islands.
+#[tokio::test(flavor = "multi_thread")]
+async fn dev_binds_and_serves_before_slow_islands_step() {
+    let _serial = SERIAL.lock().await;
+    let Some(esbuild) = locate_esbuild() else {
+        eprintln!("[dev_bind_before_walk_e2e] no esbuild; skipping.");
+        return;
+    };
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let slow = SLOW_MS.to_string();
+    // Eager mode runs the full boot render on the background task too, so the
+    // islands slow step sits behind the render — the bind precedes BOTH.
+    let mut session = spawn_dev(
+        &tmp,
+        &esbuild,
+        &[
+            ("ZFB_DEV_TEST_SLOW_ISLANDS_MS", slow.as_str()),
+            ("ZFB_DEV_EAGER", "1"),
+        ],
+    );
+
+    let Some(port) = wait_for_banner_port(&mut session).await else {
+        return; // known-skip
+    };
+    let base = format!("http://localhost:{port}");
+    let client = client();
+
+    // `GET /__zfb/reload` is 200 the instant the router is mounted,
+    // independent of any render / islands build. Answering within
+    // FIRST_RESPONSE_DEADLINE (< SLOW_MS) while the slow islands step is in
+    // flight is the proof that bind precedes the islands build.
+    let url = format!("{base}/__zfb/reload");
+    let request_start = Instant::now();
+    let mut answered = false;
+    while request_start.elapsed() < FIRST_RESPONSE_DEADLINE {
+        if let Ok(resp) = client.get(&url).send().await {
+            assert_eq!(
+                resp.status().as_u16(),
+                200,
+                "SSE endpoint must answer 200; the server is serving but on a wrong status.\n{}",
+                session.logs(),
+            );
+            answered = true;
+            break;
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+
+    assert!(
+        answered,
+        "the dev server did not answer GET {url} within {}s — but the injected \
+         slow islands step is {}ms. If bind happened BEFORE the islands build, the \
+         server would answer near-instantly; this failure is the bind-before-islands \
+         regression (issue #1170).\n{}",
+        FIRST_RESPONSE_DEADLINE.as_secs(),
+        SLOW_MS,
+        session.logs(),
+    );
+
+    // Belt-and-braces: the whole answered-request round trip finished
+    // strictly before the injected slow step could have.
+    assert!(
+        request_start.elapsed().as_millis() < SLOW_MS as u128,
+        "served a response only after the injected slow islands step elapsed — bind \
+         did not precede the islands build.\n{}",
+        session.logs(),
+    );
+
+    // The deferred slow step is still sleeping; Drop group-kills it.
 }

--- a/crates/zfb/tests/dev_bind_before_walk_e2e.rs
+++ b/crates/zfb/tests/dev_bind_before_walk_e2e.rs
@@ -85,6 +85,25 @@ const SLOW_MS: u64 = 12_000;
 /// generous for cold V8 + esbuild boot.
 const BANNER_DEADLINE: Duration = Duration::from_secs(90);
 
+/// The injected islands slow-step for the bind-before-islands guard (issue
+/// #1170). Deliberately set LONGER than `BANNER_DEADLINE`. The ready banner
+/// is printed immediately after a successful bind, so in the correct
+/// (post-bind) ordering the banner lands at boot time, far under
+/// `BANNER_DEADLINE`. If the islands build — and this co-located sleep — were
+/// moved back BEFORE the bind, the banner would be delayed by
+/// `SLOW_ISLANDS_MS` (> `BANNER_DEADLINE`) and `wait_for_banner_port` would
+/// time out and fail the test. Anchoring to the banner-vs-bind ordering (not
+/// a banner-relative window) is what makes the guard genuinely falsifiable
+/// without fighting V8-boot variance. A green run never waits this out — it
+/// answers fast and Drop SIGKILLs the group — so the large value is free.
+const SLOW_ISLANDS_MS: u64 = 120_000;
+
+const _: () = assert!(
+    SLOW_ISLANDS_MS > BANNER_DEADLINE.as_secs() * 1000,
+    "SLOW_ISLANDS_MS must exceed BANNER_DEADLINE — otherwise a pre-bind islands build \
+     would still print the banner within the deadline and the guard proves nothing"
+);
+
 /// Deadline for the FIRST successful HTTP response after the banner.
 /// This MUST be shorter than `SLOW_MS` for the guard to mean anything:
 /// answering within this window while the deferred step is still
@@ -590,20 +609,29 @@ async fn early_shutdown_before_digest_skips_graph_save() {
 /// step #1166 had not yet moved). It now runs on the deferred boot task.
 ///
 /// The dev binary reads a TEST-ONLY env var `ZFB_DEV_TEST_SLOW_ISLANDS_MS`
-/// and sleeps that long right before the deferred islands build. With a long
-/// sleep the server must STILL bind and answer an HTTP request well before it
-/// elapses — proving the listener binds BEFORE the islands build.
+/// and sleeps that long right before the deferred islands build. This test
+/// sets `SLOW_ISLANDS_MS` (> `BANNER_DEADLINE`) and checks TWO things:
 ///
-/// Falsifiability: the slow step is co-located with the islands build, so
-/// moving the build back ahead of the bind moves the sleep with it — the bind
-/// would then be delayed by `SLOW_MS` and the `< FIRST_RESPONSE_DEADLINE`
-/// assertion fails. This is independent of `ZFB_DEV_TEST_SLOW_DIGEST_MS`
-/// (which pins the digest's position); this pins the islands build's.
+/// 1. **Bind precedes the islands build.** The ready banner is printed
+///    immediately after a successful bind, so in the correct (post-bind)
+///    ordering it lands at boot time — well under `BANNER_DEADLINE`. If the
+///    islands build (and its co-located sleep) were moved back BEFORE the
+///    bind, the banner would be delayed by `SLOW_ISLANDS_MS`
+///    (> `BANNER_DEADLINE`) and `wait_for_banner_port` would time out → the
+///    test fails. Anchoring to the banner-vs-bind ordering — NOT a
+///    banner-relative response window — is what makes this falsifiable: a
+///    banner-relative deadline does NOT catch a pre-bind build, because the
+///    banner floats with the bind.
+/// 2. **The serve path does not block on the deferred islands build.** The
+///    server answers `GET /__zfb/reload` (200 the instant the router is
+///    mounted) within `FIRST_RESPONSE_DEADLINE` of the banner while the
+///    islands slow-step is still in flight on the boot task.
 ///
-/// The `dev-loop-basic` fixture ships no `"use client"` islands, so the build
-/// itself produces no bundle — but the injected sleep runs unconditionally
-/// right before it, so the guard holds regardless of whether the project has
-/// islands.
+/// Independent of `ZFB_DEV_TEST_SLOW_DIGEST_MS` (which pins the digest's
+/// position); this pins the islands build's. The `dev-loop-basic` fixture
+/// ships no `"use client"` islands, so the build produces no bundle — but the
+/// injected sleep runs unconditionally right before it, so the guard holds
+/// regardless of whether the project has islands.
 #[tokio::test(flavor = "multi_thread")]
 async fn dev_binds_and_serves_before_slow_islands_step() {
     let _serial = SERIAL.lock().await;
@@ -613,9 +641,10 @@ async fn dev_binds_and_serves_before_slow_islands_step() {
     };
 
     let tmp = tempfile::tempdir().expect("tempdir");
-    let slow = SLOW_MS.to_string();
+    let slow = SLOW_ISLANDS_MS.to_string();
     // Eager mode runs the full boot render on the background task too, so the
     // islands slow step sits behind the render — the bind precedes BOTH.
+    let spawn_t = Instant::now();
     let mut session = spawn_dev(
         &tmp,
         &esbuild,
@@ -625,16 +654,35 @@ async fn dev_binds_and_serves_before_slow_islands_step() {
         ],
     );
 
+    // Guarantee 1 (bind precedes islands): the banner follows the bind, so it
+    // lands at boot time in the correct ordering. A pre-bind islands build
+    // would delay the banner by SLOW_ISLANDS_MS (> BANNER_DEADLINE) and the
+    // wait below would time out — that timeout IS the regression signal.
     let Some(port) = wait_for_banner_port(&mut session).await else {
         return; // known-skip
     };
+    // Explicit, clearly-messaged form of the same guarantee (in case the
+    // deadlines are ever retuned): the banner — and the bind it follows —
+    // landed well before the injected islands slow-step could have.
+    let banner_elapsed = spawn_t.elapsed();
+    assert!(
+        (banner_elapsed.as_millis() as u64) < SLOW_ISLANDS_MS,
+        "ready banner appeared {}ms after spawn, but the injected islands slow-step is \
+         {}ms — the islands build (and its sleep) ran BEFORE the bind/banner \
+         (bind-before-islands regression, issue #1170).\n{}",
+        banner_elapsed.as_millis(),
+        SLOW_ISLANDS_MS,
+        session.logs(),
+    );
+
     let base = format!("http://localhost:{port}");
     let client = client();
 
+    // Guarantee 2 (serve path is not blocked by the deferred build):
     // `GET /__zfb/reload` is 200 the instant the router is mounted,
     // independent of any render / islands build. Answering within
-    // FIRST_RESPONSE_DEADLINE (< SLOW_MS) while the slow islands step is in
-    // flight is the proof that bind precedes the islands build.
+    // FIRST_RESPONSE_DEADLINE of the banner while the islands slow-step is
+    // still in flight proves the serve path does not wait on the build.
     let url = format!("{base}/__zfb/reload");
     let request_start = Instant::now();
     let mut answered = false;
@@ -651,24 +699,12 @@ async fn dev_binds_and_serves_before_slow_islands_step() {
         }
         tokio::time::sleep(POLL_INTERVAL).await;
     }
-
     assert!(
         answered,
-        "the dev server did not answer GET {url} within {}s — but the injected \
-         slow islands step is {}ms. If bind happened BEFORE the islands build, the \
-         server would answer near-instantly; this failure is the bind-before-islands \
-         regression (issue #1170).\n{}",
+        "the dev server did not answer GET {url} within {}s of the banner while the \
+         islands slow-step was in flight — the serve path is blocking on the deferred \
+         islands build (issue #1170).\n{}",
         FIRST_RESPONSE_DEADLINE.as_secs(),
-        SLOW_MS,
-        session.logs(),
-    );
-
-    // Belt-and-braces: the whole answered-request round trip finished
-    // strictly before the injected slow step could have.
-    assert!(
-        request_start.elapsed().as_millis() < SLOW_MS as u128,
-        "served a response only after the injected slow islands step elapsed — bind \
-         did not precede the islands build.\n{}",
         session.logs(),
     );
 


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1172
- epic
    - https://github.com/Takazudo/zudo-front-builder/issues/1171

---

## Summary

`zfb dev` still bound its TCP listener slowly on large-dependency consumers because the **eager initial islands bundle** (`build_default_islands_payload`) ran synchronously **before** `TcpListener::bind`. #1166 had already deferred the manifest digest + persisted-graph load + graph seed + boot render onto a post-bind background task; the islands build was the last size-bound step still on the pre-bind path (its `"use client"` scan + esbuild bundle dominated the cold-start wait). This moves it onto the same deferred boot task so the listener accepts connections in O(1) regardless of the consumer's dependency-tree size.

## Changes

- **Extract `rebundle_islands()`** — the build → write `islands.js` → refresh/prune chunk companions → publish the shared `islands_bundle_url_handle` (`Arc<RwLock<Option<String>>>`) → return `IslandsBundleInfo` logic that the `run_islands` watcher closure already performed. Both the watcher tick and the new boot build call it, so they cannot drift.
- **Run the islands build inside the deferred boot hook** (post-bind), and **fold its `IslandsBundleInfo` into the boot `BuildOutcome`** so `run_with_boot` broadcasts a `ReloadEvent::Islands` (via `outcome_to_events`) — a browser that loaded a page during the pre-bundle window then re-imports the bundle and hydrates. The reload fires **even when the boot render returns `None`** (boot-lazy / no-pages / render error) by synthesising a `BuildOutcome` carrying only the islands info.
- **Islands build / write failure during boot warns-and-continues** (handle stays `None`, server stays up), matching the pre-change eager contract. Until the bundle lands the server omits the `<script type="module">` — the same contract the project-has-no-islands path already ships.
- **Add `ZFB_DEV_TEST_SLOW_ISLANDS_MS`** + a **genuinely falsifiable** bind-before-islands e2e guard (`dev_binds_and_serves_before_slow_islands_step`). The slow-step is set larger than `BANNER_DEADLINE`: since the ready banner is printed right after the bind, a pre-bind islands build delays the banner past the deadline and the test fails. Verified empirically (simulating the pre-#1170 ordering fails the test).

## Notes for reviewers

- **Minor behavior unification (intended):** on the rare double-failure where `islands.js` writes OK but a chunk write fails, the boot path now injects **no** `<script type="module">` (instead of one whose chunk imports would 404), because `rebundle_islands` returns `Err` before publishing the URL. This unifies boot onto the watcher tick's stricter contract — both are degraded states for the same rare disk failure.
- **Test blind spot:** no e2e proves a browser that loaded during the pre-bundle window actually receives the `Islands` SSE event and hydrates (no `"use client"` fixture exists in the e2e suite). That path is covered by the `outcome_to_events` unit tests in `zfb-server` (which pin the exact `changed: true, components: []` → single generic `ReloadEvent::Islands` shape the boot fold emits) composed with the unchanged `rebundle_islands` watcher path.

## Test plan

- `cargo clippy -p zfb --all-targets -D warnings`, `cargo fmt --check` — clean.
- `cargo test -p zfb --test dev_bind_before_walk_e2e` (4/4, incl. the new guard), `--test dev_serve_e2e` (3/3), `--test dev_public_large_tree_smoke_e2e` (1/1).
- `cargo test -p zfb-server` (incl. `outcome_to_events` islands tests).
- Falsifiability verified: simulating a pre-bind islands slow-step fails the new guard (banner timeout).

Closes #1172.