### PR TITLE
fix(css): serialize tailwind oxide .node extraction across processes (kills health-gate flake)

### DIFF
--- a/crates/zfb-css/src/engine.rs
+++ b/crates/zfb-css/src/engine.rs
@@ -1,6 +1,6 @@
 //! The "CSS engine" abstraction.
 //!
-//! Tailwind v4 is delivered as a Go-built standalone CLI. To keep our build
+//! Tailwind v4 is delivered as a Bun-compiled standalone CLI. To keep our build
 //! pipeline portable we shell out to that binary today — but the long-term
 //! plan is to swap in a Rust-native implementation (e.g. a future port of
 //! Tailwind's class-engine, or our own equivalent) without touching the rest
@@ -18,6 +18,7 @@ use std::process::Command;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use anyhow::{anyhow, Context, Result};
+use sha2::{Digest, Sha256};
 
 /// Abstraction over "produce a single CSS string of utility classes for the
 /// given project sources".
@@ -704,8 +705,8 @@ impl CssEngine for TailwindSubprocessEngine {
 }
 
 /// Force the Tailwind v4 standalone binary to extract its embedded oxide
-/// native addon (`.node`) **once, serialized**, before any concurrent build
-/// invocation can race on it.
+/// native addon (`.node`) **once, serialized across processes**, before any
+/// concurrent build invocation can race on it.
 ///
 /// ## Why this exists (external-tool quirk — not recoverable from our code)
 ///
