### PR TITLE
[Dev Dep Invalidation] Invalidate dependent routes + refresh CSS on imported-component / transitive-CSS edits in dev

### DIFF
--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -742,6 +742,16 @@ pub struct BundlerOutput {
     /// Routes the bundle serves (also addressable through
     /// `bundle.routes` at runtime).
     pub manifest: BundleManifest,
+    /// Per-route transitive `Module` deps parsed from esbuild's `--metafile`
+    /// (#1284/#1287). Populated only for [`BundleMode::Development`] (the live
+    /// dev graph is the sole consumer); empty for the prod / SSG path, whose
+    /// esbuild arg set and output stay byte-identical to before. Each entry's
+    /// `source_path` is the route's project-relative page source (`PageId`), and
+    /// `module_deps` are the canonicalised real on-disk paths it transitively
+    /// imports — what the dev graph upserts as `DepKind::Module` edges and what
+    /// the watcher registers as extra targets for out-of-root (symlinked
+    /// workspace) deps.
+    pub route_module_deps: Vec<crate::metafile_deps::RouteModuleDeps>,
 }
 
 /// What the bundle exports, in a form a downstream tool can read without
@@ -2364,6 +2374,18 @@ pub fn bundle_with_session(
     let bundle_path = outdir.join(bundle_filename);
     let sourcemap_path = outdir.join(format!("{bundle_filename}.map"));
 
+    // Per-route transitive `Module` deps via esbuild's `--metafile` — dev only
+    // (#1284/#1287). The metafile is written inside the shadow tree and parsed
+    // BEFORE `owned_work` (the shadow) is dropped at the end of this fn; the
+    // resulting edges key on real `project_root` paths, which persist.
+    let want_metafile_deps =
+        matches!(input.mode, BundleMode::Development) && input.mock_subprocess_output.is_none();
+    let metafile_path: Option<PathBuf> = if want_metafile_deps {
+        Some(shadow.join(".zfb-metafile.json"))
+    } else {
+        None
+    };
+
     if let Some(mock) = input.mock_subprocess_output.as_ref() {
         fs::write(&bundle_path, mock).with_context(|| {
             format!(
@@ -2372,9 +2394,39 @@ pub fn bundle_with_session(
             )
         })?;
     } else {
-        run_esbuild(&input, shadow, &bundle_path)?;
+        run_esbuild(&input, shadow, &bundle_path, metafile_path.as_deref())?;
     }
     let esbuild_ms = esbuild_start.map(|t| t.elapsed().as_millis());
+
+    // Parse the metafile into per-route `Module` edges while the shadow tree
+    // still exists. A missing / malformed metafile yields an empty set (the
+    // dev path then falls back to its prior selection) — never a hard error.
+    let route_module_deps: Vec<crate::metafile_deps::RouteModuleDeps> = match metafile_path.as_ref()
+    {
+        Some(meta_path) => match fs::read(meta_path) {
+            Ok(bytes) => {
+                let route_refs: Vec<crate::metafile_deps::RouteEntryRef> = routes
+                    .iter()
+                    .filter(|r| !r.static_html)
+                    .map(|r| crate::metafile_deps::RouteEntryRef {
+                        source_path: r.source_path.clone(),
+                        // The shadow mirrors the project tree by relative path,
+                        // so a route's metafile-input key equals its
+                        // project-relative source path in forward-slash form.
+                        metafile_key: rel_to_forward_slash(&r.source_path),
+                    })
+                    .collect();
+                crate::metafile_deps::route_module_deps(
+                    &bytes,
+                    &route_refs,
+                    shadow,
+                    &input.project_root,
+                )
+            }
+            Err(_) => Vec::new(),
+        },
+        None => Vec::new(),
+    };
 
     let post_start = if timing_enabled {
         Some(std::time::Instant::now())
@@ -2425,6 +2477,7 @@ pub fn bundle_with_session(
         bundle_path,
         sourcemap_path,
         manifest,
+        route_module_deps,
     })
 }
 
@@ -5411,7 +5464,18 @@ fn esbuild_will_preserve_symlinks(input: &BundlerInput) -> bool {
 }
 
 /// Resolve and run the esbuild subprocess.
-fn run_esbuild(input: &BundlerInput, shadow: &Path, bundle_path: &Path) -> Result<()> {
+///
+/// When `metafile_path` is `Some`, esbuild also writes its `--metafile` JSON
+/// there. The metafile's `inputs` graph is the canonical *transitive* import
+/// graph esbuild itself resolved — the dev path parses it to populate per-route
+/// `DepKind::Module` edges (#1284/#1287). It is a free by-product of the bundle
+/// pass; the prod path passes `None` and is byte-identical to before.
+fn run_esbuild(
+    input: &BundlerInput,
+    shadow: &Path,
+    bundle_path: &Path,
+    metafile_path: Option<&Path>,
+) -> Result<()> {
     let bin = resolve_esbuild_binary(input.esbuild_binary.as_deref())?;
     let entry = shadow.join(SHADOW_ENTRY_FILENAME);
     let tsconfig = shadow.join(SHADOW_TSCONFIG_FILENAME);
@@ -5436,6 +5500,9 @@ fn run_esbuild(input: &BundlerInput, shadow: &Path, bundle_path: &Path) -> Resul
 
     cmd.arg(format!("--tsconfig={}", tsconfig.display()));
     cmd.arg(format!("--outfile={}", bundle_path.display()));
+    if let Some(meta) = metafile_path {
+        cmd.arg(format!("--metafile={}", meta.display()));
+    }
 
     // MDX modules emitted by `compile_mdx_to_jsx_module_cached` carry a
     // hard-coded `import { Fragment as _Fragment } from "react/jsx-runtime";`

--- a/crates/zfb-build/src/lib.rs
+++ b/crates/zfb-build/src/lib.rs
@@ -53,6 +53,7 @@ pub mod atomic;
 pub mod bundler;
 pub mod head_inject;
 pub mod link_base_rewrite;
+pub mod metafile_deps;
 pub mod orchestrator;
 pub mod pipeline;
 pub mod plan;
@@ -75,6 +76,7 @@ pub use head_inject::{
     css_link_tag, inject_prod_head_assets, island_module_script_tag, needs_html5_doctype,
     ProdHeadAssets, HTML5_DOCTYPE_PREFIX,
 };
+pub use metafile_deps::{route_module_deps, RouteEntryRef, RouteModuleDeps};
 pub use orchestrator::{
     BuildOrchestrator, DiscoveryHook, DiscoveryOutcome, ExternalInvalidationHook,
     OrchestratorConfig,

--- a/crates/zfb-build/src/metafile_deps.rs
+++ b/crates/zfb-build/src/metafile_deps.rs
@@ -1,0 +1,367 @@
+//! Parse esbuild's `--metafile` JSON into per-route transitive module-dep
+//! edge sets (#1284/#1287).
+//!
+//! esbuild already runs once per dev bundle; passing `--metafile=<path>` makes
+//! it emit a JSON describing every input file it resolved and that input's own
+//! imports. `metafile.inputs[file].imports[*].path` is the canonical
+//! *transitive* import graph esbuild itself resolved — no second Rust resolver
+//! pass to drift from the real bundle.
+//!
+//! This module is pure: it takes the metafile bytes plus the
+//! shadow-root / project-root / per-route entry mapping and returns, for each
+//! route, the set of real on-disk source paths that route transitively imports.
+//! The dev path ([`crate`]'s caller in `zfb dev`) upserts those as
+//! `DepKind::Module` edges so `dirty_pages(component)` resolves to the
+//! consuming route, and registers any out-of-root real paths (symlinked
+//! workspace component deps) as extra watch targets.
+
+use std::collections::{BTreeSet, HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+/// Minimal view of esbuild's metafile — only the `inputs` graph is needed.
+///
+/// Schema (esbuild stable): `{ "inputs": { "<path>": { "imports": [ { "path":
+/// "<path>", "kind": "..." }, ... ] }, ... }, "outputs": { ... } }`. Paths in
+/// `inputs` are relative to esbuild's working directory (the shadow root, since
+/// `run_esbuild` sets `current_dir(shadow)`), except node_modules deps which
+/// may appear canonicalised to their real location when esbuild does not
+/// preserve symlinks.
+#[derive(Debug, Deserialize)]
+struct Metafile {
+    #[serde(default)]
+    inputs: HashMap<String, MetaInput>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MetaInput {
+    #[serde(default)]
+    imports: Vec<MetaImport>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MetaImport {
+    path: String,
+}
+
+/// A route's entry file as esbuild sees it, paired with the route's
+/// project-relative source path the dependency graph keys pages on.
+#[derive(Debug, Clone)]
+pub struct RouteEntryRef {
+    /// The page's source path **relative to `project_root`** (e.g.
+    /// `pages/index.tsx`). This becomes the `PageId` the graph upserts.
+    pub source_path: PathBuf,
+    /// The same file as it appears in the metafile's `inputs` keys — i.e.
+    /// relative to the shadow root (esbuild's cwd). For an in-repo page this
+    /// equals `source_path`; kept separate so a future shadow layout that
+    /// differs from the project layout does not silently misresolve.
+    pub metafile_key: String,
+}
+
+/// For each route: its project-relative source path and the set of real
+/// on-disk module paths it transitively imports (canonicalised).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RouteModuleDeps {
+    pub source_path: PathBuf,
+    pub module_deps: BTreeSet<PathBuf>,
+}
+
+/// Parse `metafile_bytes` and, for each route in `routes`, walk the transitive
+/// `inputs` import graph from that route's entry to collect every reachable
+/// source input, mapping each back to a real project path.
+///
+/// `shadow_root` is esbuild's working directory; `project_root` is the real
+/// project tree the watcher reports paths against. A metafile input key is
+/// mapped to a real path by:
+/// 1. joining it onto `shadow_root` and, if that exists, mapping the
+///    shadow-relative tail onto `project_root` (the shadow mirrors the project
+///    tree by relative path), then canonicalising;
+/// 2. otherwise treating the key as already real (the node_modules /
+///    out-of-root symlink-canonicalised case) and canonicalising it.
+///
+/// The route's own entry file is excluded from its dep set (the graph adds a
+/// page self-edge on `upsert`); virtual / generated shadow entries
+/// (`entry.mjs`, `.zfb-*`) and anything that does not resolve to a real file
+/// are skipped.
+pub fn route_module_deps(
+    metafile_bytes: &[u8],
+    routes: &[RouteEntryRef],
+    shadow_root: &Path,
+    project_root: &Path,
+) -> Vec<RouteModuleDeps> {
+    let meta: Metafile = match serde_json::from_slice(metafile_bytes) {
+        Ok(m) => m,
+        // A malformed / empty metafile must never break the bundle — the dev
+        // path falls back to the prior (imprecise) selection on empty deps.
+        Err(_) => return Vec::new(),
+    };
+
+    routes
+        .iter()
+        .map(|route| {
+            let reachable = transitive_inputs(&meta, &route.metafile_key);
+            let mut module_deps: BTreeSet<PathBuf> = BTreeSet::new();
+            for key in reachable {
+                // Exclude the route's own entry (graph adds a self-edge).
+                if key == route.metafile_key {
+                    continue;
+                }
+                if is_synthetic_input(&key) {
+                    continue;
+                }
+                if let Some(real) = map_to_real(&key, shadow_root, project_root) {
+                    module_deps.insert(real);
+                }
+            }
+            RouteModuleDeps {
+                source_path: route.source_path.clone(),
+                module_deps,
+            }
+        })
+        .collect()
+}
+
+/// Collect every input transitively reachable from `entry` via the metafile's
+/// per-input `imports` lists (including `entry` itself).
+fn transitive_inputs(meta: &Metafile, entry: &str) -> HashSet<String> {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut stack: Vec<String> = vec![entry.to_string()];
+    while let Some(cur) = stack.pop() {
+        if !seen.insert(cur.clone()) {
+            continue;
+        }
+        if let Some(input) = meta.inputs.get(&cur) {
+            for imp in &input.imports {
+                if !seen.contains(&imp.path) {
+                    stack.push(imp.path.clone());
+                }
+            }
+        }
+    }
+    seen
+}
+
+/// esbuild synthesises some shadow inputs that are not real project source —
+/// the generated entry, hydrate shim, plugin virtual-module temp files. These
+/// must never become watch targets or graph edges.
+fn is_synthetic_input(key: &str) -> bool {
+    let name = Path::new(key)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(key);
+    name == "entry.mjs"
+        || name.starts_with(".zfb-virtual-")
+        || name.starts_with(".zfb-")
+        || name.contains("zfb-hydrate")
+}
+
+/// Map a metafile input key to a real on-disk path (see [`route_module_deps`]).
+fn map_to_real(key: &str, shadow_root: &Path, project_root: &Path) -> Option<PathBuf> {
+    let key_path = Path::new(key);
+
+    // Absolute keys (node_modules canonicalised by esbuild) are already real.
+    if key_path.is_absolute() {
+        return canonical_or_self(key_path);
+    }
+
+    // Shadow-relative key. The shadow mirrors the project tree by relative
+    // path, so the same relative tail under `project_root` is the real source.
+    let in_project = project_root.join(key_path);
+    if in_project.exists() {
+        return canonical_or_self(&in_project);
+    }
+
+    // Fall back to the shadow location itself (e.g. a materialised copy that
+    // has no project-tree twin). Canonicalising follows any symlink to the
+    // real workspace file — exactly the watch target a symlinked dep needs.
+    let in_shadow = shadow_root.join(key_path);
+    if in_shadow.exists() {
+        return canonical_or_self(&in_shadow);
+    }
+
+    None
+}
+
+/// Canonicalise, falling back to the path as-given when canonicalisation fails
+/// (e.g. the file was removed between the bundle and this read) — a best-effort
+/// real path is still a usable graph key.
+fn canonical_or_self(p: &Path) -> Option<PathBuf> {
+    Some(std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write(dir: &Path, rel: &str, body: &str) -> PathBuf {
+        let p = dir.join(rel);
+        if let Some(parent) = p.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&p, body).unwrap();
+        p
+    }
+
+    #[test]
+    fn direct_import_becomes_route_dep() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        write(root, "pages/index.tsx", "import './x'");
+        write(root, "components/Header.tsx", "x");
+
+        let metafile = br#"{
+            "inputs": {
+                "pages/index.tsx": { "imports": [ { "path": "components/Header.tsx" } ] },
+                "components/Header.tsx": { "imports": [] }
+            }
+        }"#;
+        let routes = vec![RouteEntryRef {
+            source_path: PathBuf::from("pages/index.tsx"),
+            metafile_key: "pages/index.tsx".to_string(),
+        }];
+
+        let deps = route_module_deps(metafile, &routes, root, root);
+        assert_eq!(deps.len(), 1);
+        assert_eq!(deps[0].source_path, PathBuf::from("pages/index.tsx"));
+        let real_header = std::fs::canonicalize(root.join("components/Header.tsx")).unwrap();
+        assert!(
+            deps[0].module_deps.contains(&real_header),
+            "direct component import must become a real-path module dep; got {:?}",
+            deps[0].module_deps
+        );
+    }
+
+    #[test]
+    fn transitive_import_is_flattened_into_route_dep() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        write(root, "pages/index.tsx", "import './h'");
+        write(root, "components/Header.tsx", "import './l'");
+        write(root, "components/Logo.tsx", "x");
+
+        // index -> Header -> Logo
+        let metafile = br#"{
+            "inputs": {
+                "pages/index.tsx": { "imports": [ { "path": "components/Header.tsx" } ] },
+                "components/Header.tsx": { "imports": [ { "path": "components/Logo.tsx" } ] },
+                "components/Logo.tsx": { "imports": [] }
+            }
+        }"#;
+        let routes = vec![RouteEntryRef {
+            source_path: PathBuf::from("pages/index.tsx"),
+            metafile_key: "pages/index.tsx".to_string(),
+        }];
+
+        let deps = route_module_deps(metafile, &routes, root, root);
+        let real_logo = std::fs::canonicalize(root.join("components/Logo.tsx")).unwrap();
+        assert!(
+            deps[0].module_deps.contains(&real_logo),
+            "a transitively-imported component must be flattened into the route's deps"
+        );
+    }
+
+    #[test]
+    fn route_own_entry_and_synthetic_inputs_are_excluded() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        write(root, "pages/index.tsx", "x");
+
+        let metafile = br#"{
+            "inputs": {
+                "entry.mjs": { "imports": [ { "path": "pages/index.tsx" } ] },
+                "pages/index.tsx": { "imports": [ { "path": "entry.mjs" } ] }
+            }
+        }"#;
+        let routes = vec![RouteEntryRef {
+            source_path: PathBuf::from("pages/index.tsx"),
+            metafile_key: "pages/index.tsx".to_string(),
+        }];
+
+        let deps = route_module_deps(metafile, &routes, root, root);
+        assert!(
+            deps[0].module_deps.is_empty(),
+            "the route's own entry and the synthetic entry.mjs must not be deps; got {:?}",
+            deps[0].module_deps
+        );
+    }
+
+    #[test]
+    fn nonexistent_input_is_skipped() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        write(root, "pages/index.tsx", "x");
+
+        let metafile = br#"{
+            "inputs": {
+                "pages/index.tsx": { "imports": [ { "path": "components/Ghost.tsx" } ] }
+            }
+        }"#;
+        let routes = vec![RouteEntryRef {
+            source_path: PathBuf::from("pages/index.tsx"),
+            metafile_key: "pages/index.tsx".to_string(),
+        }];
+
+        let deps = route_module_deps(metafile, &routes, root, root);
+        assert!(
+            deps[0].module_deps.is_empty(),
+            "an input with no real file on disk is skipped, not invented"
+        );
+    }
+
+    #[test]
+    fn malformed_metafile_yields_empty_not_panic() {
+        let routes = vec![RouteEntryRef {
+            source_path: PathBuf::from("pages/index.tsx"),
+            metafile_key: "pages/index.tsx".to_string(),
+        }];
+        let deps = route_module_deps(b"not json", &routes, Path::new("/p"), Path::new("/p"));
+        assert!(deps.is_empty());
+    }
+
+    #[test]
+    fn symlinked_workspace_dep_canonicalises_to_real_path() {
+        // shadow tree differs from project tree; a metafile key resolves only
+        // under the shadow root, where it is a symlink to the real workspace
+        // file. The dep must canonicalise to that real file (the watch target).
+        let tmp = tempfile::tempdir().unwrap();
+        let project = tmp.path().join("project");
+        let shadow = tmp.path().join("shadow");
+        let real_pkg = tmp.path().join("workspace/design-system/Button.tsx");
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::create_dir_all(shadow.join("node_modules/@ds")).unwrap();
+        write(&project, "pages/index.tsx", "x");
+        std::fs::create_dir_all(real_pkg.parent().unwrap()).unwrap();
+        std::fs::write(&real_pkg, "btn").unwrap();
+
+        let link = shadow.join("node_modules/@ds/Button.tsx");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&real_pkg, &link).unwrap();
+        #[cfg(not(unix))]
+        std::fs::write(&link, "btn").unwrap();
+
+        write(&project, "pages/index.tsx", "x");
+
+        let metafile = br#"{
+            "inputs": {
+                "pages/index.tsx": { "imports": [ { "path": "node_modules/@ds/Button.tsx" } ] },
+                "node_modules/@ds/Button.tsx": { "imports": [] }
+            }
+        }"#;
+        let routes = vec![RouteEntryRef {
+            source_path: PathBuf::from("pages/index.tsx"),
+            metafile_key: "pages/index.tsx".to_string(),
+        }];
+
+        let deps = route_module_deps(metafile, &routes, &shadow, &project);
+        #[cfg(unix)]
+        {
+            let real = std::fs::canonicalize(&real_pkg).unwrap();
+            assert!(
+                deps[0].module_deps.contains(&real),
+                "symlinked workspace dep must canonicalise to the real file; got {:?}",
+                deps[0].module_deps
+            );
+        }
+    }
+}

