### PR TITLE
fix(router): user-wins pre-scan records dynamic .md/.html shape keys (#1201)

### DIFF
--- a/crates/zfb-router/src/lib.rs
+++ b/crates/zfb-router/src/lib.rs
@@ -20,7 +20,7 @@ pub mod scan;
 
 pub use error::RouterError;
 pub use route::{Route, RouteKind, Segment};
-pub use scan::{route_shape_key_for_pages_rel, scan_pages, shape_key};
+pub use scan::{route_shape_key_for_pages_rel, scan_pages, shape_key, user_page_shape_keys};
 
 use std::path::{Path, PathBuf};
 

--- a/crates/zfb-router/src/scan.rs
+++ b/crates/zfb-router/src/scan.rs
@@ -208,6 +208,15 @@ fn scan_pages_inner(pages_dir: &Path) -> Result<(Vec<Route>, Vec<String>), Route
             // it silently shadow this page. Side data only — never fed to
             // `detect_ambiguity` (see `user_page_shape_keys`).
             skipped_dynamic_md_html_shape_keys.push(shape_key(&route.segments));
+            // An optional catchall (`[[...rest]]`) ALSO owns its zero-segment
+            // prefix URL — `pages/docs/[[...rest]].md` serves `/docs` too. Record
+            // the prefix shape as well, mirroring `detect_optional_catchall_conflicts`,
+            // so a package route at the bare URL can't slip past the exact-key
+            // pre-scan and silently shadow it (codex review).
+            if matches!(route.segments.last(), Some(Segment::OptionalCatchall(_))) {
+                let prefix = &route.segments[..route.segments.len() - 1];
+                skipped_dynamic_md_html_shape_keys.push(shape_key(prefix));
+            }
             continue;
         }
 
@@ -923,6 +932,25 @@ mod tests {
             "census must include the catchall .md shape; got {keys:?}"
         );
         assert!(scan_tree(&["docs/[...rest].md"]).unwrap().is_empty());
+    }
+
+    #[test]
+    fn census_records_optional_catchall_md_zero_segment_prefix() {
+        // An optional-catchall `.md` page (`docs/[[...rest]].md`) owns BOTH its
+        // catchall shape AND its zero-segment prefix URL (`/docs`). Both must be
+        // in the census or a package `/docs` route would silently shadow the bare
+        // URL the user's optional catchall serves (codex review).
+        let keys = census_tree(&["docs/[[...rest]].md"]).unwrap();
+        let catchall_key = route_shape_key_for_pages_rel(Path::new("docs/[[...rest]].md")).unwrap();
+        let bare_key = route_shape_key_for_pages_rel(Path::new("docs/index.tsx")).unwrap();
+        assert!(
+            keys.contains(&catchall_key),
+            "census must include the optional-catchall shape; got {keys:?}"
+        );
+        assert!(
+            keys.contains(&bare_key),
+            "census must include the zero-segment `/docs` prefix shape; got {keys:?}"
+        );
     }
 
     #[test]

--- a/crates/zfb-router/src/scan.rs
+++ b/crates/zfb-router/src/scan.rs
@@ -41,7 +41,7 @@
 //! `.tsx` if any of those transformations are needed. SSG-only: `.html`
 //! pages are not supported in SSR mode.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Component, Path};
 
 use walkdir::WalkDir;