@@ -715,10 +716,8 @@ impl CssEngine for TailwindSubprocessEngine {
 /// on the first real scan, NOT on `--help`/`--version` — to a single
 /// content-addressed path under `$TMPDIR` (`$TMPDIR/.<exe-hash>-*.node`) that is
 /// **shared by every invocation of the same binary**. When several `tailwindcss`
-/// processes are spawned concurrently against a cold cache (e.g. the parallel
-/// integration tests under `cargo test`, all driving this one shared binary),
-/// two can race that first extraction and a reader `dlopen`s a half-written
-/// addon, surfacing as:
+/// processes are spawned concurrently against a cold cache, two can race that
+/// first extraction and a reader `dlopen`s a half-written addon, surfacing as:
 ///
 /// ```text
 /// TypeError: undefined is not a constructor (evaluating 'new import_oxide.Scanner(...)')
@@ -726,59 +725,139 @@ impl CssEngine for TailwindSubprocessEngine {
 ///
 /// (Observed intermittently — ~1 in 8 — on the `health` CI gate; zfb#1237.)
 ///
-/// The fix: run one throwaway minimal build while holding a process-global
-/// lock, so the addon is fully extracted before any parallel invocation
-/// proceeds. Later invocations find the extracted addon on disk and reuse it
-/// (it persists for the life of `$TMPDIR`). Keyed by binary path so an
-/// env/temp-dir override is warmed independently.
+/// ## Why the serialization must be cross-process
 ///
-/// Best-effort: a warm-up failure is swallowed — the real invocation that
+/// The contention is NOT just between threads of one process: the integration
+/// tests spawn many short-lived `zfb build` child **processes** in parallel
+/// (libtest threads each shell out via `Command`), all sharing the one extracted
+/// addon under `$TMPDIR`. A within-process lock cannot serialize separate child
+/// processes, so we coordinate through an advisory **file lock** keyed by the
+/// binary path. The first holder runs one throwaway minimal build (which forces
+/// the lazy extraction) and drops a `.done` marker; everyone else blocks on the
+/// lock, then finds the marker and the extracted addon already in place. Lock +
+/// marker live under `$TMPDIR` next to the addon, so they share its lifetime
+/// (clear `$TMPDIR` → both vanish → the next cold process re-warms).
+///
+/// An in-process [`OnceLock`] set is the fast path: once a process has run the
+/// protocol for a binary, later calls return without touching the filesystem,
+/// and it collapses this process's own threads to a single protocol run.
+///
+/// Best-effort: any IO/warm-up failure is swallowed — the real invocation that
 /// follows is the source of truth for genuine errors.
 ///
-/// Caveat: serialization is per-process. Plain `cargo test` runs test binaries
-/// sequentially, so the first process warms the shared addon and later ones
-/// reuse it; a cross-process runner (`cargo nextest`) sharing one `$TMPDIR`
-/// could still race two cold processes. zfb uses plain `cargo test`.
-///
-/// Returns `true` if this call performed the warm-up, `false` if the binary was
-/// already warmed by an earlier caller. The production call site ignores the
-/// return; tests use it to assert the once-only / serialized contract.
+/// Returns `true` if this call ran the protocol, `false` if this process had
+/// already warmed the binary. The production call site ignores the return;
+/// tests use it to assert the once-per-process / serialized contract.
 fn ensure_oxide_extracted(binary_path: &Path) -> bool {
     static WARMED: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
     let warmed = WARMED.get_or_init(|| Mutex::new(HashSet::new()));
 
-    // Hold the lock ACROSS the warm-up spawn: concurrent callers block on
-    // `.lock()` until the first has fully extracted the addon — that blocking
-    // is the entire point, so the check and the spawn must share one critical
-    // section (do not collapse this into `insert()`'s bool, which would let the
-    // second caller proceed while the first is still extracting).
-    let mut guard = warmed.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    // In-process fast path. Holding the lock across the protocol also serializes
+    // this process's threads so only one runs it; later calls hit `contains`.
+    let mut guard = warmed
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
     if guard.contains(binary_path) {
         return false;
     }
-
-    // A minimal `@import "tailwindcss";` build makes the CLI construct its
-    // scanner, which triggers the lazy oxide `.node` extraction. `--help` does
-    // not, so the warm-up must be a real build.
-    if let Ok(dir) = tempfile::tempdir() {
-        let in_css = dir.path().join("warmup.css");
-        let out_css = dir.path().join("warmup.out.css");
-        if std::fs::write(&in_css, b"@import \"tailwindcss\";\n").is_ok() {
-            let _ = Command::new(binary_path)
-                .arg("-i")
-                .arg(&in_css)
-                .arg("-o")
-                .arg(&out_css)
-                .output();
-        }
-        // `dir` is cleaned on drop.
-    }
-
-    // Mark warmed regardless of warm-up outcome: a persistent failure is a real
-    // binary problem the next real invocation will report — we must not spin on
-    // the warm-up every call.
+    warm_oxide_cross_process(binary_path);
     guard.insert(binary_path.to_path_buf());
     true
+}
+
+/// Cross-process half of [`ensure_oxide_extracted`]: serialize the first oxide
+/// extraction via an advisory file lock, so concurrent `zfb build` child
+/// processes do not race the shared addon. Best-effort — any IO error is
+/// swallowed.
+///
+/// ## Keyed by binary CONTENT, not path
+///
+/// Each `zfb build` extracts its embedded tailwind binary to a *fresh* tempdir
+/// (`render_pipeline::embedded_binary`), so the children's binary *paths* all
+/// differ — yet Bun addresses the extracted addon by executable *content*, so
+/// the identical-content children share one addon and race it. (If Bun keyed by
+/// path the children would be isolated and there would be no cross-process race
+/// to begin with — but CI proves there is one.) So the `.done` marker is keyed
+/// by a content hash of the binary; all identical-content invocations agree on
+/// one marker and warm exactly once. The lock file is a single global one under
+/// `$TMPDIR` — distinct versions merely serialize their (separate) warm-ups,
+/// which is harmless. Marker lives next to Bun's addon under `$TMPDIR`, sharing
+/// its lifetime (clear `$TMPDIR` → both vanish → the next cold process re-warms).
+fn warm_oxide_cross_process(binary_path: &Path) {
+    let Some(key) = tailwind_content_key(binary_path) else {
+        return;
+    };
+    let base = std::env::temp_dir();
+    let lock_path = base.join("zfb-tailwind-oxide-warmup.lock");
+    let done_path = base.join(format!("zfb-tailwind-oxide-warmup-{key}.done"));
+
+    // Fast path for fresh processes: this binary content was already warmed in
+    // this `$TMPDIR`; skip the lock entirely.
+    if done_path.exists() {
+        return;
+    }
+
+    let Ok(lock_file) = std::fs::File::create(&lock_path) else {
+        return;
+    };
+    // Blocking advisory exclusive lock (flock / LockFileEx via std). Released on
+    // unlock, drop, or process exit — so a crashed holder leaves no stale lock.
+    if lock_file.lock().is_err() {
+        return;
+    }
+    // Re-check under the lock: another process may have warmed while we waited.
+    if !done_path.exists() && run_oxide_warmup_build(binary_path) {
+        // Mark done only on success: a failed warm-up must not let the next
+        // process skip warming against a still-unextracted addon.
+        let _ = std::fs::File::create(&done_path);
+    }
+    let _ = lock_file.unlock();
+}
+
+/// A stable key for the tailwind binary's *content* — `sha256` of the file
+/// bytes, truncated to 16 hex chars. Read in chunks to avoid buffering the
+/// whole ~80 MiB binary; the just-extracted file is usually still warm in the
+/// page cache, so this is cheap in practice. Returns `None` if the file cannot
+/// be read (the real invocation will report that failure).
+fn tailwind_content_key(binary_path: &Path) -> Option<String> {
+    use std::io::Read;
+    let mut file = std::fs::File::open(binary_path).ok()?;
+    let mut hasher = Sha256::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let n = file.read(&mut buf).ok()?;
+        if n == 0 {
+            break;
+        }
+        hasher.update(&buf[..n]);
+    }
+    Some(hex::encode(&hasher.finalize()[..8]))
+}
+
+/// Run one throwaway minimal Tailwind build to force Bun's lazy oxide `.node`
+/// extraction. Returns whether it succeeded. Spawned with its CWD set to the
+/// scratch dir so Tailwind v4's working-directory source auto-detection (active
+/// for a bare `@import "tailwindcss";` with no `source(...)`) scans only the
+/// empty temp dir — never the user's project/monorepo.
+fn run_oxide_warmup_build(binary_path: &Path) -> bool {
+    let Ok(dir) = tempfile::tempdir() else {
+        return false;
+    };
+    let in_css = dir.path().join("warmup.css");
+    let out_css = dir.path().join("warmup.out.css");
+    if std::fs::write(&in_css, b"@import \"tailwindcss\";\n").is_err() {
+        return false;
+    }
+    Command::new(binary_path)
+        .current_dir(dir.path())
+        .arg("-i")
+        .arg(&in_css)
+        .arg("-o")
+        .arg(&out_css)
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+    // `dir` is cleaned on drop.
 }
 
 /// Default content roots that the project scans for utility classes.

--- a/crates/zfb-css/src/engine.rs
+++ b/crates/zfb-css/src/engine.rs
@@ -840,6 +840,14 @@ fn tailwind_content_key(binary_path: &Path) -> Option<String> {
 /// for a bare `@import "tailwindcss";` with no `source(...)`) scans only the
 /// empty temp dir — never the user's project/monorepo.
 fn run_oxide_warmup_build(binary_path: &Path) -> bool {
+    // The binary path must be made absolute BEFORE we override the child's cwd:
+    // a relative program path (the default `crates/zfb/binaries/tailwindcss-v4`,
+    // or a relative `ZFB_TAILWIND_BIN`) would otherwise be resolved against the
+    // scratch `current_dir` below — not the caller's cwd — so the spawn would
+    // fail and silently skip the warm-up.
+    let Ok(abs_bin) = binary_path.canonicalize() else {
+        return false;
+    };
     let Ok(dir) = tempfile::tempdir() else {
         return false;
     };
@@ -848,7 +856,7 @@ fn run_oxide_warmup_build(binary_path: &Path) -> bool {
     if std::fs::write(&in_css, b"@import \"tailwindcss\";\n").is_err() {
         return false;
     }
-    Command::new(binary_path)
+    Command::new(&abs_bin)
         .current_dir(dir.path())
         .arg("-i")
         .arg(&in_css)

--- a/crates/zfb-css/src/engine.rs
+++ b/crates/zfb-css/src/engine.rs
@@ -11,11 +11,11 @@
 //! Everything stage-2 and beyond (CSS Modules, hashing, asset emission)
 //! is engine-agnostic.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, OnceLock};
 
 use anyhow::{anyhow, Context, Result};
 
@@ -615,6 +615,15 @@ impl CssEngine for TailwindSubprocessEngine {
             ));
         }
 
+        // External-tool quirk: make the Bun-embedded oxide `.node` extract
+        // exactly once, serialized, before any parallel invocation can race on
+        // the shared addon file. Without this, concurrent cold spawns (e.g. the
+        // parallel integration tests all driving this one binary) intermittently
+        // load a half-written addon and die with
+        // `undefined is not a constructor (new import_oxide.Scanner(...))`.
+        // See `ensure_oxide_extracted` and zfb#1237 for the full rationale.
+        ensure_oxide_extracted(&self.config.binary_path);
+
         // Self-heal: delete entry temp files stranded by a past abnormal
         // termination (SIGKILL / crash / Ctrl-C skips the RAII `Drop` that
         // normally removes them). Done before we create the new file so the
@@ -692,6 +701,84 @@ impl CssEngine for TailwindSubprocessEngine {
             .context("failed to read tailwind output file")?;
         Ok(css)
     }
+}
+
+/// Force the Tailwind v4 standalone binary to extract its embedded oxide
+/// native addon (`.node`) **once, serialized**, before any concurrent build
+/// invocation can race on it.
+///
+/// ## Why this exists (external-tool quirk — not recoverable from our code)
+///
+/// The `tailwindcss` v4 standalone CLI is a Bun-compiled single-file
+/// executable. Its Rust scanner (`@tailwindcss/oxide`) ships as a native
+/// `.node` addon embedded in that binary. Bun extracts the addon **lazily** —
+/// on the first real scan, NOT on `--help`/`--version` — to a single
+/// content-addressed path under `$TMPDIR` (`$TMPDIR/.<exe-hash>-*.node`) that is
+/// **shared by every invocation of the same binary**. When several `tailwindcss`
+/// processes are spawned concurrently against a cold cache (e.g. the parallel
+/// integration tests under `cargo test`, all driving this one shared binary),
+/// two can race that first extraction and a reader `dlopen`s a half-written
+/// addon, surfacing as:
+///
+/// ```text
+/// TypeError: undefined is not a constructor (evaluating 'new import_oxide.Scanner(...)')
+/// ```
+///
+/// (Observed intermittently — ~1 in 8 — on the `health` CI gate; zfb#1237.)
+///
+/// The fix: run one throwaway minimal build while holding a process-global
+/// lock, so the addon is fully extracted before any parallel invocation
+/// proceeds. Later invocations find the extracted addon on disk and reuse it
+/// (it persists for the life of `$TMPDIR`). Keyed by binary path so an
+/// env/temp-dir override is warmed independently.
+///
+/// Best-effort: a warm-up failure is swallowed — the real invocation that
+/// follows is the source of truth for genuine errors.
+///
+/// Caveat: serialization is per-process. Plain `cargo test` runs test binaries
+/// sequentially, so the first process warms the shared addon and later ones
+/// reuse it; a cross-process runner (`cargo nextest`) sharing one `$TMPDIR`
+/// could still race two cold processes. zfb uses plain `cargo test`.
+///
+/// Returns `true` if this call performed the warm-up, `false` if the binary was
+/// already warmed by an earlier caller. The production call site ignores the
+/// return; tests use it to assert the once-only / serialized contract.
+fn ensure_oxide_extracted(binary_path: &Path) -> bool {
+    static WARMED: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
+    let warmed = WARMED.get_or_init(|| Mutex::new(HashSet::new()));
+
+    // Hold the lock ACROSS the warm-up spawn: concurrent callers block on
+    // `.lock()` until the first has fully extracted the addon — that blocking
+    // is the entire point, so the check and the spawn must share one critical
+    // section (do not collapse this into `insert()`'s bool, which would let the
+    // second caller proceed while the first is still extracting).
+    let mut guard = warmed.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+    if guard.contains(binary_path) {
+        return false;
+    }
+
+    // A minimal `@import "tailwindcss";` build makes the CLI construct its
+    // scanner, which triggers the lazy oxide `.node` extraction. `--help` does
+    // not, so the warm-up must be a real build.
+    if let Ok(dir) = tempfile::tempdir() {
+        let in_css = dir.path().join("warmup.css");
+        let out_css = dir.path().join("warmup.out.css");
+        if std::fs::write(&in_css, b"@import \"tailwindcss\";\n").is_ok() {
+            let _ = Command::new(binary_path)
+                .arg("-i")
+                .arg(&in_css)
+                .arg("-o")
+                .arg(&out_css)
+                .output();
+        }
+        // `dir` is cleaned on drop.
+    }
+
+    // Mark warmed regardless of warm-up outcome: a persistent failure is a real
+    // binary problem the next real invocation will report — we must not spin on
+    // the warm-up every call.
+    guard.insert(binary_path.to_path_buf());
+    true
 }
 
 /// Default content roots that the project scans for utility classes.
@@ -1048,5 +1135,46 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let missing = dir.path().join("does-not-exist");
         sweep_stale_entry_files_at(&missing, future_now()); // must not panic
+    }
+
+    /// The oxide warm-up must run exactly once per binary path even when many
+    /// callers hit it concurrently — that single serialized extraction is what
+    /// prevents the Bun `.node` race (zfb#1237). Exercised deterministically
+    /// with a non-existent binary: the warm-up spawn fails (best-effort,
+    /// swallowed), but the once-only / serialized bookkeeping is exactly what we
+    /// assert, with no dependency on the real tailwind binary.
+    #[test]
+    fn ensure_oxide_extracted_warms_exactly_once_under_concurrency() {
+        use std::thread;
+
+        // Unique, non-existent path so it is guaranteed absent from the
+        // process-global warmed set at the start of this test.
+        let dir = tempfile::tempdir().expect("tempdir");
+        let fake_bin = Arc::new(dir.path().join("not-a-real-tailwind"));
+
+        const N: usize = 16;
+        let handles: Vec<_> = (0..N)
+            .map(|_| {
+                let p = Arc::clone(&fake_bin);
+                thread::spawn(move || ensure_oxide_extracted(&p))
+            })
+            .collect();
+        let warmed_count = handles
+            .into_iter()
+            .map(|h| h.join().expect("warm-up thread panicked"))
+            .filter(|&did_warm| did_warm)
+            .count();
+
+        assert_eq!(
+            warmed_count, 1,
+            "exactly one of {N} concurrent callers must perform the warm-up; \
+             the rest must see it already warmed (serialized first-extraction)"
+        );
+
+        // A later call for the same path is a no-op (stays warmed).
+        assert!(
+            !ensure_oxide_extracted(&fake_bin),
+            "already-warmed path must not warm again"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes the intermittent (~1 in 8) `health` CI failure where `cargo test --workspace` died inside the Tailwind v4 standalone binary with:

```
TypeError: undefined is not a constructor (evaluating 'new import_oxide.Scanner(...)')
```

### Root cause

The `tailwindcss` v4 standalone CLI is a **Bun-compiled** single-file executable. Its Rust scanner (`@tailwindcss/oxide`) ships as an embedded native `.node` addon that Bun extracts **lazily** (on the first real scan — not `--help`/`--version`) to a path **addressed by executable content** and shared across invocations. The zfb integration tests spawn many short-lived `zfb build` **child processes** in parallel (libtest threads each shell out via `Command`); each child extracts its embedded tailwind to a *fresh* tempdir, so paths differ but the **content is identical** → they share one addon and race its first extraction. A reader `dlopen`s a half-written addon → the `Scanner` constructor is `undefined`.

### Fix

A best-effort, process-then-cross-process serialized **warm-up** in the CSS engine (`crates/zfb-css/src/engine.rs`), so the oxide addon is fully extracted once before any parallel invocation proceeds:

- **In-process** `OnceLock` fast path collapses a process's own threads and avoids re-touching the filesystem after the first call.
- **Cross-process**: a single advisory **file lock** (`std::fs::File::lock`, flock/LockFileEx) under `$TMPDIR`, gated by a `.done` marker keyed by a **SHA-256 of the binary's content** — so all identical-content children agree on one marker and warm exactly once.
- The warm-up runs one throwaway minimal `@import "tailwindcss";` build (the only thing that triggers Bun's lazy extraction), with its **CWD bounded to a scratch dir** and the **binary canonicalized to absolute** first (a relative program path would otherwise resolve against the scratch cwd and silently fail).
- Lives in the engine, so production `zfb build` is protected too — not just tests.

Safe under both Bun models: if the addon is shared-by-content (the model consistent with the CI failure) the marker serializes correctly; if it were per-process-isolated there is no race and skipping a redundant warm-up is harmless.

## Changes

- `crates/zfb-css/src/engine.rs`: `ensure_oxide_extracted` + `warm_oxide_cross_process` + `tailwind_content_key` + `run_oxide_warmup_build`, called once before the real subprocess spawn. Corrects a stale crate-doc claim ("Go-built" → Bun-compiled).
- New deterministic unit test asserting exactly one of N concurrent callers performs the warm-up (no dependency on the real binary).

## Test plan / what was (and was not) proven

- ✅ Deterministic serialization unit test (`ensure_oxide_extracted_warms_exactly_once_under_concurrency`).
- ✅ `zfb-css` full suite + `cargo test -p zfb` integration suite green repeatedly.
- ✅ Cold-cache `build_cleans_outdir` run: all parallel `zfb build` children produced **one** content-keyed `.done` marker + one global lock (was ~15 distinct path-keys pre-fix), proving the cross-process serialization.
- ⚠️ **Not proven locally:** the race itself could not be reproduced on macOS/arm64 (it surfaced only on the linux-x64 CI runner — platform-timing-sensitive). The ultimate proof is this PR's `health` run on linux.

Reviewed via 3 rounds of `/codex-review`; converged clean after fixing: within-process→cross-process serialization, warm-up source-scan scope, and the relative-path/cwd spawn bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)