### PR TITLE
fix(dev): isolate dev-served assets from the build out_dir so a concurrent `zfb build` can't clobber `/assets/styles.css` (#1189)

### DIFF
--- a/crates/zfb-server/src/assets_containment.rs
+++ b/crates/zfb-server/src/assets_containment.rs
@@ -66,46 +66,85 @@ type ReqBody = Body;
 /// The concrete inner Service type (ServeDir with default fallback, Body request).
 type InnerService = ServeDir;
 
-/// A thin Tower [`Service`] that enforces symlink-containment on the
-/// `dist/assets/` directory before delegating to the inner [`ServeDir`].
-///
-/// Constructed via [`ContainedAssetsService::new`].
+/// One asset root: its raw dir, the pre-canonicalized form, and the inner
+/// [`ServeDir`] that serves files from it.
 #[derive(Clone)]
-pub(crate) struct ContainedAssetsService {
-    /// Canonical form of `<dist_root>/assets/`.  Pre-computed at
-    /// construction time so the per-request hot path only calls
-    /// `tokio::fs::canonicalize` once (for the candidate path).
+struct AssetRoot {
+    /// Canonical form of the assets dir.  Pre-computed at construction time
+    /// so the per-request hot path only calls `tokio::fs::canonicalize` once
+    /// (for the candidate path).
     ///
-    /// `None` means the assets directory didn't exist at boot (first dev
-    /// boot before a build finishes).  Each request retries the
-    /// canonicalize so assets start serving as soon as the dir appears.
+    /// `None` means the dir didn't exist at boot (first dev boot before a
+    /// build finishes).  Each request retries the canonicalize so assets
+    /// start serving as soon as the dir appears.
     ///
     /// Wrapped in `Arc` so cloning (required by Tower) is cheap.
     canonical_root: Arc<Option<PathBuf>>,
     /// The raw (non-canonical) assets directory.
     assets_dir: PathBuf,
-    /// Inner service that does the actual file serving.
+    /// Inner service that does the actual file serving for this root.
     inner: InnerService,
 }
 
-impl ContainedAssetsService {
-    /// Build a new [`ContainedAssetsService`] that serves files from
-    /// `assets_dir`, rejecting any request whose resolved FS path escapes
-    /// that directory (even via symlinks).
-    ///
-    /// `assets_dir` need not exist at construction time — a missing root
-    /// simply means every request will get a 404 (same behaviour as an
-    /// empty directory from the client's perspective).
-    pub(crate) fn new(assets_dir: PathBuf) -> Self {
+impl AssetRoot {
+    fn new(assets_dir: PathBuf) -> Self {
         // Best-effort pre-canonicalize at boot (sync, outside the hot loop).
-        // If the dir doesn't exist yet, `canonical_root` is None and the
-        // per-request path retries canonicalize so it becomes available
-        // as soon as the first build completes.
         let canonical_root = std::fs::canonicalize(&assets_dir).ok();
         Self {
             canonical_root: Arc::new(canonical_root),
             inner: ServeDir::new(&assets_dir),
             assets_dir,
+        }
+    }
+}
+
+/// A thin Tower [`Service`] that enforces symlink-containment on one or more
+/// `assets/` directories before delegating to the inner [`ServeDir`].
+///
+/// Constructed via [`ContainedAssetsService::new`] (single root) or
+/// [`ContainedAssetsService::layered`] (ordered roots).
+#[derive(Clone)]
+pub(crate) struct ContainedAssetsService {
+    /// Asset roots tried IN ORDER on every request: the first root whose
+    /// containment check passes AND that actually holds the file serves it;
+    /// a miss falls through to the next root.
+    ///
+    /// `zfb dev` (issue #1189) passes two roots — the isolated
+    /// `.zfb-build/dev-assets/assets/` first, then the build `dist/assets/`
+    /// as a boot-lazy-seed fallback — so a concurrent `zfb build` that wipes
+    /// `dist/` can never 404 dev's stable `/assets/styles.css`. The
+    /// namespaces don't collide: dev's isolated dir only holds STABLE names
+    /// (`styles.css`, `islands.js`, chunks, `client/*.js`) while a prebuilt
+    /// seed only serves HASHED names, so isolated-first never shadows a
+    /// legitimately newer hashed seed asset. Single-root callers (preview /
+    /// embed / tests) get exactly the historical behavior.
+    roots: Vec<AssetRoot>,
+}
+
+impl ContainedAssetsService {
+    /// Build a single-root [`ContainedAssetsService`] that serves files from
+    /// `assets_dir`, rejecting any request whose resolved FS path escapes
+    /// that directory (even via symlinks). Byte-identical to the historical
+    /// behavior (preview / embed / tests).
+    ///
+    /// `assets_dir` need not exist at construction time — a missing root
+    /// simply means every request will get a 404 (same behaviour as an
+    /// empty directory from the client's perspective).
+    pub(crate) fn new(assets_dir: PathBuf) -> Self {
+        Self {
+            roots: vec![AssetRoot::new(assets_dir)],
+        }
+    }
+
+    /// Build a layered [`ContainedAssetsService`]: the roots are tried in
+    /// priority order, and the first one that contains the requested file
+    /// serves it. Each root is canonicalized and containment-checked
+    /// INDEPENDENTLY, so the symlink-containment guarantee holds for every
+    /// root (never canonicalize a merged root). Used by `zfb dev` to put the
+    /// isolated dev-assets dir ahead of the build `dist/assets/` (#1189).
+    pub(crate) fn layered(assets_dirs: Vec<PathBuf>) -> Self {
+        Self {
+            roots: assets_dirs.into_iter().map(AssetRoot::new).collect(),
         }
     }
 
@@ -159,46 +198,73 @@ impl Service<Request<ReqBody>> for ContainedAssetsService {
     type Future = BoxedFuture<Result<Self::Response, Self::Error>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        <InnerService as Service<Request<ReqBody>>>::poll_ready(&mut self.inner, cx)
+        // ServeDir is always immediately ready (no bounded resource pool), so
+        // this loop short-circuits on the first poll. Polling every root keeps
+        // the contract honest if that ever changes.
+        for root in &mut self.roots {
+            match <InnerService as Service<Request<ReqBody>>>::poll_ready(&mut root.inner, cx) {
+                Poll::Ready(Ok(())) => {}
+                // ServeDir's error is `Infallible` — the arm is uninhabited.
+                Poll::Ready(Err(e)) => match e {},
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+        Poll::Ready(Ok(()))
     }
 
     fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
         let uri_path = req.uri().path().to_owned();
-        let assets_dir = self.assets_dir.clone();
-        let canonical_root = Arc::clone(&self.canonical_root);
-
-        // Clone the inner service so we can move it into the async block.
-        let mut inner = self.inner.clone();
+        // Clone the roots so we can move them into the async block.
+        let roots = self.roots.clone();
 
         Box::pin(async move {
-            // Build the candidate FS path using the same logic as ServeDir.
-            let candidate = match Self::candidate_path(&assets_dir, &uri_path) {
-                Some(p) => p,
-                None => return Ok(not_found()),
-            };
+            // Phase 1 — find the first root that actually contains the file. A
+            // successful `canonicalize` means the file exists; a failure (or a
+            // containment-check failure) is a miss for THIS root, so we fall
+            // through to the next. ServeDir is invoked only for the winning
+            // root (Phase 2), so `req` is moved exactly once regardless of how
+            // many roots are probed.
+            let mut hit: Option<(PathBuf, PathBuf, InnerService)> = None;
+            for root in &roots {
+                // Build the candidate FS path using the same logic as ServeDir.
+                let Some(candidate) = Self::candidate_path(&root.assets_dir, &uri_path) else {
+                    continue;
+                };
 
-            // Canonicalize resolves symlinks; if it fails the file/target
-            // doesn't exist — 404.
-            let canonical_candidate = match tokio::fs::canonicalize(&candidate).await {
-                Ok(p) => p,
-                Err(_) => return Ok(not_found()),
-            };
-
-            // Determine the canonical root.  Prefer the pre-computed value;
-            // fall back to a fresh canonicalize if it was None at boot.
-            let canon_root = match canonical_root.as_ref() {
-                Some(r) => r.clone(),
-                None => match tokio::fs::canonicalize(&assets_dir).await {
+                // Canonicalize resolves symlinks; if it fails the file/target
+                // doesn't exist in this root — try the next root.
+                let canonical_candidate = match tokio::fs::canonicalize(&candidate).await {
                     Ok(p) => p,
-                    Err(_) => return Ok(not_found()),
-                },
-            };
+                    Err(_) => continue,
+                };
 
-            // Containment check: the canonical candidate must be inside
-            // (or equal to) the canonical assets root.
-            if !canonical_candidate.starts_with(&canon_root) {
-                return Ok(not_found());
+                // Determine the canonical root.  Prefer the pre-computed
+                // value; fall back to a fresh canonicalize if it was None at
+                // boot. Each root is canonicalized INDEPENDENTLY so the
+                // containment guarantee holds per-root.
+                let canon_root = match root.canonical_root.as_ref() {
+                    Some(r) => r.clone(),
+                    None => match tokio::fs::canonicalize(&root.assets_dir).await {
+                        Ok(p) => p,
+                        Err(_) => continue,
+                    },
+                };
+
+                // Containment check: the canonical candidate must be inside
+                // (or equal to) this canonical assets root. An escape is a
+                // miss for this root (and will escape the others too) — fall
+                // through; the loop ends in a 404.
+                if !canonical_candidate.starts_with(&canon_root) {
+                    continue;
+                }
+
+                hit = Some((canonical_candidate, canon_root, root.inner.clone()));
+                break;
             }
+
+            let Some((canonical_candidate, canon_root, mut inner)) = hit else {
+                return Ok(not_found());
+            };
 
             // TOCTOU narrowing: rewrite the request URI to the CANONICAL
             // path relative to the canonical root before delegating, so
@@ -505,6 +571,130 @@ mod tests {
             b"body{color:red}",
             "rewritten-URI delegation must serve the canonical target's bytes"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // Layered two-root service (issue #1189) — `zfb dev` serves `/assets/*`
+    // from the isolated dev-assets root first, with `dist/assets/` as the
+    // boot-lazy-seed fallback. A concurrent `zfb build` that wipes `dist/`
+    // must not 404 the dev-served stylesheet.
+    // -----------------------------------------------------------------------
+
+    /// Build a layered service over two tempdirs (primary tried first), run
+    /// `setup` on each, and return `(service, primary_dir, secondary_dir)`.
+    /// The tempdirs are returned so the caller keeps them alive.
+    fn make_layered(
+        primary_setup: impl FnOnce(&Path),
+        secondary_setup: impl FnOnce(&Path),
+    ) -> (ContainedAssetsService, tempfile::TempDir, tempfile::TempDir) {
+        let primary = tempfile::tempdir().expect("primary tempdir");
+        let secondary = tempfile::tempdir().expect("secondary tempdir");
+        primary_setup(primary.path());
+        secondary_setup(secondary.path());
+        let svc = ContainedAssetsService::layered(vec![
+            primary.path().to_path_buf(),
+            secondary.path().to_path_buf(),
+        ]);
+        (svc, primary, secondary)
+    }
+
+    async fn body_for(svc: ContainedAssetsService, path: &str) -> (StatusCode, Vec<u8>) {
+        let resp = svc
+            .oneshot(Request::builder().uri(path).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let status = resp.status();
+        let bytes = to_bytes(resp.into_body(), 4096).await.unwrap();
+        (status, bytes.to_vec())
+    }
+
+    #[tokio::test]
+    async fn layered_serves_from_primary_root() {
+        let (svc, _p, _s) = make_layered(
+            |p| std::fs::write(p.join("styles.css"), b"primary{}").unwrap(),
+            |_s| {},
+        );
+        let (status, body) = body_for(svc, "/styles.css").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(&body[..], b"primary{}", "primary root must serve its file");
+    }
+
+    #[tokio::test]
+    async fn layered_falls_back_to_secondary_root() {
+        // Mirrors a boot-lazy prebuilt seed: only the build `dist/assets/`
+        // (secondary) holds the hashed asset; the isolated dev root doesn't.
+        let (svc, _p, _s) = make_layered(
+            |_p| {},
+            |s| std::fs::write(s.join("styles-abc123.css"), b"seed{}").unwrap(),
+        );
+        let (status, body) = body_for(svc, "/styles-abc123.css").await;
+        assert_eq!(status, StatusCode::OK, "must fall through to dist seed");
+        assert_eq!(&body[..], b"seed{}");
+    }
+
+    #[tokio::test]
+    async fn layered_primary_shadows_same_name_in_secondary() {
+        let (svc, _p, _s) = make_layered(
+            |p| std::fs::write(p.join("styles.css"), b"dev-stable{}").unwrap(),
+            |s| std::fs::write(s.join("styles.css"), b"stale-build{}").unwrap(),
+        );
+        let (status, body) = body_for(svc, "/styles.css").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            &body[..],
+            b"dev-stable{}",
+            "primary (isolated dev-assets) must win over the secondary"
+        );
+    }
+
+    /// THE regression for issue #1189: dev's stable `styles.css` lives in the
+    /// isolated primary root; a concurrent `zfb build` wipes the secondary
+    /// (`dist/`). The stylesheet must STILL be served (before the fix, dev
+    /// wrote into `dist/assets/` and this returned 404 → unstyled site).
+    #[tokio::test]
+    async fn layered_primary_survives_secondary_wipe() {
+        let (svc, _p, secondary) = make_layered(
+            |p| std::fs::write(p.join("styles.css"), b"body{color:blue}").unwrap(),
+            |s| {
+                std::fs::write(s.join("styles-old.css"), b"seed{}").unwrap();
+            },
+        );
+
+        // Sanity: served before the wipe.
+        let (status, body) = body_for(svc.clone(), "/styles.css").await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(&body[..], b"body{color:blue}");
+
+        // Simulate `zfb build` wiping the shared `dist/` (the secondary root).
+        std::fs::remove_dir_all(secondary.path()).unwrap();
+
+        // The dev-served stylesheet is untouched — still 200.
+        let (status, body) = body_for(svc, "/styles.css").await;
+        assert_eq!(
+            status,
+            StatusCode::OK,
+            "isolated dev stylesheet must survive a dist/ wipe (#1189)"
+        );
+        assert_eq!(&body[..], b"body{color:blue}");
+    }
+
+    #[tokio::test]
+    async fn layered_missing_in_both_roots_is_404() {
+        let (svc, _p, _s) = make_layered(|_p| {}, |_s| {});
+        let (status, _body) = body_for(svc, "/nope.css").await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn layered_enforces_containment_on_both_roots() {
+        // A traversal escape must be rejected regardless of which root it
+        // would resolve under — each root is canonicalized independently.
+        let (svc, _p, _s) = make_layered(
+            |p| std::fs::write(p.join("ok.css"), b"x{}").unwrap(),
+            |s| std::fs::write(s.join("ok.css"), b"y{}").unwrap(),
+        );
+        let (status, _body) = body_for(svc, "/../../etc/passwd").await;
+        assert_eq!(status, StatusCode::NOT_FOUND, "traversal must 404");
     }
 
     // -----------------------------------------------------------------------

--- a/crates/zfb-server/src/assets_containment.rs
+++ b/crates/zfb-server/src/assets_containment.rs
@@ -5,11 +5,23 @@
 //! symlinks freely.  A symlink planted at `dist/assets/evil → /etc/passwd`
 //! would be served without this layer.
 //!
-//! ## How it works
+//! ## One or more roots
 //!
-//! [`ContainedAssetsService`] wraps `ServeDir` and intercepts every request
-//! before forwarding it.  It replicates the exact path-building step
-//! `ServeDir` uses internally (verified against tower-http 0.6.11 source):
+//! [`ContainedAssetsService`] wraps one [`ServeDir`] per asset root and
+//! tries them in priority order: the first root whose containment check
+//! passes AND that holds the requested file serves it; a miss falls through
+//! to the next. Single-root callers (preview / embed) behave exactly as a
+//! lone `ServeDir`; `zfb dev` (issue #1189) layers the isolated
+//! `.zfb-build/dev-assets/assets/` ahead of the build `dist/assets/` so a
+//! concurrent `zfb build` can't 404 dev's stable stylesheet. Each root is
+//! canonicalized and containment-checked **independently** — the guarantee
+//! below holds per-root.
+//!
+//! ## How it works (per root)
+//!
+//! For each root in order, [`ContainedAssetsService`] replicates the exact
+//! path-building step `ServeDir` uses internally (verified against
+//! tower-http 0.6.11 source):
 //!
 //! 1. Take the URI path after `nest_service` has stripped `/assets`
 //!    (so the path starts with `/`).

--- a/crates/zfb-server/src/embed.rs
+++ b/crates/zfb-server/src/embed.rs
@@ -291,6 +291,9 @@ impl Server {
             ssr_routes: self.ssr_routes,
             embed_handlers: self.embed_handlers,
             dist_root: self.dist_root.clone(),
+            // Embed callers serve a single built `dist/assets/` — the
+            // isolated dev-assets split only matters in `zfb dev` (#1189).
+            dev_assets_root: None,
             // Embed callers do not have a separate dev HTML dir — the
             // page-cache disk fallback reads from the same `dist_root`
             // the build pipeline wrote into. The `html_root` /

--- a/crates/zfb-server/src/lib.rs
+++ b/crates/zfb-server/src/lib.rs
@@ -135,8 +135,18 @@ pub struct ServeOpts {
     pub project_root: PathBuf,
 
     /// Build output directory. `/assets/*` is served from
-    /// `<dist_root>/assets/`.
+    /// `<dist_root>/assets/` (or as the boot-lazy-seed fallback when
+    /// `dev_assets_root` is set — see [`Self::dev_assets_root`]).
     pub dist_root: PathBuf,
+
+    /// Optional isolated dev-assets root (issue #1189). `zfb dev` passes
+    /// `Some(<project_root>/.zfb-build/dev-assets)` and writes its STABLE
+    /// assets there instead of into `dist/assets/`; the router then serves
+    /// `/assets/*` from `<dev_assets_root>/assets/` first, falling back to
+    /// `<dist_root>/assets/`. This keeps a one-off `zfb build` against the
+    /// shared `dist/` from clobbering the dev-served stylesheet. `None`
+    /// (preview / embed) keeps the single-root `dist_root` mount.
+    pub dev_assets_root: Option<PathBuf>,
 
     /// Page (HTML) on-disk root used as the page-cache fallback inside
     /// the page handler. Issue #534: this used to alias `dist_root` for
@@ -382,6 +392,9 @@ where
         // builder threads its own `AppState` directly.
         embed_handlers: None,
         dist_root: opts.dist_root.clone(),
+        // Issue #1189 — isolated dev-assets root (or `None` for preview /
+        // embed). See `ServeOpts::dev_assets_root`.
+        dev_assets_root: opts.dev_assets_root.clone(),
         // Issue #534 — see `ServeOpts::html_root` for the dev / preview
         // / embed contract.
         html_root: opts.html_root.clone(),

--- a/crates/zfb-server/src/routes.rs
+++ b/crates/zfb-server/src/routes.rs
@@ -2,8 +2,11 @@
 //!
 //! ## Route map
 //!
-//! - `GET /assets/*path` — static files from `<dist_root>/assets/`,
-//!   served via [`tower_http::services::ServeDir`].
+//! - `GET /assets/*path` — static files served via
+//!   [`tower_http::services::ServeDir`] from `<dist_root>/assets/`, or —
+//!   when `dev_assets_root` is set (`zfb dev`, issue #1189) — from
+//!   `<dev_assets_root>/assets/` first with `<dist_root>/assets/` as a
+//!   fallback. See [`crate::assets_containment`].
 //! - `GET /__zfb/livereload.js` — bundled JS that opens an SSE
 //!   connection back to this server. Always served with
 //!   `Cache-Control: no-store`.
@@ -51,7 +54,7 @@
 //!   the same `dist/` + `public/` disk fallback chain described above,
 //!   so `public/logo.svg` is reachable at `/foo/logo.svg`),
 //! - `GET /foo/assets/<file>` serves built static assets from
-//!   `<dist_root>/assets/`,
+//!   `<dist_root>/assets/` (or the layered dev-assets roots above),
 //! - `GET /foo/__zfb/livereload.js` and `GET /foo/__zfb/reload` serve
 //!   live-reload (and the injected `<script src>` matches),
 //! - plugin-registered dev-middleware paths are auto-prefixed too
@@ -2172,6 +2175,113 @@ mod tests {
             !body.contains("prod-build-leftover-from-dist_root"),
             "disk fallback must NOT read from dist_root; got body:\n{body}",
         );
+    }
+
+    /// Issue #1189 wiring: `build_core_router` must mount `/assets/*` as a
+    /// TWO-ROOT lookup when `dev_assets_root` is `Some` — the isolated
+    /// dev-assets dir first, with `dist/assets/` as the boot-lazy-seed
+    /// fallback. This exercises the `layered`-vs-`new` branch end-to-end
+    /// through the real router (not `ContainedAssetsService` in isolation),
+    /// and proves the writer-dir == mount-primary-dir invariant: dev's
+    /// stable stylesheet survives a concurrent `zfb build` wiping `dist/`.
+    #[tokio::test]
+    async fn assets_mount_serves_dev_assets_first_with_dist_fallback() {
+        use tempfile::TempDir;
+        let (tx, _rx) = broadcast::channel::<ReloadEvent>(16);
+
+        let dev_assets_dir = TempDir::new().expect("dev-assets tempdir");
+        let dist_dir = TempDir::new().expect("dist tempdir");
+
+        // Dev writes its STABLE stylesheet into the isolated dev-assets root.
+        let dev_assets = dev_assets_dir.path().join("assets");
+        std::fs::create_dir_all(&dev_assets).unwrap();
+        std::fs::write(dev_assets.join("styles.css"), b"body{color:blue}").unwrap();
+
+        // A prior `zfb build` left a HASHED seed asset in `dist/assets/`.
+        let dist_assets = dist_dir.path().join("assets");
+        std::fs::create_dir_all(&dist_assets).unwrap();
+        std::fs::write(dist_assets.join("styles-abc123.css"), b"seed{}").unwrap();
+
+        let state = AppState {
+            mode: crate::ServerMode::Dev,
+            pages: PageCache::new(),
+            broadcast: tx,
+            plugins: None,
+            injected_routes: None,
+            ssr_routes: None,
+            embed_handlers: None,
+            dist_root: dist_dir.path().to_path_buf(),
+            html_root: std::env::temp_dir().join("zfb-test-html-1189"),
+            public_root: std::env::temp_dir().join("zfb-test-public-1189"),
+            base_prefix: None,
+            trailing_slash: false,
+            islands_bundle_url: None,
+            css_bundle_url: None,
+            host_validation: crate::host_validation::HostValidation::disabled(),
+            render_on_request_hook: None,
+            canonical_html_root: None,
+            canonical_dist_root: None,
+            dev_assets_root: Some(dev_assets_dir.path().to_path_buf()),
+            canonical_public_root: None,
+        };
+        let router = build_router(state);
+
+        // Stable stylesheet comes from the isolated dev-assets root (primary).
+        let resp = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/assets/styles.css")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "dev stylesheet must serve from the dev-assets primary root"
+        );
+        assert_eq!(body_string(resp).await, "body{color:blue}");
+
+        // The hashed seed asset falls through to the `dist/assets/` fallback.
+        let resp = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/assets/styles-abc123.css")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "boot-lazy seed asset must serve from the dist fallback root"
+        );
+
+        // Simulate a concurrent `zfb build` wiping `dist/`. The isolated dev
+        // stylesheet is untouched; before #1189 it lived in `dist/assets/`
+        // and this would 404.
+        drop(dist_dir);
+
+        let resp = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/assets/styles.css")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "isolated dev stylesheet must survive a dist/ wipe (#1189)"
+        );
+        assert_eq!(body_string(resp).await, "body{color:blue}");
     }
 
     #[tokio::test]

--- a/crates/zfb-server/src/routes.rs
+++ b/crates/zfb-server/src/routes.rs
@@ -398,6 +398,16 @@ pub struct AppState {
     /// renders can target a separate directory from the production
     /// `outDir` (issue #534).
     pub dist_root: std::path::PathBuf,
+    /// Optional isolated dev-assets root (issue #1189). When `Some`,
+    /// `/assets/*` is served from `<dev_assets_root>/assets/` FIRST and
+    /// falls back to `<dist_root>/assets/` for anything not found there.
+    /// `zfb dev` writes its STABLE assets (`styles.css`, `islands.js`,
+    /// island chunks, `client/*.js`) into the isolated root so a concurrent
+    /// `zfb build` that wipes `dist/` cannot 404 the dev-served stylesheet;
+    /// the `dist_root` fallback still serves a boot-lazy prebuilt seed's
+    /// HASHED assets (the namespaces never collide). `None` (preview /
+    /// embed / tests) keeps the historical single-root `dist_root` mount.
+    pub dev_assets_root: Option<std::path::PathBuf>,
     /// On-disk page root used as the page-cache fallback in
     /// `serve_page`. `<html_root>/<path>/index.html` and
     /// `<html_root>/<path>` are probed when the in-memory cache misses
@@ -611,11 +621,22 @@ pub fn build_router(state: AppState) -> Router {
 /// /api/echo`). The page handlers below strip the prefix from the
 /// captured wildcard / URI before forwarding into [`serve_page`].
 fn build_core_router(state: AppState, prefix: &str) -> Router {
-    let assets_dir = state.dist_root.join("assets");
+    let dist_assets = state.dist_root.join("assets");
     // Wrap ServeDir with symlink containment: any request whose resolved
-    // FS path escapes `assets_dir` (including via symlinks) is rejected
+    // FS path escapes the assets root (including via symlinks) is rejected
     // with 404 before ServeDir sees it.  See `assets_containment` module.
-    let assets_service = ContainedAssetsService::new(assets_dir);
+    //
+    // Issue #1189: in `zfb dev` the isolated dev-assets dir is tried first,
+    // with `dist/assets/` as a boot-lazy-seed fallback, so a concurrent
+    // `zfb build` wiping `dist/` can't 404 dev's stable `/assets/styles.css`.
+    // Preview / embed / tests pass `dev_assets_root = None` → single-root
+    // mount on `dist/assets/`, byte-identical to before.
+    let assets_service = match state.dev_assets_root.as_ref() {
+        Some(dev_assets_root) => {
+            ContainedAssetsService::layered(vec![dev_assets_root.join("assets"), dist_assets])
+        }
+        None => ContainedAssetsService::new(dist_assets),
+    };
 
     let livereload_path = format!("{prefix}/__zfb/livereload.js");
     let sse_path = format!("{prefix}/__zfb/reload");
@@ -2016,6 +2037,7 @@ mod tests {
             // Tests use bogus/temp paths — canonical roots are not precomputed.
             canonical_html_root: None,
             canonical_dist_root: None,
+            dev_assets_root: None,
             canonical_public_root: None,
         }
     }
@@ -2042,6 +2064,7 @@ mod tests {
             render_on_request_hook: None,
             canonical_html_root: None,
             canonical_dist_root: None,
+            dev_assets_root: None,
             canonical_public_root: None,
         }
     }
@@ -2124,6 +2147,7 @@ mod tests {
             render_on_request_hook: None,
             canonical_html_root: None,
             canonical_dist_root: None,
+            dev_assets_root: None,
             canonical_public_root: None,
         };
         // Cache miss — the fallback must read from html_root.
@@ -2589,6 +2613,7 @@ mod tests {
             render_on_request_hook: None,
             canonical_html_root: None,
             canonical_dist_root: None,
+            dev_assets_root: None,
             canonical_public_root: None,
         };
         // HTML must include <head></head> so inject_prod_head_assets has an anchor.
@@ -2656,6 +2681,7 @@ mod tests {
             render_on_request_hook: None,
             canonical_html_root: None,
             canonical_dist_root: None,
+            dev_assets_root: None,
             canonical_public_root: None,
         };
         state
@@ -2704,6 +2730,7 @@ mod tests {
             render_on_request_hook: None,
             canonical_html_root: None,
             canonical_dist_root: None,
+            dev_assets_root: None,
             canonical_public_root: None,
         };
         state
@@ -2802,6 +2829,7 @@ mod tests {
             render_on_request_hook: None,
             canonical_html_root: None,
             canonical_dist_root: None,
+            dev_assets_root: None,
             canonical_public_root: None,
         }
     }
@@ -3641,6 +3669,7 @@ mod tests {
             render_on_request_hook: None,
             canonical_html_root: None,
             canonical_dist_root: None,
+            dev_assets_root: None,
             canonical_public_root: None,
         };
         let router = build_router(state);
@@ -3701,6 +3730,7 @@ mod tests {
             render_on_request_hook: None,
             canonical_html_root: None,
             canonical_dist_root: None,
+            dev_assets_root: None,
             canonical_public_root: None,
         };
         let router = build_router(state);
@@ -3763,6 +3793,7 @@ mod tests {
             render_on_request_hook: None,
             canonical_html_root: None,
             canonical_dist_root: None,
+            dev_assets_root: None,
             canonical_public_root: None,
         };
         let router = build_router(state);
@@ -3819,6 +3850,7 @@ mod tests {
             render_on_request_hook: None,
             canonical_html_root: None,
             canonical_dist_root: None,
+            dev_assets_root: None,
             canonical_public_root: None,
         };
         let router = build_router(state);
@@ -3870,6 +3902,7 @@ mod tests {
             render_on_request_hook: None,
             canonical_html_root: None,
             canonical_dist_root: None,
+            dev_assets_root: None,
             canonical_public_root: None,
         };
         let router = build_router(state);
@@ -3925,6 +3958,7 @@ mod tests {
             render_on_request_hook: None,
             canonical_html_root: None,
             canonical_dist_root: None,
+            dev_assets_root: None,
             canonical_public_root: None,
         };
         let router = build_router(state);
@@ -3987,6 +4021,7 @@ mod tests {
             render_on_request_hook: None,
             canonical_html_root: None,
             canonical_dist_root: None,
+            dev_assets_root: None,
             canonical_public_root: None,
         }
     }

--- a/crates/zfb-server/tests/combined_gap_integration.rs
+++ b/crates/zfb-server/tests/combined_gap_integration.rs
@@ -127,6 +127,7 @@ async fn gap1_ssr_and_gap2_watcher_work_together() {
     let opts = ServeOpts {
         project_root: project.path().to_path_buf(),
         dist_root: dist_root.clone(),
+        dev_assets_root: None,
         html_root: dist_root,
         public_root,
         addr,

--- a/crates/zfb-server/tests/embed_ssr_smoke.rs
+++ b/crates/zfb-server/tests/embed_ssr_smoke.rs
@@ -133,6 +133,7 @@ async fn boot_with_plugins(
         // Test uses temp dirs — canonical roots not precomputed.
         canonical_html_root: None,
         canonical_dist_root: None,
+        dev_assets_root: None,
         canonical_public_root: None,
     };
     let router = build_router(state);

--- a/crates/zfb-server/tests/host_validation_integration.rs
+++ b/crates/zfb-server/tests/host_validation_integration.rs
@@ -160,6 +160,7 @@ async fn boot(
     let serve_opts = ServeOpts {
         project_root: tmp.path().to_path_buf(),
         dist_root: dist_root.clone(),
+        dev_assets_root: None,
         html_root: dist_root,
         public_root,
         addr,

--- a/crates/zfb-server/tests/integration.rs
+++ b/crates/zfb-server/tests/integration.rs
@@ -68,6 +68,7 @@ impl Harness {
         let opts = ServeOpts {
             project_root: root.clone(),
             dist_root: dist_root.clone(),
+            dev_assets_root: None,
             html_root: dist_root,
             public_root: public_root.clone(),
             addr,
@@ -471,6 +472,7 @@ async fn serve_returns_error_when_port_is_occupied() {
     let opts = ServeOpts {
         project_root: root.clone(),
         dist_root: dist_root.clone(),
+        dev_assets_root: None,
         html_root: dist_root,
         public_root,
         addr: occupied_addr,

--- a/crates/zfb-server/tests/islands_head_injection.rs
+++ b/crates/zfb-server/tests/islands_head_injection.rs
@@ -58,6 +58,7 @@ impl Harness {
         let opts = ServeOpts {
             project_root: root.clone(),
             dist_root: dist_root.clone(),
+            dev_assets_root: None,
             html_root: dist_root,
             public_root: public_root.clone(),
             addr,

--- a/crates/zfb-server/tests/plugin_middleware_integration.rs
+++ b/crates/zfb-server/tests/plugin_middleware_integration.rs
@@ -114,6 +114,7 @@ async fn boot_with_dispatcher(
     let opts = ServeOpts {
         project_root: tmp.path().to_path_buf(),
         dist_root: dist_root.clone(),
+        dev_assets_root: None,
         html_root: dist_root,
         public_root,
         addr,
@@ -433,6 +434,7 @@ async fn boot_with_failing_dispatcher(
     let opts = ServeOpts {
         project_root: tmp.path().to_path_buf(),
         dist_root: dist_root.clone(),
+        dev_assets_root: None,
         html_root: dist_root,
         public_root,
         addr,

--- a/crates/zfb-server/tests/render_hook_integration.rs
+++ b/crates/zfb-server/tests/render_hook_integration.rs
@@ -166,6 +166,7 @@ async fn boot(
     let serve_opts = ServeOpts {
         project_root: tmp.path().to_path_buf(),
         dist_root: dist_root.clone(),
+        dev_assets_root: None,
         html_root: dist_root.clone(),
         public_root,
         addr,
@@ -392,6 +393,7 @@ async fn hook_side_effect_served_after_hook_returns() {
     let serve_opts = ServeOpts {
         project_root: tmp.path().to_path_buf(),
         dist_root: html_root.clone(),
+        dev_assets_root: None,
         html_root,
         public_root: tmp.path().join("public"),
         addr,

--- a/crates/zfb-server/tests/ssr_integration.rs
+++ b/crates/zfb-server/tests/ssr_integration.rs
@@ -134,6 +134,7 @@ async fn boot_with_opts(
     let opts = ServeOpts {
         project_root: tmp.path().to_path_buf(),
         dist_root: dist_root.clone(),
+        dev_assets_root: None,
         html_root: dist_root,
         public_root,
         addr,
@@ -513,6 +514,7 @@ async fn boot_with_live_handle(
     let opts = ServeOpts {
         project_root: tmp.path().to_path_buf(),
         dist_root: dist_root.clone(),
+        dev_assets_root: None,
         html_root: dist_root,
         public_root,
         addr,

--- a/crates/zfb-server/tests/watch_add_confirm.rs
+++ b/crates/zfb-server/tests/watch_add_confirm.rs
@@ -304,6 +304,7 @@ async fn real_watcher_add_content_file_serves_new_route_as_200() {
     let opts = ServeOpts {
         project_root: project.clone(),
         dist_root: html_root.clone(),
+        dev_assets_root: None,
         html_root: html_root.clone(),
         public_root: project.join("public"),
         addr,
@@ -546,6 +547,7 @@ async fn real_watcher_edit_existing_file_still_hot_reloads() {
     let opts = ServeOpts {
         project_root: project.clone(),
         dist_root: html_root.clone(),
+        dev_assets_root: None,
         html_root: html_root.clone(),
         public_root: project.join("public"),
         addr,
@@ -748,6 +750,7 @@ async fn real_watcher_inplace_edit_reaches_served_html_via_reload() {
     let opts = ServeOpts {
         project_root: project.clone(),
         dist_root: html_root.clone(),
+        dev_assets_root: None,
         html_root: html_root.clone(),
         public_root: project.join("public"),
         addr,

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -1404,7 +1404,9 @@ pub(crate) fn build_default_client_scripts_payloads(
 ///   pass it as `prev_entry_names` on the next call.
 pub(crate) fn build_dev_client_scripts_to_disk(
     project_root: &Path,
-    dist_root: &Path,
+    // Where dev client scripts are written + served from (issue #1189: the
+    // isolated `.zfb-build/dev-assets` root, NOT the build-shared `dist/`).
+    assets_root: &Path,
     framework: crate::config::Framework,
     prev_entry_names: &std::collections::HashSet<String>,
 ) -> Result<(bool, std::collections::HashSet<String>)> {
@@ -1428,7 +1430,7 @@ pub(crate) fn build_dev_client_scripts_to_disk(
         }
     }
 
-    let client_dir = dist_root
+    let client_dir = assets_root
         .join(zfb_types::DIST_ASSETS_DIR)
         .join(zfb_types::DIST_CLIENT_SCRIPTS_DIR);
 
@@ -1505,7 +1507,7 @@ pub(crate) fn build_dev_client_scripts_to_disk(
     }
     .jsx_import_source();
     let bundle_cfg = BundleConfig::dev()
-        .with_outdir(dist_root.to_path_buf())
+        .with_outdir(assets_root.to_path_buf())
         .with_jsx_import_source(jsx_import_source);
 
     if let Some(parent) = client_dir.parent() {

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -240,6 +240,40 @@ pub async fn run(args: &DevArgs) -> Result<()> {
         })?;
     }
 
+    // Issue #1189 — dev's STABLE served assets (`styles.css`, `islands.js`,
+    // island chunks, `client/*.js`) must NOT land in the project's `outDir`
+    // (`dist/`) either. They used to, which meant a one-off `zfb build`
+    // against the shared `dist/` (a quick prod sanity-check while dev is
+    // live) wiped them and re-emitted HASHED-only assets — leaving the
+    // dev-served `/assets/styles.css` a 404 (unstyled, no self-heal). Write
+    // them to an isolated `.zfb-build/dev-assets/` dir instead (mirroring
+    // the #534 dev-HTML isolation); the router serves `/assets/*` from there
+    // first and falls back to `dist/assets/` for a boot-lazy prebuilt seed.
+    let dev_assets_root = dev_assets_root_for(&project_root);
+    // Symmetric guard to the dev-HTML one above: a pathological `outDir`
+    // that overlaps the dev-assets scratch root re-creates the clobber.
+    if dev_assets_root == dist_root
+        || dev_assets_root.starts_with(&dist_root)
+        || dist_root.starts_with(&dev_assets_root)
+    {
+        anyhow::bail!(
+            "zfb dev: configured `outDir` ({}) overlaps with the dev asset \
+             scratch root ({}). Pick an `outDir` outside `.zfb-build/` \
+             (the default `dist/` is fine) — otherwise a one-off `zfb build` \
+             would clobber the dev-served `/assets/styles.css`.",
+            dist_root.display(),
+            dev_assets_root.display(),
+        );
+    }
+    if !dev_assets_root.exists() {
+        std::fs::create_dir_all(&dev_assets_root).with_context(|| {
+            format!(
+                "failed to create dev assets dir {}",
+                dev_assets_root.display()
+            )
+        })?;
+    }
+
     let host = resolve_host(args.host.as_deref(), cfg.host.as_deref(), DEFAULT_DEV_HOST);
     let port = resolve_port(args.port, cfg.port, DEFAULT_DEV_PORT);
     let addr = resolve_addr(host.as_str(), port)?;
@@ -503,7 +537,9 @@ pub async fn run(args: &DevArgs) -> Result<()> {
 
     let run_islands: Option<IslandsRunner> = {
         let project_root = project_root.clone();
-        let dist_root_for_islands = dist_root.clone();
+        // Issue #1189: write islands.js + chunks to the isolated dev-assets
+        // root, not the build-shared `dist/`.
+        let dev_assets_root_for_islands = dev_assets_root.clone();
         let plugin_cfg = islands_plugin_config.clone();
         let framework = cfg.framework;
         let url_prefix = dev_islands_url_prefix.clone();
@@ -519,7 +555,7 @@ pub async fn run(args: &DevArgs) -> Result<()> {
         Some(Arc::new(move || -> Result<Option<IslandsBundleInfo>> {
             rebundle_islands(
                 &project_root,
-                &dist_root_for_islands,
+                &dev_assets_root_for_islands,
                 framework,
                 &plugin_cfg,
                 &url_prefix,
@@ -543,12 +579,13 @@ pub async fn run(args: &DevArgs) -> Result<()> {
     // change.
     let dev_css_url_prefix: String =
         zfb_types::dev_mount_prefix(cfg.base.as_deref()).unwrap_or_default();
-    match crate::commands::build::build_default_css_payload(&project_root, &dist_root, &cfg) {
+    match crate::commands::build::build_default_css_payload(&project_root, &dev_assets_root, &cfg) {
         Ok(Some(payload)) => {
-            // Write the bytes to dist so `GET /assets/styles.css` is
-            // immediately serveable (unlike islands, the CSS pipeline does
-            // not write to disk as a side-effect of building).
-            let out_path = dist_root.join(&payload.relative_path);
+            // Write the bytes to the isolated dev-assets root (issue #1189)
+            // so `GET /assets/styles.css` is immediately serveable (unlike
+            // islands, the CSS pipeline does not write to disk as a
+            // side-effect of building).
+            let out_path = dev_assets_root.join(&payload.relative_path);
             if let Some(parent) = out_path.parent() {
                 let _ = std::fs::create_dir_all(parent);
             }
@@ -585,14 +622,15 @@ pub async fn run(args: &DevArgs) -> Result<()> {
     // fresh bytes to disk, and updates the shared URL handle.
     let run_css: Option<CssRunner> = {
         let project_root_for_css = project_root.clone();
-        let dist_root_for_css = dist_root.clone();
+        // Issue #1189: build + write CSS into the isolated dev-assets root.
+        let dev_assets_root_for_css = dev_assets_root.clone();
         let cfg_for_css = cfg.clone();
         let url_prefix = dev_css_url_prefix.clone();
         let url_handle = Arc::clone(&css_bundle_url_handle);
         Some(Arc::new(move || -> Result<bool> {
             let payload = crate::commands::build::build_default_css_payload(
                 &project_root_for_css,
-                &dist_root_for_css,
+                &dev_assets_root_for_css,
                 &cfg_for_css,
             )?;
             let mut guard = url_handle.write().unwrap_or_else(|p| {
@@ -608,11 +646,11 @@ pub async fn run(args: &DevArgs) -> Result<()> {
                 *guard = None;
                 return Ok(false);
             };
-            // Write fresh bytes to dist so the dev server serves them
-            // immediately. This is the "freshness proof" the acceptance
-            // test checks (byte-for-byte match between payload.bytes and
-            // GET /assets/styles.css).
-            let out_path = dist_root_for_css.join(&payload.relative_path);
+            // Write fresh bytes to the isolated dev-assets root so the dev
+            // server serves them immediately. This is the "freshness proof"
+            // the acceptance test checks (byte-for-byte match between
+            // payload.bytes and GET /assets/styles.css).
+            let out_path = dev_assets_root_for_css.join(&payload.relative_path);
             if let Some(parent) = out_path.parent() {
                 let _ = std::fs::create_dir_all(parent);
             }
@@ -645,7 +683,8 @@ pub async fn run(args: &DevArgs) -> Result<()> {
     // Eager boot bundle — non-fatal, mirrors islands / CSS.
     match crate::commands::build::build_dev_client_scripts_to_disk(
         &project_root,
-        &dist_root,
+        // Issue #1189: client scripts go to the isolated dev-assets root.
+        &dev_assets_root,
         cfg.framework,
         &std::collections::HashSet::new(),
     ) {
@@ -665,7 +704,8 @@ pub async fn run(args: &DevArgs) -> Result<()> {
     // Watcher-driven rebuild closure.
     let run_client_scripts: Option<ClientScriptsRunner> = {
         let project_root_for_cs = project_root.clone();
-        let dist_root_for_cs = dist_root.clone();
+        // Issue #1189: rebuild client scripts into the isolated dev-assets root.
+        let dev_assets_root_for_cs = dev_assets_root.clone();
         let framework = cfg.framework;
         let entry_names = Arc::clone(&live_client_script_names);
         Some(Arc::new(move || -> Result<bool> {
@@ -681,7 +721,7 @@ pub async fn run(args: &DevArgs) -> Result<()> {
                 .clone();
             let (changed, new_names) = crate::commands::build::build_dev_client_scripts_to_disk(
                 &project_root_for_cs,
-                &dist_root_for_cs,
+                &dev_assets_root_for_cs,
                 framework,
                 &prev,
             )?;
@@ -828,10 +868,14 @@ pub async fn run(args: &DevArgs) -> Result<()> {
     let graph_cache_path_for_boot = graph_cache_path.clone();
     let manifest_digest_slot_for_boot = Arc::clone(&manifest_digest_slot);
     let dist_root_for_boot = dist_root.clone();
+    // Issue #1189: the deferred boot's islands rebundle writes to the
+    // isolated dev-assets root (NOT `dist_root_for_boot`, which `run_boot_render`
+    // still needs as the real `dist/` for its servable-seed check).
+    let dev_assets_root_for_boot = dev_assets_root.clone();
     // Issue #1170 — the deferred boot task also runs the eager islands
     // bundle (the last size-bound step that used to gate the bind). Clone
     // its inputs now, before `ServeOpts` / `run_islands` consume the
-    // originals: `rebundle_islands` needs the project + dist roots, the
+    // originals: `rebundle_islands` needs the project + dev-assets roots, the
     // framework, the islands plugin config, the URL prefix, the shared
     // bundle-URL handle, and the live-chunk tracker.
     let islands_url_handle_for_boot = Arc::clone(&islands_bundle_url_handle);
@@ -884,6 +928,12 @@ pub async fn run(args: &DevArgs) -> Result<()> {
     let opts = ServeOpts {
         project_root,
         dist_root,
+        // Issue #1189 — serve `/assets/*` from the isolated dev-assets root
+        // first (clobber-proof: a concurrent `zfb build` can't touch
+        // `.zfb-build/`), falling back to `dist_root/assets` for a boot-lazy
+        // prebuilt seed's hashed assets. `dist_root` above stays the real
+        // `dist/` so the seed fallback and `dist_is_servable_seed` still work.
+        dev_assets_root: Some(dev_assets_root.clone()),
         // Issue #534 — point the page-cache disk fallback at the dev
         // HTML dir, not the project's `outDir`. With `dist_root` here
         // (the historical wiring) the dev server's `read_from_dist`
@@ -1169,7 +1219,7 @@ pub async fn run(args: &DevArgs) -> Result<()> {
             }
             let islands_info = match rebundle_islands(
                 &project_root_for_boot,
-                &dist_root_for_boot,
+                &dev_assets_root_for_boot,
                 framework_for_boot,
                 &islands_plugin_config_for_boot,
                 &islands_url_prefix_for_boot,
@@ -4075,6 +4125,24 @@ fn dev_html_root_for(project_root: &Path) -> PathBuf {
     project_root.join(".zfb-build").join("dev-pages")
 }
 
+/// The isolated directory `zfb dev` writes its STABLE served assets into
+/// (issue #1189) — `styles.css`, `islands.js`, island chunks, and
+/// `client/*.js`. Its `assets/` subdir is mounted at `/assets/` FIRST,
+/// with the project's `dist/assets/` as a fallback (for a boot-lazy
+/// prebuilt seed's hashed assets).
+///
+/// Why a separate dir, mirroring [`dev_html_root_for`]: dev used to write
+/// these stable assets straight into the project's `outDir` (`dist/`),
+/// which `zfb build` shares. A one-off `zfb build` against the live `dist/`
+/// wipes it and emits HASHED-only assets, so the dev-served
+/// `/assets/styles.css` 404s and the site goes unstyled with no self-heal.
+/// Writing dev's assets under `.zfb-build/` (already `.gitignore`d) takes
+/// them out of the build's write set entirely — the same fix #534 applied
+/// to dev HTML, now for assets.
+fn dev_assets_root_for(project_root: &Path) -> PathBuf {
+    project_root.join(".zfb-build").join("dev-assets")
+}
+
 /// `true` when one of the edited entry's slug candidates appears among a
 /// route's resolved params (issue #958, spec §4). ANY-param semantics:
 /// scalars match by value, catchall arrays match by their `/`-join (an
@@ -5125,6 +5193,40 @@ mod tests {
             "dev html dir must not live anywhere under outDir ({}); got {}",
             dist_root.display(),
             dev_html_root.display(),
+        );
+    }
+
+    /// Issue #1189: dev's STABLE served assets must NOT live under the
+    /// project's `outDir` (`dist/`) — otherwise a one-off `zfb build` wipes
+    /// them and the dev server 404s `/assets/styles.css`. The relocation
+    /// target is a dedicated `.zfb-build/dev-assets` dir, distinct from both
+    /// `outDir` and the dev-HTML root.
+    #[test]
+    fn dev_assets_root_lives_under_dot_zfb_build_not_outdir() {
+        let project_root = PathBuf::from("/tmp/proj");
+        let dev_assets_root = dev_assets_root_for(&project_root);
+
+        // The exact, documented contract: `<project_root>/.zfb-build/dev-assets`.
+        assert_eq!(
+            dev_assets_root,
+            PathBuf::from("/tmp/proj/.zfb-build/dev-assets"),
+        );
+
+        // Must not collide with `outDir` (the bug) ...
+        let dist_root = project_root.join("dist");
+        assert_ne!(dev_assets_root, dist_root, "must not equal outDir");
+        assert!(
+            !dev_assets_root.starts_with(&dist_root) && !dist_root.starts_with(&dev_assets_root),
+            "dev assets dir must not overlap outDir ({}); got {}",
+            dist_root.display(),
+            dev_assets_root.display(),
+        );
+
+        // ... nor with the dev-HTML root (they're siblings under .zfb-build/).
+        assert_ne!(
+            dev_assets_root,
+            dev_html_root_for(&project_root),
+            "dev assets and dev html roots must be distinct"
         );
     }
 

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -1377,7 +1377,9 @@ pub async fn run(args: &DevArgs) -> Result<()> {
 }
 
 /// Re-bundle the project's `"use client"` islands once and publish the
-/// result: build the payload, write the stable `dist/assets/islands.js`,
+/// result: build the payload, write the stable `islands.js` under
+/// `assets_root/assets/` (issue #1189: the isolated `.zfb-build/dev-assets`
+/// root, NOT the build-shared `dist/`),
 /// refresh / prune the chunk companions, and rewrite the shared bundle-URL
 /// handle. Returns `Some(IslandsBundleInfo { changed: true, .. })` when a
 /// bundle was produced (so `outcome_to_events` emits a
@@ -1394,7 +1396,9 @@ pub async fn run(args: &DevArgs) -> Result<()> {
 /// failure is loud), the boot path warns-and-continues (issue #1170).
 fn rebundle_islands(
     project_root: &Path,
-    dist_root: &Path,
+    // Where dev assets are written + served from (issue #1189: the isolated
+    // `.zfb-build/dev-assets` root, NOT the build-shared `dist/`).
+    assets_root: &Path,
     framework: crate::config::Framework,
     plugin_config: &crate::commands::build::IslandsPluginConfig,
     url_prefix: &str,
@@ -1406,7 +1410,7 @@ fn rebundle_islands(
     // the runtime.ts warn path.
     let (payload, _marker_names) = crate::commands::build::build_default_islands_payload(
         project_root,
-        dist_root,
+        assets_root,
         framework,
         plugin_config,
     )?;
@@ -1441,7 +1445,7 @@ fn rebundle_islands(
                 );
                 p.into_inner()
             });
-            let assets_dir = dist_root.join(zfb_types::DIST_ASSETS_DIR);
+            let assets_dir = assets_root.join(zfb_types::DIST_ASSETS_DIR);
             if let Err(e) = refresh_dev_island_chunks(&assets_dir, &[], &prev) {
                 tracing::warn!(
                     error = %e,
@@ -1456,7 +1460,7 @@ fn rebundle_islands(
     // `GET /assets/islands.js`. The bundler carries bytes in memory only —
     // the dev caller owns the disk write (same pattern as the CSS path).
     {
-        let assets_dir = dist_root.join(zfb_types::DIST_ASSETS_DIR);
+        let assets_dir = assets_root.join(zfb_types::DIST_ASSETS_DIR);
         let islands_out_path = assets_dir.join(zfb_types::STABLE_ISLANDS_FILENAME);
         if let Some(parent) = islands_out_path.parent() {
             let _ = std::fs::create_dir_all(parent);
@@ -1481,7 +1485,7 @@ fn rebundle_islands(
             );
             p.into_inner()
         });
-        let assets_dir = dist_root.join(zfb_types::DIST_ASSETS_DIR);
+        let assets_dir = assets_root.join(zfb_types::DIST_ASSETS_DIR);
         match refresh_dev_island_chunks(&assets_dir, &payload.companions, &prev) {
             Ok(names) => *prev = names,
             Err(e) => {


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1189

---

## Summary

Fixes #1189. `zfb dev` wrote its **stable** served assets (`styles.css`, `islands.js`, island chunks, `client/*.js`) straight into the project's `outDir` (`dist/`), which `zfb build` shares. A one-off `zfb build` against the live `dist/` (a quick prod sanity-check while dev runs) wipes it and re-emits **hashed-only** assets, so the dev server's `/assets/styles.css` 404s — the site goes fully unstyled with no self-heal until a real content edit or a `zfb dev` restart.

This mirrors the issue-#534 dev-**HTML** isolation, now for **assets**: dev writes its stable assets to a dedicated `.zfb-build/dev-assets/` dir (out of the build's write set entirely), and the `/assets/*` mount becomes an ordered two-root lookup.

### Investigation note (corrects the issue's premise)

The issue suspected an asymmetry where `islands.js` survives because `build` reproduces a stable artifact. In fact **`build` is symmetric** — it writes hashed-only for *both* CSS and islands (verified in `pipeline/prod.rs`); the stable files exist *only* because `zfb dev` writes them. So a build wipe clobbers both; the "islands survives" observation is a watcher-trigger timing artifact. Isolating dev's assets fixes the whole class (CSS + islands + chunks + client-scripts) and also closes the #534 reverse direction (dev no longer writes into `dist/` at all). Approach validated by an independent design second-opinion before implementation.

## Changes

- **`zfb-server` — layered asset mount.** `ContainedAssetsService` now holds an *ordered* list of roots (`AssetRoot`). Each root is canonicalized and symlink-containment-checked **independently**; the first root that contains the requested file serves it, a miss falls through to the next. `new(dir)` stays single-root (byte-identical); `layered(dirs)` is the new ordered form.
- **`ServeOpts` / `AppState`** gain `dev_assets_root: Option<PathBuf>`. `Some` (dev) → `/assets/*` served from `<dev_assets_root>/assets/` first, then `<dist_root>/assets/`. `None` (preview / embed / tests) → unchanged single-root `dist/assets/` mount.
- **`zfb dev`** computes `dev_assets_root_for(project_root)` = `.zfb-build/dev-assets`, creates it at boot, guards it against an overlapping `outDir` (symmetric to the existing dev-HTML guard), and repoints **every** stable-asset write (CSS boot + runner, islands runner, the deferred boot-lazy islands rebundle, client-scripts boot + runner) at it. `dist_root` stays the real `dist/` so boot-lazy `dist_is_servable_seed` and the seed fallback keep working.
- Renamed the now-misleading `dist_root` params on `rebundle_islands` / `build_dev_client_scripts_to_disk` to `assets_root`.

### Why namespaces never collide

Dev's isolated dir only ever holds **stable** names (`styles.css`, `islands.js`, chunks, `client/*.js`); a boot-lazy prebuilt seed in `dist/assets/` only holds **hashed** names (`styles-<hash>.css`). So isolated-first never shadows a legitimately newer hashed seed asset, and a hashed request correctly falls through to the `dist/assets` fallback.

## Test Plan

- **`assets_containment` (Level 2/3, deterministic):** 6 new layered-mount tests, including `layered_primary_survives_secondary_wipe` — the exact regression: a wiped `dist/` secondary does **not** 404 a primary dev asset. Plus fallback, primary-shadows-secondary, both-missing-404, and per-root containment-enforcement cases.
- **`routes` (Level 3, deterministic):** `assets_mount_serves_dev_assets_first_with_dist_fallback` drives the **real router** (`build_router`) to prove the `layered`-vs-`new` branch wiring + clobber survival end-to-end.
- **`dev` (unit):** `dev_assets_root_for` path-contract test (isolated under `.zfb-build/`, distinct from `outDir` and the dev-HTML root).
- **No regression** verified via the real-process e2e suites `dev_serve_e2e` (3) and `dev_build_static_parity` (4) on macOS.
- `cargo fmt --check` + `cargo clippy --all-targets -D warnings` clean on both crates; full `zfb-server` suite green.

**Not covered (blind spot):** no automated test runs a real `zfb build` against a live `zfb dev` and re-checks `/assets/styles.css`. That Level-4 path was deliberately deferred — it pulls in V8 + Tailwind + a dev↔build process race (zfb's dominant flake shape) for marginal confidence over the already-proven mount-level invariant. The deterministic Level-3 router test covers the wiring instead.