### PR TITLE
Binary Fetch Hardening: harden build.rs binary download (stream + retry + timeout)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5562,6 +5562,7 @@ dependencies = [
  "tracing",
  "url",
  "walkdir",
+ "zfb-binfetch",
  "zfb-build",
  "zfb-config-loader",
  "zfb-content",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5581,6 +5581,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "zfb-binfetch"
+version = "0.0.0"
+dependencies = [
+ "reqwest",
+ "tempfile",
+]
+
+[[package]]
 name = "zfb-build"
 version = "0.0.0"
 dependencies = [

--- a/crates/zfb-binfetch/Cargo.toml
+++ b/crates/zfb-binfetch/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "zfb-binfetch"
+version = "0.0.0"
+edition = "2021"
+license = "MIT"
+description = "zfb-binfetch: streaming retry download helper used by zfb build scripts"
+
+[dependencies]
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/zfb-binfetch/src/lib.rs
+++ b/crates/zfb-binfetch/src/lib.rs
@@ -9,7 +9,10 @@ pub struct FetchOpts {
     /// TCP connect timeout per attempt. Default: 15 s.
     pub connect_timeout: Duration,
     /// Overall request timeout (used as a fallback cap because reqwest 0.12's
-    /// blocking client does not expose a per-read idle timeout).  Default: 60 s.
+    /// blocking client does not expose a per-read idle timeout). Kept generous
+    /// — the body is a ~75 MB download that must not be aborted on a slow link;
+    /// this is a stuck-transfer backstop, not a tight per-request limit.
+    /// Default: 300 s.
     pub read_timeout: Duration,
     /// Backoff before the second attempt; doubled each retry. Default: 500 ms.
     pub initial_backoff: Duration,
@@ -20,7 +23,7 @@ impl Default for FetchOpts {
         Self {
             attempts: 3,
             connect_timeout: Duration::from_secs(15),
-            read_timeout: Duration::from_secs(60),
+            read_timeout: Duration::from_secs(300),
             initial_backoff: Duration::from_millis(500),
         }
     }
@@ -36,9 +39,9 @@ pub fn fetch_to_file(url: &str, dest: &Path, opts: &FetchOpts) -> Result<(), Str
         .use_rustls_tls()
         .connect_timeout(opts.connect_timeout)
         // reqwest 0.12 blocking::ClientBuilder does not expose read_timeout, so
-        // we use the overall `.timeout()` as a fallback cap.  This is a generous
-        // deadline (default 60 s) rather than a tight per-request limit, so it
-        // won't abort a legitimately slow large download within that window.
+        // we use the overall `.timeout()` as a fallback cap. This is a generous
+        // deadline (default 300 s) rather than a tight per-request limit, so it
+        // won't abort a legitimately slow ~75 MB download within that window.
         // If a future reqwest version adds blocking read_timeout, swap this for
         // `.read_timeout(opts.read_timeout)` and remove the overall cap.
         .timeout(opts.read_timeout)

--- a/crates/zfb-binfetch/src/lib.rs
+++ b/crates/zfb-binfetch/src/lib.rs
@@ -180,17 +180,14 @@ mod tests {
         let addr = listener.local_addr().unwrap();
         let queue: Arc<Mutex<VecDeque<Handler>>> = Arc::new(Mutex::new(VecDeque::from(handlers)));
 
-        std::thread::spawn(move || loop {
-            match listener.accept() {
-                Ok((mut stream, _)) => {
-                    drain_request_headers(&mut stream);
-                    let handler = queue.lock().unwrap().pop_front();
-                    if let Some(h) = handler {
-                        h(&mut stream);
-                    }
-                    // If no handler remains, close the connection silently.
+        std::thread::spawn(move || {
+            while let Ok((mut stream, _)) = listener.accept() {
+                drain_request_headers(&mut stream);
+                let handler = queue.lock().unwrap().pop_front();
+                if let Some(h) = handler {
+                    h(&mut stream);
                 }
-                Err(_) => break,
+                // If no handler remains, close the connection silently.
             }
         });
 

--- a/crates/zfb-binfetch/src/lib.rs
+++ b/crates/zfb-binfetch/src/lib.rs
@@ -8,12 +8,18 @@ pub struct FetchOpts {
     pub attempts: u32,
     /// TCP connect timeout per attempt. Default: 15 s.
     pub connect_timeout: Duration,
-    /// Overall request timeout (used as a fallback cap because reqwest 0.12's
-    /// blocking client does not expose a per-read idle timeout). Kept generous
-    /// — the body is a ~75 MB download that must not be aborted on a slow link;
-    /// this is a stuck-transfer backstop, not a tight per-request limit.
-    /// Default: 300 s.
-    pub read_timeout: Duration,
+    /// Optional **whole-request** deadline. `None` by default — deliberately so.
+    ///
+    /// reqwest 0.12's blocking client exposes no per-read *idle* timeout, only
+    /// `.timeout()`, which bounds the entire request including the body read.
+    /// Applying that to a ~75 MB binary download would abort a legitimately
+    /// slow-but-healthy transfer (e.g. a throttled link under ~250 KB/s) — a
+    /// regression from the original unbounded `response.bytes()` read. So the
+    /// default imposes no whole-request deadline: a stuck *connect* is caught by
+    /// `connect_timeout`, and a mid-stream reset surfaces as a body error that
+    /// the retry loop recovers from. Callers who genuinely want a hard ceiling
+    /// (and accept the slow-link risk) can set `Some(..)`.
+    pub overall_timeout: Option<Duration>,
     /// Backoff before the second attempt; doubled each retry. Default: 500 ms.
     pub initial_backoff: Duration,
 }
@@ -23,7 +29,7 @@ impl Default for FetchOpts {
         Self {
             attempts: 3,
             connect_timeout: Duration::from_secs(15),
-            read_timeout: Duration::from_secs(300),
+            overall_timeout: None,
             initial_backoff: Duration::from_millis(500),
         }
     }
@@ -35,16 +41,16 @@ impl Default for FetchOpts {
 /// remains at `dest`. The caller is responsible for hashing, chmod, and renaming
 /// into the final slot, and **MUST** ensure `dest`'s parent directory exists.
 pub fn fetch_to_file(url: &str, dest: &Path, opts: &FetchOpts) -> Result<(), String> {
-    let client = reqwest::blocking::ClientBuilder::new()
+    let mut builder = reqwest::blocking::ClientBuilder::new()
         .use_rustls_tls()
-        .connect_timeout(opts.connect_timeout)
-        // reqwest 0.12 blocking::ClientBuilder does not expose read_timeout, so
-        // we use the overall `.timeout()` as a fallback cap. This is a generous
-        // deadline (default 300 s) rather than a tight per-request limit, so it
-        // won't abort a legitimately slow ~75 MB download within that window.
-        // If a future reqwest version adds blocking read_timeout, swap this for
-        // `.read_timeout(opts.read_timeout)` and remove the overall cap.
-        .timeout(opts.read_timeout)
+        .connect_timeout(opts.connect_timeout);
+    // Only apply a whole-request deadline when the caller opted in. reqwest 0.12
+    // blocking has no per-read idle timeout, and a whole-request `.timeout()`
+    // would abort a slow-but-healthy large download — see `overall_timeout`.
+    if let Some(t) = opts.overall_timeout {
+        builder = builder.timeout(t);
+    }
+    let client = builder
         .build()
         .map_err(|e| format!("failed to build HTTP client: {e}"))?;
 
@@ -196,7 +202,9 @@ mod tests {
         FetchOpts {
             attempts,
             connect_timeout: Duration::from_secs(5),
-            read_timeout: Duration::from_secs(5),
+            // Exercise the opt-in whole-request cap path; tests hit a local
+            // server so 5 s is ample and never bites a healthy response.
+            overall_timeout: Some(Duration::from_secs(5)),
             initial_backoff: Duration::from_millis(2),
         }
     }

--- a/crates/zfb-binfetch/src/lib.rs
+++ b/crates/zfb-binfetch/src/lib.rs
@@ -1,0 +1,336 @@
+use std::fs::File;
+use std::path::Path;
+use std::time::Duration;
+
+/// Options controlling fetch behaviour.
+pub struct FetchOpts {
+    /// Number of attempts before giving up. Default: 3.
+    pub attempts: u32,
+    /// TCP connect timeout per attempt. Default: 15 s.
+    pub connect_timeout: Duration,
+    /// Overall request timeout (used as a fallback cap because reqwest 0.12's
+    /// blocking client does not expose a per-read idle timeout).  Default: 60 s.
+    pub read_timeout: Duration,
+    /// Backoff before the second attempt; doubled each retry. Default: 500 ms.
+    pub initial_backoff: Duration,
+}
+
+impl Default for FetchOpts {
+    fn default() -> Self {
+        Self {
+            attempts: 3,
+            connect_timeout: Duration::from_secs(15),
+            read_timeout: Duration::from_secs(60),
+            initial_backoff: Duration::from_millis(500),
+        }
+    }
+}
+
+/// Stream `url` to `dest` (a caller-owned temp path), retrying on transient errors.
+///
+/// On `Ok`, the full body has been written to `dest`. On `Err`, no partial file
+/// remains at `dest`. The caller is responsible for hashing, chmod, and renaming
+/// into the final slot, and **MUST** ensure `dest`'s parent directory exists.
+pub fn fetch_to_file(url: &str, dest: &Path, opts: &FetchOpts) -> Result<(), String> {
+    let client = reqwest::blocking::ClientBuilder::new()
+        .use_rustls_tls()
+        .connect_timeout(opts.connect_timeout)
+        // reqwest 0.12 blocking::ClientBuilder does not expose read_timeout, so
+        // we use the overall `.timeout()` as a fallback cap.  This is a generous
+        // deadline (default 60 s) rather than a tight per-request limit, so it
+        // won't abort a legitimately slow large download within that window.
+        // If a future reqwest version adds blocking read_timeout, swap this for
+        // `.read_timeout(opts.read_timeout)` and remove the overall cap.
+        .timeout(opts.read_timeout)
+        .build()
+        .map_err(|e| format!("failed to build HTTP client: {e}"))?;
+
+    let mut backoff = opts.initial_backoff;
+    let mut last_err = String::new();
+
+    for attempt in 1..=opts.attempts {
+        // Fresh GET each attempt — never reuse a response across retries.
+        let response = match client.get(url).send() {
+            Ok(r) => r,
+            Err(e) => {
+                last_err = format!("attempt {attempt}/{}: send error: {e}", opts.attempts);
+                if attempt < opts.attempts {
+                    std::thread::sleep(backoff);
+                    backoff *= 2;
+                }
+                continue;
+            }
+        };
+
+        let status = response.status();
+        if !status.is_success() {
+            last_err = format!("attempt {attempt}/{}: HTTP {status}", opts.attempts);
+            if attempt < opts.attempts {
+                std::thread::sleep(backoff);
+                backoff *= 2;
+            }
+            continue;
+        }
+
+        // Per-attempt File::create truncates any partial write from the previous
+        // attempt so stale bytes never bleed into the next try.
+        let mut file = match File::create(dest) {
+            Ok(f) => f,
+            Err(e) => {
+                let _ = std::fs::remove_file(dest);
+                return Err(format!("cannot create dest file: {e}"));
+            }
+        };
+
+        let mut response = response;
+        match response.copy_to(&mut file) {
+            Ok(_) => return Ok(()),
+            Err(e) => {
+                last_err = format!("attempt {attempt}/{}: body error: {e}", opts.attempts);
+            }
+        }
+
+        if attempt < opts.attempts {
+            std::thread::sleep(backoff);
+            backoff *= 2;
+        }
+    }
+
+    // All attempts failed — remove any partial dest file before returning.
+    let _ = std::fs::remove_file(dest);
+    let reason = if last_err.is_empty() {
+        // attempts == 0: the loop never ran.
+        format!("no attempts made (opts.attempts = {})", opts.attempts)
+    } else {
+        last_err
+    };
+    Err(format!(
+        "{reason}. \
+         Tip: set ZFB_ESBUILD_BIN or ZFB_TAILWIND_BIN to an existing binary \
+         path to skip the download entirely."
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+    use std::io::{Read, Write};
+    use std::net::{TcpListener, TcpStream};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    // ── server helpers ───────────────────────────────────────────────────────
+
+    /// Drain HTTP request headers (read until `\r\n\r\n`).
+    fn drain_request_headers(stream: &mut TcpStream) {
+        stream
+            .set_read_timeout(Some(Duration::from_millis(500)))
+            .ok();
+        let mut buf = Vec::with_capacity(512);
+        let mut byte = [0u8; 1];
+        loop {
+            match stream.read(&mut byte) {
+                Ok(0) | Err(_) => break,
+                Ok(_) => {
+                    buf.push(byte[0]);
+                    if buf.ends_with(b"\r\n\r\n") {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Write a complete HTTP/1.1 200 OK response with the given body.
+    fn serve_full(stream: &mut TcpStream, body: &[u8]) {
+        let header = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        );
+        let _ = stream.write_all(header.as_bytes());
+        let _ = stream.write_all(body);
+    }
+
+    /// Write a truncated response: claims `claimed_len` bytes in Content-Length
+    /// but only sends `partial_body`, then closes — forcing a body decode error.
+    fn serve_truncated(stream: &mut TcpStream, partial_body: &[u8], claimed_len: usize) {
+        let header = format!("HTTP/1.1 200 OK\r\nContent-Length: {claimed_len}\r\n\r\n");
+        let _ = stream.write_all(header.as_bytes());
+        let _ = stream.write_all(partial_body);
+        // Socket closes here; reqwest detects the body is shorter than Content-Length.
+    }
+
+    type Handler = Box<dyn FnOnce(&mut TcpStream) + Send + 'static>;
+
+    /// Spawn a background HTTP/1.1 server that serves each incoming connection
+    /// with the next handler from the queue, then idles (blocks on `accept`).
+    /// Returns the URL (e.g. `http://127.0.0.1:PORT/`).
+    fn spawn_server(handlers: Vec<Handler>) -> String {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        let queue: Arc<Mutex<VecDeque<Handler>>> = Arc::new(Mutex::new(VecDeque::from(handlers)));
+
+        std::thread::spawn(move || loop {
+            match listener.accept() {
+                Ok((mut stream, _)) => {
+                    drain_request_headers(&mut stream);
+                    let handler = queue.lock().unwrap().pop_front();
+                    if let Some(h) = handler {
+                        h(&mut stream);
+                    }
+                    // If no handler remains, close the connection silently.
+                }
+                Err(_) => break,
+            }
+        });
+
+        format!("http://{addr}/")
+    }
+
+    /// Tiny opts for tests: small backoff so suites finish quickly.
+    fn tiny_opts(attempts: u32) -> FetchOpts {
+        FetchOpts {
+            attempts,
+            connect_timeout: Duration::from_secs(5),
+            read_timeout: Duration::from_secs(5),
+            initial_backoff: Duration::from_millis(2),
+        }
+    }
+
+    // ── tests ────────────────────────────────────────────────────────────────
+
+    /// Attempt 1 truncates; attempt 2 serves the full body.
+    /// Assert: Ok, file == full body, counter == 2.
+    #[test]
+    fn truncate_then_succeed() {
+        const FULL_BODY: &[u8] = b"the complete response body for the test";
+
+        let counter = Arc::new(AtomicUsize::new(0));
+        let c1 = Arc::clone(&counter);
+        let c2 = Arc::clone(&counter);
+
+        let handlers: Vec<Handler> = vec![
+            Box::new(move |s: &mut TcpStream| {
+                c1.fetch_add(1, Ordering::SeqCst);
+                // claim 200 bytes but only send 9 — forces a body error
+                serve_truncated(s, b"the compl", FULL_BODY.len() + 200);
+            }),
+            Box::new(move |s: &mut TcpStream| {
+                c2.fetch_add(1, Ordering::SeqCst);
+                serve_full(s, FULL_BODY);
+            }),
+        ];
+
+        let url = spawn_server(handlers);
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("out.bin");
+
+        let result = fetch_to_file(&url, &dest, &tiny_opts(3));
+        assert!(result.is_ok(), "expected Ok, got: {result:?}");
+        assert_eq!(std::fs::read(&dest).unwrap(), FULL_BODY);
+        assert_eq!(counter.load(Ordering::SeqCst), 2);
+    }
+
+    /// All attempts truncate → Err after exactly `attempts` tries.
+    /// Assert: Err, dest file absent, counter == attempts.
+    #[test]
+    fn all_attempts_fail() {
+        let attempts: u32 = 3;
+        let counter = Arc::new(AtomicUsize::new(0));
+
+        let handlers: Vec<Handler> = (0..attempts)
+            .map(|_| {
+                let c = Arc::clone(&counter);
+                let h: Handler = Box::new(move |s: &mut TcpStream| {
+                    c.fetch_add(1, Ordering::SeqCst);
+                    serve_truncated(s, b"part", 9_999);
+                });
+                h
+            })
+            .collect();
+
+        let url = spawn_server(handlers);
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("out.bin");
+
+        let result = fetch_to_file(&url, &dest, &tiny_opts(attempts));
+        assert!(result.is_err(), "expected Err, got Ok");
+        assert!(!dest.exists(), "dest must not exist after all-fail");
+        assert_eq!(counter.load(Ordering::SeqCst), attempts as usize);
+    }
+
+    /// Single clean response → Ok, file matches.
+    #[test]
+    fn happy_path() {
+        const BODY: &[u8] = b"happy response body";
+        let counter = Arc::new(AtomicUsize::new(0));
+        let c = Arc::clone(&counter);
+
+        let handlers: Vec<Handler> = vec![Box::new(move |s: &mut TcpStream| {
+            c.fetch_add(1, Ordering::SeqCst);
+            serve_full(s, BODY);
+        })];
+
+        let url = spawn_server(handlers);
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("out.bin");
+
+        let result = fetch_to_file(&url, &dest, &tiny_opts(3));
+        assert!(result.is_ok(), "expected Ok, got: {result:?}");
+        assert_eq!(std::fs::read(&dest).unwrap(), BODY);
+        assert_eq!(counter.load(Ordering::SeqCst), 1);
+    }
+
+    /// Attempt 1 writes distinct garbage bytes then truncates.  Attempt 2 serves
+    /// the real body.  The final file must equal the real body and must NOT
+    /// contain the garbage, proving per-attempt `File::create` truncated it.
+    #[test]
+    fn truncate_replaced_between_attempts() {
+        const GARBAGE: &[u8] = b"GARBAGE";
+        const REAL_BODY: &[u8] = b"CORRECT_RESPONSE_BODY";
+
+        let handlers: Vec<Handler> = vec![
+            Box::new(|s: &mut TcpStream| {
+                // Claim a large body; only write distinctive garbage.
+                serve_truncated(s, GARBAGE, 9_999);
+            }),
+            Box::new(|s: &mut TcpStream| {
+                serve_full(s, REAL_BODY);
+            }),
+        ];
+
+        let url = spawn_server(handlers);
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("out.bin");
+
+        let result = fetch_to_file(&url, &dest, &tiny_opts(3));
+        assert!(result.is_ok(), "expected Ok, got: {result:?}");
+        let got = std::fs::read(&dest).unwrap();
+        assert_eq!(got, REAL_BODY, "final file must match real body");
+        // Belt-and-suspenders: garbage from attempt 1 must not appear anywhere.
+        assert!(
+            !got.windows(GARBAGE.len()).any(|w| w == GARBAGE),
+            "garbage bytes from attempt 1 must not appear in the final file"
+        );
+    }
+
+    /// Clean body with `Connection: close` and no `Content-Length` → Ok, file matches.
+    #[test]
+    fn no_content_length_body() {
+        const BODY: &[u8] = b"no content length response body";
+
+        let handlers: Vec<Handler> = vec![Box::new(|s: &mut TcpStream| {
+            let _ = s.write_all(b"HTTP/1.1 200 OK\r\nConnection: close\r\n\r\n");
+            let _ = s.write_all(BODY);
+        })];
+
+        let url = spawn_server(handlers);
+        let dir = tempfile::tempdir().unwrap();
+        let dest = dir.path().join("out.bin");
+
+        let result = fetch_to_file(&url, &dest, &tiny_opts(3));
+        assert!(result.is_ok(), "expected Ok, got: {result:?}");
+        assert_eq!(std::fs::read(&dest).unwrap(), BODY);
+    }
+}

--- a/crates/zfb/Cargo.toml
+++ b/crates/zfb/Cargo.toml
@@ -126,9 +126,9 @@ local-ip-address = "0.6"
 # build.rs reads zfb_toolchain_pins::EXPECTED_ESBUILD_VERSION to construct
 # the npm registry download URL for the pinned esbuild binary.
 zfb-toolchain-pins = { path = "../zfb-toolchain-pins" }
-# Binary download and SHA-256 verification in build.rs.
-# reqwest blocking + rustls-tls avoids a system OpenSSL dependency.
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
+# Streaming retry downloader used by build.rs; owns reqwest + rustls-tls
+# so we no longer need a direct reqwest build-dependency here.
+zfb-binfetch = { path = "../zfb-binfetch" }
 # SHA-256 for binary verification (same version used by zfb-build).
 sha2 = "0.10"
 hex = "0.4"

--- a/crates/zfb/build.rs
+++ b/crates/zfb/build.rs
@@ -177,6 +177,24 @@ fn sha256_hex(bytes: &[u8]) -> String {
     hex::encode(h.finalize())
 }
 
+/// Compute the SHA-256 of the file at `path` by reading it in 64 KiB chunks,
+/// avoiding a full in-memory buffer for large files (e.g. the ~75 MB tailwind
+/// binary).
+fn sha256_hex_file(path: &Path) -> io::Result<String> {
+    use sha2::{Digest, Sha256};
+    let mut file = fs::File::open(path)?;
+    let mut h = Sha256::new();
+    let mut buf = [0u8; 65536];
+    loop {
+        let n = file.read(&mut buf)?;
+        if n == 0 {
+            break;
+        }
+        h.update(&buf[..n]);
+    }
+    Ok(hex::encode(h.finalize()))
+}
+
 /// Return `true` if `path` exists and its SHA-256 matches `expected_hex`.
 fn binary_already_correct(path: &Path, expected_hex: &str) -> bool {
     let Ok(bytes) = fs::read(path) else {
@@ -188,40 +206,13 @@ fn binary_already_correct(path: &Path, expected_hex: &str) -> bool {
 // ---------------------------------------------------------------------------
 // HTTP download helper
 // ---------------------------------------------------------------------------
-
-/// Download `url` into a `Vec<u8>`.
-///
-/// On network failure, returns a descriptive error that includes the two
-/// escape-hatch env var names.
-fn fetch_bytes(url: &str) -> Result<Vec<u8>, String> {
-    let client = reqwest::blocking::Client::builder()
-        .use_rustls_tls()
-        .build()
-        .map_err(|e| format!("failed to build HTTP client: {e}"))?;
-
-    let response = client.get(url).send().map_err(|e| {
-        format!(
-            "network error fetching `{url}`: {e}\n\
-                 Hint: if no network is available, set ZFB_ESBUILD_BIN and \
-                 ZFB_TAILWIND_BIN to paths of manually-downloaded binaries."
-        )
-    })?;
-
-    if !response.status().is_success() {
-        return Err(format!(
-            "GET `{url}` returned HTTP {}: {}\n\
-             Hint: if no network is available, set ZFB_ESBUILD_BIN and \
-             ZFB_TAILWIND_BIN to paths of manually-downloaded binaries.",
-            response.status().as_u16(),
-            response.status().canonical_reason().unwrap_or("unknown")
-        ));
-    }
-
-    response
-        .bytes()
-        .map(|b| b.to_vec())
-        .map_err(|e| format!("failed to read response body from `{url}`: {e}"))
-}
+//
+// Downloads are handled by `zfb_binfetch::fetch_to_file`, which streams each
+// URL directly to a caller-supplied temp path with retry (3 attempts by
+// default), connect + overall timeouts, and automatic cleanup of partial
+// writes on failure. The caller owns SHA-256 verification, chmod, and atomic
+// rename into the final slot. See `crates/zfb-binfetch/src/lib.rs` for the
+// full implementation.
 
 // ---------------------------------------------------------------------------
 // esbuild download
@@ -337,7 +328,30 @@ fn download_esbuild(platform: Platform, slot_path: &Path) -> Result<(), String> 
     let url = esbuild_tarball_url(meta.npm_pkg, EXPECTED_ESBUILD_VERSION);
     println!("cargo:warning=Downloading esbuild {EXPECTED_ESBUILD_VERSION} from {url} ...");
 
-    let tgz_bytes = fetch_bytes(&url)?;
+    // Ensure the slot's parent directory exists before writing the temp file.
+    let slot_parent = slot_path
+        .parent()
+        .ok_or_else(|| format!("slot path {} has no parent directory", slot_path.display()))?;
+    fs::create_dir_all(slot_parent).map_err(|e| {
+        format!(
+            "failed to create esbuild dir {}: {e}",
+            slot_parent.display()
+        )
+    })?;
+
+    // Stream the .tgz to a sibling temp file, then read into memory for
+    // extraction.  The tgz is small (~a few MB) so in-memory extraction is
+    // acceptable; the heavy ~75 MB tailwind binary uses a streaming hash
+    // instead (see `download_tailwindcss`).
+    let tgz_tmp = slot_parent.join("esbuild-download.tgz.tmp");
+    zfb_binfetch::fetch_to_file(&url, &tgz_tmp, &zfb_binfetch::FetchOpts::default())
+        .map_err(|e| format!("download failed for esbuild from `{url}`: {e}"))?;
+
+    let tgz_bytes = fs::read(&tgz_tmp);
+    // Always clean up the temp tgz, even if the read fails.
+    let _ = fs::remove_file(&tgz_tmp);
+    let tgz_bytes = tgz_bytes.map_err(|e| format!("failed to read esbuild tgz temp file: {e}"))?;
+
     let binary_bytes = extract_from_tgz(&tgz_bytes, meta.tarball_binary_path)?;
 
     let actual_sha = sha256_hex(&binary_bytes);
@@ -410,10 +424,33 @@ fn download_tailwindcss(platform: Platform, slot_path: &Path) -> Result<(), Stri
     let url = format!("{release_base}/{asset_name}");
     println!("cargo:warning=Downloading tailwindcss {TAILWIND_VERSION} from {url} ...");
 
-    let binary_bytes = fetch_bytes(&url)?;
+    // Ensure the `binaries/` parent directory exists before writing the temp
+    // file.  `fetch_to_file` requires the dest's parent to exist.
+    if let Some(parent) = slot_path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("failed to create binaries dir {}: {e}", parent.display()))?;
+    }
 
-    let actual_sha = sha256_hex(&binary_bytes);
+    // Stream directly to a .tmp sibling — avoids buffering the full ~75 MB
+    // tailwind binary in memory.  The hash is computed by reading the on-disk
+    // temp file in chunks (see `sha256_hex_file`).
+    let tmp = slot_path.with_extension("tmp");
+    zfb_binfetch::fetch_to_file(&url, &tmp, &zfb_binfetch::FetchOpts::default())
+        .map_err(|e| format!("download failed for tailwindcss from `{url}`: {e}"))?;
+
+    let actual_sha = match sha256_hex_file(&tmp) {
+        Ok(sha) => sha,
+        Err(e) => {
+            let _ = fs::remove_file(&tmp);
+            return Err(format!(
+                "failed to hash tailwindcss temp file {}: {e}",
+                tmp.display()
+            ));
+        }
+    };
+
     if !actual_sha.eq_ignore_ascii_case(expected_sha) {
+        let _ = fs::remove_file(&tmp);
         return Err(format!(
             "SHA-256 mismatch for tailwindcss binary from `{url}`:\n\
              expected: {expected_sha}\n\
@@ -424,7 +461,10 @@ fn download_tailwindcss(platform: Platform, slot_path: &Path) -> Result<(), Stri
         ));
     }
 
-    stage_binary(slot_path, &binary_bytes).map_err(|e| {
+    stage_binary_from_file(&tmp, slot_path).map_err(|e| {
+        // Best-effort cleanup: if chmod or rename fails, remove the stale temp
+        // file so a subsequent build can retry the fetch cleanly.
+        let _ = fs::remove_file(&tmp);
         format!(
             "failed to stage tailwindcss binary at {}: {e}",
             slot_path.display()
@@ -441,6 +481,27 @@ fn download_tailwindcss(platform: Platform, slot_path: &Path) -> Result<(), Stri
 // ---------------------------------------------------------------------------
 // Binary staging helper
 // ---------------------------------------------------------------------------
+
+/// Promote a fully-downloaded temp file to its final slot path atomically.
+///
+/// Ensures `dest`'s parent directory exists, sets the executable bit (`0o755`)
+/// on Unix, then renames `tmp` into `dest`. The caller must have already
+/// verified the SHA-256 checksum. Used by `download_tailwindcss` to avoid
+/// loading the full binary into memory a second time after streaming to disk.
+fn stage_binary_from_file(tmp: &Path, dest: &Path) -> io::Result<()> {
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(tmp, fs::Permissions::from_mode(0o755))?;
+    }
+
+    fs::rename(tmp, dest)?;
+    Ok(())
+}
 
 /// Write `bytes` to `dest` atomically (via a `.tmp` sibling) and make the
 /// file executable on Unix.


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1276

---

## Summary

Hardens `crates/zfb/build.rs`'s pinned-binary download against the large-body fetch flake from #1275 (`error decoding response body` on the ~75 MB tailwindcss release asset). Root cause: `fetch_bytes()` buffered the whole body via reqwest blocking `response.bytes()` with **no retry**, so a transient mid-stream reset over the GitHub → `release-assets.githubusercontent.com` → Azure-blob redirect chain surfaced as a body-decode error. `curl --retry` / Node `fetch` (which stream + retry) succeed on the identical URL.

Implements epic #1276 (sub-issues #1277 → #1278).

## What changed

**New build-only crate `crates/zfb-binfetch`** (auto-registered via `members = ["crates/*"]`):
- `fetch_to_file(url, dest, &FetchOpts)` — streams the body to a caller-owned temp path (`response.copy_to`, never `.bytes()`), with a **fresh-GET bounded retry-with-backoff** (the actual recovery mechanism), a `connect_timeout`, and an **opt-in** whole-request timeout (`None` by default — see below). On all-attempts-fail it removes the partial file so nothing un-verified can be promoted.
- 5 deterministic tests over a local `TcpListener` server (no real network): truncate-then-succeed, all-attempts-fail (+ no leftover file), happy path, truncate-replaced-between-attempts, no-Content-Length body.

**`crates/zfb/build.rs`** rewired to consume it:
- `download_tailwindcss` streams to a `.tmp` sibling, hashes it on disk in 64 KiB chunks (`sha256_hex_file` — no 75 MB in-memory buffer), verifies the pinned SHA-256, then atomically stages via a new `stage_binary_from_file`.
- `download_esbuild` streams the small `.tgz`, then extracts in-memory as before.
- `fetch_bytes` removed; the dead `reqwest` **build-dependency** dropped from `crates/zfb/Cargo.toml` (runtime + dev `reqwest` untouched).
- All existing guarantees preserved: SHA-256 hard-fail-on-mismatch, `binary_already_correct()` idempotency, `ZFB_ESBUILD_BIN` / `ZFB_TAILWIND_BIN` escape hatches, and the `cargo:warning=`/`cargo:error=` / `rerun-if-changed` directives.

### Timeout design (deep-review P2)

reqwest 0.12 **blocking** has no per-read *idle* timeout — only `.timeout()`, which bounds the entire request. A whole-request cap would abort a slow-but-healthy 75 MB download (a regression from the original unbounded read), so `overall_timeout` defaults to `None`: a stuck *connect* is caught by `connect_timeout`, and a mid-stream reset is recovered by the retry loop. Callers can opt into a hard ceiling via `Some(..)`.

## Verification (Linux x86_64 host)

- Round-trip: `rm` both binary slots + `cargo build -p zfb` re-downloads **both** binaries through the new streaming path against the real GitHub/Azure chain; both SHA-256 gates pass; full zfb compile clean.
- Idempotency: second build is a no-op (skip). Escape hatch: `ZFB_TAILWIND_BIN=…` skips the tailwind download.
- `cargo fmt --check`, `cargo clippy -p zfb -p zfb-binfetch -D warnings`, `cargo test -p zfb-binfetch` (5/5) all green.

**Blind spot:** the macOS-specific transient truncation can't be deterministically reproduced on the Linux host — the streaming + retry change is the mitigation, guarded by zfb-binfetch's deterministic retry test and the existing SHA gate. Source-issue proposed-fix 4 (shell-out fallback to `fetch-tailwind.mjs`/`curl`) was deliberately left out of scope (documented in #1276).

## Topic PRs
- #1277 — zfb-binfetch crate (merged locally into base)
- #1278 — build.rs wiring (merged locally into base)