--- a/crates/zfb-build/src/orchestrator.rs
+++ b/crates/zfb-build/src/orchestrator.rs
@@ -476,6 +476,15 @@ impl<P: AssetPipeline> BuildOrchestrator<P> {
                     {
                         plan.mark_islands();
                     }
+                    // #1288 — a component (`.tsx` `Module`) edit may author a
+                    // new Tailwind utility class (symptom C). The CSS content
+                    // scan only re-runs on `rerun_css`, which a `.css` edit
+                    // sets today; a `.tsx` edit did not. Re-run the content
+                    // scan so a newly-introduced class is emitted into
+                    // `/assets/styles.css` without touching the CSS entry.
+                    if matches!(class, PathClass::Module) {
+                        plan.mark_css();
+                    }
                 }
                 PathClass::Style => {
                     plan.mark_css();
@@ -1228,7 +1237,11 @@ mod tests {
         }
         // components/ is in default islands roots -> islands rerun.
         assert!(plan.rerun_islands);
-        assert!(!plan.rerun_css);
+        // #1288 — a component (`Module`) edit now also re-runs the CSS content
+        // scan, because it may author a new Tailwind utility class that must be
+        // emitted into `/assets/styles.css` without touching the CSS entry
+        // (symptom C of #1284). This flipped from the previous `!rerun_css`.
+        assert!(plan.rerun_css);
     }
 
     #[test]

