### PR TITLE
fix(zfb-css): hoist external @import url() to top of bundled stylesheet

### DIFF
--- a/crates/zfb-css/src/pipeline.rs
+++ b/crates/zfb-css/src/pipeline.rs
@@ -330,12 +330,267 @@ fn write_class_map_files(
 /// Combine engine output + CSS Modules output exactly as the hashing stage
 /// will see it. Exposed as a free function so tests and the hashing helper
 /// agree on the canonical form.
+///
+/// After concatenation, external `@import` at-rules are hoisted to the top
+/// of the stylesheet via [`hoist_external_imports`] — see that function for
+/// why. The hash (`hash_8`) is computed from the raw `(tailwind, modules)`
+/// halves, not from this combined form, so hoisting does not perturb asset
+/// hashing: it is a deterministic pure function of the same inputs.
 pub(crate) fn combine(tailwind: &str, modules: &str) -> String {
     let mut out = String::with_capacity(tailwind.len() + modules.len() + 1);
     out.push_str(tailwind);
     out.push('\n');
     out.push_str(modules);
+    hoist_external_imports(&out)
+}
+
+/// Move every top-level `@import` at-rule to the top of the stylesheet so it
+/// stays spec-valid regardless of authored position.
+///
+/// **Why this exists (external CSS-spec contract, issue #1280):** the CSS
+/// spec (Cascade & Inheritance) requires `@import` rules to precede all other
+/// at-rules and style rules in a stylesheet — the only things allowed before
+/// them are a leading `@charset` and empty `@layer name, …;` layer-ordering
+/// statements. **An `@import` that follows any style rule is invalid and
+/// silently dropped by every browser.** zfb's Tailwind v4 pipeline inlines
+/// the local `@import "tailwindcss/…"` statements into real style rules *in
+/// place*, so a consumer's external `@import url(<webfont>)` authored *below*
+/// those lines ends up after thousands of emitted rules and is dropped — the
+/// webfont never loads, with every build/lint gate still green because the
+/// string is present but inert. Hoisting here makes the position-sensitivity
+/// trap disappear.
+///
+/// The pass:
+/// - operates on **top-level** statements only (brace depth 0); a nested
+///   `@import` is already invalid and is left untouched;
+/// - is comment-, string-, and `url(<…>)`-aware (a `;` inside `( … )` — e.g.
+///   `url(data:text/css;base64,…)` — does not terminate the statement);
+/// - re-inserts the collected imports, in their original relative order,
+///   after any leading `@charset` and leading `@layer name,…;` statements and
+///   before all other content;
+/// - is a **fixed point on its own output** — running it twice equals running
+///   it once, and a stylesheet whose imports are already correctly positioned
+///   is returned unchanged.
+pub(crate) fn hoist_external_imports(css: &str) -> String {
+    let nodes = split_top_level(css);
+    let kinds: Vec<NodeKind> = nodes
+        .iter()
+        .map(|&(s, e)| classify_node(&css[s..e]))
+        .collect();
+
+    let import_idxs: Vec<usize> = (0..nodes.len())
+        .filter(|&i| kinds[i] == NodeKind::Import)
+        .collect();
+    if import_idxs.is_empty() {
+        return css.to_string();
+    }
+
+    // Leading run of `@charset` / `@layer name,…;` statements the imports
+    // must sit *after* (per the spec). The run stops at the first node that
+    // is an import or anything else.
+    let mut prefix_end = 0;
+    while prefix_end < nodes.len()
+        && matches!(
+            kinds[prefix_end],
+            NodeKind::Charset | NodeKind::LayerStatement
+        )
+    {
+        prefix_end += 1;
+    }
+
+    let mut out = String::with_capacity(css.len());
+    // 1. The leading @charset / @layer-statement prefix, verbatim.
+    for &(s, e) in &nodes[..prefix_end] {
+        out.push_str(&css[s..e]);
+    }
+    // 2. Every import, in original order.
+    for &i in &import_idxs {
+        let (s, e) = nodes[i];
+        out.push_str(&css[s..e]);
+    }
+    // 3. Everything else after the prefix, in original order, imports removed.
+    for i in prefix_end..nodes.len() {
+        if kinds[i] != NodeKind::Import {
+            let (s, e) = nodes[i];
+            out.push_str(&css[s..e]);
+        }
+    }
     out
+}
+
+/// Classification of a top-level stylesheet node for import hoisting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NodeKind {
+    /// `@charset "…";` — must stay first; imports go after it.
+    Charset,
+    /// `@layer name, …;` statement form (no block) — allowed before `@import`.
+    LayerStatement,
+    /// `@import …;` — the at-rule being hoisted.
+    Import,
+    /// Any style rule, populated `@layer { … }`, `@media { … }`, declaration,
+    /// or other content — the imports must end up above all of these.
+    Other,
+}
+
+/// Split a stylesheet into contiguous top-level node spans `[start, end)`.
+///
+/// The spans cover the entire string with no gaps (concatenating them in
+/// order reproduces the input), so reordering nodes only permutes the exact
+/// source bytes — preserving content and idempotency. Each node carries the
+/// whitespace/comments that lead up to its statement; the final span is any
+/// trailing remainder after the last terminator.
+///
+/// The scan tracks string literals, block (`/* */`) and line (`//`) comments,
+/// brace depth, and paren depth, so statement terminators are only recognised
+/// outside those contexts. Paren tracking is what makes a `;` inside
+/// `url(data:…;…)` non-terminating without a dedicated `url(` token scanner
+/// (unquoted `url()` cannot contain unescaped parentheses per the CSS spec).
+fn split_top_level(css: &str) -> Vec<(usize, usize)> {
+    let b = css.as_bytes();
+    let n = b.len();
+    let mut nodes: Vec<(usize, usize)> = Vec::new();
+    let mut seg_start = 0usize;
+    let mut i = 0usize;
+    let mut brace: i32 = 0;
+    let mut paren: i32 = 0;
+
+    while i < n {
+        let c = b[i];
+        match c {
+            b'"' | b'\'' | b'`' => {
+                // String literal: skip to the closing quote, honoring `\`
+                // escapes, and bail on a raw newline (matches the rest of the
+                // crate's tolerant scanners).
+                let quote = c;
+                i += 1;
+                while i < n {
+                    let d = b[i];
+                    if d == b'\\' && i + 1 < n {
+                        i += 2;
+                        continue;
+                    }
+                    if d == quote || d == b'\n' {
+                        i += 1;
+                        break;
+                    }
+                    i += 1;
+                }
+            }
+            b'/' if i + 1 < n && b[i + 1] == b'*' => {
+                i += 2;
+                while i + 1 < n && !(b[i] == b'*' && b[i + 1] == b'/') {
+                    i += 1;
+                }
+                i = (i + 2).min(n);
+            }
+            b'/' if i + 1 < n && b[i + 1] == b'/' => {
+                i += 2;
+                while i < n && b[i] != b'\n' {
+                    i += 1;
+                }
+            }
+            b'(' => {
+                paren += 1;
+                i += 1;
+            }
+            b')' => {
+                if paren > 0 {
+                    paren -= 1;
+                }
+                i += 1;
+            }
+            b'{' => {
+                brace += 1;
+                i += 1;
+            }
+            b'}' => {
+                if brace > 0 {
+                    brace -= 1;
+                }
+                i += 1;
+                if brace == 0 {
+                    nodes.push((seg_start, i));
+                    seg_start = i;
+                }
+            }
+            b';' => {
+                i += 1;
+                if brace == 0 && paren == 0 {
+                    nodes.push((seg_start, i));
+                    seg_start = i;
+                }
+            }
+            _ => {
+                i += 1;
+            }
+        }
+    }
+
+    if seg_start < n {
+        nodes.push((seg_start, n));
+    }
+    nodes
+}
+
+/// Classify a node by its first significant token (skipping leading
+/// whitespace, a UTF-8 BOM, and comments). At-rule names are ASCII
+/// case-insensitive, so the comparison is too.
+fn classify_node(node: &str) -> NodeKind {
+    let rest = significant_rest(node);
+    if starts_with_ascii_ci(rest, "@charset") {
+        NodeKind::Charset
+    } else if starts_with_ascii_ci(rest, "@import") {
+        NodeKind::Import
+    } else if starts_with_ascii_ci(rest, "@layer") && !rest.contains('{') {
+        // `@layer a, b;` (no block) is a layer-ordering statement, allowed
+        // before `@import`. A populated `@layer name { … }` contains `{` and
+        // is treated as Other (an insertion ceiling).
+        NodeKind::LayerStatement
+    } else {
+        NodeKind::Other
+    }
+}
+
+/// Return the slice of `node` starting at its first significant byte,
+/// skipping leading ASCII whitespace, a leading UTF-8 BOM, and leading
+/// block/line comments.
+fn significant_rest(node: &str) -> &str {
+    let b = node.as_bytes();
+    let n = b.len();
+    let mut i = 0usize;
+    // Optional leading UTF-8 BOM (EF BB BF).
+    if n >= 3 && b[0] == 0xEF && b[1] == 0xBB && b[2] == 0xBF {
+        i = 3;
+    }
+    loop {
+        while i < n && (b[i] as char).is_ascii_whitespace() {
+            i += 1;
+        }
+        if i + 1 < n && b[i] == b'/' && b[i + 1] == b'*' {
+            i += 2;
+            while i + 1 < n && !(b[i] == b'*' && b[i + 1] == b'/') {
+                i += 1;
+            }
+            i = (i + 2).min(n);
+            continue;
+        }
+        if i + 1 < n && b[i] == b'/' && b[i + 1] == b'/' {
+            i += 2;
+            while i < n && b[i] != b'\n' {
+                i += 1;
+            }
+            continue;
+        }
+        break;
+    }
+    &node[i.min(n)..]
+}
+
+/// ASCII-case-insensitive `starts_with` (at-rule keywords are ASCII).
+fn starts_with_ascii_ci(haystack: &str, needle: &str) -> bool {
+    let h = haystack.as_bytes();
+    let nd = needle.as_bytes();
+    h.len() >= nd.len() && h[..nd.len()].eq_ignore_ascii_case(nd)
 }
 
 /// Compute the 8-char hex hash for the given (tailwind, modules) pair.
