### PR TITLE
fix(dev): defer eager dev bundle past TcpListener::bind in boot-lazy mode (#1182)

### DIFF
--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -314,6 +314,21 @@ pub async fn run(args: &DevArgs) -> Result<()> {
     // the hook entries hold references into it.
     let _setup_registries = plugin_setup.setup_registries;
 
+    // Issue #1182 — decide whether the eager dev bundle is DEFERRED past
+    // `TcpListener::bind`. Only in boot-lazy mode with a servable prebuilt
+    // `dist/`: then the prebuilt `dist/` serves every route until the deferred
+    // boot task publishes the renderer, so first-accept is O(1) regardless of
+    // project size (the residual of #1161 that #1166/#1170 left behind). The
+    // gate matches `run_boot_render`'s boot-lazy gate exactly, so a deferred
+    // boot always takes the boot-lazy branch there. Decided here (before
+    // `boot_dev_renderer`) so the scaffold-vs-eager choice and the deferred
+    // task agree on one value.
+    let defer_dev_bundle = defer_dev_bundle_decision(
+        lazy_dev_render_enabled(),
+        std::env::var("ZFB_DEV_BOOT_LAZY").ok().as_deref(),
+        dist_is_servable_seed(&dist_root),
+    );
+
     // 2. Stand up the long-lived renderer state if the project looks
     //    runnable. We surface failures as a warning + fall back to the
     //    noop renderer so the dev server still boots — the user can
@@ -325,6 +340,7 @@ pub async fn run(args: &DevArgs) -> Result<()> {
         v8_plugin_hooks,
         dev_plugin_alias_entries.clone(),
         dev_plugin_virtual_modules.clone(),
+        defer_dev_bundle,
     ) {
         Ok(s) => Some(s),
         Err(err) => {
@@ -823,6 +839,13 @@ pub async fn run(args: &DevArgs) -> Result<()> {
     let islands_plugin_config_for_boot = islands_plugin_config.clone();
     let islands_url_prefix_for_boot = dev_islands_url_prefix.clone();
     let framework_for_boot = cfg.framework;
+    // Issue #1182 — the deferred boot task publishes the live SSR route handle
+    // after the deferred bundle lands (`refresh_bundle_and_routes` swaps the
+    // session's tables but NOT the server's `ssr_route_set` handle — its
+    // callers do that). Clone the handle now, before `ServeOpts` consumes the
+    // original below. `None` when the renderer is disabled. Inert unless
+    // `defer_dev_bundle` is set.
+    let ssr_route_set_for_boot = ssr_route_set.clone();
 
     // 6. Build the serve options and announce readiness.
     //
@@ -1011,6 +1034,68 @@ pub async fn run(args: &DevArgs) -> Result<()> {
                 }
             }
 
+            // 0. Deferred dev bundle (issue #1182). When the eager dev bundle
+            //    was deferred past `TcpListener::bind` (boot-lazy + servable
+            //    `dist/` — `defer_dev_bundle`), build the renderer + route
+            //    tables NOW, on this deferred boot task, and publish them in
+            //    place via `refresh_bundle_and_routes` (it swaps the first live
+            //    V8 host into the scaffold's `None` renderer slot and swaps the
+            //    rebuilt tables in under the route `RwLock`). Until this lands
+            //    the prebuilt `dist/` serves every route — that is what makes
+            //    first-accept O(1) regardless of project size.
+            //
+            //    Ordered FIRST in the hook — before the graph seed (step 3) —
+            //    because the seed reads `session.page_ids()`, which is empty on
+            //    the scaffold until the route tables are published here. Run
+            //    before the seed, the graph is populated from a live route
+            //    table; run after, every watcher tick would be a cold-start
+            //    no-op.
+            if defer_dev_bundle {
+                // Test-only slow-step injection (issue #1182 regression guard):
+                // `ZFB_DEV_TEST_SLOW_BUNDLE_MS` sleeps right before the deferred
+                // bundle, so an e2e can prove the port accepts connections /
+                // answers HTTP while this slow step is still in flight.
+                // Reverting the deferral (bundling before the bind) makes that
+                // assertion fail — the falsifiable proof that bind precedes the
+                // bundle. Blocking `std::thread::sleep` is fine: request
+                // handling runs on other multi-thread runtime workers.
+                // Independent of the digest / boot-render / islands slow-steps.
+                if let Ok(raw) = std::env::var("ZFB_DEV_TEST_SLOW_BUNDLE_MS") {
+                    if let Ok(ms) = raw.trim().parse::<u64>() {
+                        if ms > 0 {
+                            std::thread::sleep(std::time::Duration::from_millis(ms));
+                        }
+                    }
+                }
+                if let Some(ref session) = dev_session_for_boot {
+                    match session.refresh_bundle_and_routes() {
+                        Ok(_) => {
+                            // Publish the live SSR route handle now the route
+                            // tables exist: `refresh_bundle_and_routes` swaps
+                            // the SESSION tables but not the server's
+                            // `ssr_route_set` handle (issue #807 — its callers
+                            // do). Without this, `prerender = false` routes keep
+                            // resolving against the empty pre-bind set until the
+                            // first watcher tick.
+                            if let Some(handle) = &ssr_route_set_for_boot {
+                                refresh_live_ssr_routes(session, handle);
+                            }
+                        }
+                        Err(e) => {
+                            // Same warn-and-continue contract as the eager
+                            // islands boot build below: the server stays up
+                            // serving the prebuilt `dist/`, the renderer slot
+                            // stays `None`, and the next watcher tick's
+                            // `reload_renderer` retries the bundle.
+                            output::warn(format!(
+                                "deferred dev bundle failed (serving prebuilt dist/ until \
+                                 the next successful rebuild): {e:#}"
+                            ));
+                        }
+                    }
+                }
+            }
+
             // 1. Manifest digest — the size-bound walk moved past bind.
             let manifest_digest = compute_manifest_digest(&project_root_for_boot, &watch_roots);
 
@@ -1118,7 +1203,27 @@ pub async fn run(args: &DevArgs) -> Result<()> {
             //    synthesise a `BuildOutcome` carrying only the islands info.
             //    A single merged outcome is returned (one broadcast), never
             //    two.
-            match (render_outcome, islands_info) {
+            // Issue #1182 — drain the routes the deferred publish marked stale.
+            // In a deferred boot, step 0 published the renderer and
+            // `run_boot_render`'s boot-lazy branch then staled every known
+            // route. Fold those into `pages_stale` so the single
+            // `run_with_boot` broadcast emits one `ReloadEvent::Page`
+            // (livereload.rs): a tab that loaded the prebuilt `dist/` during the
+            // pre-renderer window reloads, and its GET re-renders through the
+            // now-live request-time hook. Drained from the same tick buffer the
+            // pipeline's stale probe uses; the per-route stale map (claimable
+            // for request-time render) is untouched — this is the broadcast,
+            // not a second one. Empty and inert unless the bundle was deferred.
+            let boot_stale: Vec<PathBuf> = if defer_dev_bundle {
+                dev_session_for_boot
+                    .as_ref()
+                    .map(|s| s.inner.take_tick_stale())
+                    .unwrap_or_default()
+            } else {
+                Vec::new()
+            };
+
+            let mut outcome = match (render_outcome, islands_info) {
                 (Some(mut outcome), Some(info)) => {
                     outcome.islands_rerun = true;
                     outcome.islands_changed = info.changed;
@@ -1133,7 +1238,19 @@ pub async fn run(args: &DevArgs) -> Result<()> {
                     ..BuildOutcome::default()
                 }),
                 (None, None) => None,
+            };
+            if !boot_stale.is_empty() {
+                match &mut outcome {
+                    Some(o) => o.pages_stale = boot_stale,
+                    None => {
+                        outcome = Some(BuildOutcome {
+                            pages_stale: boot_stale,
+                            ..BuildOutcome::default()
+                        })
+                    }
+                }
             }
+            outcome
         };
 
         // Orchestrator watcher loop — registers the watch, runs the boot
@@ -1696,6 +1813,30 @@ fn boot_lazy_enabled(lazy_render_on: bool) -> bool {
 /// "requires lazy" rule is unit-testable without process-global env mutation.
 fn boot_lazy_decision(lazy_render_on: bool, boot_lazy_var: Option<&str>) -> bool {
     lazy_render_on && resolve_boot_lazy(boot_lazy_var)
+}
+
+/// Pure decision for the deferred dev bundle (issue #1182): defer the eager
+/// `assemble_and_bundle_dev` (+ V8 host start + `paths()`-expanding route-table
+/// build) past `TcpListener::bind` only when
+///
+/// 1. boot-lazy is active ([`boot_lazy_decision`]) — so the request-time
+///    render-on-request hook (#1026) is installed and the prebuilt `dist/` is
+///    the serving source for every route until the renderer is published, AND
+/// 2. a servable `dist/` seed is present ([`dist_is_servable_seed`]).
+///
+/// Both conditions match [`run_boot_render`]'s boot-lazy gate exactly, so a
+/// deferred boot always takes the boot-lazy branch there (mark-stale, no eager
+/// render). When the gate is off, `boot_dev_renderer` builds the renderer
+/// eagerly before bind exactly as before — the deferral is strictly additive.
+///
+/// Split out so the gate is unit-testable without process-global env mutation
+/// or a real `dist/` tree.
+fn defer_dev_bundle_decision(
+    lazy_render_on: bool,
+    boot_lazy_var: Option<&str>,
+    dist_servable: bool,
+) -> bool {
+    boot_lazy_decision(lazy_render_on, boot_lazy_var) && dist_servable
 }
 
 /// Pure precedence rule for the boot-lazy switch (issue #1057):
@@ -3636,6 +3777,14 @@ fn boot_dev_renderer(
     // Plugin-registered virtual-module `(specifier, source)` pairs.
     // Threaded into `BundlerInput::plugin_virtual_modules` (#268).
     plugin_virtual_modules: Vec<(String, String)>,
+    // Issue #1182 — when `true`, return a SCAFFOLD session (no V8 host, empty
+    // route tables) and SKIP `assemble_and_bundle_dev` + host start +
+    // route-table build. The deferred boot task runs that expensive work past
+    // `TcpListener::bind` via [`DevRenderSession::refresh_bundle_and_routes`]
+    // (it swaps the host into the `None` slot and publishes the rebuilt tables
+    // in place). Gated by [`defer_dev_bundle_decision`] in `run`. `false`
+    // keeps the eager pre-bind path unchanged.
+    defer_bundle: bool,
 ) -> Result<DevRenderSession> {
     check_runtime_installed(project_root)?;
 
@@ -3703,56 +3852,109 @@ fn boot_dev_renderer(
     // `DevRenderInner` so every refresh reuses the same shadow tree.
     let mut shadow_session = ShadowSession::new()?;
 
-    // Boot path — timing not collected here (one-shot at startup, not a
-    // hot-path tick). `timing_enabled = false` so no Instant::now() overhead.
-    let bundler_out: BundlerOutput = assemble_and_bundle_dev(
-        project_root,
-        cfg,
-        plugin_alias_entries,
-        plugin_virtual_modules,
-        false,
-        Some(&mut shadow_session),
-        rebuild_inputs.esbuild_path(),
-    )?
-    .output;
-
-    let state = start(RendererStartInput {
-        bundle_path: bundler_out.bundle_path.clone(),
-        sourcemap_path: bundler_out.sourcemap_path.clone(),
-        backend: Backend::EmbeddedV8 {
-            host_factory: crate::v8_host_adapter::make_v8_host_factory_with_hooks(v8_plugin_hooks),
-        },
-        request_timeout: None,
-    })
-    .map_err(anyhow::Error::from)
-    .context("renderer start failed")?;
-
-    // Wrap the renderer state in the shared `Arc<Mutex<Option<...>>>` up
-    // front so the SSG `paths()` runtime-evaluation phase below can borrow
-    // the live embedded V8 host out of the same handle the SSG render
-    // callback and the SSR adapter use later (#502/#507). One host, shared
-    // across boot-time paths() eval, build-time SSG render, and request-time
-    // SSR.
-    let renderer: Arc<Mutex<Option<RendererState>>> = Arc::new(Mutex::new(Some(state)));
-
-    // Issue #367 — extract `export const prerender = …` per page so
-    // we can keep SSG-eligible pages in `routes_by_source` (the SSG
-    // render callback's lookup table) while routing `prerender =
-    // false` pages into the request-time SSR set instead. Without this
-    // split the SSG callback would stamp a stale snapshot to disk on
-    // every watcher tick and the dist fallback would shadow the SSR
-    // handler.
-    // Build the route tables from the router scan + the live host (#659:
-    // extracted into `build_dev_route_tables` so the watch-ADD rebuild
-    // reproduces the boot tables exactly).
-    //
     // #994 item B — the PathsCache is seeded here and stored on
     // `DevRenderInner` below, so every refresh tick reuses the entries
     // this boot-time build populated (boot/refresh parity: both go
-    // through the same cache).
+    // through the same cache). Built before the eager/deferred branch so the
+    // deferred-scaffold path also stores a (still-empty) cache the deferred
+    // `refresh_bundle_and_routes` then populates.
     let mut paths_cache = PathsCache::new();
-    let (routes_by_source, ssr_routes, url_index) =
-        build_dev_route_tables(&router, &plan, project_root, &renderer, &mut paths_cache)?;
+
+    // Issue #1182 — deferred dev bundle. The eager `assemble_and_bundle_dev`
+    // (content-snapshot embed + esbuild over the route graph) is the dominant,
+    // size-scaling pre-bind cost — the residual of #1161 that #1166/#1170 left
+    // behind. When `defer_bundle` is set (boot-lazy + a servable prebuilt
+    // `dist/`, decided by `defer_dev_bundle_decision`), build a SCAFFOLD
+    // session here: NO V8 host (renderer slot `None`) and EMPTY route tables.
+    // The deferred boot task then runs the bundle + host start +
+    // `paths()`-expanding route-table build past `TcpListener::bind` via
+    // `refresh_bundle_and_routes`, which swaps the host into this `None` slot
+    // and publishes the rebuilt tables in place. The prebuilt `dist/` serves
+    // every route until that publish lands, so first-accept is O(1) regardless
+    // of project size. When `defer_bundle` is false, the eager pre-bind path
+    // below runs exactly as before.
+    let (renderer, routes_by_source, ssr_routes, url_index) = if defer_bundle {
+        (
+            // Scaffold renderer slot — the deferred `refresh_bundle_and_routes`
+            // swaps the first live host into this same `Arc` (which the render
+            // callback, SSR adapter, and render-on-request hook all already
+            // hold a clone of).
+            Arc::new(Mutex::new(None)),
+            HashMap::new(),
+            Vec::new(),
+            HashMap::new(),
+        )
+    } else {
+        // Test-only slow-step injection (issue #1182 falsifiability guard,
+        // EAGER half): `ZFB_DEV_TEST_SLOW_BUNDLE_MS` sleeps right before the
+        // EAGER pre-bind bundle. This is the co-located twin of the
+        // deferred-task seam in `run` — together they make the bind-before-bundle
+        // e2e falsifiable wherever the BOOT bundle runs. In the correct ordering
+        // a boot-lazy + servable-`dist/` boot takes the scaffold branch above,
+        // so this eager seam never fires and only the deferred-task seam does
+        // (after bind → banner stays fast). If the deferral is reverted — the
+        // boot bundle moved back here, before `TcpListener::bind` — THIS seam
+        // fires before bind and delays the ready banner past the e2e's deadline,
+        // failing the guard. Without a co-located eager seam, an un-defer revert
+        // would silently pass. Runs synchronously in `run` before bind, so the
+        // blocking sleep delays bind exactly as a real pre-bind bundle would.
+        if let Ok(raw) = std::env::var("ZFB_DEV_TEST_SLOW_BUNDLE_MS") {
+            if let Ok(ms) = raw.trim().parse::<u64>() {
+                if ms > 0 {
+                    std::thread::sleep(std::time::Duration::from_millis(ms));
+                }
+            }
+        }
+
+        // Boot path — timing not collected here (one-shot at startup, not a
+        // hot-path tick). `timing_enabled = false` so no Instant::now() overhead.
+        let bundler_out: BundlerOutput = assemble_and_bundle_dev(
+            project_root,
+            cfg,
+            plugin_alias_entries,
+            plugin_virtual_modules,
+            false,
+            Some(&mut shadow_session),
+            rebuild_inputs.esbuild_path(),
+        )?
+        .output;
+
+        let state = start(RendererStartInput {
+            bundle_path: bundler_out.bundle_path.clone(),
+            sourcemap_path: bundler_out.sourcemap_path.clone(),
+            backend: Backend::EmbeddedV8 {
+                host_factory: crate::v8_host_adapter::make_v8_host_factory_with_hooks(
+                    v8_plugin_hooks,
+                ),
+            },
+            request_timeout: None,
+        })
+        .map_err(anyhow::Error::from)
+        .context("renderer start failed")?;
+
+        // Wrap the renderer state in the shared `Arc<Mutex<Option<...>>>` up
+        // front so the SSG `paths()` runtime-evaluation phase below can borrow
+        // the live embedded V8 host out of the same handle the SSG render
+        // callback and the SSR adapter use later (#502/#507). One host, shared
+        // across boot-time paths() eval, build-time SSG render, and request-time
+        // SSR.
+        let renderer: Arc<Mutex<Option<RendererState>>> = Arc::new(Mutex::new(Some(state)));
+
+        // Issue #367 — extract `export const prerender = …` per page so
+        // we can keep SSG-eligible pages in `routes_by_source` (the SSG
+        // render callback's lookup table) while routing `prerender =
+        // false` pages into the request-time SSR set instead. Without this
+        // split the SSG callback would stamp a stale snapshot to disk on
+        // every watcher tick and the dist fallback would shadow the SSR
+        // handler.
+        // Build the route tables from the router scan + the live host (#659:
+        // extracted into `build_dev_route_tables` so the watch-ADD rebuild
+        // reproduces the boot tables exactly).
+        let (routes_by_source, ssr_routes, url_index) =
+            build_dev_route_tables(&router, &plan, project_root, &renderer, &mut paths_cache)?;
+
+        (renderer, routes_by_source, ssr_routes, url_index)
+    };
 
     // Issue #958 — seed the frontmatter gate cache so the FIRST body-only
     // edit of a pre-existing collection file can already narrow (G4 only
@@ -5698,6 +5900,30 @@ mod tests {
                 // lazy on but env off/unset => off.
                 assert!(!boot_lazy_decision(true, None));
                 assert!(!boot_lazy_decision(true, Some("0")));
+            }
+
+            /// Issue #1182 — the eager dev bundle is deferred past
+            /// `TcpListener::bind` ONLY when boot-lazy is active AND a servable
+            /// `dist/` seed is present. Both conjuncts are load-bearing: drop
+            /// boot-lazy and there is no request-time render-on-request hook to
+            /// recover the deferred renderer; drop the servable seed and there
+            /// is nothing to serve during the pre-renderer window. The gate is
+            /// `boot_lazy_decision(..) && dist_servable`.
+            #[test]
+            fn defer_dev_bundle_requires_boot_lazy_and_servable_dist() {
+                // boot-lazy on (lazy on + env on) + servable dist => defer.
+                assert!(defer_dev_bundle_decision(true, Some("1"), true));
+                assert!(defer_dev_bundle_decision(true, Some("true"), true));
+                // boot-lazy on but NO servable dist => eager (no safe seed).
+                assert!(!defer_dev_bundle_decision(true, Some("1"), false));
+                // servable dist but boot-lazy OFF (env off) => eager.
+                assert!(!defer_dev_bundle_decision(true, None, true));
+                assert!(!defer_dev_bundle_decision(true, Some("0"), true));
+                // servable dist + env on but lazy rendering OFF => eager
+                // (no render-on-request hook is installed).
+                assert!(!defer_dev_bundle_decision(false, Some("1"), true));
+                // neither => eager.
+                assert!(!defer_dev_bundle_decision(false, None, false));
             }
 
             /// Issue #1057 — the freshness gate accepts a `dist/` only when it

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -1829,6 +1829,20 @@ fn boot_lazy_decision(lazy_render_on: bool, boot_lazy_var: Option<&str>) -> bool
 /// render). When the gate is off, `boot_dev_renderer` builds the renderer
 /// eagerly before bind exactly as before — the deferral is strictly additive.
 ///
+/// SSR-window trade-off (issue #1182, accepted): the gate only proves SOME
+/// servable `index.html` exists, not that every route is covered during the
+/// deferred-bundle window. SSG routes with a prebuilt `dist/<route>/index.html`
+/// serve from the `read_from_dist` leg (`ServeOpts.dist_root`) the whole window;
+/// SSR-only (`prerender = false`) routes have no static artifact, so they serve
+/// the controlled dev 404 (+ livereload) until the renderer publishes — then the
+/// post-publish `pages_stale` broadcast reloads those tabs and they resolve.
+/// This is the same request-before-render contract #1166 already ships, just
+/// over the bundle window; it does extend the SSR-unavailable window (which was
+/// ~0 in non-deferred boot-lazy, where the renderer was live before bind) to the
+/// bundle duration. Acceptable for the large-SSG projects this targets; a
+/// per-route dist-coverage gate would need the route tables, which need the
+/// bundle we are deferring. Tracked for revisit in issue-raising below.
+///
 /// Split out so the gate is unit-testable without process-global env mutation
 /// or a real `dist/` tree.
 fn defer_dev_bundle_decision(

--- a/crates/zfb/tests/dev_bind_before_walk_e2e.rs
+++ b/crates/zfb/tests/dev_bind_before_walk_e2e.rs
@@ -63,6 +63,14 @@
 //!    deferred boot task. Uses the same strategy with a co-located
 //!    `ZFB_DEV_TEST_SLOW_ISLANDS_MS` slow step, independent of the digest
 //!    one, so it specifically pins the islands build's position past bind.
+//! 5. `dev_binds_and_serves_before_slow_bundle_step` — the
+//!    bind-before-bundle guard (issue #1182). The eager esbuild dev bundle
+//!    (`assemble_and_bundle_dev`) used to run synchronously before the bind
+//!    even in boot-lazy mode with a servable `dist/` (the residual of #1161);
+//!    it now runs on the deferred boot task in that mode. Runs boot-lazy with
+//!    a seeded servable `dist/` and pins the bundle's position past bind via
+//!    TWO co-located `ZFB_DEV_TEST_SLOW_BUNDLE_MS` seams (deferred + eager) so
+//!    an un-defer revert is caught.
 //!
 //! ## Spawn / teardown discipline (from `dev_serve_e2e.rs` /
 //! `build_terminates.rs`)
@@ -135,6 +143,25 @@ const _: () = assert!(
      would still print the banner within the deadline and the guard proves nothing"
 );
 
+/// The injected dev-bundle slow-step for the bind-before-bundle guard (issue
+/// #1182). Same rationale as `SLOW_DIGEST_MS` / `SLOW_ISLANDS_MS`, pinning the
+/// EAGER esbuild dev bundle (`assemble_and_bundle_dev`) — the dominant,
+/// size-scaling pre-bind cost #1166/#1170 left behind. Deliberately set LONGER
+/// than `BANNER_DEADLINE`: the binary reads `ZFB_DEV_TEST_SLOW_BUNDLE_MS` from
+/// TWO co-located seams — one before the DEFERRED boot bundle (which runs after
+/// bind, so in the correct ordering the banner lands fast), one before the
+/// EAGER pre-bind bundle (which fires only if the deferral is reverted, delaying
+/// the banner past `BANNER_DEADLINE` so `wait_for_banner_port` times out and
+/// fails). A green run never waits this out — it answers fast and Drop SIGKILLs
+/// the group — so the large value is free.
+const SLOW_BUNDLE_MS: u64 = 120_000;
+
+const _: () = assert!(
+    SLOW_BUNDLE_MS > BANNER_DEADLINE.as_secs() * 1000,
+    "SLOW_BUNDLE_MS must exceed BANNER_DEADLINE — otherwise an un-deferred pre-bind dev \
+     bundle would still print the banner within the deadline and the guard proves nothing"
+);
+
 /// Deadline for the FIRST successful HTTP response after the banner. The banner
 /// timeout is the PRIMARY bind-ordering signal (see `SLOW_DIGEST_MS`); this is
 /// the belt-and-braces serve-path check — answering within this window while
@@ -152,6 +179,12 @@ const _: () = assert!(
 const _: () = assert!(
     FIRST_RESPONSE_DEADLINE.as_secs() * 1000 < SLOW_ISLANDS_MS,
     "FIRST_RESPONSE_DEADLINE must be shorter than SLOW_ISLANDS_MS or Test 4's serve-path \
+     belt-and-braces check proves nothing"
+);
+
+const _: () = assert!(
+    FIRST_RESPONSE_DEADLINE.as_secs() * 1000 < SLOW_BUNDLE_MS,
+    "FIRST_RESPONSE_DEADLINE must be shorter than SLOW_BUNDLE_MS or Test 5's serve-path \
      belt-and-braces check proves nothing"
 );
 
@@ -313,7 +346,8 @@ fn spawn_dev(tmp: &tempfile::TempDir, esbuild: &Path, extra_env: &[(&str, &str)]
         .env_remove("ZFB_LAZY_DEV_RENDER")
         .env_remove("ZFB_DEV_BOOT_LAZY")
         .env_remove("ZFB_DEV_TEST_SLOW_DIGEST_MS")
-        .env_remove("ZFB_DEV_TEST_SLOW_ISLANDS_MS");
+        .env_remove("ZFB_DEV_TEST_SLOW_ISLANDS_MS")
+        .env_remove("ZFB_DEV_TEST_SLOW_BUNDLE_MS");
     for (k, v) in extra_env {
         cmd.env(k, v);
     }
@@ -838,4 +872,145 @@ async fn dev_binds_and_serves_before_slow_islands_step() {
     );
 
     // The deferred slow step is still sleeping; Drop group-kills it.
+}
+
+// ---------------------------------------------------------------------------
+// Test 5 — bind-before-bundle guard (issue #1182).
+// ---------------------------------------------------------------------------
+
+/// Bind-before-bundle guard (issue #1182). The eager esbuild dev bundle
+/// (`assemble_and_bundle_dev`, via `boot_dev_renderer`) used to run
+/// SYNCHRONOUSLY before `TcpListener::bind`; on a large project its
+/// content-snapshot embed + esbuild over the route graph was the dominant
+/// pre-bind cost (the residual of #1161 that #1166/#1170 left behind), so
+/// first-accept took ~140–250s even in boot-lazy mode with a servable `dist/`.
+/// #1182 defers it past the bind, on the deferred boot task, gated on boot-lazy
+/// + a servable `dist/` seed.
+///
+/// ## Mode — boot-lazy + servable `dist/` (the ONLY mode the deferral applies)
+///
+/// The deferral gate is `ZFB_DEV_BOOT_LAZY=1` (with lazy rendering on, the
+/// default) AND `dist_is_servable_seed(dist/)`. So this test sets
+/// `ZFB_DEV_BOOT_LAZY=1` and seeds a minimal servable `dist/index.html` BEFORE
+/// spawning. A hand-written seed (not a full `zfb build`) is deliberate: the
+/// gate only checks for a servable `index.html`, and a real build would add the
+/// multi-minute V8 + esbuild cost this very test exists to keep OFF the bind
+/// critical path — far too heavy for the PR gate. Without the seed, boot-lazy
+/// falls back to eager and the bundle would NOT be deferred (the test would be
+/// vacuous).
+///
+/// ## Falsifiability — two co-located seams, anchored to banner-vs-bind ordering
+///
+/// The binary reads `ZFB_DEV_TEST_SLOW_BUNDLE_MS` from TWO seams co-located
+/// with the boot bundle: one before the DEFERRED bundle (deferred boot task,
+/// after bind) and one before the EAGER bundle (`boot_dev_renderer`, before
+/// bind). `SLOW_BUNDLE_MS` (> `BANNER_DEADLINE`).
+///
+/// - Correct (deferred) ordering: the boot takes the scaffold path, so only the
+///   DEFERRED seam fires — after the bind/banner. The banner lands at boot time,
+///   far under `BANNER_DEADLINE`. ✅
+/// - Reverted ordering (the bug): the boot bundle runs eagerly before bind, so
+///   the EAGER seam fires before bind, delaying the banner by `SLOW_BUNDLE_MS`
+///   (> `BANNER_DEADLINE`) — `wait_for_banner_port` times out and the test
+///   fails. ❌ A single deferred-only seam would NOT catch an un-defer revert
+///   (the deferred block simply wouldn't run), which is exactly why the eager
+///   twin exists.
+///
+/// Belt-and-braces: `GET /__zfb/reload` answers 200 within
+/// `FIRST_RESPONSE_DEADLINE` while the deferred bundle slow-step is still in
+/// flight — proof the serve path does not block on the deferred bundle.
+#[tokio::test(flavor = "multi_thread")]
+async fn dev_binds_and_serves_before_slow_bundle_step() {
+    let _serial = SERIAL.lock().await;
+    let Some(esbuild) = locate_esbuild() else {
+        eprintln!("[dev_bind_before_walk_e2e] no esbuild; skipping.");
+        return;
+    };
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    // Seed a servable `dist/` so the deferral gate (dist_is_servable_seed) is
+    // satisfied. `spawn_dev` copies the fixture INTO this tempdir without
+    // clearing it (and `dev-loop-basic` ships no `dist/`), so the seed written
+    // here survives the copy. The dev server serves this `dist/index.html` for
+    // `/` until the deferred renderer publishes.
+    let dist = tmp.path().join("dist");
+    fs::create_dir_all(&dist).expect("create dist seed dir");
+    fs::write(
+        dist.join("index.html"),
+        "<!doctype html><html><head><title>seed</title></head>\
+         <body>servable-dist-seed</body></html>",
+    )
+    .expect("write dist seed index.html");
+
+    let slow = SLOW_BUNDLE_MS.to_string();
+    // Boot-lazy + servable seed => the eager dev bundle is DEFERRED past bind.
+    // No ZFB_DEV_EAGER (that would force eager rendering off the lazy path and
+    // disable boot-lazy / the deferral entirely).
+    let spawn_t = Instant::now();
+    let mut session = spawn_dev(
+        &tmp,
+        &esbuild,
+        &[
+            ("ZFB_DEV_TEST_SLOW_BUNDLE_MS", slow.as_str()),
+            ("ZFB_DEV_BOOT_LAZY", "1"),
+        ],
+    );
+
+    // Guarantee 1 (bind precedes the dev bundle): the banner follows the bind,
+    // so it lands at boot time in the correct (deferred) ordering. An
+    // un-deferred pre-bind bundle would fire the eager seam before bind, delay
+    // the banner by SLOW_BUNDLE_MS (> BANNER_DEADLINE), and time out the wait
+    // below — that timeout IS the bind-before-bundle regression signal.
+    let Some(port) = wait_for_banner_port(&mut session).await else {
+        return; // known-skip (no V8 / no esbuild)
+    };
+    // Explicit, clearly-messaged form of the same guarantee (in case the
+    // deadlines are ever retuned): the banner — and the bind it follows —
+    // landed well before the injected bundle slow-step could have.
+    let banner_elapsed = spawn_t.elapsed();
+    assert!(
+        (banner_elapsed.as_millis() as u64) < SLOW_BUNDLE_MS,
+        "ready banner appeared {}ms after spawn, but the injected dev-bundle slow-step is \
+         {}ms — the eager dev bundle (and its sleep) ran BEFORE the bind/banner \
+         (bind-before-bundle regression, issue #1182).\n{}",
+        banner_elapsed.as_millis(),
+        SLOW_BUNDLE_MS,
+        session.logs(),
+    );
+
+    let base = format!("http://localhost:{port}");
+    let client = client();
+
+    // Guarantee 2 (serve path is not blocked by the deferred bundle):
+    // `GET /__zfb/reload` is 200 the instant the router is mounted, independent
+    // of any bundle / render. Answering within FIRST_RESPONSE_DEADLINE of the
+    // banner while the deferred bundle slow-step is still in flight proves the
+    // serve path does not wait on the bundle.
+    let url = format!("{base}/__zfb/reload");
+    let request_start = Instant::now();
+    let mut answered = false;
+    while request_start.elapsed() < FIRST_RESPONSE_DEADLINE {
+        if let Ok(resp) = client.get(&url).send().await {
+            assert_eq!(
+                resp.status().as_u16(),
+                200,
+                "SSE endpoint must answer 200; the server is serving but on a wrong status.\n{}",
+                session.logs(),
+            );
+            answered = true;
+            break;
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+    assert!(
+        answered,
+        "the dev server did not answer GET {url} within {}s of the banner while the \
+         dev-bundle slow-step was in flight — the serve path is blocking on the deferred \
+         dev bundle (issue #1182).\n{}",
+        FIRST_RESPONSE_DEADLINE.as_secs(),
+        session.logs(),
+    );
+
+    // The deferred bundle slow step is still sleeping; Drop group-kills it.
 }


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1184
    - https://github.com/Takazudo/zudo-front-builder/issues/1182

---

## Summary

In boot-lazy mode with a servable prebuilt `dist/`, the eager esbuild dev bundle (`assemble_and_bundle_dev`, via `boot_dev_renderer`) ran **synchronously before `TcpListener::bind`**, so `zfb dev` first socket-accept took ~140–250s on large projects — the residual of #1161 that #1166/#1170 left behind. This defers it past the bind, making first-accept **O(1)** regardless of project size.

## Approach

- **Gate** `defer_dev_bundle_decision = boot_lazy_enabled && dist_is_servable_seed` (matches `run_boot_render`'s boot-lazy gate exactly).
- When set, `boot_dev_renderer` returns a **scaffold** session (renderer slot `None`, empty route tables) and skips the bundle/host-start/route-table build before bind.
- The **deferred boot task** runs that work past the bind via the existing `refresh_bundle_and_routes` swap seam (bundle → start V8 host → swap into the `None` slot → rebuild route tables → publish), then publishes the live SSR handle (`refresh_live_ssr_routes`) and folds the marked-stale routes into a `pages_stale` broadcast so a tab that loaded the prebuilt `dist/` during the window auto-upgrades.
- **Non-lazy / no-servable-seed boots keep the eager pre-bind path unchanged** — the deferral is strictly additive.

### Ordering invariants (load-bearing)

1. Deferred publish runs **before** the graph seed (the scaffold's `page_ids()` is empty until the route tables publish).
2. Live SSR handle published explicitly after the refresh (the method swaps session tables, not the server handle).
3. Boot-lazy latch + mark-stale stay in `run_boot_render` (consumed after publish).
4. `pages_stale` → `ReloadEvent::Page` broadcast so window tabs auto-upgrade.

## Trade-off (tracked: #1188)

During the bundle window, SSG routes serve from the prebuilt `dist/` (`read_from_dist` leg); SSR-only routes serve the controlled dev 404 + livereload until the renderer publishes, then auto-upgrade. Same request-before-render contract as #1166, over the bundle window. Documented at the gate; a stricter per-route gate is tracked in #1188.

## Tests

- **New falsifiable e2e** `dev_binds_and_serves_before_slow_bundle_step` (`dev_bind_before_walk_e2e.rs`): boot-lazy + seeded servable `dist/` + **two co-located `ZFB_DEV_TEST_SLOW_BUNDLE_MS` seams** (deferred + eager) so an un-defer revert delays the banner past the deadline and fails the guard. **Verified the test fails when the deferral is reverted.**
- Unit test `defer_dev_bundle_requires_boot_lazy_and_servable_dist` for the gate predicate.
- Full `dev_bind_before_walk_e2e` (5) + `dev_serve_e2e` (3) suites green; `clippy -D warnings` + `fmt --check` clean.
- **Real boot-lazy smoke test** (manual): banner in ~2.5s, `GET /` and dynamic SSG `GET /posts/a/` both serve 200 via the deferred renderer.

## Test plan / blind spots

The e2e uses the deterministic `SLOW_BUNDLE_MS` injection, not a real 682-route project (inherent, matches the #1166/#1170 guards). Real publish+serve covered by the manual smoke test above.

Closes #1182.