@@ -69,11 +69,49 @@ const INDEX_BONUS: u32 = 1;
 
 /// Walk `pages_dir` and produce the sorted list of routes.
 pub fn scan_pages(pages_dir: &Path) -> Result<Vec<Route>, RouterError> {
+    let (mut routes, _skipped_dynamic) = scan_pages_inner(pages_dir)?;
+    detect_ambiguity(&routes)?;
+    sort_routes(&mut routes);
+    Ok(routes)
+}
+
+/// Shape keys of every page-shaped file under `pages/`, **including** the dynamic
+/// `.md`/`.html` routes that [`scan_pages`] deliberately skips (those are still
+/// routes the user authored, so a package-owned route must not silently shadow
+/// them — this powers the user-wins pre-scan in `zfb`'s package-route resolver,
+/// #1201). Non-page files (`_`-prefixed, `*.client.*`, unrecognised extension)
+/// are excluded, exactly as [`scan_pages`] excludes them.
+///
+/// Buildable-route ambiguity is still surfaced — the buildable set runs through
+/// [`detect_ambiguity`]. The skipped dynamic `.md`/`.html` shapes are unioned in
+/// as **side data only**: they are NOT fed to ambiguity detection, so a
+/// `docs/[id].tsx` + `docs/[slug].md` pair does not become a false hard error
+/// (matching `scan_pages`, which skips the `.md` and succeeds).
+pub fn user_page_shape_keys(pages_dir: &Path) -> Result<HashSet<String>, RouterError> {
+    let (routes, skipped_dynamic) = scan_pages_inner(pages_dir)?;
+    // Run ambiguity detection on the BUILDABLE routes only — preserves the
+    // existing `scan_pages` error behaviour — then union the skipped-dynamic
+    // shapes in afterwards so they cannot manufacture a new ambiguity error.
+    detect_ambiguity(&routes)?;
+    let mut keys: HashSet<String> = routes.iter().map(|r| shape_key(&r.segments)).collect();
+    keys.extend(skipped_dynamic);
+    Ok(keys)
+}
+
+/// Shared directory walk for [`scan_pages`] and [`user_page_shape_keys`].
+///
+/// Returns `(routes, skipped_dynamic_md_html_shape_keys)`: the buildable routes,
+/// plus the shape keys of the dynamic `.md`/`.html` files skipped at the v1 gate
+/// (recorded here so callers can apply user-wins precedence without
+/// re-implementing the walk and drifting from the filename rules). Runs neither
+/// [`detect_ambiguity`] nor [`sort_routes`] — each caller decides.
+fn scan_pages_inner(pages_dir: &Path) -> Result<(Vec<Route>, Vec<String>), RouterError> {
     if !pages_dir.is_dir() {
         return Err(RouterError::PagesDirMissing(pages_dir.to_path_buf()));
     }
 
     let mut routes: Vec<Route> = Vec::new();
+    let mut skipped_dynamic_md_html_shape_keys: Vec<String> = Vec::new();
 
     for entry in WalkDir::new(pages_dir)
         .follow_links(false)
@@ -164,15 +202,19 @@ pub fn scan_pages(pages_dir: &Path) -> Result<Vec<Route>, RouterError> {
                 "dynamic .md / .html page routes are not supported in v1 (no paths() story); \
                  this file will be skipped — author it as .tsx if dynamic paths are needed"
             );
+            // The file is skipped as a buildable route, but the user DID author a
+            // page at this route shape — record its shape key so the user-wins
+            // pre-scan (#1201) drops a same-shape package route instead of letting
+            // it silently shadow this page. Side data only — never fed to
+            // `detect_ambiguity` (see `user_page_shape_keys`).
+            skipped_dynamic_md_html_shape_keys.push(shape_key(&route.segments));
             continue;
         }
 
         routes.push(route);
     }
 
-    detect_ambiguity(&routes)?;
-    sort_routes(&mut routes);
-    Ok(routes)
+    Ok((routes, skipped_dynamic_md_html_shape_keys))
 }
 
 /// Parse a single source file into a [`Route`].