@@ -436,6 +691,164 @@ fn atomic_write(dest: &Path, bytes: &[u8]) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- hoist_external_imports (issue #1280) ------------------------------
+
+    /// The byte offset of the first occurrence of `needle` in `s`.
+    fn offset_of(s: &str, needle: &str) -> usize {
+        s.find(needle)
+            .unwrap_or_else(|| panic!("expected to find {needle:?} in:\n{s}"))
+    }
+
+    #[test]
+    fn hoist_moves_font_import_above_style_rules() {
+        // The #1280 repro: a font @import authored *after* style rules.
+        let css = "@layer a, b;\n.x { color: red }\n.y { color: blue }\n\
+                   @import url(\"https://fonts.googleapis.com/css2?family=Noto\");\n";
+        let out = hoist_external_imports(css);
+        // After hoist, the @import precedes the first style rule...
+        assert!(
+            offset_of(&out, "@import") < offset_of(&out, ".x"),
+            "import must precede the first style rule:\n{out}"
+        );
+        // ...and follows the @layer ordering statement.
+        assert!(
+            offset_of(&out, "@layer a, b;") < offset_of(&out, "@import"),
+            "import must follow the leading @layer statement:\n{out}"
+        );
+    }
+
+    #[test]
+    fn hoist_preserves_relative_order_of_multiple_imports() {
+        let css = ".x {}\n@import url(\"a.css\");\n@import url(\"b.css\");\n";
+        let out = hoist_external_imports(css);
+        assert!(offset_of(&out, "a.css") < offset_of(&out, "b.css"));
+        assert!(offset_of(&out, "@import") < offset_of(&out, ".x"));
+    }
+
+    #[test]
+    fn hoist_keeps_charset_first() {
+        let css = "@charset \"utf-8\";\n.x {}\n@import url(\"a.css\");\n";
+        let out = hoist_external_imports(css);
+        assert!(
+            out.starts_with("@charset \"utf-8\";"),
+            "charset must stay first:\n{out}"
+        );
+        assert!(offset_of(&out, "@charset") < offset_of(&out, "@import"));
+        assert!(offset_of(&out, "@import") < offset_of(&out, ".x"));
+    }
+
+    #[test]
+    fn hoist_ignores_import_inside_block_comment() {
+        let css = ".x {}\n/* @import url(\"commented.css\"); */\n.y {}\n";
+        let out = hoist_external_imports(css);
+        // Nothing real to hoist → unchanged.
+        assert_eq!(out, css);
+    }
+
+    #[test]
+    fn hoist_ignores_import_inside_line_comment() {
+        let css = ".x {}\n// @import url(\"commented.css\");\n.y {}\n";
+        let out = hoist_external_imports(css);
+        assert_eq!(out, css);
+    }
+
+    #[test]
+    fn hoist_ignores_import_like_text_in_a_string() {
+        // A declaration value that merely contains "@import" text must not
+        // be detected as a statement-level import.
+        let css = ".x { --u: \"@import url(evil)\"; }\n.y {}\n";
+        let out = hoist_external_imports(css);
+        assert_eq!(out, css);
+    }
+
+    #[test]
+    fn hoist_does_not_truncate_data_url_with_semicolon() {
+        // The `;` inside url(data:...;base64,...) is NOT the statement
+        // terminator — paren tracking must carry past it.
+        let css = ".x {}\n@import url(data:text/css;base64,AAA);\n.y {}\n";
+        let out = hoist_external_imports(css);
+        assert!(
+            out.contains("@import url(data:text/css;base64,AAA);"),
+            "data-url import must survive intact:\n{out}"
+        );
+        assert!(offset_of(&out, "@import") < offset_of(&out, ".x"));
+    }
+
+    #[test]
+    fn hoist_preserves_conditional_import_verbatim() {
+        let import =
+            "@import url(x.css) layer(base) supports(display:grid) screen and (min-width:400px);";
+        let css = format!(".x {{}}\n{import}\n");
+        let out = hoist_external_imports(&css);
+        assert!(
+            out.contains(import),
+            "conditional import must be preserved verbatim:\n{out}"
+        );
+        assert!(offset_of(&out, "@import") < offset_of(&out, ".x"));
+    }
+
+    #[test]
+    fn hoist_places_import_above_namespace_but_below_charset() {
+        let css = "@charset \"utf-8\";\n@namespace svg url(http://www.w3.org/2000/svg);\n\
+                   .x {}\n@import url(\"a.css\");\n";
+        let out = hoist_external_imports(css);
+        assert!(out.starts_with("@charset"), "charset stays first:\n{out}");
+        assert!(
+            offset_of(&out, "@import") < offset_of(&out, "@namespace"),
+            "imports must precede @namespace:\n{out}"
+        );
+    }
+
+    #[test]
+    fn hoist_is_idempotent_and_a_fixed_point() {
+        let css =
+            "@layer a, b;\n.x { color: red }\n@import url(\"a.css\");\n@import url(\"b.css\");\n";
+        let once = hoist_external_imports(css);
+        let twice = hoist_external_imports(&once);
+        assert_eq!(
+            once, twice,
+            "the pass must be a fixed point on its own output"
+        );
+    }
+
+    #[test]
+    fn hoist_leaves_already_correct_stylesheet_unchanged() {
+        let css = "@charset \"utf-8\";\n@import url(\"a.css\");\n.x { color: red }\n";
+        let out = hoist_external_imports(css);
+        assert_eq!(
+            out, css,
+            "an already-correct stylesheet is returned unchanged"
+        );
+    }
+
+    #[test]
+    fn hoist_noop_when_no_external_imports() {
+        let css = ".a { color: red }\n.b { color: blue }\n";
+        assert_eq!(hoist_external_imports(css), css);
+    }
+
+    #[test]
+    fn hoist_ignores_nested_import_inside_a_block() {
+        // A non-top-level @import (inside a block) is already invalid; leave
+        // it where it is rather than yanking it out of the block.
+        let css = "@media screen {\n  @import url(\"nested.css\");\n}\n.x {}\n";
+        let out = hoist_external_imports(css);
+        assert_eq!(out, css);
+    }
+
+    #[test]
+    fn combine_hoists_external_import_in_the_tailwind_half() {
+        // End-to-end through the canonical combine() form: a font import that
+        // trails the (inlined) Tailwind rules lands above them.
+        let tailwind = "@layer a, b;\n.tw { color: red }\n\
+                        @import url(\"https://fonts.googleapis.com/css2?family=Noto\");";
+        let combined = combine(tailwind, "");
+        assert!(
+            offset_of(&combined, "@import") < offset_of(&combined, ".tw"),
+            "combine() must hoist the trailing font import:\n{combined}"
+        );
+    }
 
     #[test]
     fn hash_is_stable_for_identical_inputs() {

--- a/crates/zfb-css/src/pipeline.rs
+++ b/crates/zfb-css/src/pipeline.rs
@@ -541,10 +541,12 @@ fn classify_node(node: &str) -> NodeKind {
         NodeKind::Charset
     } else if starts_with_ascii_ci(rest, "@import") {
         NodeKind::Import
-    } else if starts_with_ascii_ci(rest, "@layer") && !rest.contains('{') {
+    } else if starts_with_ascii_ci(rest, "@layer") && rest.trim_end().ends_with(';') {
         // `@layer a, b;` (no block) is a layer-ordering statement, allowed
-        // before `@import`. A populated `@layer name { … }` contains `{` and
-        // is treated as Other (an insertion ceiling).
+        // before `@import`. A populated `@layer name { … }` ends in `}` and is
+        // treated as Other (an insertion ceiling). Classifying by the
+        // terminating delimiter (the node ends exactly at its `;`/`}`) is
+        // comment-proof — a raw scan for `{` would misread `@layer a /* { */;`.
         NodeKind::LayerStatement
     } else {
         NodeKind::Other
@@ -797,6 +799,31 @@ mod tests {
         assert!(
             offset_of(&out, "@import") < offset_of(&out, "@namespace"),
             "imports must precede @namespace:\n{out}"
+        );
+    }
+
+    #[test]
+    fn hoist_keeps_import_below_layer_statement_bearing_a_comment() {
+        // A leading @layer ordering statement whose node carries a comment
+        // containing `{` must still classify as a layer statement (comment-
+        // aware), so the import lands *after* it, not above it.
+        let css = "@layer a /* sets { scope */;\n.x {}\n@import url(\"z.css\");\n";
+        let out = hoist_external_imports(css);
+        assert!(
+            offset_of(&out, "@layer") < offset_of(&out, "@import"),
+            "import must stay below the @layer statement even with an inline comment:\n{out}"
+        );
+        assert!(offset_of(&out, "@import") < offset_of(&out, ".x"));
+    }
+
+    #[test]
+    fn hoist_treats_populated_layer_block_as_a_ceiling() {
+        // A populated `@layer name { … }` is content the import must sit above.
+        let css = "@layer base { .b { color: red } }\n@import url(\"z.css\");\n";
+        let out = hoist_external_imports(css);
+        assert!(
+            offset_of(&out, "@import") < offset_of(&out, "@layer base"),
+            "import must be hoisted above a populated @layer block:\n{out}"
         );
     }
 

--- a/crates/zfb-css/tests/integration.rs
+++ b/crates/zfb-css/tests/integration.rs
@@ -10,8 +10,8 @@
 use std::path::{Path, PathBuf};
 
 use zfb_css::{
-    build_synthesised_entry_css, link_href, scan_css_module_imports, CssEngine, CssModulesOutput,
-    CssModulesProcessor, CssPipeline, CssPipelineConfig, NativeRustEngine,
+    build_synthesised_entry_css, link_href, scan_css_module_imports, AuthoredCssEngine, CssEngine,
+    CssModulesOutput, CssModulesProcessor, CssPipeline, CssPipelineConfig, NativeRustEngine,
     TailwindSubprocessConfig, TailwindSubprocessEngine,
 };
 
@@ -624,4 +624,66 @@ fn build_emitter_still_writes_class_map_jsons_when_configured() {
 
     // And the hashed asset is still NOT written.
     assert!(!root.join("dist").join("assets").exists());
+}
+
+// --- Issue #1280: external @import hoisting through the full pipeline -------
+//
+// The bug has two independent manifestations, one per engine. Both produce a
+// combined stylesheet where a consumer's font @import trails the style rules
+// (spec-invalid → silently dropped by browsers). The pipeline must hoist it
+// above the first style rule regardless of which engine produced the bytes.
+
+fn first_rule_offset(css: &str) -> usize {
+    css.find(".x").expect("a style rule must be present")
+}
+
+fn import_offset(css: &str) -> usize {
+    css.find("@import").expect("an @import must be present")
+}
+
+#[test]
+fn acceptance_hoists_font_import_tailwind_engine_half() {
+    // Tailwind half: the (mock) engine emits the inlined-utilities-then-rules
+    // shape with a trailing external font @import, exactly like the real v4
+    // subprocess output that triggered #1280.
+    let mock = "@layer a, b;\n.x { color: red }\n.y { color: blue }\n\
+                @import url(\"https://fonts.googleapis.com/css2?family=Noto+Sans+JP\");\n";
+    let engine =
+        TailwindSubprocessEngine::new(TailwindSubprocessConfig::default().with_mock_output(mock));
+    let cfg = CssPipelineConfig {
+        sources: vec![PathBuf::from("pages/index.tsx")],
+        ..CssPipelineConfig::default()
+    };
+    let combined = CssPipeline::new(engine, cfg)
+        .build_emitter()
+        .expect("build_emitter");
+    let css = String::from_utf8(combined.bytes).expect("utf8");
+    assert!(
+        import_offset(&css) < first_rule_offset(&css),
+        "Tailwind-half: font @import must be hoisted above the first style rule:\n{css}"
+    );
+}
+
+#[test]
+fn acceptance_hoists_font_import_authored_engine_half() {
+    // Authored half (tailwind.enabled = false): global.css is passed verbatim
+    // with no subprocess to inline anything, so a font @import sitting below
+    // other rules reaches combine() in its authored position — a second,
+    // independent manifestation of the same bug.
+    let authored = ".x { color: red }\n.y { color: blue }\n\
+                    @import url(\"https://fonts.googleapis.com/css2?family=Noto+Sans+JP\");\n";
+    let engine = AuthoredCssEngine::new(authored);
+    let cfg = CssPipelineConfig {
+        // No sources scan needed for the authored engine.
+        auto_discover_modules: false,
+        ..CssPipelineConfig::default()
+    };
+    let combined = CssPipeline::new(engine, cfg)
+        .build_emitter()
+        .expect("build_emitter");
+    let css = String::from_utf8(combined.bytes).expect("utf8");
+    assert!(
+        import_offset(&css) < first_rule_offset(&css),
+        "Authored-half: font @import must be hoisted above the first style rule:\n{css}"
+    );
 }


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1282
    - https://github.com/Takazudo/zudo-front-builder/issues/1280

---

## Summary

zfb's Tailwind v4 pipeline inlines local `@import "tailwindcss/..."` statements into real style rules **in place**, but a consumer's **external** `@import url(...)` (e.g. a Google Fonts webfont) survives at its **authored position**. When authored below the tailwind imports it lands after thousands of emitted style rules in the bundled `dist/assets/*.css`. Per the CSS spec, an `@import` that follows any style rule is invalid and **silently dropped by every browser** — so the webfont never loads, while every build/lint gate stays green because the `@import` string is present but inert (#1280).

This hoists surviving external `@import` at-rules to the top of the combined stylesheet so they stay spec-valid regardless of authored position.

## Changes

- **`crates/zfb-css/src/pipeline.rs`** — new `hoist_external_imports()`, wired into `pipeline::combine()` (the single chokepoint feeding both `CssPipeline::build()` and `CssPipeline::build_emitter()`; the dev server and the `tailwind.enabled=false` authored path both flow through it). Supporting helpers: `split_top_level()` (contiguous top-level node spans), `classify_node()`, `significant_rest()`, `starts_with_ascii_ci()`.
- The pass:
  - operates on **top-level** statements only (a nested `@import` is already invalid → left untouched);
  - is comment-, string-, and `url()`-aware — a `;` inside `url(data:text/css;base64,...)` does **not** terminate the statement (paren-depth tracking);
  - re-inserts imports in original relative order, after a leading `@charset` and `@layer name,...;` ordering statements, before all other content;
  - is a **fixed point on its own output** (idempotent; an already-correct stylesheet is returned unchanged).
- `hash_8()` hashes the raw `(tailwind, modules)` halves, so hoisting leaves asset hashing stable.

## Test Plan

- **Unit** (`pipeline.rs`): font import hoisted above style rules; multiple imports keep order; `@charset` stays first; imports inside block/line comments and strings not moved; `url(data:...;...)` not truncated; conditional `@import ... layer()/supports()/media` preserved verbatim; `@namespace` ordering; nested-in-block import left alone; idempotency / fixed-point; no-op when no external imports; end-to-end via `combine()`.
- **Acceptance** (`tests/integration.rs`): the #1280 repro through the full pipeline for **both** engine manifestations — the Tailwind/mock half and the `AuthoredCssEngine` (`tailwind.enabled=false`) half — asserting the font `@import` ends up above the first style rule.
- Gates: `cargo test -p zfb-css` (53 unit + 17 integration + 2 doctests), `cargo clippy -p zfb-css -- -D warnings`, `cargo fmt --check` — all green.

## Out of scope

- No change to Tailwind import synthesis/stripping behavior.
- The defense-in-depth head-hook (`zudolab/zudo-doc#2435`, separate repo).

Closes #1282. Refs #1280.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UG9Z7PyUK7kWLyzhBhEgKZ)_