### PR TITLE
docs: enable dynamic page transitions on the docs site

### DIFF
--- a/docs/src/config/settings.ts
+++ b/docs/src/config/settings.ts
@@ -90,7 +90,7 @@ export const settings = {
   sidebarResizer: true as boolean,
   sidebarToggle: true as boolean,
   imageEnlarge: true as boolean,
-  dynamicPageTransition: false as boolean,
+  dynamicPageTransition: true as boolean,
   htmlPreview: undefined as HtmlPreviewConfig | undefined,
   versions: false as VersionConfig[] | false,
   claudeResources: {


### PR DESCRIPTION
## Summary

The docs site (https://zfb.takazudomodular.com/) has no client-side page transitions, unlike the zudo-doc reference site (https://zudo-doc.takazudomodular.com/). Root cause: `docs/src/config/settings.ts` has `dynamicPageTransition: false` — the zudo-doc scaffold default, never enabled on this site (verified `false` throughout git history, including across the v2 package-owned-routes migration — so it is *not* a migration regression, the option was simply never turned on).

## Changes

- Flip `dynamicPageTransition` `false → true` in `docs/src/config/settings.ts`.

Under `packageOwnedRoutes: true`, this single flag threads into `enableClientRouter` on every package-owned route (`routes/index`, `locale-index`, `doc-page-shell`, `tag-pages`, `versions-page`, `404`), mounting zfb-runtime's `<ClientRouter />` to drive same-document View Transitions via `document.startViewTransition`. The chrome-persistence CSS (`features.css`) and `page-loading.css` are already imported in `global.css`; the client router needs no host island registration.

## Test Plan

- `pnpm --filter docs build` succeeds and the emitted `docs/dist/` now wires the client router (absent when the flag is off).