### PR TITLE
islands: keep the SSR Hono router out of the client bundle — move createPageRouter to @takazudo/zfb-runtime/server (#1298)

### DIFF
--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -46,7 +46,7 @@
 //! 5. **Emit a synthetic `entry.mjs`** that imports every page module
 //!    found under `pages/`, plus the hydration shim, plus the framework's
 //!    `renderToString`, plus `createPageRouter` from
-//!    `@takazudo/zfb-runtime`, and re-exports a `routes` map of
+//!    `@takazudo/zfb-runtime/server`, and re-exports a `routes` map of
 //!    route-path → page module, a `hydrateIsland` function, and a Workers
 //!    entry shape `default { fetch }`. This is the single load-bearing
 //!    module the embedded V8 host and the runtime SSR adapter consume.
@@ -70,7 +70,7 @@
 //!   is a `(Request) => Promise<Response>` constructed by passing
 //!   `routes`, an embedded `ContentSnapshot` placeholder, and an inline
 //!   framework adapter (the framework's own `renderToString` import) to
-//!   `createPageRouter` from `@takazudo/zfb-runtime`. This is the entry
+//!   `createPageRouter` from `@takazudo/zfb-runtime/server`. This is the entry
 //!   shape the embedded V8 host expects (`export default { fetch }`);
 //!   without it, the host boot fails with a missing-export
 //!   workerd error. Even when the route map is empty the wrapper is
@@ -4929,7 +4929,7 @@ struct EntryModuleInputs<'a> {
 
 /// Generate the `entry.mjs` module that re-exports `routes`,
 /// `hydrateIsland`, and a Workers-style `default { fetch }` wrapper
-/// driven by `createPageRouter` from `@takazudo/zfb-runtime`. This is
+/// driven by `createPageRouter` from `@takazudo/zfb-runtime/server`. This is
 /// the single load-bearing module the embedded V8 host (T6/T7) and the
 /// runtime SSR adapter (T2) consume.
 ///
@@ -4997,7 +4997,11 @@ fn write_entry_module(
     src.push_str(&format!(
         "import {{ hydrateIsland }} from \"./{SHADOW_HYDRATE_FILENAME}\";\n",
     ));
-    src.push_str("import { createPageRouter } from \"@takazudo/zfb-runtime\";\n");
+    // `createPageRouter` lives at the server-only subpath so the client-safe
+    // root barrel (`@takazudo/zfb-runtime`) never pulls Hono into an island's
+    // `--platform=browser` bundle (issue #1298). This SSR entry runs on the
+    // Worker side, where resolving `hono` is expected and correct.
+    src.push_str("import { createPageRouter } from \"@takazudo/zfb-runtime/server\";\n");
     writeln!(
         &mut src,
         "import {{ renderToString as __zfb_renderToString }} from {spec};",
@@ -6152,8 +6156,9 @@ mod tests {
 
         // Imports the runtime factory and the framework's renderToString.
         assert!(
-            body.contains("from \"@takazudo/zfb-runtime\""),
-            "entry.mjs must import createPageRouter from @takazudo/zfb-runtime; got:\n{body}"
+            body.contains("from \"@takazudo/zfb-runtime/server\""),
+            "entry.mjs must import createPageRouter from the server-only subpath \
+             @takazudo/zfb-runtime/server (issue #1298); got:\n{body}"
         );
         assert!(
             body.contains("\"preact-render-to-string\""),

--- a/crates/zfb-build/tests/bundler_integration.rs
+++ b/crates/zfb-build/tests/bundler_integration.rs
@@ -152,13 +152,15 @@ fn end_to_end_bundles_aliases_mdx_islands_and_define() {
         // as external so this test doesn't need a node_modules tree
         // adjacent to the (in-tempdir) shadow root. The bundler's
         // entry.mjs now also imports `createPageRouter` from
-        // `@takazudo/zfb-runtime` and `renderToString` from the
-        // framework's render module — see
-        // `bundler::write_entry_module`.
+        // `@takazudo/zfb-runtime/server` (issue #1298 moved it off the
+        // client-safe root barrel) and `renderToString` from the
+        // framework's render module — see `bundler::write_entry_module`.
+        // esbuild `--external:@takazudo/zfb-runtime` does NOT cover the
+        // `/server` subpath, so it is listed explicitly.
         external: vec![
             "preact".into(),
             "preact-render-to-string".into(),
-            "@takazudo/zfb-runtime".into(),
+            "@takazudo/zfb-runtime/server".into(),
         ],
         outdir: root.join("dist"),
         mode: BundleMode::Production,

--- a/crates/zfb-islands/tests/server_router_excluded_from_client_bundle.rs
+++ b/crates/zfb-islands/tests/server_router_excluded_from_client_bundle.rs
@@ -1,0 +1,274 @@
+//! Real-esbuild build-output regression test for issue #1298.
+//!
+//! ## The bug
+//!
+//! In a pnpm workspace, adding the first `"use client"` island made
+//! `zfb build` fail with `esbuild: Could not resolve "hono"`. Root cause: the
+//! client-facing root barrel of `@takazudo/zfb-runtime` (`src/index.ts`)
+//! *value*-re-exported the SSR-only `createPageRouter`, whose module
+//! (`router.ts`) does `import { Hono } from "hono"`. So any island importing
+//! the bare `@takazudo/zfb-runtime` dragged the Hono server router into the
+//! `--platform=browser` graph, and esbuild had to *resolve* `hono` during
+//! graph construction — which pnpm does not hoist into the consumer's
+//! `node_modules` (it lives only in the nested virtual store).
+//!
+//! ## The fix these tests guard
+//!
+//! `createPageRouter` moved to the server-only subpath
+//! `@takazudo/zfb-runtime/server`; the root barrel is now client-safe (types
+//! only from `./router.js`). An island importing the bare root barrel must
+//! bundle **without esbuild ever needing to resolve `hono`**.
+//!
+//! ## Why Level-3 (build output), not a string assertion
+//!
+//! zfb is a code generator; a string-equality unit test proves the emit
+//! *template* is right, but only running esbuild over a realistic
+//! `node_modules` proves the module graph actually excludes the server
+//! router. Two cases:
+//!
+//! - [`root_barrel_import_excludes_server_router_and_hono`] — a stub where
+//!   `hono` is *unresolvable* (no `node_modules/hono` anywhere). If the
+//!   client graph touched the server router at all, esbuild would fail. The
+//!   build succeeding — plus the output containing no `Hono` / `"hono"` /
+//!   `createPageRouter` — proves exclusion. These negatives also reject a
+//!   hypothetical `--external:hono` "fix" (which would leave `"hono"` in the
+//!   bundle as an external import).
+//! - [`literal_1298_pnpm_store_layout_islands_build_succeeds`] — the LITERAL
+//!   #1298 layout: `hono` present only under the nested pnpm store
+//!   (`node_modules/.pnpm/@takazudo+zfb-runtime@x/node_modules/hono`), the
+//!   package symlinked to the store realpath, and NO hoisted top-level
+//!   `node_modules/hono`. Pre-fix this failed with the exact
+//!   `Could not resolve "hono"`; post-fix the islands build succeeds because
+//!   the client graph never even attempts to resolve the buried `hono`.
+//!
+//! Esbuild gating mirrors the other islands integration tests: locate a
+//! binary via `zfb_test_utils::locate_esbuild()` and skip with a printed note
+//! when none is present (NOT `#[ignore]`).
+//!
+//! ## RED-before-green (verified manually during implementation)
+//!
+//! Restoring the pre-fix barrel shape in the stub — a runtime
+//! `export { createPageRouter } from "./router.js"` on the barrel with the
+//! package's `sideEffects` removed — makes both tests fail with the exact
+//! `Could not resolve "hono"` #1298 error. Re-applying the fix makes them
+//! pass.
+
+use std::ffi::OsString;
+use std::fs;
+use std::path::Path;
+
+use zfb_islands::{
+    BundleConfig, ClientBundler, EsbuildSubprocessBundler, EsbuildSubprocessConfig, Island,
+};
+use zfb_test_utils::locate_esbuild;
+
+/// The post-fix `@takazudo/zfb-runtime` stub bodies, shared by both cases.
+///
+/// The barrel (`index.js`) is the **fixed** shape: it re-exports only the
+/// client-safe `navigate` from `./client-router.js`. `createPageRouter` and
+/// the `hono` import live behind `./router.js`, reachable ONLY via the
+/// `./server` subpath — which an island importing the bare root barrel never
+/// touches. `package.json` carries the post-fix `exports` (`.`,
+/// `./client-router`, `./server`) and the scoped `sideEffects` allowlist.
+struct RuntimeStub;
+
+impl RuntimeStub {
+    const PACKAGE_JSON: &'static str = r#"{
+  "name": "@takazudo/zfb-runtime",
+  "version": "0.0.0-test-stub",
+  "type": "module",
+  "sideEffects": ["./client-router.js"],
+  "exports": {
+    ".": "./index.js",
+    "./server": "./server.js",
+    "./client-router": "./client-router.js"
+  }
+}
+"#;
+
+    /// FIXED root barrel: client-safe re-export only. The pre-fix bug was an
+    /// additional `export { createPageRouter } from "./router.js";` here.
+    const INDEX_JS: &'static str = "export { navigate } from \"./client-router.js\";\n";
+
+    /// Client-safe surface — no `hono`.
+    const CLIENT_ROUTER_JS: &'static str = "export function navigate(_url) {}\n";
+
+    /// SSR-only router — pulls `hono`. Reachable only via `./server`.
+    const ROUTER_JS: &'static str =
+        "import { Hono } from \"hono\";\nexport function createPageRouter() { return new Hono(); }\n";
+
+    /// The `./server` subpath backing `createPageRouter`.
+    const SERVER_JS: &'static str = "export { createPageRouter } from \"./router.js\";\n";
+
+    /// Write the four stub source files + `package.json` under `pkg_dir`.
+    fn write_into(pkg_dir: &Path) {
+        fs::create_dir_all(pkg_dir).unwrap();
+        fs::write(pkg_dir.join("package.json"), Self::PACKAGE_JSON).unwrap();
+        fs::write(pkg_dir.join("index.js"), Self::INDEX_JS).unwrap();
+        fs::write(pkg_dir.join("client-router.js"), Self::CLIENT_ROUTER_JS).unwrap();
+        fs::write(pkg_dir.join("router.js"), Self::ROUTER_JS).unwrap();
+        fs::write(pkg_dir.join("server.js"), Self::SERVER_JS).unwrap();
+    }
+}
+
+/// An island that imports the **bare root barrel** (`@takazudo/zfb-runtime`)
+/// and uses its client-safe surface. Because the islands bundler wraps the
+/// island with `import * as Mod from "<island>"`, every export (and therefore
+/// the barrel edge) is retained.
+fn write_island(root: &Path) -> std::path::PathBuf {
+    fs::create_dir_all(root.join("components")).unwrap();
+    let island_path = root.join("components/counter.tsx");
+    fs::write(
+        &island_path,
+        "import { navigate } from \"@takazudo/zfb-runtime\";\n\
+         export const Counter = () => null;\n\
+         // Keep the root-barrel edge live for esbuild.\n\
+         export function goHome() { return navigate(\"/\"); }\n",
+    )
+    .unwrap();
+    island_path
+}
+
+/// Externals scoped to `@takazudo/zfb` (and subpaths) + preact — NOT
+/// `@takazudo/zfb-runtime`, which must be bundled so esbuild walks into the
+/// stub barrel. Mirrors `preact_jsx_runtime_alias.rs::shared_externals` and
+/// the real islands `shared_externals()`.
+fn shared_externals() -> Vec<OsString> {
+    [
+        "--external:preact",
+        "--external:preact/*",
+        "--external:@takazudo/zfb",
+        "--external:@takazudo/zfb/*",
+    ]
+    .into_iter()
+    .map(OsString::from)
+    .collect()
+}
+
+/// Assert the bundle body carries none of the server-router poison. Also
+/// rejects an `--external:hono` "fix" (which would leave `"hono"` behind).
+fn assert_no_server_router(body: &str) {
+    assert!(
+        !body.contains("Hono"),
+        "client bundle must not contain the Hono class (server router leaked); got:\n{body}"
+    );
+    assert!(
+        !body.contains("hono"),
+        "client bundle must not reference \"hono\" — not even as an external import \
+         (rejects an --external:hono workaround); got:\n{body}"
+    );
+    assert!(
+        !body.contains("createPageRouter"),
+        "client bundle must not contain createPageRouter (server factory leaked); got:\n{body}"
+    );
+}
+
+/// **#1298 exclusion — no resolvable `hono` at all.**
+///
+/// The stub has NO `node_modules/hono`. If the client graph reached the
+/// server router, esbuild would abort with `Could not resolve "hono"`. The
+/// build succeeding, with a bundle free of `Hono` / `"hono"` /
+/// `createPageRouter`, proves the root barrel excludes the server router.
+#[test]
+fn root_barrel_import_excludes_server_router_and_hono() {
+    let Some(esbuild) = locate_esbuild() else {
+        eprintln!("[server_router_excluded] no esbuild binary available; skipping.");
+        return;
+    };
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+
+    // Flat regular-package layout; deliberately NO node_modules/hono.
+    RuntimeStub::write_into(&root.join("node_modules/@takazudo/zfb-runtime"));
+    let island_path = write_island(root);
+
+    let cfg = EsbuildSubprocessConfig {
+        extra_args: shared_externals(),
+        ..EsbuildSubprocessConfig::default()
+    }
+    .with_binary_path(esbuild)
+    .with_working_dir(root);
+
+    let bundle_cfg = BundleConfig::default().with_outdir(root.join("dist"));
+
+    let bundler = EsbuildSubprocessBundler::new(cfg);
+    let out = bundler
+        .bundle(&[Island::new("Counter", &island_path)], &bundle_cfg)
+        .expect(
+            "issue #1298: an island importing the bare @takazudo/zfb-runtime root barrel \
+             must bundle without resolving the server-only hono dependency",
+        );
+
+    assert!(!out.bytes.is_empty(), "bundle output should be non-empty");
+    let body = String::from_utf8(out.bytes).expect("bundled bytes are valid UTF-8");
+    assert_no_server_router(&body);
+}
+
+/// **#1298 literal pnpm layout — permanent CI coverage.**
+///
+/// Reproduces the exact bug-report shape: `hono` reachable only via the
+/// nested pnpm store, `node_modules/@takazudo/zfb-runtime` a symlink to the
+/// store realpath, and NO hoisted top-level `node_modules/hono`. Pre-fix this
+/// failed with `Could not resolve "hono"`; post-fix the islands build
+/// succeeds because the client graph never attempts to resolve the buried
+/// `hono`. Symlink shape mirrors
+/// `npm_dist_islands.rs::pnpm_symlinked_regular_package_use_client_module_is_registered`
+/// (#999) and `bundler_workspace_pkg_alias.rs` (#443).
+#[cfg(unix)]
+#[test]
+fn literal_1298_pnpm_store_layout_islands_build_succeeds() {
+    let Some(esbuild) = locate_esbuild() else {
+        eprintln!("[server_router_excluded/pnpm] no esbuild binary available; skipping.");
+        return;
+    };
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+
+    // The real package lives in the pnpm content store (realpath).
+    let store = root
+        .join("node_modules/.pnpm/@takazudo+zfb-runtime@0.0.0/node_modules/@takazudo/zfb-runtime");
+    RuntimeStub::write_into(&store);
+
+    // `hono` is present ONLY nested inside the same store dir — exactly where
+    // pnpm isolates a transitive dep, unreachable from the consumer's
+    // top-level node_modules. No hoisted `node_modules/hono` is created.
+    let hono_dir = root.join("node_modules/.pnpm/@takazudo+zfb-runtime@0.0.0/node_modules/hono");
+    fs::create_dir_all(&hono_dir).unwrap();
+    fs::write(
+        hono_dir.join("package.json"),
+        "{ \"name\": \"hono\", \"version\": \"4.0.0-test\", \"type\": \"module\", \"main\": \"./index.js\" }\n",
+    )
+    .unwrap();
+    fs::write(hono_dir.join("index.js"), "export class Hono {}\n").unwrap();
+
+    // node_modules/@takazudo/zfb-runtime -> the store realpath (pnpm's shape).
+    let link = root.join("node_modules/@takazudo/zfb-runtime");
+    fs::create_dir_all(link.parent().unwrap()).unwrap();
+    std::os::unix::fs::symlink(&store, &link).expect("symlink pnpm package");
+
+    let island_path = write_island(root);
+
+    let cfg = EsbuildSubprocessConfig {
+        extra_args: shared_externals(),
+        ..EsbuildSubprocessConfig::default()
+    }
+    .with_binary_path(esbuild)
+    .with_working_dir(root);
+
+    let bundle_cfg = BundleConfig::default().with_outdir(root.join("dist"));
+
+    let bundler = EsbuildSubprocessBundler::new(cfg);
+    let out = bundler
+        .bundle(&[Island::new("Counter", &island_path)], &bundle_cfg)
+        .expect(
+            "issue #1298 (literal pnpm layout): the islands build must succeed even though \
+             hono is reachable only via the nested pnpm store — the client graph must not \
+             attempt to resolve it",
+        );
+
+    assert!(!out.bytes.is_empty(), "bundle output should be non-empty");
+    let body = String::from_utf8(out.bytes).expect("bundled bytes are valid UTF-8");
+    assert_no_server_router(&body);
+}

--- a/crates/zfb/src/render_pipeline.rs
+++ b/crates/zfb/src/render_pipeline.rs
@@ -1587,6 +1587,26 @@ mod tests {
             "missing @takazudo/zfb-runtime/src/index.ts"
         );
 
+        // Issue #1298: the server-only `createPageRouter` entry moved to
+        // `src/server.ts` (backing the `@takazudo/zfb-runtime/server`
+        // subpath). `build.rs`'s `copy_ts_src` auto-stages every non-test
+        // `.ts` file, so the embedded snapshot must carry it — otherwise the
+        // no-`node_modules` SSR emit (which now imports from `/server`) cannot
+        // resolve the factory.
+        assert!(
+            nm_path.join("@takazudo/zfb-runtime/src/server.ts").exists(),
+            "missing @takazudo/zfb-runtime/src/server.ts in extracted layout \
+             (issue #1298 server subpath)"
+        );
+        let runtime_pkg_json =
+            std::fs::read_to_string(nm_path.join("@takazudo/zfb-runtime/package.json"))
+                .expect("read embedded @takazudo/zfb-runtime/package.json");
+        assert!(
+            runtime_pkg_json.contains("\"./server\""),
+            "embedded @takazudo/zfb-runtime/package.json must declare the `./server` \
+             export condition (issue #1298); got:\n{runtime_pkg_json}"
+        );
+
         // Sub #209 — framework runtime package roots must exist alongside.
         for pkg in ["preact", "preact-render-to-string", "hono"] {
             let pkg_json = nm_path.join(pkg).join("package.json");

--- a/packages/zfb-runtime/README.md
+++ b/packages/zfb-runtime/README.md
@@ -52,8 +52,14 @@ to the chosen JSX runtime; both `preact-render-to-string` and
 
 ## Public API
 
+`createPageRouter` is **server-only** — it builds a Hono app, so it lives at
+the `@takazudo/zfb-runtime/server` subpath. Keeping it out of the client-safe
+`.` barrel means an island importing the bare `@takazudo/zfb-runtime` never
+drags `hono` into a `--platform=browser` bundle (issue #1298). Its *types*
+remain importable from the root barrel (they carry no runtime).
+
 ```ts
-import { createPageRouter } from "@takazudo/zfb-runtime";
+import { createPageRouter } from "@takazudo/zfb-runtime/server";
 import type {
   CreatePageRouterOptions,
   PageDefinition,

--- a/packages/zfb-runtime/package.json
+++ b/packages/zfb-runtime/package.json
@@ -29,10 +29,24 @@
   },
   "main": "./src/index.ts",
   "types": "./src/index.ts",
+  "sideEffects": [
+    "./src/client-router.ts",
+    "./src/client-router/index.ts",
+    "./src/client-router/router.ts",
+    "./src/client-router/prefetch.ts",
+    "./dist/client-router.js",
+    "./dist/client-router/index.js",
+    "./dist/client-router/router.js",
+    "./dist/client-router/prefetch.js"
+  ],
   "exports": {
     ".": {
       "types": "./src/index.ts",
       "default": "./src/index.ts"
+    },
+    "./server": {
+      "types": "./src/server.ts",
+      "default": "./src/server.ts"
     },
     "./snapshot": {
       "types": "./src/snapshot.ts",
@@ -57,6 +71,10 @@
       ".": {
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
+      },
+      "./server": {
+        "types": "./dist/server.d.ts",
+        "default": "./dist/server.js"
       },
       "./snapshot": {
         "types": "./dist/snapshot.d.ts",

--- a/packages/zfb-runtime/src/__tests__/root-barrel-no-server-router.test.ts
+++ b/packages/zfb-runtime/src/__tests__/root-barrel-no-server-router.test.ts
@@ -1,0 +1,57 @@
+// Structural guard for issue #1298.
+//
+// The client-facing root barrel (`src/index.ts`) must stay bundleable for
+// `--platform=browser`. Its one poison hop was a *runtime value* re-export of
+// `createPageRouter` from `./router.js` — that file imports `hono`, so the
+// re-export dragged the Hono server router into any island that imported the
+// bare `@takazudo/zfb-runtime`, and esbuild then had to resolve the
+// transitively-buried `hono` (which pnpm does not hoist) → `zfb build` failed.
+//
+// The fix moved the factory to the server-only `@takazudo/zfb-runtime/server`
+// subpath (`src/server.ts`). `export type { ... } from "./router.js"` is fine
+// — esbuild strips type-only re-exports and no runtime edge survives. A bare
+// `export { ... } from "./router.js"` is NOT fine — it is a runtime edge.
+//
+// This is a Level-1 structural test: it reads the source text rather than
+// bundling, so it always runs (no esbuild needed) and fails loudly the moment
+// someone reintroduces the runtime re-export. The behavioral proof that the
+// exclusion actually holds under esbuild lives in the Rust Level-3 test
+// `crates/zfb-islands/tests/server_router_excluded_from_client_bundle.rs`.
+
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const indexSource = readFileSync(new URL("../index.ts", import.meta.url), "utf8");
+
+// A runtime value re-export: `export { ... } from "./router.js"` — but NOT
+// `export type { ... }`. The negative lookahead after `export` rejects the
+// `type` keyword so type-only re-exports are allowed through.
+const RUNTIME_REEXPORT_FROM_ROUTER =
+  /export\s+(?!type\b)\{[^}]*\}\s*from\s*["']\.\/router(?:\.js)?["']/;
+
+// A type-only re-export: `export type { ... } from "./router.js"`.
+const TYPE_REEXPORT_FROM_ROUTER = /export\s+type\s*\{[^}]*\}\s*from\s*["']\.\/router(?:\.js)?["']/;
+
+describe("root barrel (src/index.ts) — client-safe (issue #1298)", () => {
+  it("does NOT runtime-re-export any value from ./router.js", () => {
+    expect(indexSource).not.toMatch(RUNTIME_REEXPORT_FROM_ROUTER);
+  });
+
+  it("does NOT mention createPageRouter as a runtime export", () => {
+    // Belt-and-suspenders: even a differently-shaped runtime re-export of the
+    // factory (e.g. an aliased `export { createPageRouter as x }`) is banned.
+    // `createPageRouter` may still appear inside a doc comment referencing the
+    // /server subpath, so scope the check to `export {`-form statements only.
+    const runtimeExportOfFactory =
+      /export\s+(?!type\b)\{[^}]*\bcreatePageRouter\b[^}]*\}\s*from\s*["']\.\/router(?:\.js)?["']/;
+    expect(indexSource).not.toMatch(runtimeExportOfFactory);
+  });
+
+  it("still type-re-exports the page-router types from ./router.js", () => {
+    // The types carry no runtime, so keeping them on the root barrel is the
+    // whole point — consumers still `import type { PageRouter } from
+    // "@takazudo/zfb-runtime"`. This asserts the fix did not over-reach and
+    // strip the type surface too.
+    expect(indexSource).toMatch(TYPE_REEXPORT_FROM_ROUTER);
+  });
+});

--- a/packages/zfb-runtime/src/index.ts
+++ b/packages/zfb-runtime/src/index.ts
@@ -1,9 +1,19 @@
 // Public entry point for `@takazudo/zfb-runtime`.
 //
-// Worker bundles produced by T3 import this module and invoke
+// This is the **client-safe** barrel: everything re-exported here must be
+// bundleable for `--platform=browser` without pulling a server-only
+// dependency. In particular `createPageRouter` (and the Hono server router
+// it builds) is intentionally NOT re-exported here — it lives at the
+// server-only subpath `@takazudo/zfb-runtime/server`. Re-exporting it from
+// this barrel makes any island that does `import ... from "@takazudo/zfb-runtime"`
+// drag `hono` into the browser graph, which esbuild must then resolve
+// (issue #1298). The page-router *types* below are `export type` only, so
+// esbuild strips them and no runtime edge to `./router.js` survives.
+//
+// Worker bundles produced by T3 import the server subpath and invoke
 // `createPageRouter` once, at module top, to obtain the fetch handler:
 //
-//   import { createPageRouter } from "@takazudo/zfb-runtime";
+//   import { createPageRouter } from "@takazudo/zfb-runtime/server";
 //
 //   const router = createPageRouter({
 //     pages: [...],
@@ -15,7 +25,6 @@
 //
 // The README documents the bundle shape T6 (embedded V8 host) consumes.
 
-export { createPageRouter } from "./router.js";
 export type {
   CreatePageRouterOptions,
   PageDefinition,

--- a/packages/zfb-runtime/src/server.ts
+++ b/packages/zfb-runtime/src/server.ts
@@ -1,0 +1,21 @@
+// Server-only entry point for `@takazudo/zfb-runtime` (subpath `/server`).
+//
+// `createPageRouter` builds a Hono app, so importing it pulls `hono` into the
+// module graph. That is fine — even *desirable* — on the SSR / Worker side,
+// but it must never reach a `--platform=browser` island bundle. Keeping the
+// factory behind this dedicated subpath (rather than the client-safe `.`
+// barrel in `./index.ts`) is what lets esbuild bundle an island that imports
+// the bare `@takazudo/zfb-runtime` root without ever needing to resolve
+// `hono` (issue #1298).
+//
+// The zfb SSR emit (`crates/zfb-build/src/bundler.rs`) imports
+// `createPageRouter` from here.
+
+export { createPageRouter } from "./router.js";
+export type {
+  CreatePageRouterOptions,
+  PageDefinition,
+  PageHeading,
+  PageModule,
+  PageRouter,
+} from "./router.js";

--- a/packages/zfb-runtime/src/snapshot.ts
+++ b/packages/zfb-runtime/src/snapshot.ts
@@ -5,8 +5,9 @@
 // (see `ContentSnapshot` and `EntrySnapshot`). The build-time pipeline
 // constructs the snapshot, serializes it to JSON, and embeds it in the
 // Worker bundle that the embedded V8 host loads. At Worker boot the embedded value
-// is handed to [`createPageRouter`] (re-exported from the package root),
-// which registers it with the `zfb/content` module so user pages calling
+// is handed to [`createPageRouter`] (exported from the server-only subpath
+// `@takazudo/zfb-runtime/server`), which registers it with the `zfb/content`
+// module so user pages calling
 // `getCollection("blog")` resolve from memory rather than from the
 // filesystem.
 //


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1298
    - https://github.com/Takazudo/zudo-front-builder/issues/1302

---

## Summary

Fixes #1298. In a pnpm workspace, adding the first `"use client"` island made `zfb build` fail with `esbuild: Could not resolve "hono"` from `@takazudo/zfb-runtime/dist/router.js`.

**Root cause:** the client-facing root barrel `packages/zfb-runtime/src/index.ts` **value-re-exported** the SSR-only `createPageRouter` (which imports `hono` via `router.ts`). Any island importing the bare `@takazudo/zfb-runtime` therefore dragged the Hono server router into the browser graph; with no `sideEffects` field, esbuild must *resolve* `hono` during graph construction (before tree-shaking), and pnpm doesn't hoist the transitive `hono` — while the islands esbuild step (unlike the main SSR build) has no embedded-vendor fallback.

**Fix (package-boundary split, not a blind `--external:hono`):** move `createPageRouter` to a server-only subpath `@takazudo/zfb-runtime/server`, drop the root-barrel runtime re-export (keeping the type-only re-exports), add a scoped `sideEffects`, and update zfb's SSR emit to import from `/server`. The server router is now unreachable from any client graph, independent of tree-shaking — fixing both the resolution error and the browser bloat.

## Changes

- `packages/zfb-runtime/src/index.ts` — remove the runtime `createPageRouter` re-export from the root barrel; keep the type-only re-exports; doc block points at `/server`.
- `packages/zfb-runtime/src/server.ts` (new) — server-only entry backing the `/server` subpath.
- `packages/zfb-runtime/package.json` — add `./server` to `exports` + `publishConfig.exports`; add a scoped `sideEffects` array (lists the listener-registering client-router/prefetch modules for src + dist so their side effects survive).
- `crates/zfb-build/src/bundler.rs` — SSR emit imports `createPageRouter` from `@takazudo/zfb-runtime/server`; string assertion + docs updated.
- `crates/zfb-build/tests/bundler_integration.rs` — external list updated to the `/server` subpath.
- `crates/zfb/src/render_pipeline.rs` — embedded-extraction assertion (`src/server.ts` staged + `./server` export present).
- **Tests:** `crates/zfb-islands/tests/server_router_excluded_from_client_bundle.rs` (Level-3, esbuild-gated, 2 cases incl. the literal nested-pnpm-store #1298 repro) + `packages/zfb-runtime/src/__tests__/root-barrel-no-server-router.test.ts` (structural guard).

## Verification

- `cargo test --workspace` green (137 `test result: ok`, 0 failed).
- New exclusion tests pass (real esbuild): `root_barrel_import_excludes_server_router_and_hono` + `literal_1298_pnpm_store_layout_islands_build_succeeds`.
- Falsifiability: restoring the barrel re-export reproduces the exact `Could not resolve "hono"` error, **even with `sideEffects` present** — confirming the barrel move (not `sideEffects`) is the load-bearing fix.
- `cargo clippy --all-targets -- -D warnings` clean; `pnpm -r typecheck` + `pnpm -r test` green.
- Codex review: no blocking correctness issues.

Epic #1302 · sub-issues #1303 (fix) + #1304 (verify).