--- a/crates/zfb-build/src/orchestrator.rs
+++ b/crates/zfb-build/src/orchestrator.rs
@@ -451,15 +451,19 @@ impl<P: AssetPipeline> BuildOrchestrator<P> {
                 }
                 PathClass::Page | PathClass::Module | PathClass::Content | PathClass::Data => {
                     let dirty: PageSelection = graph.dirty_pages(&path).into();
-                    // If the graph returned no dirty pages (empty specific set),
-                    // fall back to rebuilding all pages. This handles two cases:
-                    //   1. Cold start: graph seeded with page nodes but has no
-                    //      reverse edges yet (content→page deps not resolved).
-                    //   2. Untracked file: file genuinely isn't in the graph;
-                    //      rebuild everything conservatively.
-                    // `PageSelection::All` is safe here — `resolve_all` will
-                    // expand it to the known page list before the pipeline runs.
-                    let effective = if dirty.is_empty() {
+                    // Precise per-route selection backed by the dev `Module`
+                    // edges populated from esbuild's metafile (#1284/#1287).
+                    // Fall back to `PageSelection::All` ONLY when the path is
+                    // genuinely UNKNOWN to the graph (no page / dep / global
+                    // record) — then a whole-site rebuild is the conservative
+                    // choice (cold start, or a file the graph never resolved).
+                    // When the graph DOES know the path but maps it to an empty
+                    // consumer set, that empty result is authoritative — the
+                    // blunt All-fallback on every component edit was exactly the
+                    // imprecise whole-site re-render the metafile edges remove.
+                    // `PageSelection::All` is still expanded by `resolve_all` to
+                    // the known page list before the pipeline runs.
+                    let effective = if dirty.is_empty() && !graph.knows(&path) {
                         PageSelection::All
                     } else {
                         dirty

--- a/crates/zfb-build/tests/dev_dep_invalidation_1284.rs
+++ b/crates/zfb-build/tests/dev_dep_invalidation_1284.rs
@@ -1,0 +1,139 @@
+//! Reproduction tests for bug #1284 (epic #1285), Wave-1 diagnosis #1286 —
+//! orchestrator `plan_for_changes` level (Level 1, pure fold, no V8).
+//!
+//! NOTE: build/run these with `--no-default-features` to avoid the V8 first
+//! compile — the orchestrator/plan/policy code under test does not need
+//! `embed_v8`:
+//!
+//! ```sh
+//! cargo test -p zfb-build --no-default-features --test dev_dep_invalidation_1284
+//! ```
+//!
+//! These pin the page-SELECTION asymmetry that is the orchestrator half of the
+//! bug, empirically confirmed during diagnosis:
+//!
+//! - The `Page|Module|Content|Data` arm (`orchestrator.rs:~452`) falls back to
+//!   `PageSelection::All` when `dirty_pages` is empty. So a `components/**`
+//!   edit in the (edge-less) dev graph selects ALL pages — imprecise but it
+//!   *does* re-render. The #1287 fix replaces this blunt All-fallback with a
+//!   precise per-route selection driven by populated Module edges.
+//! - The `Style` arm (`orchestrator.rs:~480`) does NOT fall back to All: an
+//!   empty `dirty_pages(css)` yields `Specific({})` — zero pages. Combined
+//!   with the missing Style edges in dev, a transitively-imported CSS edit
+//!   re-renders no page (symptom B at the planner).
+//!
+//! The "current_bug_*" tests assert TODAY's behaviour (and are not ignored, to
+//! lock the regression boundary). The fixed-behaviour tests are
+//! `#[ignore = "pending fix: #1284"]`.
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use zfb_build::{BuildOrchestrator, DevAssetPipeline, OrchestratorConfig, PageSelection};
+use zfb_graph::{DependencyGraph, PageDeps, PageId};
+
+fn pid(p: PathBuf) -> PageId {
+    PageId::new(p)
+}
+
+/// Dev-seeded orchestrator: pages with NO dep edges (mirrors `dev.rs` boot
+/// seed), watching `components` + `styles`.
+fn dev_orch(project: &std::path::Path) -> BuildOrchestrator<DevAssetPipeline> {
+    let mut g = DependencyGraph::new();
+    g.upsert(PageDeps::new(pid(project.join("pages/index.tsx")), vec![]));
+    g.upsert(PageDeps::new(pid(project.join("pages/about.tsx")), vec![]));
+    let graph = Arc::new(Mutex::new(g));
+    BuildOrchestrator::new(
+        OrchestratorConfig::new(
+            project,
+            vec![PathBuf::from("components"), PathBuf::from("styles")],
+        ),
+        graph,
+        DevAssetPipeline::new(),
+    )
+}
+
+/// SYMPTOM A (current, imprecise) — a component edit selects ALL pages via the
+/// Page|Module All-fallback. Documents present behaviour; not ignored. The fix
+/// narrows this to the specific consumer route.
+#[test]
+fn current_component_edit_selects_all_pages_imprecisely() {
+    let project = PathBuf::from("/proj");
+    let orch = dev_orch(&project);
+    let plan = orch.plan_for_changes(vec![project.join("components/Header.tsx")]);
+    assert!(
+        plan.pages.is_all(),
+        "today the Page|Module arm falls back to All when the dev graph has no Module edges"
+    );
+}
+
+/// SYMPTOM A (fixed) — once Module edges exist, the component edit selects only
+/// its consumer route, NOT All. Ignored until #1287 lands.
+#[test]
+#[ignore = "pending fix: #1284"]
+fn component_edit_selects_only_consumer_route() {
+    let project = PathBuf::from("/proj");
+    let mut g = DependencyGraph::new();
+    g.upsert(PageDeps::new(
+        pid(project.join("pages/index.tsx")),
+        vec![(
+            project.join("components/Header.tsx"),
+            zfb_graph::DepKind::Module,
+        )],
+    ));
+    g.upsert(PageDeps::new(pid(project.join("pages/about.tsx")), vec![]));
+    let orch = BuildOrchestrator::new(
+        OrchestratorConfig::new(&project, vec![PathBuf::from("components")]),
+        Arc::new(Mutex::new(g)),
+        DevAssetPipeline::new(),
+    );
+
+    let plan = orch.plan_for_changes(vec![project.join("components/Header.tsx")]);
+    match plan.pages {
+        PageSelection::Specific(pages) => {
+            assert_eq!(
+                pages.into_iter().collect::<Vec<_>>(),
+                vec![pid(project.join("pages/index.tsx"))],
+                "fix selects exactly the consuming route"
+            );
+        }
+        PageSelection::All => panic!("after #1287 the selection must be precise, not All"),
+    }
+}
+
+/// SYMPTOM A (fixed) — a component edit must also re-run the CSS content
+/// re-scan, because a new utility class authored inside that component
+/// (symptom C) only reaches `/assets/styles.css` when the CSS pipeline
+/// re-runs. The #1288-owned `mark_css` edit at `orchestrator.rs:~474-478`
+/// makes a Module change set `rerun_css`. Ignored until the fix lands.
+#[test]
+#[ignore = "pending fix: #1284"]
+fn component_edit_triggers_css_rescan() {
+    let project = PathBuf::from("/proj");
+    let orch = dev_orch(&project);
+    let plan = orch.plan_for_changes(vec![project.join("components/Header.tsx")]);
+    assert!(
+        plan.rerun_css,
+        "a Module edit must trigger a CSS content re-scan so a new utility class is emitted (symptom C)"
+    );
+}
+
+/// SYMPTOM B (current) — the Style arm does NOT fall back to All. A
+/// transitively-imported CSS file (no Style edge in the dev graph) selects
+/// ZERO pages even though `rerun_css` is set. Documents present behaviour;
+/// not ignored. This is the asymmetry vs the Page|Module arm.
+#[test]
+fn current_style_arm_selects_no_pages_without_edges() {
+    let project = PathBuf::from("/proj");
+    let orch = dev_orch(&project);
+    let plan = orch.plan_for_changes(vec![project.join("styles/theme.css")]);
+    assert!(plan.rerun_css, "a styles/ edit always re-runs CSS");
+    assert!(
+        !plan.pages.is_all(),
+        "the Style arm does NOT fall back to All (asymmetry vs Page|Module arm)"
+    );
+    assert!(
+        matches!(plan.pages, PageSelection::Specific(ref s) if s.is_empty()),
+        "with no Style edge, the Style arm selects zero pages"
+    );
+}

--- a/crates/zfb-build/tests/dev_dep_invalidation_1284.rs
+++ b/crates/zfb-build/tests/dev_dep_invalidation_1284.rs
@@ -110,9 +110,8 @@ fn component_edit_selects_only_consumer_route() {
 /// re-scan, because a new utility class authored inside that component
 /// (symptom C) only reaches `/assets/styles.css` when the CSS pipeline
 /// re-runs. The #1288-owned `mark_css` edit at `orchestrator.rs:~474-478`
-/// makes a Module change set `rerun_css`. Ignored until the fix lands.
+/// makes a Module change set `rerun_css`.
 #[test]
-#[ignore = "pending fix: #1284"]
 fn component_edit_triggers_css_rescan() {
     let project = PathBuf::from("/proj");
     let orch = dev_orch(&project);

--- a/crates/zfb-build/tests/dev_dep_invalidation_1284.rs
+++ b/crates/zfb-build/tests/dev_dep_invalidation_1284.rs
@@ -75,7 +75,6 @@ fn current_component_edit_selects_all_pages_imprecisely() {
 /// SYMPTOM A (fixed) — once Module edges exist, the component edit selects only
 /// its consumer route, NOT All. Ignored until #1287 lands.
 #[test]
-#[ignore = "pending fix: #1284"]
 fn component_edit_selects_only_consumer_route() {
     let project = PathBuf::from("/proj");
     let mut g = DependencyGraph::new();

--- a/crates/zfb-build/tests/dev_dep_invalidation_1284.rs
+++ b/crates/zfb-build/tests/dev_dep_invalidation_1284.rs
@@ -25,6 +25,11 @@
 //! The "current_bug_*" tests assert TODAY's behaviour (and are not ignored, to
 //! lock the regression boundary). The fixed-behaviour tests are
 //! `#[ignore = "pending fix: #1284"]`.
+//!
+//! NOTE TO FIX AUTHORS (#1287/#1288): once your fix lands the `current_bug_*`
+//! tests WILL fail — that is expected. **Replace** each with its fixed-behaviour
+//! sibling (un-ignore the matching fixed test); a failing `current_bug_*` is a
+//! migrate-me signal, not a regression.
 
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};

--- a/crates/zfb-build/tests/integration_dev_loop.rs
+++ b/crates/zfb-build/tests/integration_dev_loop.rs
@@ -268,7 +268,14 @@ fn editing_a_use_client_component_re_bundles_islands_without_full_rerender() {
         .expect("non-noop");
 
     assert!(outcome.islands_rerun, "islands must rerun");
-    assert!(!outcome.css_rerun, "css must NOT rerun");
+    // #1288 — a component (`Module`) edit now also re-runs the CSS content
+    // scan: a new Tailwind utility class authored inside the component must be
+    // emitted into `/assets/styles.css` without touching the CSS entry
+    // (symptom C of #1284). This flipped from the previous "css must NOT rerun".
+    assert!(
+        outcome.css_rerun,
+        "css re-runs so a new utility class is emitted"
+    );
     assert_eq!(outcome.pages_rendered, 1, "only page a re-rendered");
 
     let calls = render_calls.lock().unwrap();
@@ -279,8 +286,8 @@ fn editing_a_use_client_component_re_bundles_islands_without_full_rerender() {
 
     assert_eq!(
         css_runs.load(Ordering::SeqCst),
-        0,
-        "css callback not called"
+        1,
+        "css callback runs once for the component edit (#1288 symptom-C re-scan)"
     );
     assert_eq!(islands_runs.load(Ordering::SeqCst), 1);
 }

--- a/crates/zfb-css/src/css_imports.rs
+++ b/crates/zfb-css/src/css_imports.rs
@@ -277,23 +277,18 @@ fn extract_import_specifiers(css: &str) -> Vec<String> {
     let bytes = without_comments.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
-        // Find the next `@import` (case-insensitive on the keyword is overkill;
-        // CSS at-rule names are ASCII-lowercase by convention here).
-        if bytes[i] == b'@'
-            && without_comments[i..]
-                .to_ascii_lowercase()
-                .starts_with("@import")
-        {
+        // Find the next `@import`. Compare on raw bytes (case-insensitive) rather
+        // than slicing the `&str` + allocating a lowercased suffix: the suffix-copy
+        // form was O(n^2) on `@`-dense files, and slicing `without_comments[i..]`
+        // can panic if a stray non-ASCII byte leaves `i` mid-codepoint.
+        if bytes[i] == b'@' && ascii_ci_starts_with(bytes, i, b"@import") {
             let mut j = i + "@import".len();
             // Skip whitespace.
             while j < bytes.len() && bytes[j].is_ascii_whitespace() {
                 j += 1;
             }
             // Optional `url(`.
-            if without_comments[j..]
-                .to_ascii_lowercase()
-                .starts_with("url(")
-            {
+            if ascii_ci_starts_with(bytes, j, b"url(") {
                 j += "url(".len();
                 while j < bytes.len() && bytes[j].is_ascii_whitespace() {
                     j += 1;
@@ -345,11 +340,23 @@ fn read_target(css: &str, start: usize) -> Option<(String, usize)> {
     Some((css[s..k].trim().to_string(), k))
 }
 
+/// ASCII case-insensitive `starts_with` at byte offset `at`, operating purely on
+/// bytes so it never allocates and never slices on a char boundary.
+fn ascii_ci_starts_with(bytes: &[u8], at: usize, needle: &[u8]) -> bool {
+    bytes.len() >= at + needle.len() && bytes[at..at + needle.len()].eq_ignore_ascii_case(needle)
+}
+
 /// Strip `/* … */` block comments, replacing each with a single space so byte
 /// adjacency that mattered (e.g. `@import/* x */"y"`) does not glue tokens.
+///
+/// Copies non-comment bytes verbatim into a byte buffer rather than
+/// `out.push(byte as char)` — the latter reinterprets every UTF-8 continuation
+/// byte (>=0x80) as a Latin-1 code point, corrupting non-ASCII CSS and shifting
+/// the byte offsets the scanner relies on (a single non-ASCII byte near an
+/// `@import` could then panic the resolver).
 fn strip_block_comments(css: &str) -> String {
-    let mut out = String::with_capacity(css.len());
     let bytes = css.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
     let mut i = 0;
     while i < bytes.len() {
         if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'*' {
@@ -358,13 +365,15 @@ fn strip_block_comments(css: &str) -> String {
                 i += 1;
             }
             i += 2;
-            out.push(' ');
+            out.push(b' ');
         } else {
-            out.push(bytes[i] as char);
+            out.push(bytes[i]);
             i += 1;
         }
     }
-    out
+    // Only ASCII comment delimiters were dropped; every other byte is copied
+    // verbatim from a valid `&str`, so the result is still valid UTF-8.
+    String::from_utf8(out).unwrap_or_else(|_| css.to_string())
 }
 
 #[cfg(test)]
@@ -393,6 +402,15 @@ mod tests {
                 "@scope/design-system".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn non_ascii_css_does_not_panic_and_imports_still_extracted() {
+        // A non-ASCII byte near an `@import` previously corrupted the byte
+        // offsets (`byte as char`) and could panic the scanner mid-codepoint.
+        let css = "/* コメント */\n@import \"./café.css\";\nbody::before{content:\"日本語\";}\n";
+        let specs = extract_import_specifiers(css);
+        assert_eq!(specs, vec!["./café.css".to_string()]);
     }
 
     #[test]

--- a/crates/zfb-css/src/css_imports.rs
+++ b/crates/zfb-css/src/css_imports.rs
@@ -1,0 +1,472 @@
+//! Resolve a CSS entry's `@import` graph to canonicalised real file paths
+//! (D2 of bug #1284 / sub-issue #1288).
+//!
+//! ## Why this exists
+//!
+//! zfb shells out to the Tailwind v4 standalone CLI as an opaque `-i/-o`
+//! transform ([`crate::engine`]). Tailwind resolves `@import` targets
+//! invisibly and exposes **no machine-readable dependency manifest**, so zfb
+//! never learns the real on-disk paths of the CSS files an entry transitively
+//! pulls in. That breaks dev invalidation two ways:
+//!
+//! 1. editing a transitively-imported CSS file (`@import './tokens.css';`)
+//!    does not refresh `/assets/styles.css`, because no dependency edge / watch
+//!    target exists for it; and
+//! 2. a **workspace** dep consumed via `@import '@scope/design-system'` resolves
+//!    through a `node_modules` symlink — `notify` (started recursive) does not
+//!    follow symlinks, and `node_modules` is excluded anyway, so the real file
+//!    is never watched.
+//!
+//! This module parses the `@import` graph in Rust and returns each target's
+//! **canonicalised real path** ([`std::fs::canonicalize`], which follows the
+//! workspace symlink to the real file). Those real paths are the watch targets
+//! the dev layer registers (D4) and the Style edges the graph records.
+//!
+//! ## Scope (per #1286 D2)
+//!
+//! - Resolves `@import "..."` and `@import url(...)` targets that resolve to a
+//!   file on disk: **relative** specifiers (`./`, `../`, bare-relative like
+//!   `tokens.css`) against the importing file's directory, and **bare package**
+//!   specifiers (`@scope/pkg`, `pkg/sub.css`) against `node_modules` (walking up
+//!   from the importing file, so a workspace/pnpm layout resolves).
+//! - **Recurses** into resolved CSS files so a chain
+//!   `entry → a.css → b.css` surfaces both `a.css` and `b.css`.
+//! - **Skips** `@import "tailwindcss"` (and `tailwindcss/...`) and other
+//!   virtual/builtin specifiers that do not resolve to a real on-disk file
+//!   (e.g. `@import "tw-animate-css"` with no installed file is simply dropped).
+//! - Returns canonicalised real paths, de-duplicated and sorted for stable
+//!   downstream ordering. The entry itself is **not** included.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+/// Specifiers that name Tailwind's own virtual entry — never an on-disk file
+/// zfb should resolve or watch.
+fn is_virtual_specifier(spec: &str) -> bool {
+    spec == "tailwindcss" || spec.starts_with("tailwindcss/")
+}
+
+/// Resolve the transitive `@import` graph rooted at `entry`, returning the
+/// canonicalised real paths of every imported CSS file that resolves to a file
+/// on disk.
+///
+/// `entry` is the CSS entry file (e.g. the consumer's authored global
+/// stylesheet). It is read from disk; a missing/unreadable entry yields an
+/// empty set. The entry path itself is never included in the result.
+///
+/// `project_root` anchors `node_modules` lookups when the importing file lives
+/// outside the project tree (a canonicalised symlink target); the per-file
+/// upward walk from each importer is the primary mechanism and covers the
+/// in-repo and pnpm/workspace cases.
+pub fn resolve_css_imports(entry: &Path, project_root: &Path) -> Vec<PathBuf> {
+    let mut seen_real: BTreeSet<PathBuf> = BTreeSet::new();
+    let mut out: BTreeSet<PathBuf> = BTreeSet::new();
+
+    // Seed the walk with the entry's own real path so a self-referential
+    // `@import` cycle terminates. The entry is excluded from `out`.
+    let entry_real = std::fs::canonicalize(entry).unwrap_or_else(|_| entry.to_path_buf());
+    seen_real.insert(entry_real.clone());
+
+    let mut stack: Vec<PathBuf> = vec![entry_real];
+    while let Some(importer_real) = stack.pop() {
+        let text = match std::fs::read_to_string(&importer_real) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+        for spec in extract_import_specifiers(&text) {
+            if is_virtual_specifier(&spec) {
+                continue;
+            }
+            let Some(resolved) = resolve_one(&importer_real, &spec, project_root) else {
+                // Unresolvable (virtual/builtin or not installed) — skip.
+                continue;
+            };
+            let real = match std::fs::canonicalize(&resolved) {
+                Ok(r) => r,
+                Err(_) => continue,
+            };
+            if seen_real.insert(real.clone()) {
+                out.insert(real.clone());
+                stack.push(real);
+            }
+        }
+    }
+
+    out.into_iter().collect()
+}
+
+/// Resolve a single `@import` specifier against the importing file.
+///
+/// Relative specifiers (`./`, `../`, or a bare-relative filename like
+/// `tokens.css`) resolve against the importer's directory. Package specifiers
+/// (`@scope/pkg`, `pkg/sub.css`) resolve against the nearest `node_modules`
+/// walking up from the importer; a directory target falls back to the package's
+/// `package.json` `style`/`exports`/`main` CSS entry, then `index.css`.
+fn resolve_one(importer_real: &Path, spec: &str, project_root: &Path) -> Option<PathBuf> {
+    let importer_dir = importer_real.parent().unwrap_or(Path::new("."));
+
+    if is_relative_specifier(spec) {
+        let candidate = importer_dir.join(spec);
+        return file_or_css_index(&candidate);
+    }
+
+    // Bare package specifier — walk up looking for node_modules.
+    resolve_package_specifier(importer_dir, project_root, spec)
+}
+
+/// A relative specifier resolves against the importing file's directory.
+/// Anything that is not an absolute path and not a bare package name (no
+/// leading `@scope` / `pkg` form) is treated as relative — including a plain
+/// `tokens.css` next to the importer.
+fn is_relative_specifier(spec: &str) -> bool {
+    spec.starts_with("./") || spec.starts_with("../") || spec.starts_with('/') || {
+        // A bare token with a CSS-ish extension and no path separator that
+        // does NOT look like a package (no `@scope`) is treated as relative
+        // (e.g. `theme.css`). A token like `design-system` with no extension
+        // is treated as a package specifier.
+        !spec.starts_with('@') && spec.contains('.') && !spec.contains('/')
+    }
+}
+
+/// Resolve a package specifier (`@scope/pkg`, `pkg`, `pkg/sub.css`) against the
+/// nearest `node_modules` directory, walking up from `start_dir` and finally
+/// trying `project_root/node_modules`.
+fn resolve_package_specifier(start_dir: &Path, project_root: &Path, spec: &str) -> Option<PathBuf> {
+    let (pkg_name, subpath) = split_package_specifier(spec)?;
+
+    let mut search_dirs: Vec<PathBuf> = Vec::new();
+    let mut dir = Some(start_dir);
+    while let Some(d) = dir {
+        search_dirs.push(d.join("node_modules"));
+        dir = d.parent();
+    }
+    search_dirs.push(project_root.join("node_modules"));
+
+    for nm in &search_dirs {
+        let pkg_root = nm.join(&pkg_name);
+        if !pkg_root.is_dir() {
+            continue;
+        }
+        // Explicit subpath (`pkg/dist/tokens.css`) — resolve it directly.
+        if let Some(sub) = &subpath {
+            if let Some(hit) = file_or_css_index(&pkg_root.join(sub)) {
+                return Some(hit);
+            }
+            continue;
+        }
+        // Bare package — consult package.json for a CSS entry, then index.css.
+        if let Some(hit) = package_css_entry(&pkg_root) {
+            return Some(hit);
+        }
+        if let Some(hit) = file_or_css_index(&pkg_root) {
+            return Some(hit);
+        }
+    }
+    None
+}
+
+/// Split a package specifier into `(package_name, optional_subpath)`.
+/// `@scope/pkg/sub.css` → (`@scope/pkg`, `sub.css`); `pkg/sub` → (`pkg`,
+/// `sub`); `pkg` → (`pkg`, None).
+fn split_package_specifier(spec: &str) -> Option<(String, Option<String>)> {
+    if spec.is_empty() {
+        return None;
+    }
+    let parts: Vec<&str> = spec
+        .splitn(if spec.starts_with('@') { 3 } else { 2 }, '/')
+        .collect();
+    if spec.starts_with('@') {
+        match parts.as_slice() {
+            [scope, pkg] => Some((format!("{scope}/{pkg}"), None)),
+            [scope, pkg, sub] => Some((format!("{scope}/{pkg}"), Some((*sub).to_string()))),
+            _ => None,
+        }
+    } else {
+        match parts.as_slice() {
+            [pkg] => Some(((*pkg).to_string(), None)),
+            [pkg, sub] => Some(((*pkg).to_string(), Some((*sub).to_string()))),
+            _ => None,
+        }
+    }
+}
+
+/// Read a package's `package.json` and return the CSS entry it advertises, in
+/// precedence order: `style`, an `exports` map's `"."` → `style`/`default` CSS
+/// value, then `main` when it points at a `.css` file. Returns the resolved
+/// on-disk path (un-canonicalised; the caller canonicalises).
+fn package_css_entry(pkg_root: &Path) -> Option<PathBuf> {
+    let manifest = std::fs::read_to_string(pkg_root.join("package.json")).ok()?;
+    let json: serde_json::Value = serde_json::from_str(&manifest).ok()?;
+
+    if let Some(style) = json.get("style").and_then(|v| v.as_str()) {
+        if let Some(hit) = file_or_css_index(&pkg_root.join(style)) {
+            return Some(hit);
+        }
+    }
+    if let Some(entry) = exports_css_entry(json.get("exports")) {
+        if let Some(hit) = file_or_css_index(&pkg_root.join(entry)) {
+            return Some(hit);
+        }
+    }
+    if let Some(main) = json.get("main").and_then(|v| v.as_str()) {
+        if main.ends_with(".css") {
+            if let Some(hit) = file_or_css_index(&pkg_root.join(main)) {
+                return Some(hit);
+            }
+        }
+    }
+    None
+}
+
+/// Extract a CSS-looking target from an `exports` field's root (`"."`) entry.
+/// Handles a bare string export, and a conditions object with `style` /
+/// `default` keys.
+fn exports_css_entry(exports: Option<&serde_json::Value>) -> Option<String> {
+    let exports = exports?;
+    let root = match exports {
+        serde_json::Value::String(s) => return ends_with_css(s),
+        // `exports."."` when present, else treat the object itself as the
+        // condition map (some packages put conditions at the top level).
+        serde_json::Value::Object(map) => map.get(".").unwrap_or(exports),
+        _ => return None,
+    };
+    match root {
+        serde_json::Value::String(s) => ends_with_css(s),
+        serde_json::Value::Object(map) => map
+            .get("style")
+            .or_else(|| map.get("default"))
+            .and_then(|v| v.as_str())
+            .and_then(ends_with_css),
+        _ => None,
+    }
+}
+
+fn ends_with_css(s: &str) -> Option<String> {
+    if s.ends_with(".css") {
+        Some(s.to_string())
+    } else {
+        None
+    }
+}
+
+/// Return `candidate` if it is an existing file; if it is a directory, try
+/// `<candidate>/index.css`. Returns `None` when nothing on disk matches.
+fn file_or_css_index(candidate: &Path) -> Option<PathBuf> {
+    if candidate.is_file() {
+        return Some(candidate.to_path_buf());
+    }
+    if candidate.is_dir() {
+        let idx = candidate.join("index.css");
+        if idx.is_file() {
+            return Some(idx);
+        }
+    }
+    None
+}
+
+/// Extract every `@import` target specifier from CSS text.
+///
+/// Recognises both `@import "target";` / `@import 'target';` and
+/// `@import url("target");` / `@import url(target);`. Comment- and
+/// string-aware enough for real stylesheets: block comments (`/* … */`) are
+/// stripped before scanning, and a media-query / layer suffix after the target
+/// (`@import "x.css" screen;`) is ignored because we stop at the target token.
+fn extract_import_specifiers(css: &str) -> Vec<String> {
+    let without_comments = strip_block_comments(css);
+    let mut out: Vec<String> = Vec::new();
+    let bytes = without_comments.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        // Find the next `@import` (case-insensitive on the keyword is overkill;
+        // CSS at-rule names are ASCII-lowercase by convention here).
+        if bytes[i] == b'@'
+            && without_comments[i..]
+                .to_ascii_lowercase()
+                .starts_with("@import")
+        {
+            let mut j = i + "@import".len();
+            // Skip whitespace.
+            while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+                j += 1;
+            }
+            // Optional `url(`.
+            if without_comments[j..]
+                .to_ascii_lowercase()
+                .starts_with("url(")
+            {
+                j += "url(".len();
+                while j < bytes.len() && bytes[j].is_ascii_whitespace() {
+                    j += 1;
+                }
+            }
+            if let Some((spec, next)) = read_target(&without_comments, j) {
+                if !spec.is_empty() {
+                    out.push(spec);
+                }
+                i = next;
+                continue;
+            }
+        }
+        i += 1;
+    }
+    out
+}
+
+/// Read an `@import` target starting at byte offset `start`. Handles a quoted
+/// target (`"x"` / `'x'`) or a bare `url(x)` target. Returns the target string
+/// and the offset just past it.
+fn read_target(css: &str, start: usize) -> Option<(String, usize)> {
+    let bytes = css.as_bytes();
+    if start >= bytes.len() {
+        return None;
+    }
+    let q = bytes[start];
+    if q == b'"' || q == b'\'' {
+        let mut k = start + 1;
+        let s = k;
+        while k < bytes.len() && bytes[k] != q {
+            k += 1;
+        }
+        if k >= bytes.len() {
+            return None;
+        }
+        return Some((css[s..k].to_string(), k + 1));
+    }
+    // Bare `url(target)` form (no quotes) — read until `)` or whitespace.
+    let s = start;
+    let mut k = start;
+    while k < bytes.len() && bytes[k] != b')' && !bytes[k].is_ascii_whitespace() && bytes[k] != b';'
+    {
+        k += 1;
+    }
+    if k == s {
+        return None;
+    }
+    Some((css[s..k].trim().to_string(), k))
+}
+
+/// Strip `/* … */` block comments, replacing each with a single space so byte
+/// adjacency that mattered (e.g. `@import/* x */"y"`) does not glue tokens.
+fn strip_block_comments(css: &str) -> String {
+    let mut out = String::with_capacity(css.len());
+    let bytes = css.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if i + 1 < bytes.len() && bytes[i] == b'/' && bytes[i + 1] == b'*' {
+            i += 2;
+            while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
+                i += 1;
+            }
+            i += 2;
+            out.push(' ');
+        } else {
+            out.push(bytes[i] as char);
+            i += 1;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn extracts_quoted_and_url_imports() {
+        let css = r#"
+            @import "tailwindcss";
+            @import './tokens.css';
+            @import url("theme.css");
+            @import url(reset.css);
+            @import "@scope/design-system";
+            body { color: red; }
+        "#;
+        let specs = extract_import_specifiers(css);
+        assert_eq!(
+            specs,
+            vec![
+                "tailwindcss".to_string(),
+                "./tokens.css".to_string(),
+                "theme.css".to_string(),
+                "reset.css".to_string(),
+                "@scope/design-system".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn skips_commented_out_imports() {
+        let css = r#"
+            /* @import "commented.css"; */
+            @import "./real.css";
+        "#;
+        let specs = extract_import_specifiers(css);
+        assert_eq!(specs, vec!["./real.css".to_string()]);
+    }
+
+    #[test]
+    fn resolves_relative_imports_recursively_to_real_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        fs::write(
+            root.join("entry.css"),
+            "@import \"tailwindcss\";\n@import './tokens.css';\n",
+        )
+        .unwrap();
+        fs::write(root.join("tokens.css"), "@import './base.css';\n").unwrap();
+        fs::write(root.join("base.css"), "body{}\n").unwrap();
+
+        let resolved = resolve_css_imports(&root.join("entry.css"), root);
+        let tokens_real = fs::canonicalize(root.join("tokens.css")).unwrap();
+        let base_real = fs::canonicalize(root.join("base.css")).unwrap();
+        assert!(resolved.contains(&tokens_real), "tokens.css resolved");
+        assert!(
+            resolved.contains(&base_real),
+            "base.css resolved transitively"
+        );
+        // tailwindcss is virtual — never resolved, and the entry is excluded.
+        assert_eq!(resolved.len(), 2);
+    }
+
+    #[test]
+    fn resolves_workspace_package_through_symlink_to_real_path() {
+        // Layout:
+        //   proj/styles/styles.css  @import '@scope/design-system';
+        //   real/design-system/{package.json(style: dist/tokens.css), dist/tokens.css}
+        //   proj/node_modules/@scope/design-system -> ../../real/design-system (symlink)
+        let dir = tempfile::tempdir().unwrap();
+        let base = dir.path();
+        let proj = base.join("proj");
+        let real_ds = base.join("real/design-system");
+        fs::create_dir_all(proj.join("styles")).unwrap();
+        fs::create_dir_all(proj.join("node_modules/@scope")).unwrap();
+        fs::create_dir_all(real_ds.join("dist")).unwrap();
+        fs::write(
+            proj.join("styles/styles.css"),
+            "@import \"tailwindcss\";\n@import '@scope/design-system';\n",
+        )
+        .unwrap();
+        fs::write(
+            real_ds.join("package.json"),
+            r#"{"name":"@scope/design-system","style":"dist/tokens.css"}"#,
+        )
+        .unwrap();
+        fs::write(real_ds.join("dist/tokens.css"), "body{}\n").unwrap();
+
+        // Symlink the package into node_modules (the pnpm/workspace shape).
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&real_ds, proj.join("node_modules/@scope/design-system"))
+            .unwrap();
+        #[cfg(not(unix))]
+        return; // symlink semantics differ; this test is unix-only
+
+        let resolved = resolve_css_imports(&proj.join("styles/styles.css"), &proj);
+        let tokens_real = fs::canonicalize(real_ds.join("dist/tokens.css")).unwrap();
+        assert_eq!(
+            resolved,
+            vec![tokens_real],
+            "workspace dep resolves through the node_modules symlink to its real path"
+        );
+    }
+}

--- a/crates/zfb-css/src/engine.rs
+++ b/crates/zfb-css/src/engine.rs
@@ -873,7 +873,7 @@ fn run_oxide_warmup_build(binary_path: &Path) -> bool {
 /// `zfb-css` does not enforce a specific scanning strategy — Tailwind v4 has
 /// its own — but exposes this constant so callers (and the tailwind config
 /// generator) agree on a single list.
-pub const DEFAULT_CONTENT_ROOTS: &[&str] = &["pages", "components", "layouts", "content"];
+pub const DEFAULT_CONTENT_ROOTS: &[&str] = &["pages", "components", "layouts", "content", "src"];
 
 /// Build a string `@source` declaration list from the project root, suitable
 /// for emitting into a Tailwind v4 entrypoint CSS file.

--- a/crates/zfb-css/src/lib.rs
+++ b/crates/zfb-css/src/lib.rs
@@ -77,6 +77,7 @@
 //! artefacts.
 
 pub mod authored_engine;
+pub mod css_imports;
 pub mod emitter;
 pub mod engine;
 pub mod modules;
@@ -85,6 +86,7 @@ pub mod pipeline;
 pub mod scanner;
 
 pub use authored_engine::AuthoredCssEngine;
+pub use css_imports::resolve_css_imports;
 pub use emitter::{css_relative_path, CssEmitterOutput, CssProductionEmitter};
 pub use engine::{
     build_synthesised_entry_css, is_tailwind_import_line, CssEngine, TailwindSubprocessConfig,

--- a/crates/zfb-css/tests/dev_dep_invalidation_1284.rs
+++ b/crates/zfb-css/tests/dev_dep_invalidation_1284.rs
@@ -19,6 +19,11 @@
 //!
 //! The "current_bug_*" tests assert TODAY's behaviour (not ignored — they lock
 //! the boundary). Fixed-behaviour tests are `#[ignore = "pending fix: #1284"]`.
+//!
+//! NOTE TO FIX AUTHORS (#1288): once your fix lands the `current_bug_*` test
+//! WILL fail — expected. **Replace** it with its fixed-behaviour sibling
+//! (un-ignore `src_root_is_scanned_for_utility_classes`); a failing
+//! `current_bug_*` is a migrate-me signal, not a regression.
 
 use std::path::Path;
 

--- a/crates/zfb-css/tests/dev_dep_invalidation_1284.rs
+++ b/crates/zfb-css/tests/dev_dep_invalidation_1284.rs
@@ -1,0 +1,81 @@
+//! Reproduction tests for bug #1284 (epic #1285), Wave-1 diagnosis #1286 —
+//! CSS engine level (Level 1, pure logic, no V8).
+//!
+//! - **Symptom C** — a NEW Tailwind utility class authored inside a component
+//!   under `src/**` is never emitted into `/assets/styles.css`. Root cause
+//!   pinned here: `DEFAULT_CONTENT_ROOTS` (the `@source` scan roots Tailwind
+//!   walks for utility classes) is `["pages","components","layouts","content"]`
+//!   — it OMITS `src/`. So a class in `src/components/Foo.tsx` is outside every
+//!   scanned `@source` glob and never reaches the generated stylesheet. (The
+//!   second half of symptom C — the scan not re-running on a `.tsx` Module edit
+//!   — is pinned in the orchestrator test `component_edit_triggers_css_rescan`.)
+//!
+//! - **Symptom B (engine half)** — `zfb-css` does NOT resolve local CSS
+//!   `@import` file dependencies. `build_synthesised_entry_css` only prepends
+//!   `@import "tailwindcss";` + `@source` directives and passes the user CSS
+//!   through verbatim; a user `@import './local.css'` / `@import
+//!   '@scope/design-system'` is left for the Tailwind CLI to resolve invisibly,
+//!   so zfb never learns the real (canonicalised) dependency path to watch.
+//!
+//! The "current_bug_*" tests assert TODAY's behaviour (not ignored — they lock
+//! the boundary). Fixed-behaviour tests are `#[ignore = "pending fix: #1284"]`.
+
+use std::path::Path;
+
+use zfb_css::engine::{default_source_directives, DEFAULT_CONTENT_ROOTS};
+
+/// SYMPTOM C (current) — the scan roots omit `src/`, so a `src/**` component is
+/// never scanned for utility classes. Documents present behaviour; not ignored.
+#[test]
+fn current_bug_src_root_is_not_a_scan_root() {
+    assert!(
+        !DEFAULT_CONTENT_ROOTS.contains(&"src"),
+        "today src/ is NOT a Tailwind scan root, so classes authored under src/ are dropped"
+    );
+    let dirs = default_source_directives(Path::new("/proj"));
+    assert!(
+        !dirs.contains("/proj/src"),
+        "the emitted @source directives do not cover /proj/src today"
+    );
+    // Sanity: the roots it DOES cover are present.
+    assert!(dirs.contains("/proj/components"));
+}
+
+/// SYMPTOM C (fixed) — after the fix, `src/` is a scan root so a new utility
+/// class authored in a `src/**` component is emitted. Ignored until fix lands.
+#[test]
+#[ignore = "pending fix: #1284"]
+fn src_root_is_scanned_for_utility_classes() {
+    assert!(
+        DEFAULT_CONTENT_ROOTS.contains(&"src"),
+        "fix adds src/ to the Tailwind scan roots"
+    );
+    let dirs = default_source_directives(Path::new("/proj"));
+    assert!(
+        dirs.contains("/proj/src"),
+        "after the fix the emitted @source directives cover /proj/src"
+    );
+}
+
+/// SYMPTOM B (engine half, fixed) — after #1288 the entry-CSS build (or a
+/// sibling resolver) must surface the local/workspace `@import` targets so the
+/// dev watcher can register their canonicalised real paths. Today there is no
+/// API that returns the resolved `@import` dep set; this asserts the post-fix
+/// contract and is ignored until it exists.
+///
+/// Marked ignored AND left as a contract placeholder: the exact API shape is
+/// the #1288 author's call (per D2). Re-home/implement this assertion against
+/// the real resolver entry point when it lands.
+#[test]
+#[ignore = "pending fix: #1284 — @import resolver API is owned by #1288 (D2)"]
+fn local_css_imports_are_resolved_to_real_paths() {
+    // Placeholder for the post-fix observable:
+    //   given an entry CSS containing
+    //     @import './tokens.css';
+    //     @import '@scope/design-system';
+    //   the resolver returns the canonicalised real file paths (following the
+    //   workspace symlink) so the dev layer can watch them.
+    //
+    // Once #1288 adds the resolver, replace this with a real call + assertion.
+    panic!("contract placeholder: implement against #1288's @import resolver (D2)");
+}

--- a/crates/zfb-css/tests/dev_dep_invalidation_1284.rs
+++ b/crates/zfb-css/tests/dev_dep_invalidation_1284.rs
@@ -17,39 +17,22 @@
 //!   '@scope/design-system'` is left for the Tailwind CLI to resolve invisibly,
 //!   so zfb never learns the real (canonicalised) dependency path to watch.
 //!
-//! The "current_bug_*" tests assert TODAY's behaviour (not ignored — they lock
-//! the boundary). Fixed-behaviour tests are `#[ignore = "pending fix: #1284"]`.
-//!
-//! NOTE TO FIX AUTHORS (#1288): once your fix lands the `current_bug_*` test
-//! WILL fail — expected. **Replace** it with its fixed-behaviour sibling
-//! (un-ignore `src_root_is_scanned_for_utility_classes`); a failing
-//! `current_bug_*` is a migrate-me signal, not a regression.
+//! #1288 has landed: the original `current_bug_*` tests (which locked TODAY's
+//! broken behaviour) were migrated to their fixed-behaviour siblings below —
+//! `src_root_is_scanned_for_utility_classes` and
+//! `local_css_imports_are_resolved_to_real_paths` (now exercising the real D2
+//! `@import` resolver). Both are un-ignored and green.
 
+use std::fs;
 use std::path::Path;
 
 use zfb_css::engine::{default_source_directives, DEFAULT_CONTENT_ROOTS};
+use zfb_css::resolve_css_imports;
 
-/// SYMPTOM C (current) — the scan roots omit `src/`, so a `src/**` component is
-/// never scanned for utility classes. Documents present behaviour; not ignored.
+/// SYMPTOM C (fixed) — `src/` is a scan root so a new utility class authored in
+/// a `src/**` component is emitted. (Migrated from the now-removed
+/// `current_bug_src_root_is_not_a_scan_root`, per the fix-author note above.)
 #[test]
-fn current_bug_src_root_is_not_a_scan_root() {
-    assert!(
-        !DEFAULT_CONTENT_ROOTS.contains(&"src"),
-        "today src/ is NOT a Tailwind scan root, so classes authored under src/ are dropped"
-    );
-    let dirs = default_source_directives(Path::new("/proj"));
-    assert!(
-        !dirs.contains("/proj/src"),
-        "the emitted @source directives do not cover /proj/src today"
-    );
-    // Sanity: the roots it DOES cover are present.
-    assert!(dirs.contains("/proj/components"));
-}
-
-/// SYMPTOM C (fixed) — after the fix, `src/` is a scan root so a new utility
-/// class authored in a `src/**` component is emitted. Ignored until fix lands.
-#[test]
-#[ignore = "pending fix: #1284"]
 fn src_root_is_scanned_for_utility_classes() {
     assert!(
         DEFAULT_CONTENT_ROOTS.contains(&"src"),
@@ -60,27 +43,62 @@ fn src_root_is_scanned_for_utility_classes() {
         dirs.contains("/proj/src"),
         "after the fix the emitted @source directives cover /proj/src"
     );
+    // Sanity: the roots it already covered are still present.
+    assert!(dirs.contains("/proj/components"));
 }
 
-/// SYMPTOM B (engine half, fixed) — after #1288 the entry-CSS build (or a
-/// sibling resolver) must surface the local/workspace `@import` targets so the
-/// dev watcher can register their canonicalised real paths. Today there is no
-/// API that returns the resolved `@import` dep set; this asserts the post-fix
-/// contract and is ignored until it exists.
-///
-/// Marked ignored AND left as a contract placeholder: the exact API shape is
-/// the #1288 author's call (per D2). Re-home/implement this assertion against
-/// the real resolver entry point when it lands.
+/// SYMPTOM B (engine half, fixed) — the `@import` resolver (D2) surfaces the
+/// local/workspace `@import` targets as canonicalised real paths so the dev
+/// layer can register them as watch targets. Exercises the real resolver:
+/// a relative `@import` and a workspace package consumed through a
+/// `node_modules` symlink both resolve to their real on-disk files, recursively.
 #[test]
-#[ignore = "pending fix: #1284 — @import resolver API is owned by #1288 (D2)"]
 fn local_css_imports_are_resolved_to_real_paths() {
-    // Placeholder for the post-fix observable:
-    //   given an entry CSS containing
-    //     @import './tokens.css';
-    //     @import '@scope/design-system';
-    //   the resolver returns the canonicalised real file paths (following the
-    //   workspace symlink) so the dev layer can watch them.
-    //
-    // Once #1288 adds the resolver, replace this with a real call + assertion.
-    panic!("contract placeholder: implement against #1288's @import resolver (D2)");
+    let dir = tempfile::tempdir().unwrap();
+    let base = dir.path();
+    let proj = base.join("proj");
+    let real_ds = base.join("real/design-system");
+    fs::create_dir_all(proj.join("styles")).unwrap();
+    fs::create_dir_all(proj.join("node_modules/@scope")).unwrap();
+    fs::create_dir_all(real_ds.join("dist")).unwrap();
+
+    fs::write(
+        proj.join("styles/styles.css"),
+        "@import \"tailwindcss\";\n@import './tokens.css';\n@import '@scope/design-system';\n",
+    )
+    .unwrap();
+    fs::write(proj.join("styles/tokens.css"), "body{}\n").unwrap();
+    fs::write(
+        real_ds.join("package.json"),
+        r#"{"name":"@scope/design-system","style":"dist/tokens.css"}"#,
+    )
+    .unwrap();
+    fs::write(real_ds.join("dist/tokens.css"), "body{}\n").unwrap();
+
+    // pnpm/workspace shape: the package is a symlink into node_modules.
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(&real_ds, proj.join("node_modules/@scope/design-system"))
+            .unwrap();
+
+        let resolved = resolve_css_imports(&proj.join("styles/styles.css"), &proj);
+
+        let tokens_real = fs::canonicalize(proj.join("styles/tokens.css")).unwrap();
+        let ds_real = fs::canonicalize(real_ds.join("dist/tokens.css")).unwrap();
+
+        assert!(
+            resolved.contains(&tokens_real),
+            "relative @import resolves to its real path; got {resolved:?}"
+        );
+        assert!(
+            resolved.contains(&ds_real),
+            "workspace dep resolves through the node_modules symlink to its real path; got {resolved:?}"
+        );
+        // tailwindcss is virtual — never resolved.
+        assert_eq!(
+            resolved.len(),
+            2,
+            "only the two real CSS deps, got {resolved:?}"
+        );
+    }
 }

--- a/crates/zfb-graph/src/lib.rs
+++ b/crates/zfb-graph/src/lib.rs
@@ -751,7 +751,10 @@ mod tests {
         g.mark_global("/zfb.config.ts");
 
         assert!(g.knows(&p("/pages/index.tsx")), "a page is known");
-        assert!(g.knows(&p("/components/Header.tsx")), "a recorded dep is known");
+        assert!(
+            g.knows(&p("/components/Header.tsx")),
+            "a recorded dep is known"
+        );
         assert!(g.knows(&p("/zfb.config.ts")), "a global file is known");
         assert!(
             !g.knows(&p("/components/Untracked.tsx")),
@@ -790,7 +793,9 @@ mod tests {
         ));
 
         assert_eq!(
-            g.dirty_pages(&p("/components/Header.tsx")).as_pages().unwrap(),
+            g.dirty_pages(&p("/components/Header.tsx"))
+                .as_pages()
+                .unwrap(),
             vec![pid("/pages/index.tsx")],
             "a component edit dirties the consuming route"
         );

--- a/crates/zfb-graph/src/lib.rs
+++ b/crates/zfb-graph/src/lib.rs
@@ -578,6 +578,20 @@ impl DependencyGraph {
     // Dirty-set queries
     // -------------------------------------------------------------------------
 
+    /// Whether the graph has *any* record of `path` — as a page, as a recorded
+    /// dependency (reverse-index entry), or as a global file.
+    ///
+    /// This lets callers distinguish "tracked but currently has no consumers"
+    /// (a precise empty [`DirtySet`]) from "the graph has never heard of this
+    /// path" (so a conservative whole-site rebuild may be warranted). It is the
+    /// predicate the dev orchestrator uses to decide whether an empty
+    /// `dirty_pages` result should fall back to `PageSelection::All` (#1284).
+    pub fn knows(&self, path: &Path) -> bool {
+        self.globals.contains(path)
+            || self.reverse.contains_key(path)
+            || self.pages.contains(&PageId::new(path.to_path_buf()))
+    }
+
     /// The minimal set of pages whose output is affected by changing `path`.
     ///
     /// - For a global file (see [`Self::mark_global`]) → [`DirtySet::All`].

--- a/crates/zfb-graph/src/lib.rs
+++ b/crates/zfb-graph/src/lib.rs
@@ -729,6 +729,55 @@ mod tests {
     }
 
     #[test]
+    fn knows_distinguishes_tracked_from_unknown() {
+        // #1284/#1287 — the dev orchestrator falls back to a whole-site
+        // rebuild only when the graph has NEVER heard of a path. `knows` is
+        // that predicate: true for a page, a recorded dep, or a global file;
+        // false for an untracked path.
+        let mut g = DependencyGraph::new();
+        g.upsert(PageDeps::new(
+            pid("/pages/index.tsx"),
+            vec![(p("/components/Header.tsx"), DepKind::Module)],
+        ));
+        g.mark_global("/zfb.config.ts");
+
+        assert!(g.knows(&p("/pages/index.tsx")), "a page is known");
+        assert!(g.knows(&p("/components/Header.tsx")), "a recorded dep is known");
+        assert!(g.knows(&p("/zfb.config.ts")), "a global file is known");
+        assert!(
+            !g.knows(&p("/components/Untracked.tsx")),
+            "a path with no page/dep/global record is unknown"
+        );
+    }
+
+    #[test]
+    fn page_can_hold_both_module_and_content_deps() {
+        // #1284/#1287 — a route that imports a component AND consumes a content
+        // collection must carry both edge kinds at once; the dev merge in
+        // `populate_module_edges` / the discovery hook relies on the graph
+        // resolving either kind back to the page.
+        let mut g = DependencyGraph::new();
+        g.upsert(PageDeps::new(
+            pid("/pages/index.tsx"),
+            vec![
+                (p("/components/Header.tsx"), DepKind::Module),
+                (p("/content/post.md"), DepKind::Content),
+            ],
+        ));
+
+        assert_eq!(
+            g.dirty_pages(&p("/components/Header.tsx")).as_pages().unwrap(),
+            vec![pid("/pages/index.tsx")],
+            "a component edit dirties the consuming route"
+        );
+        assert_eq!(
+            g.dirty_pages(&p("/content/post.md")).as_pages().unwrap(),
+            vec![pid("/pages/index.tsx")],
+            "a content edit on the same page still dirties it (edges coexist)"
+        );
+    }
+
+    #[test]
     fn page_self_dirties_on_change_to_its_own_source() {
         let mut g = DependencyGraph::new();
         g.upsert(PageDeps::new(pid("/pages/index.tsx"), vec![]));

--- a/crates/zfb-graph/src/lib.rs
+++ b/crates/zfb-graph/src/lib.rs
@@ -578,17 +578,26 @@ impl DependencyGraph {
     // Dirty-set queries
     // -------------------------------------------------------------------------
 
-    /// Whether the graph has *any* record of `path` — as a page, as a recorded
-    /// dependency (reverse-index entry), or as a global file.
+    /// Whether the graph has a record of `path` that resolves to a concrete
+    /// dirty set — as a page, as a dep with at least one recorded consumer, or
+    /// as a global file.
     ///
-    /// This lets callers distinguish "tracked but currently has no consumers"
-    /// (a precise empty [`DirtySet`]) from "the graph has never heard of this
-    /// path" (so a conservative whole-site rebuild may be warranted). It is the
+    /// This lets callers distinguish "tracked with a definite (possibly its own
+    /// page) consumer" from "the graph has no actionable record of this path"
+    /// (so a conservative whole-site rebuild may be warranted). It is the
     /// predicate the dev orchestrator uses to decide whether an empty
     /// `dirty_pages` result should fall back to `PageSelection::All` (#1284).
+    ///
+    /// A reverse-index entry with an EMPTY consumer set (a node registered via
+    /// [`Self::add_node`] but never wired to a page) counts as NOT known —
+    /// `dirty_pages` would return an empty set for it, and the safe response is
+    /// the conservative `All` fallback, not "select nothing".
     pub fn knows(&self, path: &Path) -> bool {
         self.globals.contains(path)
-            || self.reverse.contains_key(path)
+            || self
+                .reverse
+                .get(path)
+                .is_some_and(|consumers| !consumers.is_empty())
             || self.pages.contains(&PageId::new(path.to_path_buf()))
     }
 
@@ -747,6 +756,21 @@ mod tests {
         assert!(
             !g.knows(&p("/components/Untracked.tsx")),
             "a path with no page/dep/global record is unknown"
+        );
+
+        // A node registered with NO consumers (e.g. via `add_node`) resolves to
+        // an empty dirty set, so `knows` must report it as NOT known — the dev
+        // orchestrator then keeps its conservative `All` fallback rather than
+        // selecting zero pages.
+        g.add_node("/components/Orphan.tsx");
+        assert_eq!(
+            g.dirty_pages(&p("/components/Orphan.tsx")),
+            DirtySet::Specific(Default::default()),
+            "an add_node entry has no consumers"
+        );
+        assert!(
+            !g.knows(&p("/components/Orphan.tsx")),
+            "a consumer-less reverse entry is not 'known' (would select nothing)"
         );
     }
 

--- a/crates/zfb-graph/tests/dev_dep_invalidation_1284.rs
+++ b/crates/zfb-graph/tests/dev_dep_invalidation_1284.rs
@@ -73,7 +73,6 @@ fn current_bug_component_edit_maps_to_no_page() {
 /// edges, editing a directly-imported component dirties exactly its consumer
 /// route. Ignored until the fix lands.
 #[test]
-#[ignore = "pending fix: #1284"]
 fn component_edit_dirties_consuming_route() {
     // The fix populates Module edges; model the post-fix graph.
     let mut g = DependencyGraph::new();
@@ -95,7 +94,6 @@ fn component_edit_dirties_consuming_route() {
 /// must still dirty the route. The metafile `inputs` map is transitive, so
 /// the fix records the leaf→route edge directly. Ignored until the fix lands.
 #[test]
-#[ignore = "pending fix: #1284"]
 fn transitively_imported_component_dirties_route() {
     // pages/index -> components/Header -> components/Logo
     // The metafile flattens transitive inputs, so Logo is recorded as a

--- a/crates/zfb-graph/tests/dev_dep_invalidation_1284.rs
+++ b/crates/zfb-graph/tests/dev_dep_invalidation_1284.rs
@@ -20,10 +20,18 @@
 //!   Same graph gap: no `DepKind::Style` edge for a transitively-imported CSS
 //!   path, so `dirty_pages(css)` is empty.
 //!
-//! The CURRENT (buggy) behaviour is that these queries return empty. Each test
-//! asserts the FIXED behaviour (non-empty) and is therefore `#[ignore]`d with
+//! The CURRENT (buggy) behaviour is that these queries return empty. The
+//! fixed-behaviour tests assert non-empty and are therefore `#[ignore]`d with
 //! a pointer to #1284 so `cargo test` stays green until the fix waves land and
 //! un-ignore them. See `research/1284-dev-dep-invalidation.md`.
+//!
+//! NOTE TO FIX AUTHORS (#1287/#1288): the `current_bug_*` tests assert TODAY's
+//! broken behaviour and are intentionally NOT ignored (they lock the regression
+//! boundary). Once your fix lands they WILL fail — that is expected. **Replace
+//! (do not just delete) each `current_bug_*` test with its fixed-behaviour
+//! sibling** (un-ignore the matching fixed test), so coverage moves forward
+//! rather than vanishing. A failing `current_bug_*` after your fix is a signal
+//! to migrate it, not a regression.
 
 use std::path::PathBuf;
 
@@ -124,24 +132,32 @@ fn current_bug_transitive_css_maps_to_no_page() {
 }
 
 /// SYMPTOM B (fixed behaviour) — after #1288 resolves the `@import` graph and
-/// registers Style edges (including canonicalised symlinked workspace deps),
-/// the CSS file maps to the pages whose served stylesheet it feeds. Here we
-/// model a global stylesheet that affects every page. Ignored until fix lands.
+/// registers a `DepKind::Style` EDGE from the consuming page to the resolved
+/// real CSS path (including a canonicalised symlinked workspace dep), editing
+/// that CSS file maps to its consuming page via the reverse index — NOT via a
+/// blunt `mark_global`. This asserts the actual D2/D4 mechanism (a per-page
+/// Style edge keyed on the canonicalised real path), so it cannot pass without
+/// the resolver wiring being present. Ignored until the fix lands.
 #[test]
 #[ignore = "pending fix: #1284"]
 fn transitively_imported_css_is_tracked() {
-    // The css entry (styles/styles.css) @imports a workspace design-system.
-    // After the fix, the resolved real path is registered; editing it must be
-    // visible to the rebuild planner (here: known to the graph as a global so
-    // every page's served /assets/styles.css refreshes).
+    // styles/styles.css @imports a workspace design-system whose real file is
+    // /real/design-system/dist/tokens.css (canonicalised symlink target).
+    // After the fix, that real path is registered as a Style edge of the
+    // consuming page, so dirty_pages maps it back to that page.
+    let real_css = p("/real/design-system/dist/tokens.css");
     let mut g = DependencyGraph::new();
-    g.upsert(PageDeps::new(pid("/proj/pages/index.tsx"), vec![]));
-    g.mark_global("/real/design-system/dist/tokens.css");
+    g.upsert(PageDeps::new(
+        pid("/proj/pages/index.tsx"),
+        vec![(real_css.clone(), zfb_graph::DepKind::Style)],
+    ));
+    g.upsert(PageDeps::new(pid("/proj/pages/about.tsx"), vec![]));
 
-    let dirty = g.dirty_pages(&p("/real/design-system/dist/tokens.css"));
+    let dirty = g.dirty_pages(&real_css);
     assert_eq!(
-        dirty,
-        DirtySet::All,
-        "a resolved @import dep (canonicalised symlink target) must be tracked, not ignored"
+        dirty.as_pages().unwrap(),
+        vec![pid("/proj/pages/index.tsx")],
+        "a resolved @import dep (canonicalised symlink target) must map to its \
+         consuming page via a Style edge, not be ignored"
     );
 }

--- a/crates/zfb-graph/tests/dev_dep_invalidation_1284.rs
+++ b/crates/zfb-graph/tests/dev_dep_invalidation_1284.rs
@@ -1,0 +1,147 @@
+//! Reproduction tests for bug #1284 (epic #1285), Wave-1 diagnosis #1286.
+//!
+//! These pin the *graph-level* root cause of symptoms A and B at Level 1
+//! (pure logic, no V8, no browser):
+//!
+//! - **Symptom A** — editing an imported component (`components/**` or
+//!   `src/components/**`), direct OR transitive, does not re-render the
+//!   consuming route. Root cause proven here: in the DEV path the graph is
+//!   seeded with page nodes that carry **no `DepKind::Module` edges**
+//!   (`dev.rs` seeds `PageDeps::new(page_id, vec![])`; only `DepKind::Content`
+//!   edges are upserted later). So `dirty_pages(component)` returns the EMPTY
+//!   set — the graph cannot map a component back to its consumer route. The
+//!   orchestrator's `Page|Module` arm then falls back to `PageSelection::All`
+//!   (imprecise, and on `src/**` the watcher never even fires — that root is
+//!   not watched). The #1287 fix makes `dirty_pages(component)` NON-EMPTY by
+//!   populating per-route module-dep edges (esbuild `--metafile` `inputs`).
+//!
+//! - **Symptom B** — editing a transitively-imported CSS file (incl. a
+//!   symlinked workspace dep reached via `@import`) does not map to any page.
+//!   Same graph gap: no `DepKind::Style` edge for a transitively-imported CSS
+//!   path, so `dirty_pages(css)` is empty.
+//!
+//! The CURRENT (buggy) behaviour is that these queries return empty. Each test
+//! asserts the FIXED behaviour (non-empty) and is therefore `#[ignore]`d with
+//! a pointer to #1284 so `cargo test` stays green until the fix waves land and
+//! un-ignore them. See `research/1284-dev-dep-invalidation.md`.
+
+use std::path::PathBuf;
+
+use zfb_graph::{DependencyGraph, DirtySet, PageDeps, PageId};
+
+fn p(s: &str) -> PathBuf {
+    PathBuf::from(s)
+}
+
+fn pid(s: &str) -> PageId {
+    PageId::new(p(s))
+}
+
+/// Mirror the DEV graph seed exactly: page nodes with NO dep edges
+/// (`dev.rs` boot seed `PageDeps::new(page_id, vec![])`).
+fn dev_seeded_graph() -> DependencyGraph {
+    let mut g = DependencyGraph::new();
+    g.upsert(PageDeps::new(pid("/proj/pages/index.tsx"), vec![]));
+    g.upsert(PageDeps::new(pid("/proj/pages/about.tsx"), vec![]));
+    g
+}
+
+/// SYMPTOM A — current bug: a component edit maps to NO consuming page,
+/// because the dev graph has no Module edges. This test documents the
+/// present (broken) state and MUST pass today so the regression boundary is
+/// explicit. It is intentionally NOT ignored.
+#[test]
+fn current_bug_component_edit_maps_to_no_page() {
+    let g = dev_seeded_graph();
+    let dirty = g.dirty_pages(&p("/proj/components/Header.tsx"));
+    assert_eq!(
+        dirty,
+        DirtySet::Specific(Default::default()),
+        "dev graph has no Module edges, so a component maps to the empty set today"
+    );
+}
+
+/// SYMPTOM A (fixed behaviour) — after #1287 populates per-route module-dep
+/// edges, editing a directly-imported component dirties exactly its consumer
+/// route. Ignored until the fix lands.
+#[test]
+#[ignore = "pending fix: #1284"]
+fn component_edit_dirties_consuming_route() {
+    // The fix populates Module edges; model the post-fix graph.
+    let mut g = DependencyGraph::new();
+    g.upsert(PageDeps::new(
+        pid("/proj/pages/index.tsx"),
+        vec![(p("/proj/components/Header.tsx"), zfb_graph::DepKind::Module)],
+    ));
+    g.upsert(PageDeps::new(pid("/proj/pages/about.tsx"), vec![]));
+
+    let dirty = g.dirty_pages(&p("/proj/components/Header.tsx"));
+    assert_eq!(
+        dirty.as_pages().unwrap(),
+        vec![pid("/proj/pages/index.tsx")],
+        "after #1287 a component edit dirties exactly its consumer route, not All"
+    );
+}
+
+/// SYMPTOM A (transitive) — a component imported only via another component
+/// must still dirty the route. The metafile `inputs` map is transitive, so
+/// the fix records the leaf→route edge directly. Ignored until the fix lands.
+#[test]
+#[ignore = "pending fix: #1284"]
+fn transitively_imported_component_dirties_route() {
+    // pages/index -> components/Header -> components/Logo
+    // The metafile flattens transitive inputs, so Logo is recorded as a
+    // Module dep of the route that ultimately pulls it in.
+    let mut g = DependencyGraph::new();
+    g.upsert(PageDeps::new(
+        pid("/proj/pages/index.tsx"),
+        vec![
+            (p("/proj/components/Header.tsx"), zfb_graph::DepKind::Module),
+            (p("/proj/components/Logo.tsx"), zfb_graph::DepKind::Module),
+        ],
+    ));
+
+    let dirty = g.dirty_pages(&p("/proj/components/Logo.tsx"));
+    assert_eq!(
+        dirty.as_pages().unwrap(),
+        vec![pid("/proj/pages/index.tsx")],
+        "a transitively-imported component must dirty its ultimate consumer route"
+    );
+}
+
+/// SYMPTOM B — current bug: a transitively-imported CSS file maps to NO page
+/// because the dev graph has no Style edges. Present (broken) state; not
+/// ignored.
+#[test]
+fn current_bug_transitive_css_maps_to_no_page() {
+    let g = dev_seeded_graph();
+    let dirty = g.dirty_pages(&p("/proj/styles/theme.css"));
+    assert_eq!(
+        dirty,
+        DirtySet::Specific(Default::default()),
+        "dev graph has no Style edges for transitively-imported CSS today"
+    );
+}
+
+/// SYMPTOM B (fixed behaviour) — after #1288 resolves the `@import` graph and
+/// registers Style edges (including canonicalised symlinked workspace deps),
+/// the CSS file maps to the pages whose served stylesheet it feeds. Here we
+/// model a global stylesheet that affects every page. Ignored until fix lands.
+#[test]
+#[ignore = "pending fix: #1284"]
+fn transitively_imported_css_is_tracked() {
+    // The css entry (styles/styles.css) @imports a workspace design-system.
+    // After the fix, the resolved real path is registered; editing it must be
+    // visible to the rebuild planner (here: known to the graph as a global so
+    // every page's served /assets/styles.css refreshes).
+    let mut g = DependencyGraph::new();
+    g.upsert(PageDeps::new(pid("/proj/pages/index.tsx"), vec![]));
+    g.mark_global("/real/design-system/dist/tokens.css");
+
+    let dirty = g.dirty_pages(&p("/real/design-system/dist/tokens.css"));
+    assert_eq!(
+        dirty,
+        DirtySet::All,
+        "a resolved @import dep (canonicalised symlink target) must be tracked, not ignored"
+    );
+}

--- a/crates/zfb-graph/tests/dev_dep_invalidation_1284.rs
+++ b/crates/zfb-graph/tests/dev_dep_invalidation_1284.rs
@@ -137,9 +137,8 @@ fn current_bug_transitive_css_maps_to_no_page() {
 /// that CSS file maps to its consuming page via the reverse index — NOT via a
 /// blunt `mark_global`. This asserts the actual D2/D4 mechanism (a per-page
 /// Style edge keyed on the canonicalised real path), so it cannot pass without
-/// the resolver wiring being present. Ignored until the fix lands.
+/// the resolver wiring being present.
 #[test]
-#[ignore = "pending fix: #1284"]
 fn transitively_imported_css_is_tracked() {
     // styles/styles.css @imports a workspace design-system whose real file is
     // /real/design-system/dist/tokens.css (canonicalised symlink target).

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -1017,7 +1017,7 @@ fn strip_tailwind_imports(css: &str) -> String {
 /// Order is deterministic. If both files exist the legacy
 /// `<root>/styles/global.css` wins so existing projects on the
 /// original convention see no behaviour change.
-fn resolve_input_global_css(project_root: &Path) -> Option<PathBuf> {
+pub(crate) fn resolve_input_global_css(project_root: &Path) -> Option<PathBuf> {
     const CANDIDATES: &[&[&str]] = &[&["styles", "global.css"], &["src", "styles", "global.css"]];
     for parts in CANDIDATES {
         let mut candidate = project_root.to_path_buf();

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -2974,6 +2974,7 @@ mod tests {
                         rel_under_pages: PathBuf::from("index.tsx"),
                     }],
                 },
+                route_module_deps: Vec::new(),
             })
         }
         fn eval_deferred_paths(
@@ -3420,6 +3421,7 @@ mod tests {
                         bundle_basename: "bundle.mjs".into(),
                         routes: vec![],
                     },
+                    route_module_deps: Vec::new(),
                 })
             }
             fn eval_deferred_paths(

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -484,7 +484,23 @@ pub async fn run(args: &DevArgs) -> Result<()> {
     // share the tick path's validate → dedup → atomic-write → commit
     // discipline and its tick-vs-request exclusion (#1024).
     let request_writer = pipeline.request_writer();
-    let extra_watch_paths = resolve_extra_watch_paths(&cfg.extra_watch_paths);
+    let mut extra_watch_paths = resolve_extra_watch_paths(&cfg.extra_watch_paths);
+    // #1288 (D4) — auto-watch the CSS `@import` graph. `notify` does not
+    // follow symlinks, and `node_modules` is excluded, so a transitively
+    // imported / symlinked-workspace-dep CSS file (`@import './tokens.css'`,
+    // `@import '@scope/design-system'`) is never watched and editing it never
+    // refreshes `/assets/styles.css`. Resolve the entry's `@import` graph to
+    // canonicalised real paths and register them as extra watch targets — no
+    // manual `extraWatchPaths` config. The resolver already canonicalises, so
+    // these align with the watcher's canonical event paths. The out-of-root
+    // `.css` real paths classify as `PathClass::Style` (whitelisted extension),
+    // so editing one fires `rerun_css` and refreshes the asset.
+    let resolved_css_imports = resolve_css_import_watch_targets(&project_root);
+    for real in &resolved_css_imports {
+        if !extra_watch_paths.contains(real) {
+            extra_watch_paths.push(real.clone());
+        }
+    }
     // Configured collection roots classify as Content ahead of the
     // standard root-segment walk — without this, a collection under
     // `src/` (e.g. `src/mdx/notes`) classifies as Module and wastefully
@@ -1778,6 +1794,22 @@ fn resolve_extra_watch_paths(raw: &[PathBuf]) -> Vec<PathBuf> {
         }
     }
     resolved
+}
+
+/// Resolve the project's CSS `@import` graph to canonicalised real paths the
+/// dev watcher should follow (D4 of #1288).
+///
+/// Anchors on the conventional authored global stylesheet
+/// ([`crate::commands::build::resolve_input_global_css`] — `styles/global.css`
+/// or `src/styles/global.css`); returns an empty set when the project has no
+/// authored global CSS. Delegates the recursive `@import` resolution +
+/// canonicalisation (following workspace symlinks) to
+/// [`zfb_css::resolve_css_imports`].
+fn resolve_css_import_watch_targets(project_root: &Path) -> Vec<PathBuf> {
+    let Some(entry) = crate::commands::build::resolve_input_global_css(project_root) else {
+        return Vec::new();
+    };
+    zfb_css::resolve_css_imports(&entry, project_root)
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -2898,17 +2898,14 @@ impl DevRenderSession {
     /// route via `dirty_pages`. No-op when the graph handle is not installed
     /// or the bundle carried no metafile deps (e.g. the mock/scaffold path).
     ///
-    /// `upsert` REPLACES a page's prior dep set, so calling this every refresh
-    /// keeps the Module edges in lock-step with the live import graph — a
-    /// removed import drops its edge on the next tick. Content edges added by
-    /// the discovery hook live on different pages' upserts and the page
-    /// self-edge is re-added by `upsert`, so this does not clobber them for
-    /// the routes it owns; a route that imports both content and components
-    /// gets its Content deps via the discovery path and Module deps here on
-    /// the same `PageId`, and the LAST writer wins per tick — Module deps are
-    /// re-derived from the authoritative metafile every tick, so they are the
-    /// safe steady-state. (Content deps are re-asserted by the discovery hook
-    /// whenever a content file is (re)discovered.)
+    /// `upsert` REPLACES a page's entire dep set, so to avoid clobbering the
+    /// `DepKind::Content` edges the discovery hook records for the SAME page
+    /// (a route can import a component AND consume a content collection), this
+    /// MERGES: it reads the page's current non-`Module` deps, drops the stale
+    /// `Module` edges (re-derived fresh from the authoritative metafile every
+    /// refresh, so a removed import drops its edge next tick), and re-upserts
+    /// the preserved Content/Style/Data edges alongside the new Module set. The
+    /// page self-edge is re-added by `upsert` regardless.
     #[cfg(feature = "embed_v8")]
     fn populate_module_edges(&self, deps: &[zfb_build::RouteModuleDeps]) {
         if deps.is_empty() {
@@ -2932,19 +2929,29 @@ impl DevRenderSession {
                 // pages (project-root-joined absolute path — see the boot seed
                 // and the Content upsert path).
                 let page_id = PageId::new(project_root.join(&route.source_path));
-                let edges: Vec<(PathBuf, zfb_graph::DepKind)> = route
-                    .module_deps
-                    .iter()
-                    .map(|p| (p.clone(), zfb_graph::DepKind::Module))
+
+                // Preserve the page's existing NON-Module deps (Content/Style/
+                // Data recorded by the discovery hook); only the Module edges
+                // are replaced from the metafile this tick. The self-edge is
+                // re-added by `upsert`, so drop it here too to avoid a dup.
+                let mut edges: Vec<(PathBuf, zfb_graph::DepKind)> = g
+                    .deps_of(&page_id)
+                    .into_iter()
+                    .filter(|(dep, kind)| {
+                        *kind != zfb_graph::DepKind::Module && dep != page_id.path()
+                    })
                     .collect();
-                // A real dep path that does not live under `project_root` is a
-                // symlinked workspace dep (esbuild canonicalised it). Collect it
-                // so the watcher can register it as an extra target (#1284 D4).
-                for (dep, _) in &edges {
-                    if !dep.starts_with(project_root) {
-                        new_out_of_root.push(dep.clone());
+
+                for real in &route.module_deps {
+                    edges.push((real.clone(), zfb_graph::DepKind::Module));
+                    // A real dep path outside `project_root` is a symlinked
+                    // workspace dep (esbuild canonicalised it). Collect it so
+                    // the watcher can register it as an extra target (#1284 D4).
+                    if !real.starts_with(project_root) {
+                        new_out_of_root.push(real.clone());
                     }
                 }
+
                 g.upsert(PageDeps::new(page_id, edges));
             }
         }
@@ -5425,15 +5432,28 @@ fn make_discovery_hook(
         // Upsert each newly-created content file as a content dep of the
         // rediscovered source pages, so subsequent EDITs of the new file
         // map to their consumer page in the graph (matching how a
-        // pre-existing post behaves). `upsert` merges deps, so this does
-        // not clobber the page's other edges.
+        // pre-existing post behaves). `upsert` REPLACES a page's dep set,
+        // so MERGE: preserve the page's existing non-`Content` deps — in
+        // particular the `DepKind::Module` edges #1287 populates from the
+        // metafile — and re-assert the Content edges alongside them. (The
+        // self-edge is re-added by `upsert`.) Without this merge, a content-
+        // file creation would silently drop a route's component edges until
+        // the next full bundle refresh re-derived them (#1284/#1287).
         if !changed.is_empty() {
             if let Ok(mut g) = graph.lock() {
                 for page in &changed {
-                    let deps: Vec<(PathBuf, zfb_graph::DepKind)> = relevant
-                        .iter()
-                        .map(|c| (c.clone(), zfb_graph::DepKind::Content))
+                    let mut deps: Vec<(PathBuf, zfb_graph::DepKind)> = g
+                        .deps_of(page)
+                        .into_iter()
+                        .filter(|(dep, kind)| {
+                            *kind != zfb_graph::DepKind::Content && dep != page.path()
+                        })
                         .collect();
+                    deps.extend(
+                        relevant
+                            .iter()
+                            .map(|c| (c.clone(), zfb_graph::DepKind::Content)),
+                    );
                     g.upsert(PageDeps::new(page.clone(), deps));
                 }
             }

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -138,6 +138,11 @@ const DEFAULT_WATCH_ROOTS: &[&str] = &[
     "layouts",
     "styles",
     "data",
+    // `src` is a classification / islands / client-script root (policy.rs) and
+    // routes commonly import components from `src/components/**`. Without it,
+    // `src/**` edits fire no FS event and no tick at all, so a consuming route
+    // never re-renders (#1284 symptom-A, watch half).
+    "src",
     "zfb.config.json",
     "zfb.config.ts",
 ];
@@ -457,6 +462,21 @@ pub async fn run(args: &DevArgs) -> Result<()> {
     let graph = Arc::new(Mutex::new(DependencyGraph::new()));
     let graph_for_save = Arc::clone(&graph);
 
+    // #1284/#1287 — give the dev session a handle to the same graph so every
+    // bundle refresh populates per-route `DepKind::Module` edges from esbuild's
+    // metafile (`populate_module_edges`). The graph is created here, AFTER
+    // `boot_dev_renderer` returns, so the boot bundle's edges are seeded by the
+    // first post-boot refresh; from then on a component edit maps to its
+    // consuming route via `dirty_pages`.
+    #[cfg(feature = "embed_v8")]
+    if let Some(session) = dev_session.as_ref() {
+        session.set_dep_graph(Arc::clone(&graph));
+        // Seed the eager boot bundle's Module edges now the graph exists, so a
+        // component edit maps to its consuming route from the first edit tick
+        // (#1284/#1287). No-op on the deferred-boot path.
+        session.seed_boot_module_edges();
+    }
+
     // Issue #1166 — the manifest digest is now produced inside the
     // deferred task (it is the expensive walk we moved past bind). The
     // shutdown persistence path (step 8) reads it through this shared
@@ -484,7 +504,24 @@ pub async fn run(args: &DevArgs) -> Result<()> {
     // share the tick path's validate → dedup → atomic-write → commit
     // discipline and its tick-vs-request exclusion (#1024).
     let request_writer = pipeline.request_writer();
-    let extra_watch_paths = resolve_extra_watch_paths(&cfg.extra_watch_paths);
+    let mut extra_watch_paths = resolve_extra_watch_paths(&cfg.extra_watch_paths);
+    // #1284/#1287 (D4) — register the eager boot bundle's out-of-root real
+    // Module deps (canonicalised symlink targets of workspace `.tsx` deps
+    // esbuild resolved through `node_modules`) as extra watch targets, so an
+    // edit of the real workspace file fires a tick. `notify` does not follow
+    // symlinks and `node_modules` is excluded from the recursive watch, so
+    // without this a symlinked workspace component edit produces no event. The
+    // in-repo `src/**` case needs none of this — it is covered by
+    // `DEFAULT_WATCH_ROOTS`. Empty on the deferred-boot path (the boot bundle
+    // has not run yet there; that case relies on the in-repo `src` root).
+    #[cfg(feature = "embed_v8")]
+    if let Some(session) = dev_session.as_ref() {
+        for target in session.out_of_root_watch_targets() {
+            if !extra_watch_paths.contains(&target) {
+                extra_watch_paths.push(target);
+            }
+        }
+    }
     // Configured collection roots classify as Content ahead of the
     // standard root-segment walk — without this, a collection under
     // `src/` (e.g. `src/mdx/notes`) classifies as Module and wastefully
@@ -1219,7 +1256,16 @@ pub async fn run(args: &DevArgs) -> Result<()> {
             if let Some(ref session) = dev_session_for_boot {
                 if let Ok(mut g) = graph_for_seed.lock() {
                     for page_id in session.page_ids() {
-                        g.upsert(PageDeps::new(page_id, vec![]));
+                        // Non-clobbering seed: `upsert` REPLACES a page's dep
+                        // set, so an unconditional empty-dep upsert here would
+                        // wipe the per-route `DepKind::Module` edges the
+                        // deferred `refresh_bundle_and_routes` above already
+                        // populated from the metafile (#1284/#1287). Only seed
+                        // pages the graph does not yet know, so edge-carrying
+                        // pages keep their edges.
+                        if !g.knows(page_id.path()) {
+                            g.upsert(PageDeps::new(page_id, vec![]));
+                        }
                     }
                 }
             }
@@ -2506,6 +2552,39 @@ struct DevRenderInner {
     #[cfg(feature = "embed_v8")]
     shadow_session: Mutex<Option<ShadowSession>>,
 
+    /// Dependency graph handle for populating per-route `DepKind::Module`
+    /// edges from esbuild's metafile on every bundle refresh (#1284/#1287).
+    /// Installed after boot via [`DevRenderSession::set_dep_graph`] — the
+    /// graph is created by `run` AFTER `boot_dev_renderer` returns, so it is
+    /// `None` until then (and on the test/scaffold constructors that never
+    /// run the real refresh). When present, [`Self::refresh_bundle_and_routes`]
+    /// upserts each route's transitive module deps so a component edit
+    /// (direct or transitive, incl. symlinked workspace `.tsx`) maps to its
+    /// consuming route via `dirty_pages`, instead of falling back to a blunt
+    /// whole-site re-render.
+    #[cfg(feature = "embed_v8")]
+    dep_graph: Mutex<Option<Arc<Mutex<DependencyGraph>>>>,
+
+    /// Real on-disk module-dep paths that live OUTSIDE `project_root` —
+    /// canonicalised symlink targets of workspace `.tsx` deps esbuild resolved
+    /// through `node_modules` (#1284/#1287, D4). `notify` does not follow
+    /// symlinks and `node_modules` is excluded from the recursive watch, so
+    /// these must be registered as `extraWatchPaths`-style targets for an edit
+    /// of the real workspace file to fire a tick. Accumulated by
+    /// [`Self::populate_module_edges`] every refresh; read by `run` to extend
+    /// the watcher's extra targets. A `BTreeSet`-backed dedup keeps it stable.
+    #[cfg(feature = "embed_v8")]
+    out_of_root_watch_targets: Mutex<std::collections::BTreeSet<PathBuf>>,
+
+    /// The eager boot bundle's per-route metafile Module deps (#1284/#1287),
+    /// captured in `boot_dev_renderer` before the graph exists. `run` seeds
+    /// these into the graph via [`Self::populate_module_edges`] right after
+    /// installing the graph handle, so a component edit maps to its consuming
+    /// route from the very first edit tick (not one tick late). Empty on the
+    /// deferred-boot path (its `refresh_bundle_and_routes` seeds edges itself).
+    #[cfg(feature = "embed_v8")]
+    boot_route_module_deps: Vec<zfb_build::RouteModuleDeps>,
+
     /// Cross-tick [`PathsCache`] (#994 item B): seeded at boot and
     /// passed into every route-table build, so a `paths()` JSON output
     /// identical to a previous tick's skips the Rust-side
@@ -2790,6 +2869,104 @@ impl DevRenderSession {
     /// stale routes through the same handle.
     pub(crate) fn renderer_handle(&self) -> Arc<Mutex<Option<RendererState>>> {
         Arc::clone(&self.inner.renderer)
+    }
+
+    /// Install the dependency-graph handle so every bundle refresh can
+    /// populate per-route `DepKind::Module` edges from esbuild's metafile
+    /// (#1284/#1287). Called by `run` once the graph exists (it is created
+    /// after `boot_dev_renderer` returns). Idempotent — a later call replaces
+    /// the handle.
+    #[cfg(feature = "embed_v8")]
+    pub(crate) fn set_dep_graph(&self, graph: Arc<Mutex<DependencyGraph>>) {
+        if let Ok(mut slot) = self.inner.dep_graph.lock() {
+            *slot = Some(graph);
+        }
+    }
+
+    /// Seed the graph with the eager boot bundle's per-route Module edges
+    /// (#1284/#1287), captured before the graph existed. Call once right after
+    /// [`Self::set_dep_graph`]. No-op on the deferred-boot path (its deps are
+    /// empty; the deferred refresh seeds edges itself) and idempotent.
+    #[cfg(feature = "embed_v8")]
+    pub(crate) fn seed_boot_module_edges(&self) {
+        let deps = self.inner.boot_route_module_deps.clone();
+        self.populate_module_edges(&deps);
+    }
+
+    /// Upsert each route's transitive module deps (from esbuild's metafile)
+    /// as `DepKind::Module` edges, so a component edit maps to its consuming
+    /// route via `dirty_pages`. No-op when the graph handle is not installed
+    /// or the bundle carried no metafile deps (e.g. the mock/scaffold path).
+    ///
+    /// `upsert` REPLACES a page's prior dep set, so calling this every refresh
+    /// keeps the Module edges in lock-step with the live import graph — a
+    /// removed import drops its edge on the next tick. Content edges added by
+    /// the discovery hook live on different pages' upserts and the page
+    /// self-edge is re-added by `upsert`, so this does not clobber them for
+    /// the routes it owns; a route that imports both content and components
+    /// gets its Content deps via the discovery path and Module deps here on
+    /// the same `PageId`, and the LAST writer wins per tick — Module deps are
+    /// re-derived from the authoritative metafile every tick, so they are the
+    /// safe steady-state. (Content deps are re-asserted by the discovery hook
+    /// whenever a content file is (re)discovered.)
+    #[cfg(feature = "embed_v8")]
+    fn populate_module_edges(&self, deps: &[zfb_build::RouteModuleDeps]) {
+        if deps.is_empty() {
+            return;
+        }
+        let graph = {
+            let slot = match self.inner.dep_graph.lock() {
+                Ok(s) => s,
+                Err(_) => return,
+            };
+            match slot.as_ref() {
+                Some(g) => Arc::clone(g),
+                None => return,
+            }
+        };
+        let project_root = &self.inner.project_root;
+        let mut new_out_of_root: Vec<PathBuf> = Vec::new();
+        if let Ok(mut g) = graph.lock() {
+            for route in deps {
+                // The page key must match how the rest of the dev graph keys
+                // pages (project-root-joined absolute path — see the boot seed
+                // and the Content upsert path).
+                let page_id = PageId::new(project_root.join(&route.source_path));
+                let edges: Vec<(PathBuf, zfb_graph::DepKind)> = route
+                    .module_deps
+                    .iter()
+                    .map(|p| (p.clone(), zfb_graph::DepKind::Module))
+                    .collect();
+                // A real dep path that does not live under `project_root` is a
+                // symlinked workspace dep (esbuild canonicalised it). Collect it
+                // so the watcher can register it as an extra target (#1284 D4).
+                for (dep, _) in &edges {
+                    if !dep.starts_with(project_root) {
+                        new_out_of_root.push(dep.clone());
+                    }
+                }
+                g.upsert(PageDeps::new(page_id, edges));
+            }
+        }
+        if !new_out_of_root.is_empty() {
+            if let Ok(mut set) = self.inner.out_of_root_watch_targets.lock() {
+                set.extend(new_out_of_root);
+            }
+        }
+    }
+
+    /// Snapshot of the out-of-root real Module-dep paths discovered so far
+    /// (#1284/#1287, D4) — canonicalised symlink targets of workspace `.tsx`
+    /// deps that must be registered as extra watch targets. Read by `run`
+    /// after the boot bundle so a symlinked workspace component edit fires a
+    /// tick (the in-repo `src/**` case is covered by `DEFAULT_WATCH_ROOTS`).
+    #[cfg(feature = "embed_v8")]
+    pub(crate) fn out_of_root_watch_targets(&self) -> Vec<PathBuf> {
+        self.inner
+            .out_of_root_watch_targets
+            .lock()
+            .map(|s| s.iter().cloned().collect())
+            .unwrap_or_default()
     }
 
     /// The boot-resolved lazy dev-render switch (issue #1025/#1026).
@@ -3171,6 +3348,15 @@ impl DevRenderSession {
         let p1_assemble_ms = bundle_result.sub_timing.as_ref().map(|t| t.assemble_ms);
         let p1_bundle_ms = bundle_result.sub_timing.as_ref().map(|t| t.bundle_ms);
         let bundler_out = bundle_result.output;
+
+        // #1284/#1287 — populate per-route `DepKind::Module` edges from the
+        // bundle's metafile so a component edit (direct or transitive, incl. a
+        // symlinked workspace `.tsx`) maps to its consuming route via
+        // `dirty_pages`. Done on EVERY refresh (before the skip-key early
+        // return below is irrelevant — the edges only change when the bundle
+        // changes, and a byte-identical bundle re-asserts identical edges, a
+        // cheap idempotent upsert). No-op until the graph handle is installed.
+        self.populate_module_edges(&bundler_out.route_module_deps);
 
         // P1b — skip-key compute (SHA-256 over bundle + router + static HTML).
         // Phase B (issue #940) — skip key check.
@@ -4446,6 +4632,12 @@ fn boot_dev_renderer(
     // every route until that publish lands, so first-accept is O(1) regardless
     // of project size. When `defer_bundle` is false, the eager pre-bind path
     // below runs exactly as before.
+    // #1284/#1287 — the eager boot bundle's per-route metafile Module deps,
+    // captured here and seeded into the graph once the session + graph handle
+    // exist (see the `set_dep_graph` + populate call in `run`). On the deferred
+    // path this stays empty; the deferred `refresh_bundle_and_routes` seeds the
+    // edges itself.
+    let mut boot_route_module_deps: Vec<zfb_build::RouteModuleDeps> = Vec::new();
     let (renderer, routes_by_source, ssr_routes, url_index) = if defer_bundle {
         (
             // Scaffold renderer slot — the deferred `refresh_bundle_and_routes`
@@ -4494,6 +4686,9 @@ fn boot_dev_renderer(
             rebuild_inputs.injected_pages_root(),
         )?
         .output;
+        // #1284/#1287 — capture the boot bundle's per-route Module deps for
+        // post-graph seeding (the graph does not exist yet at this point).
+        boot_route_module_deps = bundler_out.route_module_deps.clone();
 
         let state = start(RendererStartInput {
             bundle_path: bundler_out.bundle_path.clone(),
@@ -4564,6 +4759,9 @@ fn boot_dev_renderer(
             last_successful_skip_key: Mutex::new(None),
             fm_hashes: Mutex::new(fm_hashes),
             shadow_session: Mutex::new(Some(shadow_session)),
+            dep_graph: Mutex::new(None),
+            out_of_root_watch_targets: Mutex::new(std::collections::BTreeSet::new()),
+            boot_route_module_deps,
             paths_cache: Mutex::new(paths_cache),
             stale: Mutex::new(StaleRoutes::default()),
             lazy_render: lazy_dev_render_enabled(),
@@ -5434,6 +5632,9 @@ pub(crate) fn stub_session_for_adapter_tests(
             last_successful_skip_key: Mutex::new(None),
             fm_hashes: Mutex::new(HashMap::new()),
             shadow_session: Mutex::new(None),
+            dep_graph: Mutex::new(None),
+            out_of_root_watch_targets: Mutex::new(std::collections::BTreeSet::new()),
+            boot_route_module_deps: Vec::new(),
             paths_cache: Mutex::new(PathsCache::new()),
             stale: Mutex::new(StaleRoutes::default()),
             lazy_render,
@@ -5514,6 +5715,9 @@ mod tests {
             last_successful_skip_key: Mutex::new(None),
             fm_hashes: Mutex::new(HashMap::new()),
             shadow_session: Mutex::new(None),
+            dep_graph: Mutex::new(None),
+            out_of_root_watch_targets: Mutex::new(std::collections::BTreeSet::new()),
+            boot_route_module_deps: Vec::new(),
             paths_cache: Mutex::new(PathsCache::new()),
             stale: Mutex::new(StaleRoutes::default()),
             lazy_render: false,
@@ -7594,6 +7798,7 @@ mod tests {
                 bundle_basename: "bundle.js".into(),
                 routes: Vec::new(),
             },
+            route_module_deps: Vec::new(),
         }
     }
 

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -5953,19 +5953,42 @@ mod tests {
     }
 
     /// Regression: a collection configured outside the default watch
-    /// roots (e.g. `src/mdx/notes`) was never watched, so edits there
+    /// roots (e.g. `articles/notes`) was never watched, so edits there
     /// produced no rebuild and the dev server served stale HTML until
     /// restart. Discovered during usage in a consumer project with
     /// custom collection paths.
+    ///
+    /// Uses `articles/*` (outside every default root) because `src` is now
+    /// itself a default watch root (#1284) — a `src/**` collection would be
+    /// collapsed into `src` rather than appended (see
+    /// `derive_watch_roots_collapses_src_collection_into_src_default_root`).
     #[test]
     fn derive_watch_roots_appends_custom_collection_paths() {
-        let cfg = cfg_with_collections(&["src/mdx/notes", "src/mdx/guides"]);
+        let cfg = cfg_with_collections(&["articles/notes", "articles/guides"]);
         let roots = derive_watch_roots(&cfg);
-        assert!(roots.contains(&PathBuf::from("src/mdx/notes")));
-        assert!(roots.contains(&PathBuf::from("src/mdx/guides")));
+        assert!(roots.contains(&PathBuf::from("articles/notes")));
+        assert!(roots.contains(&PathBuf::from("articles/guides")));
         // Defaults are preserved in front.
         assert!(roots.contains(&PathBuf::from("pages")));
         assert!(roots.contains(&PathBuf::from("content")));
+    }
+
+    /// #1284 — `src` is now a default watch root, so a collection declared
+    /// under `src/**` is already covered by the recursive `src` watch and
+    /// must collapse into it rather than register a redundant overlapping
+    /// root (which would deliver duplicate events for the same write).
+    #[test]
+    fn derive_watch_roots_collapses_src_collection_into_src_default_root() {
+        let cfg = cfg_with_collections(&["src/mdx/notes", "src/mdx"]);
+        let roots = derive_watch_roots(&cfg);
+        assert!(roots.contains(&PathBuf::from("src")));
+        assert!(!roots.contains(&PathBuf::from("src/mdx")));
+        assert!(!roots.contains(&PathBuf::from("src/mdx/notes")));
+        assert_eq!(
+            roots.len(),
+            DEFAULT_WATCH_ROOTS.len(),
+            "a src-nested collection adds no watch root — `src` already covers it"
+        );
     }
 
     /// Issue #1165 — `public/` must NOT appear in the default watch roots.
@@ -6002,22 +6025,26 @@ mod tests {
 
     /// Nested collections collapse to the shallowest ancestor regardless
     /// of declaration order, and duplicates dedupe.
+    ///
+    /// Uses `articles/*` (outside every default root) so the nested-collapse
+    /// logic is exercised on a path that is genuinely appended — `src/**`
+    /// would instead collapse into the `src` default root (#1284).
     #[test]
     fn derive_watch_roots_collapses_nested_and_duplicate_collections() {
-        let cfg = cfg_with_collections(&["src/mdx/notes", "src/mdx", "src/mdx/notes"]);
+        let cfg = cfg_with_collections(&["articles/notes", "articles", "articles/notes"]);
         let roots = derive_watch_roots(&cfg);
-        assert!(roots.contains(&PathBuf::from("src/mdx")));
-        assert!(!roots.contains(&PathBuf::from("src/mdx/notes")));
+        assert!(roots.contains(&PathBuf::from("articles")));
+        assert!(!roots.contains(&PathBuf::from("articles/notes")));
         assert_eq!(roots.len(), DEFAULT_WATCH_ROOTS.len() + 1);
     }
 
-    /// Leading `./` is normalized away so `./src/mdx` and `src/mdx`
+    /// Leading `./` is normalized away so `./articles` and `articles`
     /// compare equal in the dedupe/coverage checks.
     #[test]
     fn derive_watch_roots_normalizes_leading_curdir() {
-        let cfg = cfg_with_collections(&["./src/mdx", "src/mdx"]);
+        let cfg = cfg_with_collections(&["./articles", "articles"]);
         let roots = derive_watch_roots(&cfg);
-        assert!(roots.contains(&PathBuf::from("src/mdx")));
+        assert!(roots.contains(&PathBuf::from("articles")));
         assert_eq!(roots.len(), DEFAULT_WATCH_ROOTS.len() + 1);
     }
 

--- a/crates/zfb/tests/dev_dep_invalidation_1284_e2e.rs
+++ b/crates/zfb/tests/dev_dep_invalidation_1284_e2e.rs
@@ -1,0 +1,101 @@
+//! Wave-3 ACCEPTANCE gate for bug #1284 (epic #1285), authored during the
+//! Wave-1 diagnosis (#1286). Level 4 — real `zfb dev` process, edit→serve loop.
+//!
+//! These scenarios reproduce the THREE symptoms that the existing
+//! `dev_serve_e2e.rs` scenario 4 does NOT cover (that scenario edits a
+//! *directly-imported* `components/**` file, which already re-renders today via
+//! the orchestrator's blunt `PageSelection::All` fallback):
+//!
+//! - **A** — editing a component under `src/**` (NOT a watch root) does not
+//!   re-render the consuming route. Acceptance: after the fix, editing
+//!   `src/components/*.tsx` makes the route serve the new marker on next
+//!   request.
+//! - **B** — editing a transitively-imported CSS file (incl. a symlinked
+//!   workspace dep reached via `@import`) does not refresh `/assets/styles.css`.
+//!   Acceptance: after the fix, editing the imported CSS makes
+//!   `/assets/styles.css` serve the new bytes.
+//! - **C** — a NEW Tailwind utility class added inside a component is not
+//!   emitted into `/assets/styles.css` until the CSS entry is touched.
+//!   Acceptance: after the fix, the new class appears in `/assets/styles.css`
+//!   without touching the CSS entry.
+//!
+//! ## D3 — the observable (locked by #1286)
+//!
+//! Under the lazy dev model (`lazy_render_tick` marks routes STALE; it does NOT
+//! eagerly write), the test observable is **served-HTML / served-asset on the
+//! NEXT request**, polled via `poll_until_*` — NOT an eager disk write. The SSE
+//! `page` event is asserted as a secondary signal (it fires via the
+//! `pages_stale` gate), exactly as `dev_serve_e2e.rs` scenario 4 does. For the
+//! CSS symptoms the observable is the body of `GET /assets/styles.css`.
+//!
+//! ## Status — these are STUBS, intentionally `#[ignore]`d
+//!
+//! They are tagged `#[ignore = "pending fix: #1284"]` so they neither block the
+//! T1 gate nor force a 15-30 min V8 first-compile in this diagnosis wave. The
+//! Wave-3 author un-ignores them and wires them into the shared `dev_serve_e2e`
+//! harness (reusing `spawn_dev` / `boot_and_handshake` / `poll_until_contains`
+//! / `subscribe_sse`), OR fills in the `todo!()` bodies below against a local
+//! copy of those helpers. They are kept as a separate file so the acceptance
+//! contract is reviewable independently of the fix.
+//!
+//! Falsifiability is noted per scenario: revert the corresponding fix and the
+//! served-on-next-request assertion times out on the OLD marker.
+
+// The bodies are deferred to Wave-3 (see module docs). Keeping them as
+// `#[ignore]`d `todo!()` stubs documents the exact acceptance contract without
+// pulling the private `dev_serve_e2e` harness into this file or forcing a V8
+// build now. `cargo test` skips `#[ignore]`d tests, so this stays green.
+
+/// SYMPTOM A acceptance — editing `src/components/Widget.tsx` re-renders the
+/// route that imports it. Observable (D3): `GET /` serves the new marker on the
+/// next request after the edit; an SSE `page` event fires.
+///
+/// Falsifiability: with `src/` still outside the watch roots (or the All-only
+/// selection), no tick fires / the bundle is not refreshed and the route keeps
+/// serving the old marker until timeout.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "pending fix: #1284"]
+async fn e2e_src_component_edit_rerenders_route() {
+    todo!(
+        "Wave-3: copy dev-loop-basic fixture, add src/components/Widget.tsx imported \
+         by pages/index.tsx, spawn `zfb dev`, subscribe SSE, edit the widget, assert \
+         an SSE `page` event then poll `GET /` until it serves the NEW marker."
+    );
+}
+
+/// SYMPTOM B acceptance — editing a transitively-imported CSS file (a local
+/// `@import './tokens.css'` and a symlinked workspace dep `@import
+/// '@scope/design-system'`) refreshes `/assets/styles.css`. Observable (D3):
+/// `GET /assets/styles.css` serves the new bytes on the next request.
+///
+/// Falsifiability: without the resolved-`@import` watch registration, the
+/// symlinked dep edit is observed by nobody and `/assets/styles.css` stays
+/// stale until timeout.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "pending fix: #1284"]
+async fn e2e_transitive_css_import_refreshes_stylesheet() {
+    todo!(
+        "Wave-3: add styles/styles.css with `@import './tokens.css';` and a symlinked \
+         workspace `@import '@scope/design-system';`, spawn `zfb dev`, edit tokens.css \
+         AND the symlinked dep's real file, poll `GET /assets/styles.css` until both \
+         new declarations appear."
+    );
+}
+
+/// SYMPTOM C acceptance — a NEW utility class added inside a component is
+/// emitted into `/assets/styles.css` WITHOUT touching the CSS entry. Observable
+/// (D3): `GET /assets/styles.css` contains the generated rule for the new class
+/// (e.g. `gap-x-hgap-2xs`, `xl:grid-cols-[2.35fr_1fr]`) on the next request.
+///
+/// Falsifiability: without the Module→`mark_css` re-scan AND `src/` in the scan
+/// roots, the class never enters the content scan and the stylesheet never
+/// gains the rule.
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "pending fix: #1284"]
+async fn e2e_new_utility_class_in_component_is_emitted() {
+    todo!(
+        "Wave-3: edit a component to add a previously-unused utility class \
+         (e.g. `gap-x-hgap-2xs`), do NOT touch the CSS entry, poll \
+         `GET /assets/styles.css` until the generated rule for that class appears."
+    );
+}

--- a/crates/zfb/tests/dev_dep_invalidation_1284_e2e.rs
+++ b/crates/zfb/tests/dev_dep_invalidation_1284_e2e.rs
@@ -30,7 +30,7 @@
 //!
 //! ## Status — these are STUBS, intentionally `#[ignore]`d
 //!
-//! They are tagged `#[ignore = "pending fix: #1284"]` so they neither block the
+//! They are tagged `#[ignore = "Level-4 e2e: implement+run on a V8 host — #1290"]` so they neither block the
 //! T1 gate nor force a 15-30 min V8 first-compile in this diagnosis wave. The
 //! Wave-3 author un-ignores them and wires them into the shared `dev_serve_e2e`
 //! harness (reusing `spawn_dev` / `boot_and_handshake` / `poll_until_contains`
@@ -54,7 +54,7 @@
 /// selection), no tick fires / the bundle is not refreshed and the route keeps
 /// serving the old marker until timeout.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "pending fix: #1284"]
+#[ignore = "Level-4 e2e: implement+run on a V8 host — #1290"]
 async fn e2e_src_component_edit_rerenders_route() {
     todo!(
         "Wave-3: copy dev-loop-basic fixture, add src/components/Widget.tsx imported \
@@ -72,7 +72,7 @@ async fn e2e_src_component_edit_rerenders_route() {
 /// symlinked dep edit is observed by nobody and `/assets/styles.css` stays
 /// stale until timeout.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "pending fix: #1284"]
+#[ignore = "Level-4 e2e: implement+run on a V8 host — #1290"]
 async fn e2e_transitive_css_import_refreshes_stylesheet() {
     todo!(
         "Wave-3: add styles/styles.css with `@import './tokens.css';` and a symlinked \
@@ -91,7 +91,7 @@ async fn e2e_transitive_css_import_refreshes_stylesheet() {
 /// roots, the class never enters the content scan and the stylesheet never
 /// gains the rule.
 #[tokio::test(flavor = "multi_thread")]
-#[ignore = "pending fix: #1284"]
+#[ignore = "Level-4 e2e: implement+run on a V8 host — #1290"]
 async fn e2e_new_utility_class_in_component_is_emitted() {
     todo!(
         "Wave-3: edit a component to add a previously-unused utility class \

--- a/research/1284-dev-dep-invalidation.md
+++ b/research/1284-dev-dep-invalidation.md
@@ -1,0 +1,273 @@
+# #1284 — dev dependency-invalidation diagnosis (epic #1285, Wave-1 #1286)
+
+Reproduces and pins the root cause of the three symptoms in `zfb dev`, locks the
+infrastructure decisions the two Wave-2 fix agents (#1287 routes, #1288 css)
+depend on, and ships one failing reproduction test per symptom.
+
+All findings below were **empirically confirmed** (not just code-read) via the
+Level-1 reproduction tests added in this PR (run with `--no-default-features` to
+skip the V8 first-compile):
+
+```sh
+cargo test -p zfb-graph                       --test dev_dep_invalidation_1284
+cargo test -p zfb-build --no-default-features --test dev_dep_invalidation_1284
+cargo test -p zfb-css                         --test dev_dep_invalidation_1284
+```
+
+---
+
+## Symptom → exact failing code path
+
+### Symptom A — component edit does not re-render the consuming route
+
+Editing `src/components/**` (and, imprecisely, `components/**`), direct OR
+transitively imported, does not correctly re-render the consuming route.
+
+Two distinct gaps compound:
+
+1. **Watch gap (`src/`).** `DEFAULT_WATCH_ROOTS`
+   (`crates/zfb/src/commands/dev.rs:134`) = `pages, content, components, layouts,
+   styles, data` (+ collection roots, + config). **`src/` is NOT watched.** So an
+   edit under `src/components/**` produces **no FS event and no tick at all** —
+   nothing re-renders. (`src/` *is* a classification/islands/client-script root —
+   `policy.rs:237`, `policy.rs:273`, `GranularityPolicy::default().islands_roots`
+   — but classification only matters once a tick fires, which it never does.)
+2. **Graph-edge gap + blunt fallback (`components/`).** In the DEV path the graph
+   is seeded with page nodes carrying **no dep edges**
+   (`dev.rs:1222` → `PageDeps::new(page_id, vec![])`); thereafter only
+   `DepKind::Content` edges are upserted (`dev.rs:5237`). **No `Module` (page→
+   component) edges are ever populated in dev.** So `graph.dirty_pages(component)`
+   returns the **empty set** (`crates/zfb-graph/src/lib.rs:591` — it reads only
+   the `reverse` index). The orchestrator's `Page|Module|Content|Data` arm
+   (`crates/zfb-build/src/orchestrator.rs:452-466`) then hits its
+   `dirty.is_empty()` → `PageSelection::All` fallback.
+
+   **Empirically confirmed:** a `components/Header.tsx` edit selects
+   `PageSelection::All` today (`current_component_edit_selects_all_pages_imprecisely`).
+   So a *directly-imported* `components/**` edit DOES re-render — over-broadly,
+   every page — which is exactly why the existing
+   `dev_serve_e2e.rs` *scenario 4* passes. The #1284 defect surface for symptom A
+   is therefore: (i) `src/**` not watched (no tick), and (ii) the All-fallback is
+   imprecise (whole-site re-render on any component edit), masking the missing
+   per-route edges.
+
+**This is a route-SELECTION problem, confirmed — NOT a bundle-freshness problem.**
+`reload_renderer`/`refresh_bundle_and_routes()` re-bundles SSR from disk on every
+page-selecting tick (`dev.rs:~2470`), so once a route is *selected*, it renders
+from fresh bundle bytes. The fix is to make `dirty_pages(component)` non-empty
+(precise per-route selection), not to touch bundle freshness.
+
+**Fix approach (#1287):** populate per-route `DepKind::Module` edges in the dev
+graph from esbuild's metafile `inputs` (see D1); add `src` to the dev watch roots
+so `src/**` edits fire a tick at all (see D4-component-part).
+
+### Symptom B — transitively-imported CSS does not refresh `/assets/styles.css`
+
+Editing a CSS file reached transitively (`@import './x.css'`, or a symlinked
+workspace dep via `@import '@scope/design-system'`) does not refresh the served
+`/assets/styles.css`.
+
+Failing paths:
+
+- **Style-arm asymmetry.** The `Style` arm
+  (`orchestrator.rs:480-487`) sets `rerun_css` but, unlike the
+  `Page|Module|Content|Data` arm, does **NOT** fall back to `All` when
+  `dirty_pages` is empty — it selects `Specific({})` (zero pages).
+  **Empirically confirmed:** `current_style_arm_selects_no_pages_without_edges`.
+  (For pure CSS-asset refresh the page set does not matter — `rerun_css` is what
+  rebuilds `/assets/styles.css` — but the asymmetry is the orchestrator-level
+  tell, and it matters for CSS-Modules consumed by a `.tsx`.)
+- **No `@import` resolution in Rust.** `zfb-css` does NOT resolve local CSS
+  `@import` file dependencies. `pipeline.rs` only **hoists** `@import` at-rules
+  (`hoist_external_imports`, `pipeline.rs:347`) and
+  `build_synthesised_entry_css` (`engine.rs:392`) passes user CSS through
+  verbatim; the Tailwind CLI resolves `@import` invisibly. So zfb never learns
+  the real dependency path of an imported CSS file → no Style edge, and (critical
+  for the workspace case) **no watch target** for the symlinked real file.
+- **Watch gap (symlink).** `notify` is started `RecursiveMode::Recursive`
+  (`crates/zfb-watcher/src/lib.rs:181`) and **does not follow symlinks**, so a
+  workspace `@import '@scope/design-system'` resolving through a `node_modules`
+  symlink (and `node_modules` is excluded anyway) is never watched (see D4).
+
+**Fix approach (#1288):** resolve the CSS `@import` graph to canonicalised real
+paths (D2), register those real paths as extra watch targets (D4), and add the
+Module→`mark_css` re-scan trigger (see ownership split).
+
+### Symptom C — new utility class in a component is not emitted
+
+A NEW Tailwind utility class authored inside a component (e.g.
+`gap-x-hgap-2xs`, `xl:grid-cols-[2.35fr_1fr]`) is not emitted into
+`/assets/styles.css` until the CSS entry is touched.
+
+Failing paths:
+
+- **Scan roots omit `src/`.** `DEFAULT_CONTENT_ROOTS`
+  (`crates/zfb-css/src/engine.rs:876`) = `pages, components, layouts, content` —
+  **omits `src/`** — and `default_source_directives` (`engine.rs:880`) emits
+  `@source` directives only for those. So a class in `src/components/**` is
+  outside every scanned glob and never reaches the generated stylesheet.
+  **Empirically confirmed:** `current_bug_src_root_is_not_a_scan_root`.
+- **CSS pipeline never re-runs on a `.tsx` edit.** The CSS pipeline runs only on
+  `plan.rerun_css`, which only a `.css` (`PathClass::Style`) edit sets today. A
+  `.tsx` `Module` edit never sets `rerun_css`, so even a class authored in a
+  *watched* `components/**` file is not re-scanned until the CSS entry is touched.
+
+**Fix approach (#1288):** add `src` to `DEFAULT_CONTENT_ROOTS`/`@source`, and add
+the single Module→`mark_css` edit so any component edit re-runs the content scan.
+
+---
+
+## LOCKED DECISIONS
+
+### D1 — per-route module-dep source (for #1287)
+
+**Decision: invoke esbuild with `--metafile=<path>` and parse `metafile.inputs`
+to build the per-route transitive `DepKind::Module` edge set.**
+
+`BundlerOutput` / `BundleManifest` (`crates/zfb-build/src/bundler.rs:733-769`)
+expose route source paths (`RouteEntry.source_path`) but **no per-route
+transitive-import list**. Today esbuild is invoked in `run_esbuild`
+(`bundler.rs:5414`) **without** `--metafile` (confirmed: the arg list at
+`bundler.rs:5421-5500` has `--bundle --format=esm --platform=neutral … ` but no
+metafile). esbuild already runs once per dev bundle, the metafile is a free
+by-product (`--metafile=<tmp>.json`), and `inputs` is the canonical
+*transitive* import graph esbuild itself resolved — no second resolver pass to
+drift from the real bundle.
+
+- **Rejected:** a separate Rust import-resolve pass. It would re-implement
+  esbuild's resolution (tsconfig paths, aliases, `.mdx`/`.md` loaders, plugin
+  virtual modules) and is guaranteed to drift from what actually got bundled.
+- **Mechanism:** add `--metafile` to `run_esbuild`; after the subprocess, read
+  the JSON, and for each `output` whose entryPoint maps to a route, walk its
+  `inputs` to the source files, then `graph.upsert(PageDeps::new(route_page,
+  module_edges))`. Bundle-relative input paths are joined to the project root /
+  shadow root and canonicalised so they match watcher event paths.
+- **Lowest-risk note:** the metafile reflects the **shadow tree** esbuild reads;
+  map shadow paths back to real project paths using the same
+  shadow↔real mapping `run_esbuild` already maintains (the `copy_mode` /
+  `--preserve-symlinks` logic at `bundler.rs:1559-1570`) so edges key on the
+  paths the watcher will actually report.
+
+### D2 — CSS `@import` dependency source (for #1288)
+
+**Decision: parse the `@import` graph in Rust over the project's CSS sources,
+following each `@import` target to a canonicalised real path; do NOT try to
+harvest Tailwind's dependency output.**
+
+Justification: the Tailwind v4 standalone CLI exposes **no machine-readable
+dependency manifest** for what it pulled in (it has a `--watch` mode but emits no
+dep list zfb can consume), and zfb already shells out to it as an opaque
+`-i/-o` transform (`engine.rs:859`). A small Rust `@import` resolver is
+deterministic, testable at Level 1, and — critically — lets us **canonicalise**
+each target (`std::fs::canonicalize`) to follow the workspace symlink to the real
+file, which is exactly the watch target D4 needs. zfb already owns CSS text
+parsing for hoisting (`pipeline.rs:hoist_external_imports`), so the parsing
+surface is familiar.
+
+- **Scope:** resolve `@import "..."` / `@import url(...)` targets that resolve to
+  on-disk files (relative paths, and bare specifiers resolved against
+  `node_modules`/workspace), recursively; skip `@import "tailwindcss"` and other
+  virtual/builtin specifiers. Return the canonicalised real path set.
+- **Two consumers:** (1) register the real paths as Style edges / watch targets;
+  (2) feed them into the dev watcher as extra watch roots (D4).
+
+### D3 — symptom-A observable under the lazy model
+
+**Decision: the test observable is *served-HTML on the NEXT request* (polled via
+`poll_until_contains` against the route), with the SSE `page` event asserted as a
+secondary signal.**
+
+`lazy_render_tick` (`dev.rs:5017`) marks selected routes **STALE** (re-render on
+next request) for a `.tsx`/non-content tick — it does NOT eagerly write the HTML.
+This is exactly how `dev_serve_e2e.rs` *scenario 4* (`L1003-1080`) already
+asserts a component edit: it (a) asserts an SSE `page` event fires (via the
+`pages_stale` gate), then (b) `poll_until_contains` the route until it serves the
+new marker (lazy: the first request renders + write-through). The acceptance
+tests for #1284 use the **same** observable:
+
+- **Primary (must):** `GET <route>` (or `GET /assets/styles.css` for B/C) serves
+  the new marker/bytes on the next request → `poll_until_contains` /
+  `poll_until_file_contains` after the request.
+- **Secondary:** an SSE `page` event (`next_sse_event_name == Some("page")`).
+- Do **NOT** assert an eager disk write for the lazy default (the sibling stays
+  stale until requested — `assert_file_lacks` is the lazy discriminator).
+
+### D4 — symlinked-dep watch decision
+
+- **Confirmed:** `notify` does not follow symlinks (started
+  `RecursiveMode::Recursive`, `zfb-watcher/src/lib.rs:181`; the watcher already
+  supports out-of-root `extra` targets at `lib.rs:201`, the `extraWatchPaths`
+  channel).
+- **CSS (#1288):** the `@import` resolver (D2) yields **canonicalised real
+  paths** following the workspace symlink; #1288 registers those real paths as
+  `extraWatchPaths`-style watch targets automatically — **no manual user
+  config**. An out-of-root real path then arrives at the orchestrator's
+  `External`/`Style` handling; the resolved Style edge makes it map correctly.
+- **Components (.tsx) (for #1287):** a symlinked workspace **component** dep does
+  NOT need a separate manual watch story — it is covered by the **bundler/metafile
+  path (D1)**. esbuild resolves through the symlink and records the real input in
+  the metafile; that real path becomes a `Module` edge. **However**, the real
+  path must also be **watched** for an edit to fire a tick — so #1287 must
+  register the metafile-discovered out-of-root real `Module` deps as extra watch
+  targets too (mirroring how #1288 registers CSS real paths). For in-repo `src/**`
+  (the common case), the simpler fix is **adding `src` to `DEFAULT_WATCH_ROOTS`**
+  so those edits are watched directly.
+
+---
+
+## Orchestrator ownership split (so #1287 and #1288 do not collide)
+
+- **#1287 owns** the `Page|Module` page-SELECTION path: replacing the blunt
+  `dirty.is_empty() → PageSelection::All` fallback
+  (`orchestrator.rs:462-466`) with precise per-route selection backed by the new
+  `Module` edges (D1), plus adding `src` to the dev watch roots and registering
+  out-of-root `Module` real paths as watch targets (D4-component-part).
+  **#1287 must NOT touch the `mark_css` Module trigger below** — that is #1288's.
+
+- **#1288 owns** the `Style` arm (`orchestrator.rs:480-487`) AND the single
+  **Module-edit → CSS content re-scan** edit. **Exact insertion point:** inside
+  the `Page|Module|Content|Data` arm, immediately after the existing islands
+  block at `orchestrator.rs:473-478`, add a sibling guard:
+
+  ```rust
+  // (existing)
+  if matches!(class, PathClass::Module)
+      && self.config.policy.is_islands_candidate(&path)
+  {
+      plan.mark_islands();
+  }
+  // (#1288 ADDS, right here at ~L478:)
+  if matches!(class, PathClass::Module) {
+      plan.mark_css(); // a component edit may author a new utility class (symptom C)
+  }
+  ```
+
+  This is the **only** orchestrator edit #1288 makes inside the `Page|Module` arm;
+  it is additive (a new `if`), so it does not conflict with #1287's rewrite of the
+  *page-selection* lines (`L462-467`) in the same arm. The `mark_css()` helper is
+  `plan.rs:218`. #1288 also adds `src` to `DEFAULT_CONTENT_ROOTS`/`@source`
+  (`engine.rs:876`) and implements the D2 resolver + D4 CSS watch registration.
+
+---
+
+## Reproduction tests (all `#[ignore = "pending fix: #1284"]` for fixed-behaviour)
+
+| File | Level | Symptom | What it pins |
+|---|---|---|---|
+| `crates/zfb-graph/tests/dev_dep_invalidation_1284.rs` | 1 | A, B | dev graph has no Module/Style edges → `dirty_pages` empty (2 current-bug asserts pass now; 3 fixed-behaviour ignored) |
+| `crates/zfb-build/tests/dev_dep_invalidation_1284.rs` | 1 | A, B | `plan_for_changes` Page\|Module All-fallback vs Style-arm zero-pages asymmetry (2 current-bug pass now; 2 fixed ignored). **Build with `--no-default-features`.** |
+| `crates/zfb-css/tests/dev_dep_invalidation_1284.rs` | 1 | C, B | `DEFAULT_CONTENT_ROOTS`/`default_source_directives` omit `src/`; `@import` resolver contract placeholder (1 current-bug passes now; 2 fixed ignored) |
+| `crates/zfb/tests/dev_dep_invalidation_1284_e2e.rs` | 4 | A, B, C | Wave-3 acceptance gate stubs, fully `#[ignore]`d `todo!()` bodies wired to the D3 observable. Compiles (verified `--no-default-features`); full V8 dev-e2e run is the manager's job |
+
+The non-ignored "current_bug_*" tests **assert today's broken behaviour** to lock
+the regression boundary; they are NOT ignored and pass now. The fixed-behaviour
+tests are `#[ignore]`d so `cargo test` stays green until the fix waves un-ignore
+them.
+
+### What was NOT tested (blind spots)
+
+- The full Level-4 V8 dev-e2e loop was **not run** (first-compile 15-30 min; the
+  e2e stubs are `#[ignore]`d `todo!()` and deferred to Wave-3 / the manager).
+- The metafile-parsing path (D1) has no test yet — it does not exist until #1287.
+- Symptom A's `src/**` watch gap is reasoned + reproduced at the config/graph
+  level (`DEFAULT_WATCH_ROOTS` omits `src`), not via a live FS-watch e2e here.


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1285

---

## Summary

Fixes #1284 (epic #1285): in `zfb dev`, editing a `pages/**` route re-rendered, but editing an **imported component** (`src/components/**`), a **transitively-imported CSS file** (incl. a symlinked workspace dep via `@import '@scope/design-system'`), or adding a **new Tailwind class inside a component** did not invalidate the dependent route / refresh `/assets/styles.css` until the page or CSS entry was `touch`ed. This wires up dependency-graph invalidation + Tailwind content re-scan so any source a route depends on invalidates it.

## Root causes fixed
1. The dev graph never recorded page→component (`DepKind::Module`) edges (only `DepKind::Content`), so `dirty_pages(component)` was empty and consumers were never marked stale.
2. Transitively-imported / symlinked CSS edits weren't tracked or watched (`notify` doesn't follow symlinks), and a `.tsx` edit never re-ran the Tailwind content scan; `DEFAULT_CONTENT_ROOTS`/`DEFAULT_WATCH_ROOTS` omitted `src/`.

## Changes (3 waves under epic #1285)
- **#1286 diagnosis** — pinned root causes, locked 4 decisions (D1–D4), added Level-1 reproduction tests + `research/1284-dev-dep-invalidation.md`.
- **#1287 routes** — esbuild `--metafile` → per-route transitive `DepKind::Module` edges (`crates/zfb-build/src/metafile_deps.rs`); `graph.knows()` selection guard; orchestrator `Page|Module` selection rewrite; `src` watch root; out-of-root symlink watch targets; discovery-hook Content upsert made merge-preserving.
- **#1288 css** — Rust `@import` resolver → canonicalized real paths (`crates/zfb-css/src/css_imports.rs`); `src` content root; additive `Module → mark_css` guard; auto-watch of resolved CSS imports (incl. symlinked workspace deps).

## Testing
- **Level 1 (green):** `zfb-graph`, `zfb-css`, `zfb-build` (`--no-default-features`) suites incl. the un-ignored reproduction tests for all three symptoms; `cargo fmt --check` clean; `build-no-v8` compiles.
- **Level 4 (deferred):** the dev-e2e acceptance tests (`crates/zfb/tests/dev_dep_invalidation_1284_e2e.rs`) stay `#[ignore]`d — they need a V8 host + running dev server, which the web env can't run (fresh-V8 rustc ICE). The full `embed_v8` workspace build/test runs in CI. Implementing + running them on a V8 host is tracked in #1290.

## Review
Step-9 Opus code review: **SOUND, no blockers/high.** One MEDIUM (persisted-graph load clobbering boot Module edges — self-healing on first tick) and LOW refinements are tracked in #1290. The css `/light-review` found + fixed a UTF-8 panic in the `@import` scanner (committed).

## Follow-ups
- #1290 — boot-time edge re-seed (MEDIUM), mid-session watch resolution (LOW), Level-4 e2e implementation (LOW).

---
_Generated by [Claude Code](https://claude.ai/code/session_014JcgbcmjRXPVnaTLj9wSer)_