@@ -788,6 +830,99 @@ mod tests {
         // TempDir must outlive the scan; routes carry owned PathBufs so
         // returning them after drop is fine.
         scan_pages(tmp.path())
+    }
+
+    /// Like [`scan_tree`] but returns the [`user_page_shape_keys`] census.
+    fn census_tree(files: &[&str]) -> Result<HashSet<String>, RouterError> {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let tmp = TempDir::new().unwrap();
+        for rel in files {
+            let abs = tmp.path().join(rel);
+            fs::create_dir_all(abs.parent().unwrap()).unwrap();
+            fs::write(&abs, "export default function P() { return null; }\n").unwrap();
+        }
+        user_page_shape_keys(tmp.path())
+    }
+
+    #[test]
+    fn census_includes_dynamic_md_html_that_scan_pages_skips() {
+        // scan_pages skips a dynamic `.md`/`.html` route (v1-unsupported) → no route.
+        assert!(scan_tree(&["docs/[slug].md"]).unwrap().is_empty());
+        assert!(scan_tree(&["docs/[slug].html"]).unwrap().is_empty());
+
+        // ...but the census MUST record their shape keys so a same-shape package
+        // route can be dropped by the user-wins pre-scan (#1201). Compute the
+        // expected key via the public grammar helper rather than hardcoding it.
+        let md_key = route_shape_key_for_pages_rel(Path::new("docs/[slug].md")).unwrap();
+        let keys = census_tree(&["docs/[slug].md"]).unwrap();
+        assert!(
+            keys.contains(&md_key),
+            "census must include the skipped dynamic .md shape; got {keys:?}"
+        );
+
+        let html_key = route_shape_key_for_pages_rel(Path::new("docs/[slug].html")).unwrap();
+        let keys = census_tree(&["docs/[slug].html"]).unwrap();
+        assert!(
+            keys.contains(&html_key),
+            "census must include the skipped dynamic .html shape; got {keys:?}"
+        );
+    }
+
+    #[test]
+    fn census_excludes_non_page_files() {
+        // `_`-prefixed, `*.client.*`, and unrecognised-extension files are not
+        // page routes — they must be excluded, exactly as scan_pages excludes them.
+        let keys = census_tree(&[
+            "_private/helper.tsx",
+            "_app.tsx",
+            "widget.client.tsx",
+            "notes.txt",
+        ])
+        .unwrap();
+        assert!(
+            keys.is_empty(),
+            "non-page files must be excluded; got {keys:?}"
+        );
+    }
+
+    #[test]
+    fn census_does_not_invent_ambiguity_for_tsx_plus_dynamic_md_sibling() {
+        // `docs/[id].tsx` (buildable) + `docs/[slug].md` (skipped dynamic) share
+        // the shape `/docs/:*`. scan_pages skips the `.md` and succeeds; the census
+        // must likewise NOT hard-error (skipped shapes are side data, never fed to
+        // detect_ambiguity) and must still contain the shape.
+        let key = route_shape_key_for_pages_rel(Path::new("docs/[slug].md")).unwrap();
+        let keys = census_tree(&["docs/[id].tsx", "docs/[slug].md"]).unwrap();
+        assert!(
+            keys.contains(&key),
+            "census should contain the /docs/:* shape; got {keys:?}"
+        );
+    }
+
+    #[test]
+    fn census_still_errors_on_buildable_ambiguity() {
+        // Two BUILDABLE dynamic siblings at the same shape are a genuine ambiguity —
+        // detect_ambiguity must still fire (buildable-route behaviour unchanged).
+        let err = census_tree(&["docs/[id].tsx", "docs/[slug].tsx"]).unwrap_err();
+        assert!(
+            matches!(err, RouterError::AmbiguousShape { .. }),
+            "expected AmbiguousShape, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn census_records_dynamic_catchall_md_shape() {
+        // A catchall `.md` page contributes its catchall shape to the census,
+        // while scan_pages still skips it.
+        let key = route_shape_key_for_pages_rel(Path::new("docs/[...rest].md")).unwrap();
+        let keys = census_tree(&["docs/[...rest].md"]).unwrap();
+        assert!(
+            keys.contains(&key),
+            "census must include the catchall .md shape; got {keys:?}"
+        );
+        assert!(scan_tree(&["docs/[...rest].md"]).unwrap().is_empty());
     }
 
     #[test]

--- a/crates/zfb/src/commands/package_routes.rs
+++ b/crates/zfb/src/commands/package_routes.rs
@@ -1120,6 +1120,26 @@ export default function Page() { return null; }
     }
 
     #[test]
