### PR TITLE
fix(build): honor lone `export const prerender` on frontmatter-less pages (#1198)

### DIFF
--- a/crates/zfb-content/src/tsx_frontmatter.rs
+++ b/crates/zfb-content/src/tsx_frontmatter.rs
@@ -107,8 +107,16 @@ pub enum TsxFrontmatterError {
 
     /// No top-level `export const frontmatter` was found. The engine
     /// requires a frontmatter export on every TSX page.
+    ///
+    /// `prerender` carries the value the loop resolved *before* this
+    /// error was raised — a lone `export const prerender = <bool>` with
+    /// no `frontmatter` sibling is still parsed (default `true`). The
+    /// consumer ([`crate::extract_tsx_frontmatter`] caller
+    /// `build_prerender_map`) reads it so the `output: static` gate can
+    /// reject a frontmatter-less `prerender = false` page instead of
+    /// silently shipping it as SSG (#1198).
     #[error("{file}: missing required `export const frontmatter`")]
-    MissingFrontmatter { file: String },
+    MissingFrontmatter { file: String, prerender: bool },
 
     /// The source declared `export const <name>` more than once at the
     /// top level. We refuse to silently pick one.
@@ -334,6 +342,10 @@ pub fn extract(source: &str, file_name: &str) -> Result<TsxFrontmatter, TsxFront
 
     let frontmatter = frontmatter.ok_or_else(|| TsxFrontmatterError::MissingFrontmatter {
         file: file_name.to_string(),
+        // Surface the loop-resolved `prerender` instead of discarding it:
+        // a lone `export const prerender = false` (no `frontmatter`) must
+        // still reach the `output: static` gate (#1198).
+        prerender,
     })?;
 
     Ok(TsxFrontmatter {
@@ -1032,7 +1044,31 @@ mod tests {
         let src = "export const other = 1;\n";
         let err = extract(src, "no-fm.tsx").expect_err("must fail");
         match err {
-            TsxFrontmatterError::MissingFrontmatter { file } => assert_eq!(file, "no-fm.tsx"),
+            // No `prerender` export → carries the SSG default (`true`).
+            TsxFrontmatterError::MissingFrontmatter { file, prerender } => {
+                assert_eq!(file, "no-fm.tsx");
+                assert!(prerender, "absent prerender defaults to SSG (true)");
+            }
+            other => unreachable!("expected MissingFrontmatter, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn lone_prerender_false_surfaced_on_missing_frontmatter() {
+        // A page with `export const prerender = false` and NO `frontmatter`
+        // still fails with MissingFrontmatter — but the resolved flag must
+        // ride along so the `output: static` gate can reject it (#1198),
+        // rather than being silently discarded and defaulting to SSG.
+        let src = "export const prerender = false;\nexport default function() { return null; }\n";
+        let err = extract(src, "ssr-only.tsx").expect_err("must fail (no frontmatter)");
+        match err {
+            TsxFrontmatterError::MissingFrontmatter { file, prerender } => {
+                assert_eq!(file, "ssr-only.tsx");
+                assert!(
+                    !prerender,
+                    "lone `prerender = false` must survive on MissingFrontmatter"
+                );
+            }
             other => unreachable!("expected MissingFrontmatter, got {other:?}"),
         }
     }

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -5301,6 +5301,57 @@ mod tests {
         );
     }
 
+    /// #1198 regression: a page with a lone `export const prerender = false`
+    /// and NO `export const frontmatter` must be caught by the `output:
+    /// static` gate, not silently shipped as SSG. Exercises the real chain —
+    /// `build_prerender_map` → `is_ssr_route` → `resolve_v8_mode(Static)` —
+    /// so a regression in any link re-opens the safety hole. No V8 boot.
+    #[test]
+    fn output_static_rejects_frontmatterless_prerender_false_page() {
+        let dir = tempdir().unwrap();
+        let pages = dir.path().join("pages");
+        std::fs::create_dir_all(&pages).unwrap();
+        // Lone `prerender = false`, no `frontmatter` — the exact shape #1198
+        // used to let slip through as SSG.
+        std::fs::write(
+            pages.join("ssr.tsx"),
+            "export const prerender = false;\nexport default function() { return null; }\n",
+        )
+        .unwrap();
+
+        let routes = vec![static_route(vec!["ssr"], "pages/ssr.tsx")];
+        let map = build_prerender_map(&routes, dir.path(), |_| {});
+
+        // The frontmatter-less SSR page must now register as SSR (the bug was
+        // it registered as SSG and never reached the gate).
+        let templates: Vec<String> = routes.iter().map(|r| r.template()).collect();
+        let ssr_refs: Vec<SsrRouteRef<'_>> = templates
+            .iter()
+            .filter(|t| is_ssr_route(&map, t))
+            .map(|t| SsrRouteRef {
+                route_key: t,
+                url_path: t,
+            })
+            .collect();
+        assert_eq!(
+            ssr_refs.len(),
+            1,
+            "frontmatter-less `prerender = false` page must be detected as SSR"
+        );
+
+        let err = resolve_v8_mode(OutputMode::Static, &ssr_refs)
+            .expect_err("output: static must reject the frontmatter-less SSR page");
+        let msg = format!("{err:#}");
+        assert!(
+            msg.contains("output: \"static\""),
+            "error must name the config setting; got: {msg}"
+        );
+        assert!(
+            msg.contains("/ssr"),
+            "error must name the offending route; got: {msg}"
+        );
+    }
+
     /// Codex review (4.1b PR) flagged a missing case: a dynamic route
     /// with `prerender = false` AND a non-literal `paths()` lives in
     /// `still_deferred`, not `static_routes`. The detection seam must

--- a/crates/zfb/src/commands/package_routes.rs
+++ b/crates/zfb/src/commands/package_routes.rs
@@ -422,15 +422,17 @@ pub(crate) fn pattern_to_pages_rel(pattern: &str) -> Result<PathBuf> {
 /// prerender = …` so the frontmatter extractor and the `output: static`
 /// safety gate actually SEE the prerender flag.
 ///
-/// Why BOTH must be inlined: `extract_tsx_frontmatter` only honours a
-/// top-level `export const prerender` when an `export const frontmatter`
-/// is ALSO present — without `frontmatter` the extractor returns
-/// `MissingFrontmatter`, which `build_prerender_map` swallows, defaulting
-/// the route to SSG and silently dropping the `prerender = false`. So a
-/// `prerender` hint requires the `frontmatter` sibling for the flag to be
-/// effective (re-exports are invisible to the syntactic extractor — both
-/// must be physically present here). With no hint, both are omitted →
-/// SSG default (the desired default for package routes).
+/// Why both are inlined (rather than re-exported): the overlay re-exports
+/// only the package page's `default`, so the page's own `prerender` /
+/// `frontmatter` exports are invisible to the syntactic extractor — to give
+/// the overlay a `prerender` flag at all, it must be physically present
+/// top-level. As of #1198 a lone inlined `export const prerender = false`
+/// (no `frontmatter`) IS surfaced — `build_prerender_map` records it on the
+/// `MissingFrontmatter` path — so the empty `frontmatter` is no longer
+/// strictly required for the flag to reach the gate. We still inline it
+/// alongside `prerender` so the overlay presents a complete, conventional
+/// page shape. With no hint, both are omitted → SSG default (the desired
+/// default for package routes).
 ///
 /// The entrypoint is imported by its absolute path; esbuild resolves an
 /// absolute specifier as-is, so this is independent of where the overlay
@@ -475,9 +477,11 @@ pub(crate) fn synthesize_static_overlay_module(
 /// dynamic synthesizers).
 ///
 /// Inlined top-level (NOT re-exported) so the frontmatter extractor — and
-/// the `output: static` gate via `build_prerender_map` — sees the flag.
-/// `frontmatter` MUST accompany `prerender` or the extractor returns
-/// `MissingFrontmatter` and the flag is silently dropped (#1193).
+/// the `output: static` gate via `build_prerender_map` — sees the flag; a
+/// re-export of the package page's own exports would be invisible to the
+/// syntactic extractor (#1193). The empty `frontmatter` is inlined as a
+/// conventional sibling: as of #1198 a lone `prerender` is honored even
+/// without it, but keeping it presents a complete page shape.
 fn push_inlined_prerender(out: &mut String, prerender: Option<bool>) {
     let Some(prerender) = prerender else { return };
     out.push_str(

--- a/crates/zfb/src/render_pipeline.rs
+++ b/crates/zfb/src/render_pipeline.rs
@@ -1146,7 +1146,19 @@ pub fn build_prerender_map(
             // default". Warning on it is misleading (it reads as "your page is
             // broken") and fires on every frontmatter-less page, so stay silent
             // and let the missing-key default of `true` (SSG) apply. See #505.
-            Err(TsxFrontmatterError::MissingFrontmatter { .. }) => {}
+            //
+            // BUT a lone `export const prerender = false` (no `frontmatter`)
+            // must still be honored, or the `output: static` gate
+            // (`resolve_v8_mode`) never sees the SSR route and silently ships
+            // it as SSG (#1198). Record only the non-default `false`; a
+            // `true`/absent prerender stays out of the map and rides the
+            // missing-key SSG default, preserving the sparse map and #505's
+            // "no entry for plain frontmatter-less pages" behavior.
+            Err(TsxFrontmatterError::MissingFrontmatter { prerender, .. }) => {
+                if !prerender {
+                    map.insert(route.template(), prerender);
+                }
+            }
             // Any other extraction error means the frontmatter IS present but
             // malformed (parse error, duplicate/computed/wrong-shape export).
             // That's a real mistake worth surfacing.
@@ -1384,6 +1396,14 @@ mod tests {
             "export default function() { return null; }\n",
         )
         .unwrap();
+        // No frontmatter but a lone `export const prerender = false` — VALID and
+        // must NOT warn (#505), but the SSR flag must still be recorded so the
+        // `output: static` gate can reject it instead of silently shipping SSG (#1198).
+        std::fs::write(
+            pages.join("ssr-nofm.tsx"),
+            "export const prerender = false;\nexport default function() { return null; }\n",
+        )
+        .unwrap();
         // Frontmatter IS present but malformed (non-literal/computed value) —
         // a real mistake that should still surface a warning.
         std::fs::write(
@@ -1396,6 +1416,7 @@ mod tests {
             static_route(vec!["about"], "pages/about.tsx"),
             static_route(vec!["preview"], "pages/preview.tsx"),
             static_route(vec!["nofm"], "pages/nofm.tsx"),
+            static_route(vec!["ssr-nofm"], "pages/ssr-nofm.tsx"),
             static_route(vec!["malformed"], "pages/malformed.tsx"),
         ];
 
@@ -1403,8 +1424,19 @@ mod tests {
         let map = build_prerender_map(&routes, dir.path(), |msg| warnings.push(msg.to_string()));
         assert_eq!(map.get("/about"), Some(&true));
         assert_eq!(map.get("/preview"), Some(&false));
-        // Absent frontmatter: no entry (default SSG), and crucially no warning.
+        // Absent frontmatter, no prerender: no entry (default SSG), and crucially no warning.
         assert!(!map.contains_key("/nofm"));
+        assert!(
+            !is_ssr_route(&map, "/nofm"),
+            "plain frontmatter-less page is SSG"
+        );
+        // Absent frontmatter + lone `prerender = false`: the SSR flag IS recorded
+        // (so the output:static gate sees it) but still produces no warning (#1198).
+        assert_eq!(map.get("/ssr-nofm"), Some(&false));
+        assert!(
+            is_ssr_route(&map, "/ssr-nofm"),
+            "lone `prerender = false` on a frontmatter-less page must read as SSR"
+        );
         // Malformed frontmatter: no entry, and exactly one warning naming it.
         assert!(!map.contains_key("/malformed"));
         assert_eq!(


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1204
    - https://github.com/Takazudo/zudo-front-builder/issues/1198

---

## Summary

Fixes the `output: static` safety hole (#1198): a page with a lone top-level
`export const prerender = false` and **no** `export const frontmatter` was silently shipped as
SSG instead of being **rejected**.

The extractor already resolved `prerender` during its module-item loop (independent of
`frontmatter`), but returned `Err(MissingFrontmatter)` on the post-loop check and **discarded**
the value. `build_prerender_map` swallowed that error → the route got no map entry →
`is_ssr_route` defaulted to SSG → the route never reached `resolve_v8_mode`'s `output: static`
gate.

## Changes

- **`zfb-content/src/tsx_frontmatter.rs`** — add `prerender: bool` to the `MissingFrontmatter`
  error variant and pass the loop-resolved value at construction, so a lone `prerender` is no
  longer thrown away. Updated the variant doc.
- **`zfb/src/render_pipeline.rs`** — `build_prerender_map`'s `MissingFrontmatter` arm now records
  the recovered flag **only when `false`** (the non-default the gate must catch), preserving the
  #505 sparse-map / no-warning behavior for plain frontmatter-less pages.
- **`zfb/src/commands/package_routes.rs`** — comment refresh only: the extractor no longer drops a
  lone `prerender`; the inlined `frontmatter = {}` is kept as a conventional sibling, not a
  requirement. Workaround code unchanged.

## Test Plan

- **L1** `tsx_frontmatter.rs` — `extract` on a lone `prerender = false` (no frontmatter) returns
  `Err(MissingFrontmatter { prerender: false, .. })`; the no-prerender case carries `true`.
- **L1** `render_pipeline.rs` — extended `build_prerender_map_warns_on_malformed_but_not_on_absent_frontmatter`:
  a frontmatter-less `prerender = false` page → `map.get == Some(&false)` **and**
  `is_ssr_route == true`, no warning; a plain frontmatter-less page stays absent.
- **L3** `commands/build.rs` — `output_static_rejects_frontmatterless_prerender_false_page`:
  full `build_prerender_map` → `is_ssr_route` → `resolve_v8_mode(Static)` chain returns `Err`
  naming the route and `output: "static"`. No V8 boot.
- `cargo test -p zfb-content -p zfb` green; `cargo clippy -D warnings` clean; `cargo fmt --check` clean. CI all green.

Closes #1204. Fixes #1198.