### PR TITLE
[Dev Dep Invalidation Followups] boot-edge merge-not-replace, watch-target note, Level-4 e2e

### DIFF
--- a/crates/zfb-graph/src/lib.rs
+++ b/crates/zfb-graph/src/lib.rs
@@ -699,6 +699,107 @@ impl DependencyGraph {
         })
     }
 
+    /// Merge edges from a `persisted` graph into `self`, preserving any
+    /// existing `DepKind::Module` edges that `self` already carries.
+    ///
+    /// This is the boot-graph assembly step (#1293): on a digest cache hit the
+    /// dev command loads a persisted graph and wants to blend its
+    /// Content/Style/Data/Other edges (built up over previous sessions) into the
+    /// live graph without clobbering the `DepKind::Module` edges that
+    /// `seed_boot_module_edges` / `refresh_bundle_and_routes` already populated
+    /// from the current session's esbuild metafile.
+    ///
+    /// Rules:
+    ///
+    /// - For every page in `persisted`:
+    ///   - Collect the live graph's existing `DepKind::Module` edges for that
+    ///     page (may be empty when the page is not yet known to `self`).
+    ///   - **Module edges**: if `self` already has Module edges for the page
+    ///     (from `seed_boot_module_edges` / `refresh_bundle_and_routes`), those
+    ///     live edges are used as-is (more current than persisted). When the
+    ///     live graph has NO Module edges for the page (page not yet known to
+    ///     this session), the persisted Module edges are used instead so the
+    ///     page is not left edge-less.
+    ///   - **Non-Module edges** (Content, Style, Data, Asset, Other): always
+    ///     taken from `persisted` (the live graph has not yet accumulated them
+    ///     this session).
+    ///   - `upsert` the combined edge set so the reverse index is consistent.
+    /// - Globals: every path marked global in `persisted` is also marked global
+    ///   in `self` (additive; no globals are removed from `self`).
+    /// - Asset deps: for pages not already tracked in `self`'s asset layer,
+    ///   copy the asset record from `persisted`. Pages already tracked in
+    ///   `self` keep their live asset record (more current).
+    pub fn merge_from_persisted(&mut self, persisted: DependencyGraph) {
+        // Merge globals first: persisted globals cover files the live session
+        // has not yet re-evaluated.
+        for path in persisted.globals {
+            self.globals.insert(path);
+        }
+
+        // Merge per-page source edges.
+        for page in &persisted.pages {
+            // Live Module edges to preserve (from seed_boot_module_edges /
+            // refresh_bundle_and_routes, which ran before the cache load).
+            // The page self-edge is re-added by `upsert`; skip it here.
+            let live_module_edges: Vec<(PathBuf, DepKind)> = self
+                .forward
+                .get(page)
+                .map(|edges| {
+                    edges
+                        .iter()
+                        .filter(|(dep, kind)| *kind == DepKind::Module && dep != page.path())
+                        .cloned()
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            // Module edges to use: prefer live (more current, derived from the
+            // current session's esbuild metafile) when they exist; fall back to
+            // persisted when the page is not yet known to the live graph.
+            let module_edges = if live_module_edges.is_empty() {
+                persisted
+                    .forward
+                    .get(page)
+                    .map(|edges| {
+                        edges
+                            .iter()
+                            .filter(|(dep, kind)| *kind == DepKind::Module && dep != page.path())
+                            .cloned()
+                            .collect::<Vec<_>>()
+                    })
+                    .unwrap_or_default()
+            } else {
+                live_module_edges
+            };
+
+            // Non-Module edges from persisted (Content, Style, Data, Asset,
+            // Other). The self-edge is re-added by `upsert`; skip it here.
+            let persisted_non_module: Vec<(PathBuf, DepKind)> = persisted
+                .forward
+                .get(page)
+                .map(|edges| {
+                    edges
+                        .iter()
+                        .filter(|(dep, kind)| *kind != DepKind::Module && dep != page.path())
+                        .cloned()
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            let mut merged = module_edges;
+            merged.extend(persisted_non_module);
+            self.upsert(PageDeps::new(page.clone(), merged));
+        }
+
+        // Asset layer: copy persisted records for pages the live graph has
+        // not yet tracked. Live records are more current; do not overwrite.
+        for (page, asset_deps) in persisted.assets {
+            if !self.assets.contains_key(&page) {
+                self.set_assets_for_page(page, asset_deps);
+            }
+        }
+    }
+
     /// Snapshot for diagnostics: every (dep -> sorted consumers) pair, keyed
     /// for deterministic ordering. Mostly useful in tests.
     pub fn snapshot(&self) -> BTreeMap<PathBuf, Vec<PageId>> {

--- a/crates/zfb-graph/tests/boot_graph_assembly_1293.rs
+++ b/crates/zfb-graph/tests/boot_graph_assembly_1293.rs
@@ -1,0 +1,288 @@
+//! Regression tests for #1293: persisted-graph load must not clobber
+//! `DepKind::Module` edges that were populated before the cache load.
+//!
+//! # Background
+//!
+//! The dev boot sequence has two paths:
+//!
+//! - **Eager path**: `seed_boot_module_edges` populates Module edges into the
+//!   live graph synchronously at boot, BEFORE the deferred boot task loads the
+//!   persisted graph.
+//! - **Deferred path**: `refresh_bundle_and_routes` (inside the deferred boot
+//!   task, step 0) populates Module edges, THEN the cache load (step 2+3) runs.
+//!
+//! In both cases the cache load used to do `*g = persisted`, wholesale-replacing
+//! the graph and dropping any Module edges that had just been seeded.  The fix
+//! (#1293) switches to `merge_from_persisted`, which preserves live Module edges
+//! while blending in persisted non-Module edges.
+//!
+//! The `assemble_boot_graph` function in `dev.rs` wraps both the merge and the
+//! empty-seed step for unknown pages; these tests exercise `merge_from_persisted`
+//! directly because the types it operates on live in `zfb-graph`.
+
+use std::path::PathBuf;
+
+use zfb_graph::{AssetDeps, DepKind, DependencyGraph, DirtySet, PageDeps, PageId};
+
+fn p(s: &str) -> PathBuf {
+    PathBuf::from(s)
+}
+
+fn pid(s: &str) -> PageId {
+    PageId::new(p(s))
+}
+
+/// Regression: on a digest cache hit the Module edges seeded before the load
+/// must survive. The old `*g = persisted` wiped them; `merge_from_persisted`
+/// must not.
+#[test]
+fn module_edges_survive_persisted_graph_load() {
+    // Simulate the live graph after seed_boot_module_edges / refresh_bundle_and_routes.
+    let mut live = DependencyGraph::new();
+    live.upsert(PageDeps::new(
+        pid("/proj/pages/index.tsx"),
+        vec![(p("/proj/components/Header.tsx"), DepKind::Module)],
+    ));
+    live.upsert(PageDeps::new(
+        pid("/proj/pages/about.tsx"),
+        vec![(p("/proj/components/Nav.tsx"), DepKind::Module)],
+    ));
+
+    // Simulate a persisted graph from a previous session: same pages but with
+    // Content and Style edges that the current metafile doesn't know yet.
+    let mut persisted = DependencyGraph::new();
+    persisted.upsert(PageDeps::new(
+        pid("/proj/pages/index.tsx"),
+        vec![
+            (p("/proj/content/post.md"), DepKind::Content),
+            (p("/proj/styles/global.css"), DepKind::Style),
+        ],
+    ));
+    persisted.upsert(PageDeps::new(
+        pid("/proj/pages/about.tsx"),
+        vec![(p("/proj/content/team.md"), DepKind::Content)],
+    ));
+
+    // This is the fix: merge rather than replace.
+    live.merge_from_persisted(persisted);
+
+    // Module edges from the live graph must still be present.
+    assert_eq!(
+        live.dirty_pages(&p("/proj/components/Header.tsx"))
+            .as_pages()
+            .unwrap(),
+        vec![pid("/proj/pages/index.tsx")],
+        "Module edge from live graph must survive merge_from_persisted"
+    );
+    assert_eq!(
+        live.dirty_pages(&p("/proj/components/Nav.tsx"))
+            .as_pages()
+            .unwrap(),
+        vec![pid("/proj/pages/about.tsx")],
+        "Module edge for second page must survive"
+    );
+
+    // Non-Module edges from persisted must be present too.
+    assert_eq!(
+        live.dirty_pages(&p("/proj/content/post.md"))
+            .as_pages()
+            .unwrap(),
+        vec![pid("/proj/pages/index.tsx")],
+        "Content edge from persisted must be present after merge"
+    );
+    assert_eq!(
+        live.dirty_pages(&p("/proj/styles/global.css"))
+            .as_pages()
+            .unwrap(),
+        vec![pid("/proj/pages/index.tsx")],
+        "Style edge from persisted must be present after merge"
+    );
+    assert_eq!(
+        live.dirty_pages(&p("/proj/content/team.md"))
+            .as_pages()
+            .unwrap(),
+        vec![pid("/proj/pages/about.tsx")],
+        "Content edge for second page must be present after merge"
+    );
+}
+
+/// Regression: the old `*g = persisted` path. Demonstrates what broke before
+/// the fix: Module edges are lost when the whole graph is replaced.
+/// This test ASSERTS THE BUG to lock the regression boundary so a revert is
+/// immediately visible.
+#[test]
+fn replace_not_merge_loses_module_edges_regression_anchor() {
+    let mut live = DependencyGraph::new();
+    live.upsert(PageDeps::new(
+        pid("/proj/pages/index.tsx"),
+        vec![(p("/proj/components/Header.tsx"), DepKind::Module)],
+    ));
+
+    let mut persisted = DependencyGraph::new();
+    persisted.upsert(PageDeps::new(
+        pid("/proj/pages/index.tsx"),
+        vec![(p("/proj/content/post.md"), DepKind::Content)],
+    ));
+
+    // Simulate the OLD bug: wholesale replace drops Module edges.
+    live = persisted;
+
+    let dirty = live.dirty_pages(&p("/proj/components/Header.tsx"));
+    assert_eq!(
+        dirty,
+        DirtySet::Specific(Default::default()),
+        "BUG ANCHOR: wholesale replace loses Module edges — if this assertion \
+         fails the regression has been introduced again"
+    );
+}
+
+/// Globals from the persisted graph are merged into live.
+#[test]
+fn globals_are_merged_from_persisted() {
+    let mut live = DependencyGraph::new();
+    live.mark_global("/proj/zfb.config.ts");
+
+    let mut persisted = DependencyGraph::new();
+    persisted.mark_global("/proj/extra.config.ts");
+
+    live.merge_from_persisted(persisted);
+
+    // Live global unchanged.
+    assert!(
+        live.is_global(&p("/proj/zfb.config.ts")),
+        "pre-existing global must survive merge"
+    );
+    // Persisted global added.
+    assert!(
+        live.is_global(&p("/proj/extra.config.ts")),
+        "persisted global must be merged in"
+    );
+
+    assert!(
+        live.dirty_pages(&p("/proj/zfb.config.ts")).is_all(),
+        "pre-existing global still triggers DirtySet::All"
+    );
+    assert!(
+        live.dirty_pages(&p("/proj/extra.config.ts")).is_all(),
+        "merged-in global triggers DirtySet::All"
+    );
+}
+
+/// Asset deps from the persisted graph are copied for pages not already
+/// tracked in the live asset layer.
+#[test]
+fn asset_deps_are_merged_for_untracked_pages() {
+    let mut live = DependencyGraph::new();
+    live.upsert(PageDeps::new(
+        pid("/proj/pages/index.tsx"),
+        vec![(p("/proj/components/Counter.tsx"), DepKind::Module)],
+    ));
+
+    let mut persisted = DependencyGraph::new();
+    persisted.upsert(PageDeps::new(pid("/proj/pages/index.tsx"), vec![]));
+    persisted.set_assets_for_page(
+        pid("/proj/pages/index.tsx"),
+        AssetDeps::new(["Counter".to_string()], [p("/styles/counter.module.css")]),
+    );
+
+    live.merge_from_persisted(persisted);
+
+    // Live graph has no prior asset record for index.tsx; persisted record is
+    // adopted.
+    let assets = live
+        .assets_for_page(&pid("/proj/pages/index.tsx"))
+        .expect("asset record from persisted should be present");
+    assert!(
+        assets.islands.contains("Counter"),
+        "island from persisted asset record must be present"
+    );
+    assert!(
+        assets
+            .css_modules
+            .contains(&p("/styles/counter.module.css")),
+        "CSS module from persisted asset record must be present"
+    );
+}
+
+/// When the live graph already has an asset record for a page, the persisted
+/// record does NOT overwrite it (live record is more current).
+#[test]
+fn live_asset_record_wins_over_persisted() {
+    let mut live = DependencyGraph::new();
+    live.upsert(PageDeps::new(pid("/proj/pages/index.tsx"), vec![]));
+    live.set_assets_for_page(
+        pid("/proj/pages/index.tsx"),
+        AssetDeps::new(["LiveIsland".to_string()], []),
+    );
+
+    let mut persisted = DependencyGraph::new();
+    persisted.upsert(PageDeps::new(pid("/proj/pages/index.tsx"), vec![]));
+    persisted.set_assets_for_page(
+        pid("/proj/pages/index.tsx"),
+        AssetDeps::new(["StaleIsland".to_string()], []),
+    );
+
+    live.merge_from_persisted(persisted);
+
+    let assets = live
+        .assets_for_page(&pid("/proj/pages/index.tsx"))
+        .expect("asset record should exist");
+    assert!(
+        assets.islands.contains("LiveIsland"),
+        "live island must be kept"
+    );
+    assert!(
+        !assets.islands.contains("StaleIsland"),
+        "stale persisted island must not overwrite the live record"
+    );
+}
+
+/// A page that exists ONLY in `persisted` (not yet seeded in live) has all its
+/// edges (including non-Module) imported into live. Live has no Module edges
+/// for it to preserve, so the persisted edges — including any Module ones —
+/// are all taken.
+#[test]
+fn page_only_in_persisted_gets_all_its_edges() {
+    let mut live = DependencyGraph::new();
+    // index is already live; about is only in persisted.
+    live.upsert(PageDeps::new(
+        pid("/proj/pages/index.tsx"),
+        vec![(p("/proj/components/Header.tsx"), DepKind::Module)],
+    ));
+
+    let mut persisted = DependencyGraph::new();
+    persisted.upsert(PageDeps::new(
+        pid("/proj/pages/about.tsx"),
+        vec![
+            (p("/proj/components/Nav.tsx"), DepKind::Module),
+            (p("/proj/content/team.md"), DepKind::Content),
+        ],
+    ));
+
+    live.merge_from_persisted(persisted);
+
+    // The about page's Module and Content edges must appear in live.
+    assert_eq!(
+        live.dirty_pages(&p("/proj/components/Nav.tsx"))
+            .as_pages()
+            .unwrap(),
+        vec![pid("/proj/pages/about.tsx")],
+        "Module edge for persisted-only page must be imported"
+    );
+    assert_eq!(
+        live.dirty_pages(&p("/proj/content/team.md"))
+            .as_pages()
+            .unwrap(),
+        vec![pid("/proj/pages/about.tsx")],
+        "Content edge for persisted-only page must be imported"
+    );
+
+    // The live index page must be unchanged.
+    assert_eq!(
+        live.dirty_pages(&p("/proj/components/Header.tsx"))
+            .as_pages()
+            .unwrap(),
+        vec![pid("/proj/pages/index.tsx")],
+        "live page's Module edge must be untouched"
+    );
+}

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -516,6 +516,16 @@ pub async fn run(args: &DevArgs) -> Result<()> {
     // has not run yet there; that case relies on the in-repo `src` root).
     #[cfg(feature = "embed_v8")]
     if let Some(session) = dev_session.as_ref() {
+        // Boot-time-only limitation (#1293): these targets are resolved once
+        // from the eager boot bundle's metafile and registered before the
+        // `BuildOrchestrator` is constructed.  Any NEW out-of-root dep paths
+        // discovered by later bundle refreshes (tick N+1, N+2, …) are NOT
+        // dynamically added to the watcher — the watcher's watch set is fixed
+        // after `OrchestratorConfig` is built here.  A `zfb dev` restart is
+        // required to pick up a newly-symlinked workspace dep as a watch
+        // target.  On the deferred-boot path this set is always empty (the
+        // boot bundle has not run yet), so this limitation is only relevant
+        // on the eager path.
         for target in session.out_of_root_watch_targets() {
             if !extra_watch_paths.contains(&target) {
                 extra_watch_paths.push(target);
@@ -532,6 +542,12 @@ pub async fn run(args: &DevArgs) -> Result<()> {
     // these align with the watcher's canonical event paths. The out-of-root
     // `.css` real paths classify as `PathClass::Style` (whitelisted extension),
     // so editing one fires `rerun_css` and refreshes the asset.
+    //
+    // Boot-time-only limitation (#1293): `resolve_css_import_watch_targets`
+    // walks the CSS entry's `@import` graph once at boot and the result is
+    // fixed for the lifetime of the `BuildOrchestrator`.  If a new `@import`
+    // is added to the CSS entry during a dev session, that new transitive dep
+    // is NOT registered as a watch target until `zfb dev` is restarted.
     let resolved_css_imports = resolve_css_import_watch_targets(&project_root);
     for real in &resolved_css_imports {
         if !extra_watch_paths.contains(real) {
@@ -1252,37 +1268,34 @@ pub async fn run(args: &DevArgs) -> Result<()> {
             // 1. Manifest digest — the size-bound walk moved past bind.
             let manifest_digest = compute_manifest_digest(&project_root_for_boot, &watch_roots);
 
-            // 2. Load the persisted graph (digest-gated). On a hit, replace
-            //    the orchestrator's (currently empty) graph contents under
-            //    the lock; on a miss leave it empty (built fresh on ticks).
-            if let Some(persisted) =
-                load_persisted_graph(&graph_cache_path_for_boot, manifest_digest.as_ref())
+            // 2+3. Load the persisted graph (digest-gated) and assemble the
+            //      boot graph under a single lock acquisition.
+            //
+            //      On a cache hit, `assemble_boot_graph` MERGES the persisted
+            //      graph into the live graph instead of replacing it (#1293):
+            //      `DepKind::Module` edges already present in the live graph
+            //      (populated by `seed_boot_module_edges` on the eager path, or
+            //      by `refresh_bundle_and_routes` on the deferred path above)
+            //      are preserved; non-Module edges (Content/Style/Data/Other)
+            //      are taken from the persisted graph for pages not yet carrying
+            //      them. Globals from the persisted graph are merged in too.
+            //
+            //      The seed step (formerly step 3) is folded in: pages the
+            //      router scan knows but the graph does not yet have any record
+            //      of are seeded with an empty dep set so `plan_for_changes`
+            //      can resolve `PageSelection::All` before the first watcher
+            //      tick.  Only pages with NO known record are seeded; pages
+            //      that already carry edges (from the merge or from the Module
+            //      seed above) are left untouched.
             {
+                let persisted =
+                    load_persisted_graph(&graph_cache_path_for_boot, manifest_digest.as_ref());
+                let page_ids: Vec<PageId> = dev_session_for_boot
+                    .as_ref()
+                    .map(|s| s.page_ids())
+                    .unwrap_or_default();
                 if let Ok(mut g) = graph_for_seed.lock() {
-                    *g = persisted;
-                }
-            }
-
-            // 3. Seed the graph with all page source paths from the router
-            //    scan so `plan_for_changes` can resolve `PageSelection::All`
-            //    to a concrete page list even before the first file-change
-            //    tick. Without this seeding the graph is empty, `resolve_all`
-            //    produces an empty page set, and every watcher tick is a
-            //    no-op (cold-start bug).
-            if let Some(ref session) = dev_session_for_boot {
-                if let Ok(mut g) = graph_for_seed.lock() {
-                    for page_id in session.page_ids() {
-                        // Non-clobbering seed: `upsert` REPLACES a page's dep
-                        // set, so an unconditional empty-dep upsert here would
-                        // wipe the per-route `DepKind::Module` edges the
-                        // deferred `refresh_bundle_and_routes` above already
-                        // populated from the metafile (#1284/#1287). Only seed
-                        // pages the graph does not yet know, so edge-carrying
-                        // pages keep their edges.
-                        if !g.knows(page_id.path()) {
-                            g.upsert(PageDeps::new(page_id, vec![]));
-                        }
-                    }
+                    assemble_boot_graph(&mut g, persisted, page_ids);
                 }
             }
 
@@ -1802,6 +1815,40 @@ fn load_persisted_graph(
                 graph_cache_path.display()
             ));
             None
+        }
+    }
+}
+
+/// Assemble the boot graph in-place from an optional persisted snapshot and
+/// a list of page ids from the router scan (#1293).
+///
+/// This is a pure function (no I/O, no locks) so it can be unit-tested
+/// directly.  The caller is responsible for acquiring the graph mutex before
+/// calling this.
+///
+/// Behaviour:
+///
+/// 1. **Merge** — when `persisted` is `Some`, call
+///    [`DependencyGraph::merge_from_persisted`] which blends the persisted
+///    graph's non-Module edges and globals into `live` while preserving any
+///    `DepKind::Module` edges already in `live` (populated earlier by
+///    `seed_boot_module_edges` / `refresh_bundle_and_routes`).
+/// 2. **Seed** — for every `PageId` in `page_ids`, if the graph has NO
+///    existing record for that page (neither from the merge above nor from an
+///    earlier `seed_boot_module_edges` call), upsert an empty dep set so
+///    `plan_for_changes` can resolve `PageSelection::All` before the first
+///    watcher tick.  Pages already tracked (with edges) are left untouched.
+pub(crate) fn assemble_boot_graph(
+    live: &mut DependencyGraph,
+    persisted: Option<DependencyGraph>,
+    page_ids: impl IntoIterator<Item = PageId>,
+) {
+    if let Some(p) = persisted {
+        live.merge_from_persisted(p);
+    }
+    for page_id in page_ids {
+        if !live.knows(page_id.path()) {
+            live.upsert(PageDeps::new(page_id, vec![]));
         }
     }
 }

--- a/crates/zfb/tests/dev_dep_invalidation_1284_e2e.rs
+++ b/crates/zfb/tests/dev_dep_invalidation_1284_e2e.rs
@@ -1,5 +1,5 @@
 //! Wave-3 ACCEPTANCE gate for bug #1284 (epic #1285), authored during the
-//! Wave-1 diagnosis (#1286). Level 4 — real `zfb dev` process, edit→serve loop.
+//! Wave-1 diagnosis (#1286). Level 4 — real `zfb dev` edit→serve loop.
 //!
 //! These scenarios reproduce the THREE symptoms that the existing
 //! `dev_serve_e2e.rs` scenario 4 does NOT cover (that scenario edits a
@@ -41,10 +41,338 @@
 //! Falsifiability is noted per scenario: revert the corresponding fix and the
 //! served-on-next-request assertion times out on the OLD marker.
 
-// The bodies are deferred to Wave-3 (see module docs). Keeping them as
-// `#[ignore]`d `todo!()` stubs documents the exact acceptance contract without
-// pulling the private `dev_serve_e2e` harness into this file or forcing a V8
-// build now. `cargo test` skips `#[ignore]`d tests, so this stays green.
+// ---------------------------------------------------------------------------
+// Shared harness (local copy of the helpers from dev_serve_e2e.rs, adapted
+// for these three scenarios). The helpers are private to that file's binary;
+// Rust integration tests are separate binaries and cannot import each other's
+// private items. zfb-test-utils (already a dev-dep) provides locate_esbuild,
+// next_sse_event_name, and the zfb_binary! macro.
+// ---------------------------------------------------------------------------
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::process::CommandExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, LazyLock};
+use std::time::{Duration, Instant};
+
+use zfb_test_utils::{locate_esbuild, next_sse_event_name, zfb_binary};
+
+// Serialise the three tests: each boots a full V8 + esbuild + Tailwind dev
+// session; running them concurrently would double/triple memory and produce
+// flaky boot deadlines.
+static SERIAL: LazyLock<tokio::sync::Mutex<()>> = LazyLock::new(|| tokio::sync::Mutex::new(()));
+
+/// Overall wall-clock watchdog for each test.
+const OVERALL_DEADLINE: Duration = Duration::from_secs(300);
+
+/// Deadline for the dev server to print its ready banner + first `GET /` 200.
+const BOOT_DEADLINE: Duration = Duration::from_secs(90);
+
+/// Per-scenario deadline for the marker to appear in the served response.
+const SCENARIO_DEADLINE: Duration = Duration::from_secs(60);
+
+/// Deadline for the watcher-live handshake + per-scenario SSE tick signal.
+const SSE_DEADLINE: Duration = Duration::from_secs(30);
+
+const POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+// ---------------------------------------------------------------------------
+// Harness types and helpers (mirrors dev_serve_e2e.rs)
+// ---------------------------------------------------------------------------
+
+fn base_fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("dev-loop-basic")
+}
+
+/// Recursive directory copy.
+fn copy_dir(src: &Path, dst: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(dst)?;
+    for entry in fs::read_dir(src)? {
+        let entry = entry?;
+        let ty = entry.file_type()?;
+        let dst_path = dst.join(entry.file_name());
+        if ty.is_dir() {
+            copy_dir(&entry.path(), &dst_path)?;
+        } else {
+            fs::copy(entry.path(), dst_path)?;
+        }
+    }
+    Ok(())
+}
+
+struct DevServerGuard {
+    child: std::process::Child,
+    pgid: libc::pid_t,
+}
+
+impl DevServerGuard {
+    fn try_exit_status(&mut self) -> Option<std::process::ExitStatus> {
+        self.child.try_wait().expect("try_wait on `zfb dev`")
+    }
+}
+
+impl Drop for DevServerGuard {
+    fn drop(&mut self) {
+        unsafe { libc::kill(-self.pgid, libc::SIGKILL) };
+        let _ = self.child.wait();
+    }
+}
+
+fn read_log(p: &Path) -> String {
+    fs::read_to_string(p).unwrap_or_default()
+}
+
+fn dump_logs(stdout_path: &Path, stderr_path: &Path) -> String {
+    format!(
+        "--- zfb dev stdout ---\n{}\n--- zfb dev stderr ---\n{}",
+        read_log(stdout_path),
+        read_log(stderr_path),
+    )
+}
+
+struct DevSession {
+    root: PathBuf,
+    guard: DevServerGuard,
+    stdout_path: PathBuf,
+    stderr_path: PathBuf,
+}
+
+impl DevSession {
+    fn logs(&self) -> String {
+        dump_logs(&self.stdout_path, &self.stderr_path)
+    }
+}
+
+/// Extract the port from the dev ready banner (`→ ready on http://localhost:PORT/`).
+fn parse_ready_port(log: &str) -> Option<u16> {
+    let mut rest = log;
+    while let Some(idx) = rest.find("http://") {
+        let candidate = &rest[idx + "http://".len()..];
+        let token: &str = candidate.split_whitespace().next().unwrap_or("");
+        if let Some(colon) = token.find(':') {
+            let digits: String = token[colon + 1..]
+                .chars()
+                .take_while(|c| c.is_ascii_digit())
+                .collect();
+            if let Ok(port) = digits.parse() {
+                return Some(port);
+            }
+        }
+        rest = &rest[idx + "http://".len()..];
+    }
+    None
+}
+
+/// Spawn `zfb dev --port 0` over the already-prepared fixture root, in its own
+/// process group, with stdout/stderr captured to files. Callers copy and extend
+/// the fixture BEFORE calling this.
+fn spawn_dev(root: PathBuf, esbuild: &Path, extra_env: &[(&str, &str)]) -> DevSession {
+    let stdout_path = root.join(".zfb-dev-stdout.log");
+    let stderr_path = root.join(".zfb-dev-stderr.log");
+    let stdout_file = fs::File::create(&stdout_path).expect("create stdout log file");
+    let stderr_file = fs::File::create(&stderr_path).expect("create stderr log file");
+
+    let mut cmd = Command::new(zfb_binary!());
+    cmd.arg("dev")
+        .arg("--port")
+        .arg("0")
+        .current_dir(&root)
+        .env("ZFB_ESBUILD_BIN", esbuild)
+        .stdout(Stdio::from(stdout_file))
+        .stderr(Stdio::from(stderr_file));
+    cmd.env_remove("ZFB_DEV_EAGER")
+        .env_remove("ZFB_LAZY_DEV_RENDER")
+        .env_remove("ZFB_DEV_DEFER_BUNDLE")
+        .env_remove("ZFB_DEV_TEST_SLOW_BOOT_RENDER_MS");
+    for (k, v) in extra_env {
+        cmd.env(k, v);
+    }
+    cmd.process_group(0);
+
+    let child = cmd.spawn().expect("spawn `zfb dev`");
+    let pgid = child.id() as libc::pid_t;
+    DevSession {
+        root,
+        guard: DevServerGuard { child, pgid },
+        stdout_path,
+        stderr_path,
+    }
+}
+
+/// Poll `url` until the body contains `needle` with status 200.
+async fn poll_until_contains(
+    client: &reqwest::Client,
+    url: &str,
+    needle: &str,
+    deadline: Duration,
+    phase: &str,
+    session: &DevSession,
+) {
+    let start = Instant::now();
+    let mut last_observation = String::from("(no response yet)");
+    while start.elapsed() < deadline {
+        match client.get(url).send().await {
+            Ok(resp) => {
+                let status = resp.status().as_u16();
+                let body = resp.text().await.unwrap_or_default();
+                if status == 200 && body.contains(needle) {
+                    return;
+                }
+                last_observation = format!("status {status}, body:\n{body}");
+            }
+            Err(e) => last_observation = format!("request error: {e}"),
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+    panic!(
+        "[{phase}] GET {url} did not serve a body containing {needle:?} within {}s.\n\
+         Last observation: {last_observation}\n{}",
+        deadline.as_secs(),
+        session.logs(),
+    );
+}
+
+/// Subscribe to the dev server's SSE live-reload endpoint. Must be called
+/// BEFORE the edit whose tick it is meant to observe.
+async fn subscribe_sse(client: &reqwest::Client, base: &str) -> reqwest::Response {
+    let resp = client
+        .get(format!("{base}/__zfb/reload"))
+        .send()
+        .await
+        .expect("subscribe to /__zfb/reload");
+    assert_eq!(
+        resp.status().as_u16(),
+        200,
+        "SSE endpoint /__zfb/reload must answer 200"
+    );
+    resp
+}
+
+enum ScenarioOutcome {
+    Completed,
+    /// The binary exited with a known environmental skip indicator (no V8 /
+    /// no esbuild / no Tailwind) — skip without failing.
+    Skipped,
+}
+
+/// Phases A-C: ready-banner port discovery, HTTP readiness, and the
+/// watcher-live handshake. Returns `None` when the binary exited with a
+/// recognized environmental skip indicator, otherwise `(base_url, client)`.
+async fn boot_and_handshake(session: &mut DevSession) -> Option<(String, reqwest::Client)> {
+    // Phase A: discover the ephemeral port from the ready banner.
+    let boot_start = Instant::now();
+    let port = loop {
+        if let Some(status) = session.guard.try_exit_status() {
+            let combined = format!(
+                "{}{}",
+                read_log(&session.stdout_path),
+                read_log(&session.stderr_path)
+            );
+            if combined.contains("embed_v8")
+                || combined.contains("no esbuild")
+                || combined.contains("no tailwind")
+                || combined.contains("tailwindcss") && combined.contains("not found")
+            {
+                eprintln!(
+                    "[dep_inval_e2e] `zfb dev` exited with a known-skip indicator \
+                     (V8/esbuild/tailwind unavailable); skipping test.\n{}",
+                    session.logs(),
+                );
+                return None;
+            }
+            panic!(
+                "`zfb dev` exited prematurely (status {status:?}) before printing the \
+                 ready banner.\n{}",
+                session.logs(),
+            );
+        }
+        if let Some(port) = parse_ready_port(&read_log(&session.stdout_path)) {
+            break port;
+        }
+        assert!(
+            boot_start.elapsed() < BOOT_DEADLINE,
+            "`zfb dev` did not print a parseable ready banner within {}s.\n{}",
+            BOOT_DEADLINE.as_secs(),
+            session.logs(),
+        );
+        tokio::time::sleep(POLL_INTERVAL).await;
+    };
+    let base = format!("http://localhost:{port}");
+
+    let client = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(5))
+        .timeout(Duration::from_secs(10))
+        .build()
+        .expect("build reqwest client");
+
+    // Phase B: HTTP readiness — poll GET / until 200.
+    {
+        let start = Instant::now();
+        loop {
+            match client.get(format!("{base}/")).send().await {
+                Ok(resp) if resp.status().as_u16() == 200 => break,
+                _ => {}
+            }
+            assert!(
+                start.elapsed() < BOOT_DEADLINE,
+                "GET / never answered 200 within {}s after the ready banner.\n{}",
+                BOOT_DEADLINE.as_secs(),
+                session.logs(),
+            );
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+
+    // Phase C: watcher-live handshake.
+    //
+    // Subscribe to SSE FIRST, then write fresh-named warmup content files
+    // until the first SSE event arrives — proving the watch stream is past its
+    // startup dead window. Mirrors dev_serve_e2e.rs.
+    {
+        let sse = subscribe_sse(&client, &base).await;
+        let stop = Arc::new(AtomicBool::new(false));
+        let writer = {
+            let root = session.root.to_path_buf();
+            let stop = Arc::clone(&stop);
+            tokio::spawn(async move {
+                let mut i = 0u32;
+                while !stop.load(Ordering::SeqCst) {
+                    let warmup = root.join(format!("content/posts/__warmup-{i}.md"));
+                    let _ = fs::write(
+                        &warmup,
+                        format!("---\ntitle: warmup {i}\n---\n\nwarmup body {i}\n"),
+                    );
+                    i += 1;
+                    tokio::time::sleep(Duration::from_millis(400)).await;
+                }
+            })
+        };
+        let first = next_sse_event_name(sse, SSE_DEADLINE)
+            .await
+            .expect("read SSE stream during watcher-live handshake");
+        stop.store(true, Ordering::SeqCst);
+        let _ = writer.await;
+        assert!(
+            first.is_some(),
+            "watcher never became live: no warmup-induced SSE event within {}s\n{}",
+            SSE_DEADLINE.as_secs(),
+            session.logs(),
+        );
+    }
+
+    Some((base, client))
+}
+
+// ---------------------------------------------------------------------------
+// SYMPTOM A
+// ---------------------------------------------------------------------------
 
 /// SYMPTOM A acceptance — editing `src/components/Widget.tsx` re-renders the
 /// route that imports it. Observable (D3): `GET /` serves the new marker on the
@@ -56,12 +384,181 @@
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "Level-4 e2e: implement+run on a V8 host — #1290"]
 async fn e2e_src_component_edit_rerenders_route() {
-    todo!(
-        "Wave-3: copy dev-loop-basic fixture, add src/components/Widget.tsx imported \
-         by pages/index.tsx, spawn `zfb dev`, subscribe SSE, edit the widget, assert \
-         an SSE `page` event then poll `GET /` until it serves the NEW marker."
-    );
+    let _serial = SERIAL.lock().await;
+    let Some(esbuild) = locate_esbuild() else {
+        eprintln!(
+            "[dep_inval_e2e symptom-A] no esbuild binary available; skipping. \
+             Set ZFB_ESBUILD_BIN or install esbuild on PATH."
+        );
+        return;
+    };
+
+    // Build a dev-loop-basic-derived fixture that has `src/components/Widget.tsx`
+    // imported by `pages/index.tsx`. The `src/` directory is in DEFAULT_WATCH_ROOTS
+    // after the #1284 fix, so an edit to `src/**` fires a watcher tick and
+    // re-renders the consuming route.
+    let tmp = tempfile::tempdir().expect("create tempdir for symptom-A fixture");
+    let root = tmp
+        .path()
+        .canonicalize()
+        .expect("canonicalize fixture root");
+    copy_dir(&base_fixture_dir(), &root).expect("copy dev-loop-basic fixture");
+
+    // Add src/components/Widget.tsx with a unique initial marker.
+    fs::create_dir_all(root.join("src").join("components")).expect("create src/components/");
+    fs::write(
+        root.join("src/components/Widget.tsx"),
+        "export function Widget() {\n  \
+         return <p data-testid=\"widget\">WIDGET-MARKER-V1</p>;\n}\n",
+    )
+    .expect("write src/components/Widget.tsx");
+
+    // Extend pages/index.tsx to import and render Widget from src/.
+    // We completely replace the file so the import is stable from boot.
+    fs::write(
+        root.join("pages/index.tsx"),
+        r#"
+import { SharedNote } from "../components/shared-note";
+import { Widget } from "../src/components/Widget";
+
+type Post = {
+  slug: string;
+  data: { title: string };
+};
+
+export async function getStaticProps() {
+  const { getCollection } = await import("@takazudo/zfb/content");
+  const posts = (await getCollection("posts")) as Post[];
+  const sorted = [...posts].sort((a, b) => a.slug.localeCompare(b.slug));
+  return { props: { posts: sorted } };
 }
+
+type Props = {
+  posts: Post[];
+};
+
+export default function HomePage({ posts }: Props) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <title>dev-loop-basic fixture</title>
+      </head>
+      <body>
+        <h1>dev-loop-basic</h1>
+        <SharedNote />
+        <Widget />
+        <ul>
+          {posts.map((post) => (
+            <li key={post.slug}>
+              <a href={`/posts/${post.slug}`}>{post.data.title}</a>
+            </li>
+          ))}
+        </ul>
+      </body>
+    </html>
+  );
+}
+"#,
+    )
+    .expect("write extended pages/index.tsx");
+
+    let mut session = spawn_dev(root, &esbuild, &[]);
+    let pgid = session.guard.pgid;
+
+    let body = async {
+        let Some((base, client)) = boot_and_handshake(&mut session).await else {
+            return ScenarioOutcome::Skipped;
+        };
+
+        // Baseline: `GET /` serves the initial Widget marker.
+        poll_until_contains(
+            &client,
+            &format!("{base}/"),
+            "WIDGET-MARKER-V1",
+            SCENARIO_DEADLINE,
+            "symptom-A baseline: GET / serves Widget V1 marker",
+            &session,
+        )
+        .await;
+
+        // ── THE EDIT ──────────────────────────────────────────────────────
+        // Subscribe to SSE BEFORE the edit so we catch the watcher tick.
+        let sse = subscribe_sse(&client, &base).await;
+        fs::write(
+            session.root.join("src/components/Widget.tsx"),
+            "export function Widget() {\n  \
+             return <p data-testid=\"widget\">WIDGET-MARKER-V2</p>;\n}\n",
+        )
+        .expect("edit src/components/Widget.tsx");
+
+        // The tick must broadcast an SSE `page` event (via pages_stale gate,
+        // exactly as dev_serve_e2e.rs scenario 4 does).
+        let ev = next_sse_event_name(sse, SSE_DEADLINE)
+            .await
+            .expect("read SSE stream after src/components/Widget.tsx edit");
+        assert_eq!(
+            ev.as_deref(),
+            Some("page"),
+            "editing src/components/Widget.tsx must broadcast an SSE `page` event \
+             — the #1284 fix added `src/` to DEFAULT_WATCH_ROOTS so the tick fires. \
+             Without the fix no tick fires at all.\n{}",
+            session.logs(),
+        );
+
+        // The authoritative assertion (D3): GET / on the NEXT request serves
+        // the new marker. In lazy mode the poll's first 200-bearing iteration is
+        // itself that triggering request, so polling is the correct test shape.
+        //
+        // Falsifiability: revert the #1284 `src/` watch-root addition. No tick
+        // fires, no stale mark is set, and the route keeps serving the old marker
+        // until this assertion times out.
+        poll_until_contains(
+            &client,
+            &format!("{base}/"),
+            "WIDGET-MARKER-V2",
+            SCENARIO_DEADLINE,
+            "symptom-A: GET / must serve the new Widget V2 marker after src/ component edit",
+            &session,
+        )
+        .await;
+
+        // Belt-and-suspenders: V1 must be gone from the served body.
+        let served = client
+            .get(format!("{base}/"))
+            .send()
+            .await
+            .expect("GET / after Widget edit")
+            .text()
+            .await
+            .unwrap_or_default();
+        assert!(
+            !served.contains("WIDGET-MARKER-V1"),
+            "GET / still contains the old WIDGET-MARKER-V1 after the src/ edit — \
+             the route was not re-rendered (lazy stale → request-time render path \
+             regressed).\n{}",
+            session.logs(),
+        );
+
+        ScenarioOutcome::Completed
+    };
+
+    let outcome = tokio::time::timeout(OVERALL_DEADLINE, body).await;
+    match outcome {
+        Ok(ScenarioOutcome::Completed) | Ok(ScenarioOutcome::Skipped) => {}
+        Err(_) => panic!(
+            "[watchdog] symptom-A e2e did not finish within {}s — hang or \
+             src/ edit never re-rendered the consuming route. \
+             Process group {pgid} will be killed.\n{}",
+            OVERALL_DEADLINE.as_secs(),
+            session.logs(),
+        ),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SYMPTOM B
+// ---------------------------------------------------------------------------
 
 /// SYMPTOM B acceptance — editing a transitively-imported CSS file (a local
 /// `@import './tokens.css'` and a symlinked workspace dep `@import
@@ -74,13 +571,196 @@ async fn e2e_src_component_edit_rerenders_route() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "Level-4 e2e: implement+run on a V8 host — #1290"]
 async fn e2e_transitive_css_import_refreshes_stylesheet() {
-    todo!(
-        "Wave-3: add styles/styles.css with `@import './tokens.css';` and a symlinked \
-         workspace `@import '@scope/design-system';`, spawn `zfb dev`, edit tokens.css \
-         AND the symlinked dep's real file, poll `GET /assets/styles.css` until both \
-         new declarations appear."
-    );
+    let _serial = SERIAL.lock().await;
+    let Some(esbuild) = locate_esbuild() else {
+        eprintln!(
+            "[dep_inval_e2e symptom-B] no esbuild binary available; skipping. \
+             Set ZFB_ESBUILD_BIN or install esbuild on PATH."
+        );
+        return;
+    };
+
+    // Build the fixture.
+    let tmp = tempfile::tempdir().expect("create tempdir for symptom-B fixture");
+    let root = tmp
+        .path()
+        .canonicalize()
+        .expect("canonicalize fixture root");
+    copy_dir(&base_fixture_dir(), &root).expect("copy dev-loop-basic fixture");
+
+    // Create a "real" package directory OUTSIDE the project root. The dev
+    // server resolves `@import '@scope/design-system'` through the symlinked
+    // node_modules entry; canonicalize() follows the symlink to the real file
+    // outside the project tree, which is the actual watcher target (#1288 D4).
+    let pkg_dir = tempfile::tempdir().expect("create tempdir for fake @scope/design-system");
+    let pkg_real_path = pkg_dir.path().canonicalize().expect("canonicalize pkg dir");
+    // The package provides a single CSS file. Boot-time content: a known
+    // V1 CSS custom property.
+    let pkg_css_path = pkg_real_path.join("index.css");
+    fs::write(
+        &pkg_css_path,
+        "/* @scope/design-system v1 */\n:root { --ds-color: #V1DS; }\n",
+    )
+    .expect("write @scope/design-system index.css");
+    // Provide a package.json with `style` pointing at index.css so the
+    // bare-package CSS resolver picks it up (#1288 css_imports).
+    fs::write(
+        pkg_real_path.join("package.json"),
+        "{\"name\":\"@scope/design-system\",\"version\":\"1.0.0\",\"style\":\"index.css\"}\n",
+    )
+    .expect("write @scope/design-system package.json");
+
+    // Symlink node_modules/@scope/design-system → the real pkg dir.
+    // This mirrors a pnpm/yarn workspace symlink: `node_modules` points
+    // outside the project tree, notify doesn't follow it, and without #1288
+    // the real path is never registered as a watch target.
+    let nm_scope_dir = root.join("node_modules").join("@scope");
+    fs::create_dir_all(&nm_scope_dir).expect("create node_modules/@scope/");
+    std::os::unix::fs::symlink(&pkg_real_path, nm_scope_dir.join("design-system"))
+        .expect("symlink node_modules/@scope/design-system");
+
+    // `styles/tokens.css` — the LOCAL transitive import.
+    // The #1288 fix also registers this file as a watch target because it is
+    // in the `@import` graph of the CSS entry.
+    fs::create_dir_all(root.join("styles")).expect("create styles/");
+    fs::write(
+        root.join("styles/tokens.css"),
+        "/* local tokens v1 */\n:root { --token-spacing: 4px; /* V1-TOKEN */ }\n",
+    )
+    .expect("write styles/tokens.css");
+
+    // `styles/global.css` — the project CSS entry (zfb convention).
+    // BOTH `@import` declarations must be present AT BOOT (see module docs:
+    // mid-session-added imports are deliberately unregistered — #1293).
+    fs::write(
+        root.join("styles/global.css"),
+        "@import \"tailwindcss\";\n\
+         @import './tokens.css';\n\
+         @import '@scope/design-system';\n\
+         \n\
+         body { font-family: sans-serif; }\n",
+    )
+    .expect("write styles/global.css");
+
+    let mut session = spawn_dev(root, &esbuild, &[]);
+    let pgid = session.guard.pgid;
+
+    // `pkg_dir` must outlive the session — the symlink's real target must
+    // remain on disk for the watcher registration to be meaningful.
+    let _pkg_dir = pkg_dir;
+
+    let css_url_fn = |base: &str| format!("{base}/assets/styles.css");
+
+    let body = async {
+        let Some((base, client)) = boot_and_handshake(&mut session).await else {
+            return ScenarioOutcome::Skipped;
+        };
+
+        // Baseline: GET /assets/styles.css serves a 200 (the boot CSS bundle).
+        // We only check status here because the exact content depends on the
+        // Tailwind binary's output — we don't assert a specific V1 token yet.
+        {
+            let start = Instant::now();
+            loop {
+                match client.get(css_url_fn(&base)).send().await {
+                    Ok(resp) if resp.status().as_u16() == 200 => break,
+                    _ => {}
+                }
+                assert!(
+                    start.elapsed() < SCENARIO_DEADLINE,
+                    "GET /assets/styles.css never answered 200 within {}s after boot.\n{}",
+                    SCENARIO_DEADLINE.as_secs(),
+                    session.logs(),
+                );
+                tokio::time::sleep(POLL_INTERVAL).await;
+            }
+        }
+
+        // ── EDIT 1: local transitive import (tokens.css) ──────────────────
+        // The #1288 fix registers `styles/tokens.css` (resolved from the
+        // `@import './tokens.css'` in `styles/global.css`) as a watch target.
+        // Editing it fires a PathClass::Style tick → rerun_css refreshes the
+        // asset.
+        let sse = subscribe_sse(&client, &base).await;
+        fs::write(
+            session.root.join("styles/tokens.css"),
+            "/* local tokens v2 */\n:root { --token-spacing: 8px; /* V2-TOKEN */ }\n",
+        )
+        .expect("edit styles/tokens.css");
+
+        // SSE signal: a Style tick does not mark pages stale (no SSE `page`
+        // event), but it does update the CSS asset bytes. We do NOT assert SSE
+        // here — the observable is the served CSS bytes.
+        // Allow the tick to settle before polling (the SSE connection gives us
+        // the tick signal for page events; for CSS-only ticks we just poll).
+        // The `next_sse_event_name` future is consumed but the event type may
+        // be anything or nothing — we only care about the CSS asset body.
+        let _ = next_sse_event_name(sse, SSE_DEADLINE).await;
+
+        // The authoritative assertion: the new V2-TOKEN comment appears in the
+        // served stylesheet. Tailwind passes the synthesised CSS through its
+        // pipeline, so the custom property value appears in the output.
+        //
+        // Falsifiability: without the #1288 `@import`-graph watch registration,
+        // tokens.css is not watched; no tick fires; the asset stays stale and
+        // this assertion times out.
+        poll_until_contains(
+            &client,
+            &css_url_fn(&base),
+            "V2-TOKEN",
+            SCENARIO_DEADLINE,
+            "symptom-B (local import): /assets/styles.css must reflect tokens.css edit",
+            &session,
+        )
+        .await;
+
+        // ── EDIT 2: symlinked workspace dep (@scope/design-system) ────────
+        // The #1288 fix canonicalises the `@scope/design-system` node_modules
+        // symlink to the real file outside the project root and registers that
+        // real path as an extra watch target. Editing the real file fires a tick.
+        let sse2 = subscribe_sse(&client, &base).await;
+        fs::write(
+            &pkg_css_path,
+            "/* @scope/design-system v2 */\n:root { --ds-color: #V2DS; }\n",
+        )
+        .expect("edit @scope/design-system index.css (real canonical path)");
+
+        let _ = next_sse_event_name(sse2, SSE_DEADLINE).await;
+
+        // The new V2DS marker must appear in the served stylesheet.
+        //
+        // Falsifiability: without canonicalisation + extra-watch-target
+        // registration, the symlinked real file is never watched; no tick fires;
+        // this assertion times out.
+        poll_until_contains(
+            &client,
+            &css_url_fn(&base),
+            "V2DS",
+            SCENARIO_DEADLINE,
+            "symptom-B (symlinked dep): /assets/styles.css must reflect @scope/design-system edit",
+            &session,
+        )
+        .await;
+
+        ScenarioOutcome::Completed
+    };
+
+    let outcome = tokio::time::timeout(OVERALL_DEADLINE, body).await;
+    match outcome {
+        Ok(ScenarioOutcome::Completed) | Ok(ScenarioOutcome::Skipped) => {}
+        Err(_) => panic!(
+            "[watchdog] symptom-B e2e did not finish within {}s — hang or \
+             transitive CSS edit never refreshed /assets/styles.css. \
+             Process group {pgid} will be killed.\n{}",
+            OVERALL_DEADLINE.as_secs(),
+            session.logs(),
+        ),
+    }
 }
+
+// ---------------------------------------------------------------------------
+// SYMPTOM C
+// ---------------------------------------------------------------------------
 
 /// SYMPTOM C acceptance — a NEW utility class added inside a component is
 /// emitted into `/assets/styles.css` WITHOUT touching the CSS entry. Observable
@@ -93,9 +773,191 @@ async fn e2e_transitive_css_import_refreshes_stylesheet() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "Level-4 e2e: implement+run on a V8 host — #1290"]
 async fn e2e_new_utility_class_in_component_is_emitted() {
-    todo!(
-        "Wave-3: edit a component to add a previously-unused utility class \
-         (e.g. `gap-x-hgap-2xs`), do NOT touch the CSS entry, poll \
-         `GET /assets/styles.css` until the generated rule for that class appears."
-    );
+    let _serial = SERIAL.lock().await;
+    let Some(esbuild) = locate_esbuild() else {
+        eprintln!(
+            "[dep_inval_e2e symptom-C] no esbuild binary available; skipping. \
+             Set ZFB_ESBUILD_BIN or install esbuild on PATH."
+        );
+        return;
+    };
+
+    // Build the fixture.
+    let tmp = tempfile::tempdir().expect("create tempdir for symptom-C fixture");
+    let root = tmp
+        .path()
+        .canonicalize()
+        .expect("canonicalize fixture root");
+    copy_dir(&base_fixture_dir(), &root).expect("copy dev-loop-basic fixture");
+
+    // `styles/global.css` — project CSS entry with the Tailwind import so the
+    // CSS pipeline actually runs Tailwind's content scan and emits utility
+    // class rules. The fixture starts with one known class (`font-bold`) so we
+    // can confirm the Tailwind pipeline ran at boot before asserting the new
+    // one appears after the component edit.
+    fs::create_dir_all(root.join("styles")).expect("create styles/");
+    fs::write(
+        root.join("styles/global.css"),
+        "@import \"tailwindcss\";\n\
+         \n\
+         /* symptom-C fixture: Tailwind content scan baseline */\n\
+         body { font-family: sans-serif; }\n",
+    )
+    .expect("write styles/global.css");
+
+    // `src/components/CardWidget.tsx` — a component that starts with a
+    // commonly-generated Tailwind class (`font-bold`) at boot. The test edits
+    // it mid-session to add the NEVER-BEFORE-SEEN class `gap-x-hgap-2xs`.
+    // This class is chosen because:
+    //   - It is a legitimate Tailwind v4 utility (gap-x with a custom value).
+    //   - It looks distinctive enough that a substring match in the CSS body is
+    //     unambiguous (`.gap-x-hgap-2xs`).
+    // Without the #1284 fix the content scan is not re-run on Module ticks,
+    // so the new class never reaches the generated stylesheet.
+    fs::create_dir_all(root.join("src").join("components")).expect("create src/components/");
+    fs::write(
+        root.join("src/components/CardWidget.tsx"),
+        "export function CardWidget() {\n  \
+         return <div class=\"font-bold\">CardWidget V1</div>;\n}\n",
+    )
+    .expect("write src/components/CardWidget.tsx");
+
+    // Wire CardWidget into `pages/index.tsx` so the component IS part of the
+    // project's source tree and is included in the Tailwind content scan.
+    fs::write(
+        root.join("pages/index.tsx"),
+        r#"
+import { SharedNote } from "../components/shared-note";
+import { CardWidget } from "../src/components/CardWidget";
+
+type Post = {
+  slug: string;
+  data: { title: string };
+};
+
+export async function getStaticProps() {
+  const { getCollection } = await import("@takazudo/zfb/content");
+  const posts = (await getCollection("posts")) as Post[];
+  const sorted = [...posts].sort((a, b) => a.slug.localeCompare(b.slug));
+  return { props: { posts: sorted } };
+}
+
+type Props = {
+  posts: Post[];
+};
+
+export default function HomePage({ posts }: Props) {
+  return (
+    <html lang="en">
+      <head>
+        <meta charSet="utf-8" />
+        <title>dev-loop-basic fixture</title>
+      </head>
+      <body>
+        <h1>dev-loop-basic</h1>
+        <SharedNote />
+        <CardWidget />
+        <ul>
+          {posts.map((post) => (
+            <li key={post.slug}>
+              <a href={`/posts/${post.slug}`}>{post.data.title}</a>
+            </li>
+          ))}
+        </ul>
+      </body>
+    </html>
+  );
+}
+"#,
+    )
+    .expect("write extended pages/index.tsx");
+
+    let mut session = spawn_dev(root, &esbuild, &[]);
+    let pgid = session.guard.pgid;
+
+    let css_url_fn = |base: &str| format!("{base}/assets/styles.css");
+
+    let body = async {
+        let Some((base, client)) = boot_and_handshake(&mut session).await else {
+            return ScenarioOutcome::Skipped;
+        };
+
+        // Baseline: GET /assets/styles.css serves a 200.
+        // We do not assert `font-bold` specifically because Tailwind v4's
+        // generated output format varies (it may inline or merge utilities
+        // differently). The key assertion is that a NEW class added mid-session
+        // eventually appears without touching the CSS entry.
+        {
+            let start = Instant::now();
+            loop {
+                match client.get(css_url_fn(&base)).send().await {
+                    Ok(resp) if resp.status().as_u16() == 200 => break,
+                    _ => {}
+                }
+                assert!(
+                    start.elapsed() < SCENARIO_DEADLINE,
+                    "GET /assets/styles.css never answered 200 within {}s after boot.\n{}",
+                    SCENARIO_DEADLINE.as_secs(),
+                    session.logs(),
+                );
+                tokio::time::sleep(POLL_INTERVAL).await;
+            }
+        }
+
+        // ── THE EDIT ──────────────────────────────────────────────────────
+        // Add `gap-x-hgap-2xs` to the component WITHOUT touching styles/global.css.
+        // Before #1284: the Module tick does NOT re-run the Tailwind content scan,
+        // so this new class never enters the stylesheet.
+        // After  #1284: a Module tick with a `.tsx` change fires mark_css which
+        // triggers a Tailwind re-scan, surfacing the new class.
+        //
+        // We subscribe to SSE to observe the tick, but a Module tick may or may
+        // not emit a `page` event depending on the route fan-out. The authoritative
+        // assertion is the served CSS body.
+        let sse = subscribe_sse(&client, &base).await;
+        fs::write(
+            session.root.join("src/components/CardWidget.tsx"),
+            "export function CardWidget() {\n  \
+             return <div class=\"font-bold gap-x-hgap-2xs\">CardWidget V2</div>;\n}\n",
+        )
+        .expect("edit src/components/CardWidget.tsx to add gap-x-hgap-2xs");
+
+        // Wait for any SSE event from the tick (page or css — either signals
+        // the tick completed). Ignore timeout: the CSS poll below is the
+        // authoritative gate.
+        let _ = next_sse_event_name(sse, SSE_DEADLINE).await;
+
+        // The authoritative assertion (D3): GET /assets/styles.css on the next
+        // request must contain a CSS rule for `gap-x-hgap-2xs`. Tailwind v4
+        // emits utility classes as `.gap-x-hgap-2xs { … }` or within a layer.
+        // We match the class selector fragment to stay output-format-agnostic.
+        //
+        // Falsifiability: revert the #1284 Module→mark_css re-scan addition.
+        // The Tailwind content scan is not re-run on this tick; the class
+        // is never seen; this assertion times out on the old CSS body.
+        poll_until_contains(
+            &client,
+            &css_url_fn(&base),
+            "gap-x-hgap-2xs",
+            SCENARIO_DEADLINE,
+            "symptom-C: /assets/styles.css must emit the new gap-x-hgap-2xs rule \
+             after the component edit (without touching the CSS entry)",
+            &session,
+        )
+        .await;
+
+        ScenarioOutcome::Completed
+    };
+
+    let outcome = tokio::time::timeout(OVERALL_DEADLINE, body).await;
+    match outcome {
+        Ok(ScenarioOutcome::Completed) | Ok(ScenarioOutcome::Skipped) => {}
+        Err(_) => panic!(
+            "[watchdog] symptom-C e2e did not finish within {}s — hang or \
+             new Tailwind class was never emitted into /assets/styles.css after \
+             component edit. Process group {pgid} will be killed.\n{}",
+            OVERALL_DEADLINE.as_secs(),
+            session.logs(),
+        ),
+    }
 }


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1292 (epic)
    - Closes #1293, #1294

---

## Summary

Closes the three #1284 dependency-invalidation follow-ups tracked in epic #1292 (which superseded #1290).

### #1293 — boot Module edges survive a persisted-graph cache hit (MEDIUM) + watch-target lifecycle note (LOW)
- **Merge-not-replace.** On a digest cache hit the boot task previously ran `*g = persisted`, wholesale-replacing the live graph and dropping the `DepKind::Module` edges just populated by `seed_boot_module_edges` (eager path) / `refresh_bundle_and_routes` (deferred path). New `DependencyGraph::merge_from_persisted` (`crates/zfb-graph/src/lib.rs`) blends the persisted graph's non-Module edges, globals, and asset records into the live graph while **preserving live Module edges** (falling back to persisted Module edges only for pages the live session doesn't yet know). This fixes the eager and deferred paths uniformly and sidesteps the empty-`boot_route_module_deps` trap on the deferred path.
- **Seam extraction.** The load→merge→seed assembly is extracted into a pure `assemble_boot_graph` (`crates/zfb/src/commands/dev.rs`) so the regression is testable at Level-1 without V8. 6 new tests in `crates/zfb-graph/tests/boot_graph_assembly_1293.rs` (incl. the primary `module_edges_survive_persisted_graph_load`), all passing; `cargo clippy -p zfb-graph -- -D warnings` clean.
- **Item 2 (LOW).** Added comments at both boot watch-target resolution sites documenting that the out-of-root `.tsx` targets and the CSS `@import` graph are resolved once at boot — a mid-session-added target needs a `zfb dev` restart.

### #1294 — implement the three Level-4 dev-dep-invalidation e2e tests (LOW)
- Filled the three `todo!()` bodies in `crates/zfb/tests/dev_dep_invalidation_1284_e2e.rs` (symptoms A/B/C), wired to a local copy of the `dev_serve_e2e.rs` harness (integration tests are separate binaries) reusing `zfb-test-utils` where it exists. Symptom-B's `@import`s are present at boot (mid-session-added imports are unregistered by design — see #1293 item 2).
- **The tests remain `#[ignore]`d** — they require a running `zfb dev` + staged esbuild/tailwind + V8, which this web env lacks (fresh-V8 compile ICE). **They must be run on a V8-capable host (Mac/CI)** before they can be promoted to a tier.

## Verification
- `zfb-graph`: tests (6/6 new + 42/42 lib) and clippy ran green in-env.
- `crates/zfb/src/commands/dev.rs` and the e2e file could **not** be compiled here (the `zfb` build script needs `pnpm install` + V8) — CI (`build-no-v8` + the V8-on clippy gate) is the authoritative compile gate. A `code-reviewer` pass reviewed both statically and approved.

## Notes
- Commits are unsigned: the SSH signing key is absent in this web environment (committer identity is correct: `Claude <noreply@anthropic.com>`).
- **Mac follow-up:** #1294's e2e tests are unverified here and need a run on a V8 host.

---
_Generated by [Claude Code](https://claude.ai/code/session_011xyX7vH7XnRpygpjXjgCiX)_