+    fn user_optional_catchall_md_wins_over_bare_url_package_route() {
+        // #1201 (codex review): a user's optional-catchall `.md` page
+        // (`pages/docs/[[...rest]].md`) serves the bare `/docs` URL too. A package
+        // route at the bare `/docs` must be dropped (user-wins), not silently
+        // shadow the zero-segment URL the optional catchall owns.
+        let tmp = tempfile::tempdir().unwrap();
+        let pages = tmp.path().join("pages");
+        let docs = pages.join("docs");
+        std::fs::create_dir_all(&docs).unwrap();
+        std::fs::write(docs.join("[[...rest]].md"), "# user docs\n").unwrap();
+
+        let routes = vec![route("/docs", "/pkg/docs.tsx")];
+        let res = resolve_build_pages_root(&pages, &routes).unwrap();
+        assert!(
+            res.materialized.is_empty(),
+            "package route at the bare URL of a user optional-catchall .md page must be dropped"
+        );
+    }
+
+    #[test]
     fn empty_pages_with_root_package_route() {
         let tmp = tempfile::tempdir().unwrap();
         // No real pages/ dir at all.

--- a/crates/zfb/src/commands/package_routes.rs
+++ b/crates/zfb/src/commands/package_routes.rs
@@ -336,17 +336,24 @@ pub(crate) fn resolve_build_pages_root(
 /// collisions possible). Routing errors are surfaced — a broken user
 /// `pages/` would fail the scan anyway, so failing here gives the same
 /// outcome with clearer context.
+///
+/// Uses `zfb_router::user_page_shape_keys`, which — unlike `scan_pages` —
+/// also records the shape keys of DYNAMIC `.md`/`.html` pages the scanner
+/// skips as v1-unsupported. Those are still routes the user authored, so
+/// including them lets the user-wins pre-scan drop a same-shape package
+/// route instead of letting it silently shadow the user's page (#1201).
 fn collect_user_pages_shape_keys(real_pages_dir: &Path) -> Result<HashSet<String>> {
-    let mut keys = HashSet::new();
+    // Package routes intentionally allow an absent user `pages/` — keep the
+    // empty early-return so an absent dir is "no collisions", not an error.
     if !real_pages_dir.is_dir() {
-        return Ok(keys);
+        return Ok(HashSet::new());
     }
-    let routes = zfb_router::scan_pages(real_pages_dir)
-        .map_err(|e| anyhow!("user pages/ scan failed: {e}"))?;
-    for route in routes {
-        keys.insert(zfb_router::shape_key(&route.segments));
-    }
-    Ok(keys)
+    // `user_page_shape_keys` (NOT `scan_pages`) so a user's DYNAMIC `.md`/`.html`
+    // page — which `scan_pages` skips as v1-unsupported — still contributes its
+    // shape key here. Without it, a same-shape package route would NOT be dropped
+    // by the user-wins pre-scan and would silently shadow the user's page (#1201).
+    zfb_router::user_page_shape_keys(real_pages_dir)
+        .map_err(|e| anyhow!("user pages/ scan failed: {e}"))
 }
 
 /// Convert a route pattern (`pages/`-filename grammar, leading `/`) to its
@@ -1073,6 +1080,42 @@ export default function Page() { return null; }
         assert!(
             res.materialized.is_empty(),
             "shape-duplicate package route ([id] vs [slug]) must be dropped"
+        );
+    }
+
+    #[test]
+    fn user_dynamic_md_wins_over_same_shape_package_route() {
+        // #1201: a user's DYNAMIC `.md` page is skipped by `scan_pages` (v1-
+        // unsupported) but still OWNS the `/docs/:*` shape. A same-shape package
+        // route must be dropped (user-wins), not silently shadow the user's page.
+        let tmp = tempfile::tempdir().unwrap();
+        let pages = tmp.path().join("pages");
+        let docs = pages.join("docs");
+        std::fs::create_dir_all(&docs).unwrap();
+        std::fs::write(docs.join("[slug].md"), "# user docs page\n").unwrap();
+
+        let routes = vec![route("/docs/[id]", "/pkg/docs-id.tsx")];
+        let res = resolve_build_pages_root(&pages, &routes).unwrap();
+        assert!(
+            res.materialized.is_empty(),
+            "package route at a user dynamic .md page's shape must be dropped"
+        );
+    }
+
+    #[test]
+    fn user_dynamic_html_wins_over_same_shape_package_route() {
+        // Same as above for a dynamic `.html` page.
+        let tmp = tempfile::tempdir().unwrap();
+        let pages = tmp.path().join("pages");
+        let docs = pages.join("docs");
+        std::fs::create_dir_all(&docs).unwrap();
+        std::fs::write(docs.join("[slug].html"), "<h1>user</h1>\n").unwrap();
+
+        let routes = vec![route("/docs/[id]", "/pkg/docs-id.tsx")];
+        let res = resolve_build_pages_root(&pages, &routes).unwrap();
+        assert!(
+            res.materialized.is_empty(),
+            "package route at a user dynamic .html page's shape must be dropped"
         );
     }
 


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1207
    - https://github.com/Takazudo/zudo-front-builder/issues/1201

---

## Summary

Fixes #1201: a package-owned route at the same route **shape** as a user's **dynamic `.md`/`.html`**
page silently shadowed it. `collect_user_pages_shape_keys` built the user-wins precedence set via
`zfb_router::scan_pages`, which **skips** dynamic `.md`/`.html` routes (v1-unsupported) — so those
files contributed no shape key and a same-shape package route was never dropped by the user-wins
pre-scan.

## Changes

- **`zfb-router/src/scan.rs`** — add `user_page_shape_keys(pages_dir)`: a shape-key census that
  includes the dynamic `.md`/`.html` routes `scan_pages` skips. Implemented via a shared
  `scan_pages_inner` walk returning `(routes, skipped_dynamic_md_html_shape_keys)`; `scan_pages` is
  behaviorally unchanged. Skipped-dynamic shapes are **side data only** — never fed to
  `detect_ambiguity` (so `docs/[id].tsx` + `docs/[slug].md` doesn't become a false hard error;
  buildable ambiguity still surfaces). Optional-catchall pages also record their **zero-segment
  prefix** shape (`docs/[[...rest]].md` owns `/docs` too — codex review). Exported from `lib.rs`.
- **`zfb/src/commands/package_routes.rs`** — `collect_user_pages_shape_keys` consumes the census
  (preserving the absent-`pages/` empty early-return); doc-note refreshed.

## Test Plan

- **L1/L2 (zfb-router):** census includes the skipped dynamic `.md`/`.html` shape (while `scan_pages`
  skips the file); excludes `_`-prefixed / `*.client.*` / unknown-extension files; no false ambiguity
  on a `tsx`+dynamic-`md` sibling; buildable ambiguity still errors; catchall `.md` recorded;
  optional-catchall `.md` records both its shape and the zero-segment `/docs` prefix.
- **L3 (package_routes):** a same-shape package route is dropped (user-wins) for user dynamic `.md`
  and `.html` pages, and for the bare `/docs` URL of a user optional-catchall `.md` page.
- `cargo test -p zfb-router -p zfb` green; clippy `-D warnings` clean; fmt clean.

## Scope

Does NOT add support for dynamic `.md`/`.html` pages (still skipped with a warning) — only f当ixes the
precedence so a package route can't silently shadow a user-authored route shape.

Closes #1207. Fixes #1201.
