### PR TITLE
Zfb Issue Sweep: fix dev skip-key page-staleness (#1301) and CSS relative-import base (#1300)

### DIFF
--- a/crates/zfb-build/src/pipeline/dev.rs
+++ b/crates/zfb-build/src/pipeline/dev.rs
@@ -632,10 +632,16 @@ impl AssetPipeline for DevAssetPipeline {
 
         // True when the reloader reported [`RefreshOutcome::Skipped`]
         // (issue #956): byte-identical bundle + unchanged route universe.
-        // The render fan-out is bypassed for the tick — re-rendering
-        // against an identical bundle would re-emit identical HTML, the
-        // same determinism assumption the `last_bytes` byte-dedup cache
-        // already makes. CSS, islands, and plan prune paths still run.
+        // The V8 host boot + `paths()` re-expansion inside the reloader is
+        // bypassed (the #940/#956 win) — but the render fan-out itself is
+        // NOT (issue #1301): the skip-key carries no page-selection info, so
+        // bypassing render would silently lose a later tick's route staleness
+        // when its selection differs from an earlier byte-identical tick.
+        // Instead only the PRUNE half is skipped here — on a skip the route
+        // table did not move, so nothing vanished. The render half still
+        // runs; redundant re-renders against an identical bundle re-emit
+        // identical HTML and are absorbed by the `last_bytes` byte-dedup
+        // cache (no write, no SSE). CSS, islands, and plan prune paths run.
         let mut renderer_refresh_skipped = false;
 
         // Content-narrowing hint for the render callback (issues #958 /
@@ -710,24 +716,31 @@ impl AssetPipeline for DevAssetPipeline {
             }
         }
 
-        // Prune safety on a skipped tick (issue #956 gate (c) / #727): when
-        // the refresh was skipped, the route table did not move, so nothing
-        // vanished this tick. By bypassing this whole block neither the
-        // stale-output candidates nor the live-dests bookkeeping run — an
-        // unrendered URL can never be mistaken for a vanished one.
-        if !pages.is_empty() && !renderer_refresh_skipped {
+        // Render + write is decoupled from prune (issue #1301): a skipped
+        // tick (issue #956) still re-renders its SELECTED pages so a later
+        // tick whose page-selection differs from an earlier byte-identical
+        // tick does not silently serve stale bytes. The skip-key carries no
+        // page-selection info, so the bypass could drop the second tick's
+        // route staleness entirely. Redundant re-renders against an
+        // identical bundle are absorbed by `WriteCache.last_bytes` byte-dedup
+        // (already-fresh pages produce no write, no SSE), the same
+        // determinism assumption the skip originally relied on.
+        //
+        // Only the render + write half runs unconditionally when `pages` is
+        // non-empty; the prune half stays gated on `!renderer_refresh_skipped`
+        // below — on a skip the route table did not move, so nothing vanished.
+        let mut prune_candidates: Vec<PathBuf> = Vec::new();
+        let mut live_dests: HashSet<PathBuf> = HashSet::new();
+        if !pages.is_empty() {
             let rendered = (ctx.render_pages)(&pages, narrowing.as_ref())?;
             outcome.pages_rendered = rendered.len();
 
             // Collect prune candidates and the live dest set during the
             // write loop; the actual deletes are deferred to after the
-            // loop. This prevents a page's prune from deleting a path
-            // that a sibling page in the same tick has already written
-            // (or will write) to — i.e. the two-page output-path swap
-            // scenario described in issue #727.
-            let mut prune_candidates: Vec<PathBuf> = Vec::new();
-            let mut live_dests: HashSet<PathBuf> = HashSet::new();
-
+            // loop (and gated on `!renderer_refresh_skipped`). This prevents
+            // a page's prune from deleting a path that a sibling page in the
+            // same tick has already written (or will write) to — i.e. the
+            // two-page output-path swap scenario described in issue #727.
             for r in rendered {
                 // Reject any output_path that escapes dist_root via
                 // `..` or absolute roots before we touch the
@@ -751,7 +764,16 @@ impl AssetPipeline for DevAssetPipeline {
                     outcome.pages_written.push(r.page.clone());
                 }
             }
+        }
 
+        // Prune safety on a skipped tick (issue #956 gate (c) / #727): when
+        // the refresh was skipped, the route table did not move, so nothing
+        // vanished this tick. Bypassing the deferred-prune loop means neither
+        // the stale-output candidates nor the vanished-route paths are acted
+        // on — an unrendered URL can never be mistaken for a vanished one. The
+        // render + write half above still ran, keeping the selected pages
+        // fresh (issue #1301).
+        if !pages.is_empty() && !renderer_refresh_skipped {
             // Deferred prune: remove candidates that are no longer live.
             // Skip any path that appears in live_dests — another page in
             // this same tick now owns it, so deleting it would remove
@@ -762,7 +784,10 @@ impl AssetPipeline for DevAssetPipeline {
             // table after this tick's rebuild — e.g. a content file was
             // deleted or a dynamic route's paths() output shrank). Apply
             // the same live_dests guard: if route A lost /x while route B
-            // simultaneously gained /x, /x must NOT be deleted.
+            // simultaneously gained /x, /x must NOT be deleted. `route_vanished`
+            // carries `plan.prune_paths`; on a skip this block does not run,
+            // so those paths are handled once by the plan-prune block (1b)
+            // below instead.
             for prev in prune_candidates.into_iter().chain(route_vanished) {
                 if live_dests.contains(&prev) {
                     continue; // another page now owns this path — skip
@@ -777,12 +802,16 @@ impl AssetPipeline for DevAssetPipeline {
         // supplied by the orchestrator from a discovery refresh that already
         // set renderer_fresh (so reload_renderer was skipped and these paths
         // could not be returned through the normal vanished-routes channel).
-        // Only runs when the render loop above did not — pages empty, or the
-        // renderer refresh was skipped (issue #956; defensive: a discovery
-        // refresh sets renderer_fresh, so a Skipped reload never coincides
-        // with plan prune paths in practice). If the render loop ran,
-        // prune_paths were already included in route_vanished and processed
-        // there.
+        // This block's gate is the exact complement of the deferred-prune
+        // block above (`!pages.is_empty() && !renderer_refresh_skipped`), so
+        // `plan.prune_paths` — carried into `route_vanished` and consumed
+        // there when that block runs — is processed EXACTLY ONCE: it runs
+        // here only when pages are empty or the renderer refresh was skipped
+        // (issue #956; defensive: a discovery refresh sets renderer_fresh, so
+        // a Skipped reload never coincides with plan prune paths in practice).
+        // Note the render+write half (issue #1301) may still have run above on
+        // a skipped tick — that half does not consume `route_vanished`, only
+        // the deferred-prune half does.
         if (pages.is_empty() || renderer_refresh_skipped) && !plan.prune_paths.is_empty() {
             for prev in &plan.prune_paths {
                 let _ = std::fs::remove_file(prev);
@@ -1314,12 +1343,14 @@ mod tests {
         }
     }
 
-    /// A `Skipped` reload must bypass the render fan-out entirely: the
-    /// render callback is never invoked, no HTML is written, and nothing
-    /// already on disk is pruned (gate (c) — an unrendered URL must not
-    /// be mistaken for a vanished one).
+    /// A `Skipped` reload still renders its selected pages (issue #1301 —
+    /// the skip-key carries no page selection, so bypassing render would
+    /// drop a later tick's route staleness), but it must PRUNE NOTHING
+    /// (gate (c) — an unrendered/unmoved URL must not be mistaken for a
+    /// vanished one). Re-rendering the identical bundle re-emits identical
+    /// HTML, absorbed by the `last_bytes` byte-dedup (no write on tick 2).
     #[test]
-    fn skipped_reload_bypasses_render_and_prunes_nothing() {
+    fn skipped_reload_renders_selection_but_prunes_nothing() {
         let dir = tempdir().unwrap();
         let pipeline = DevAssetPipeline::new();
         let rendered = vec![RenderedPage {
@@ -1345,8 +1376,9 @@ mod tests {
         assert_eq!(first.pages_rendered, 1);
         assert!(dir.path().join("a/index.html").exists());
 
-        // Tick 2: byte-identical bundle → Skipped. No render, no write,
-        // no prune; the existing HTML stays on disk.
+        // Tick 2: byte-identical bundle → Skipped. The render half still
+        // runs (issue #1301), but the identical HTML is deduped (no write)
+        // and nothing is pruned; the existing HTML stays on disk.
         let calls2 = Arc::new(AtomicUsize::new(0));
         let ctx2 = ctx_with_reload_outcome(
             dir.path().to_path_buf(),
@@ -1357,14 +1389,17 @@ mod tests {
         let second = pipeline.apply(&plan, &ctx2).unwrap();
         assert_eq!(
             calls2.load(Ordering::SeqCst),
-            0,
-            "Skipped tick must not invoke the render callback"
+            1,
+            "Skipped tick still renders its selected pages (issue #1301)"
         );
-        assert_eq!(second.pages_rendered, 0, "no pages rendered on skip");
-        assert!(second.pages_written.is_empty(), "no HTML written on skip");
+        assert_eq!(second.pages_rendered, 1, "selected page rendered on skip");
+        assert!(
+            second.pages_written.is_empty(),
+            "identical HTML is byte-deduped — no write on skip"
+        );
         assert!(
             second.pages_pruned.is_empty(),
-            "skip must not treat unrendered URLs as vanished; pruned={:?}",
+            "skip must not treat unrendered/unmoved URLs as vanished; pruned={:?}",
             second.pages_pruned,
         );
         assert!(
@@ -1373,8 +1408,8 @@ mod tests {
         );
     }
 
-    /// A `Skipped` reload bypasses only the render loop — CSS and islands
-    /// requested by the plan must still run.
+    /// A `Skipped` reload still runs the render half (issue #1301) as well
+    /// as any CSS and islands requested by the plan.
     #[test]
     fn skipped_reload_still_runs_css_and_islands() {
         let dir = tempdir().unwrap();
@@ -1410,7 +1445,11 @@ mod tests {
         plan.rerun_islands = true;
 
         let outcome = pipeline.apply(&plan, &ctx).unwrap();
-        assert_eq!(render_calls.load(Ordering::SeqCst), 0, "render bypassed");
+        assert_eq!(
+            render_calls.load(Ordering::SeqCst),
+            1,
+            "render half still runs on a skipped tick (issue #1301)"
+        );
         assert!(outcome.css_rerun, "CSS still reruns on a skipped tick");
         assert_eq!(css_calls.load(Ordering::SeqCst), 1);
         assert!(
@@ -1418,6 +1457,116 @@ mod tests {
             "islands still rerun on a skipped tick"
         );
         assert_eq!(islands_calls.load(Ordering::SeqCst), 1);
+    }
+
+    /// Straddling-tick regression (issue #1301, fixes #1301): tick A
+    /// produces a bundle selecting only route R1; tick B produces a
+    /// BYTE-IDENTICAL bundle (`RefreshOutcome::Skipped`) but the incoming
+    /// plan selects route R2 (the differing selection comes from the plan's
+    /// `pages` — driven by the dirty set — NOT from the route table). R2
+    /// must be rendered and written on tick B; before the fix the skip
+    /// short-circuited the whole render fan-out and R2 stayed silently
+    /// stale until the next real bundle change.
+    #[test]
+    fn skipped_tick_still_renders_differing_page_selection() {
+        let dir = tempdir().unwrap();
+        let pipeline = DevAssetPipeline::new();
+
+        // The render callback maps each selected PageId to its own output
+        // path so the plan's selection genuinely drives what is rendered —
+        // exactly the coupling the skip-key discards.
+        fn render_by_selection(calls: Arc<AtomicUsize>) -> crate::pipeline::PageRenderer {
+            Arc::new(move |pages: &[PageId], _| {
+                calls.fetch_add(1, Ordering::SeqCst);
+                Ok(pages
+                    .iter()
+                    .map(|p| {
+                        let name = p.path().file_stem().unwrap().to_string_lossy().into_owned();
+                        RenderedPage {
+                            page: p.clone(),
+                            output_path: RelDistPath::new(format!("{name}/index.html")).unwrap(),
+                            html: format!("<h1>{name}</h1>"),
+                            content_type: None,
+                        }
+                    })
+                    .collect())
+            })
+        }
+
+        fn plan_selecting(page: &str) -> RebuildPlan {
+            let mut sel = BTreeSet::new();
+            sel.insert(pid(page));
+            RebuildPlan {
+                pages: PageSelection::Specific(sel),
+                rerun_css: false,
+                rerun_islands: false,
+                rerun_client_scripts: false,
+                renderer_fresh: false,
+                ssr_reload_needed: false,
+                prune_paths: vec![],
+                triggers: vec![],
+                content_narrowing: None,
+            }
+        }
+
+        // Tick A: real refresh, selection = R1 only.
+        let calls_a = Arc::new(AtomicUsize::new(0));
+        let ctx_a = BuildContext {
+            dist_root: dir.path().to_path_buf(),
+            render_pages: render_by_selection(calls_a.clone()),
+            run_css: None,
+            run_islands: None,
+            run_client_scripts: None,
+            reload_renderer: Some(Arc::new(|| {
+                Ok(RefreshOutcome::Refreshed {
+                    vanished: vec![],
+                    changed_sources: vec![],
+                })
+            })),
+        };
+        let plan_a = plan_selecting("/p/r1.tsx");
+        let a = pipeline.apply(&plan_a, &ctx_a).unwrap();
+        assert_eq!(a.pages_rendered, 1);
+        assert!(dir.path().join("r1/index.html").exists());
+        assert!(
+            !dir.path().join("r2/index.html").exists(),
+            "R2 was not selected on tick A"
+        );
+
+        // Tick B: byte-identical bundle → Skipped; selection = R2 only.
+        let calls_b = Arc::new(AtomicUsize::new(0));
+        let ctx_b = BuildContext {
+            dist_root: dir.path().to_path_buf(),
+            render_pages: render_by_selection(calls_b.clone()),
+            run_css: None,
+            run_islands: None,
+            run_client_scripts: None,
+            reload_renderer: Some(Arc::new(|| Ok(RefreshOutcome::Skipped))),
+        };
+        let plan_b = plan_selecting("/p/r2.tsx");
+        let b = pipeline.apply(&plan_b, &ctx_b).unwrap();
+
+        assert_eq!(
+            calls_b.load(Ordering::SeqCst),
+            1,
+            "a skipped tick must still render its (differing) selection"
+        );
+        assert_eq!(b.pages_rendered, 1, "R2 rendered on the skipped tick");
+        assert!(
+            b.pages_written.contains(&pid("/p/r2.tsx")),
+            "R2 must be freshly written on tick B, not left stale; written={:?}",
+            b.pages_written,
+        );
+        assert!(
+            dir.path().join("r2/index.html").exists(),
+            "R2 output must exist after the skipped tick (issue #1301)"
+        );
+        // Prune stays gated off on a skip — R1 must survive untouched.
+        assert!(b.pages_pruned.is_empty(), "skip prunes nothing");
+        assert!(
+            dir.path().join("r1/index.html").exists(),
+            "R1 must survive the skipped tick"
+        );
     }
 
     /// Plan-carried prune paths (issue #804 P2) are still processed when
@@ -1442,11 +1591,18 @@ mod tests {
         plan.prune_paths = vec![stale.clone()];
 
         let outcome = pipeline.apply(&plan, &ctx).unwrap();
-        assert_eq!(calls.load(Ordering::SeqCst), 0, "render bypassed");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "render half still runs on a skipped tick (issue #1301)"
+        );
         assert!(!stale.exists(), "plan prune path must still be deleted");
-        assert!(
-            outcome.pages_pruned.contains(&stale),
-            "pages_pruned must report the plan prune path; got {:?}",
+        // Processed exactly once: the deferred-prune loop is gated off on a
+        // skip, so the plan-prune block (1b) is the sole handler here.
+        assert_eq!(
+            outcome.pages_pruned.iter().filter(|p| **p == stale).count(),
+            1,
+            "plan prune path must be reported exactly once; got {:?}",
             outcome.pages_pruned,
         );
     }

--- a/crates/zfb-build/tests/integration_lazy_staleness.rs
+++ b/crates/zfb-build/tests/integration_lazy_staleness.rs
@@ -509,11 +509,14 @@ fn vanished_route_is_evicted_from_stale_set_and_pruned() {
     assert_eq!(outcome.pages_rendered, 0, "zero eager renders on this tick");
 }
 
-/// Skipped tick class (#956): a Phase-B `Skipped` reload bypasses the
-/// render callback entirely — the stale set, the tick generation, the
-/// dist tree, and `pages_stale` are all untouched.
+/// Skipped tick class (#956 + #1301): a Phase-B `Skipped` reload still
+/// bypasses the V8 host boot, the table swap, the generation bump, and
+/// disk pruning — but the render callback now runs for the tick's
+/// SELECTED pages so their staleness is not silently dropped (#1301). An
+/// all-lazy `.tsx` tick renders nothing eagerly yet re-announces its
+/// selected routes as stale.
 #[test]
-fn skipped_tick_touches_neither_stale_state_nor_disk() {
+fn skipped_tick_stales_selection_without_table_swap_or_prune() {
     let dir = tempdir().unwrap();
     let project = dir.path();
     let (graph, session) = matrix_fixture(project);
@@ -545,10 +548,16 @@ fn skipped_tick_touches_neither_stale_state_nor_disk() {
         .expect("tick succeeded")
         .expect("non-noop");
 
+    // #1301: the skipped tick renders nothing eagerly (all-lazy .tsx) but
+    // still re-stales its SELECTED routes rather than dropping them.
     assert_eq!(outcome.pages_rendered, 0);
-    assert!(
-        outcome.pages_stale.is_empty(),
-        "a skipped tick announces nothing as stale"
+    assert_eq!(
+        outcome.pages_stale,
+        vec![
+            PathBuf::from("blog/a/index.html"),
+            PathBuf::from("blog/b/index.html"),
+        ],
+        "a skipped tick re-announces its selected routes as stale (#1301)"
     );
     assert!(outcome.pages_pruned.is_empty());
     assert_eq!(
@@ -558,12 +567,12 @@ fn skipped_tick_touches_neither_stale_state_nor_disk() {
     );
     assert!(
         session.is_stale("blog/a/index.html") && session.is_stale("blog/b/index.html"),
-        "previously-stale entries survive a skipped tick untouched"
+        "the selected routes remain stale after a skipped tick"
     );
     assert_eq!(
         &session.events()[events_before..],
-        &["reload:skipped"],
-        "the render callback must never run on a skipped tick"
+        &["reload:skipped", "render:stale-marked"],
+        "the render callback now runs on a skipped tick (#1301), after the skip"
     );
 }
 

--- a/crates/zfb-css/src/engine.rs
+++ b/crates/zfb-css/src/engine.rs
@@ -534,6 +534,45 @@ const ENTRY_TMP_SUFFIX: &str = ".css";
 /// unlinked at all.
 const ENTRY_TMP_STALE_AFTER: std::time::Duration = std::time::Duration::from_secs(60);
 
+/// Directory the synthesised Tailwind entry temp file is created in — and
+/// the directory the stale-entry sweep must sweep. The two MUST agree, so
+/// both the create site and the sweep site call this single helper.
+///
+/// Resolution: `input_css`'s contents are inlined verbatim into the
+/// synthesised entry (see [`build_synthesised_entry_css`]), so any relative
+/// `@import "./x.css";` inside it resolves against the entry file's own
+/// directory. That directory must therefore be `input_css`'s parent — not
+/// `working_dir` — for such a sibling import to find `./x.css` (zfb#1300).
+/// When there is no `input_css` (fully synthesised entry, no user file to
+/// inline), there is no relative-import scope to preserve, so the entry
+/// falls back to `working_dir`.
+///
+/// `@source` directives are unaffected either way — they are always emitted
+/// as absolute paths (see `default_source_directives` / the globs built in
+/// `crates/zfb/src/commands/build.rs`).
+///
+/// `input_css` is expected to be absolute in production (the sole caller,
+/// `resolve_input_global_css` in `crates/zfb/src/commands/build.rs`, builds
+/// it by joining onto an absolute `project_root`). Defensively, a *relative*
+/// parent is still resolved against `working_dir` rather than the process's
+/// own cwd, so the temp file always lands next to `input_css` regardless of
+/// how the caller constructed the path.
+fn entry_dir(cfg: &TailwindSubprocessConfig) -> PathBuf {
+    match &cfg.input_css {
+        Some(input_css) => match input_css.parent() {
+            Some(parent) if !parent.as_os_str().is_empty() => {
+                if parent.is_absolute() {
+                    parent.to_path_buf()
+                } else {
+                    cfg.working_dir.join(parent)
+                }
+            }
+            _ => cfg.working_dir.clone(),
+        },
+        None => cfg.working_dir.clone(),
+    }
+}
+
 /// Delete `zfb-tailwind-entry-*.css` files left in `dir` by a previous run
 /// that died before its [`tempfile::NamedTempFile`] `Drop` could clean up
 /// (SIGKILL / crash / Ctrl-C). See zfb#821.
@@ -625,25 +664,36 @@ impl CssEngine for TailwindSubprocessEngine {
         // See `ensure_oxide_extracted` and zfb#1237 for the full rationale.
         ensure_oxide_extracted(&self.config.binary_path);
 
+        // Both the sweep and the temp-file create below must agree on the
+        // entry's directory — compute it once via the shared helper.
+        let entry_dir = entry_dir(&self.config);
+
         // Self-heal: delete entry temp files stranded by a past abnormal
         // termination (SIGKILL / crash / Ctrl-C skips the RAII `Drop` that
         // normally removes them). Done before we create the new file so the
-        // project root is clean even if `git add -A` ran since the leak.
-        // See zfb#821.
-        sweep_stale_entry_files(&self.config.working_dir);
+        // entry dir is clean even if `git add -A` ran since the leak. See
+        // zfb#821.
+        sweep_stale_entry_files(&entry_dir);
 
-        // Materialise the synthesised entry CSS into a temp file so
-        // Tailwind's `@source` resolution uses our wrapper. The file lives
-        // in `working_dir` (not a subdir like `.zfb/`) on purpose: the
-        // user's `input_css` is inlined into this entry, so any relative
-        // `@import "./x.css";` in it resolves against the entry file's
-        // directory — which must be `working_dir` for those imports to find
-        // the user's siblings. `@source` paths are already absolute, so they
-        // are unaffected by the location.
+        // Materialise the synthesised entry CSS into a temp file. There are
+        // two distinct resolution scopes at play here:
+        //
+        // - `@source` directives are always absolute (built in
+        //   `crates/zfb/src/commands/build.rs` / `default_source_directives`),
+        //   so they resolve correctly regardless of where the entry file
+        //   lives.
+        // - The user's `input_css` (e.g. `styles/global.css`) is inlined
+        //   verbatim into this entry (see `build_synthesised_entry_css`), so
+        //   any relative `@import "./x.css";` it contains resolves against
+        //   the entry file's OWN directory. The entry must therefore live
+        //   next to `input_css` (its parent dir) — not `working_dir` — for
+        //   such sibling imports to find `./x.css` (zfb#1300). When there is
+        //   no `input_css`, there is no relative-import scope to preserve,
+        //   so we fall back to `working_dir`. See [`entry_dir`].
         let mut entry_tmp = tempfile::Builder::new()
             .prefix(ENTRY_TMP_PREFIX)
             .suffix(ENTRY_TMP_SUFFIX)
-            .tempfile_in(&self.config.working_dir)
+            .tempfile_in(&entry_dir)
             .context("failed to allocate temp file for tailwind entry CSS")?;
         {
             use std::io::Write;
@@ -1136,6 +1186,57 @@ mod tests {
             stripped.contains("@import \"tailwindcss\";"),
             "active import after block comment must survive stripping; got:\n{stripped}"
         );
+    }
+
+    // -----------------------------------------------------------------------
+    // zfb#1300 — entry dir must follow input_css so relative sibling
+    // `@import`s in the user's CSS resolve correctly
+    // -----------------------------------------------------------------------
+
+    /// When `input_css` is set, the synthesised entry must be created in
+    /// its parent directory — not `working_dir` — so an inlined relative
+    /// sibling `@import "./tokens.css";` resolves against the entry's own
+    /// location (zfb#1300).
+    #[test]
+    fn entry_dir_follows_input_css_parent_when_set() {
+        let cfg = TailwindSubprocessConfig::default()
+            .with_working_dir("/project/root")
+            .with_input_css("/project/root/styles/global.css");
+        assert_eq!(entry_dir(&cfg), PathBuf::from("/project/root/styles"));
+    }
+
+    /// When `input_css` is `None` (fully synthesised entry, nothing to
+    /// inline), there is no relative-import scope to preserve, so the entry
+    /// falls back to `working_dir`.
+    #[test]
+    fn entry_dir_falls_back_to_working_dir_when_input_css_is_none() {
+        let cfg = TailwindSubprocessConfig::default().with_working_dir("/project/root");
+        assert_eq!(entry_dir(&cfg), PathBuf::from("/project/root"));
+    }
+
+    /// A bare filename `input_css` (no directory component) has an empty
+    /// `parent()` — fall back to `working_dir` rather than resolving
+    /// against an empty path.
+    #[test]
+    fn entry_dir_falls_back_to_working_dir_when_input_css_has_no_parent() {
+        let cfg = TailwindSubprocessConfig::default()
+            .with_working_dir("/project/root")
+            .with_input_css("global.css");
+        assert_eq!(entry_dir(&cfg), PathBuf::from("/project/root"));
+    }
+
+    /// Defensive case: production always passes an absolute `input_css`
+    /// (built by joining onto an absolute `project_root`), but a
+    /// *relative* `input_css` with a relative parent must still resolve
+    /// against `working_dir` — not the process's own cwd — so the temp
+    /// file lands next to `input_css` regardless of how the caller built
+    /// the path.
+    #[test]
+    fn entry_dir_resolves_relative_input_css_parent_against_working_dir() {
+        let cfg = TailwindSubprocessConfig::default()
+            .with_working_dir("/project/root")
+            .with_input_css("styles/global.css");
+        assert_eq!(entry_dir(&cfg), PathBuf::from("/project/root/styles"));
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1306
    - https://github.com/Takazudo/zudo-front-builder/issues/1307 (fixes #1301)
    - https://github.com/Takazudo/zudo-front-builder/issues/1308 (fixes #1300)

---

## Summary

Epic #1306 — two independent product-side bugfixes swept from #1294 e2e fixture work.

### #1301 — dev skip-key dropping page-staleness (`crates/zfb-build/src/pipeline/dev.rs`)
The #940/#956 skip-key short-circuits a watcher tick when the freshly-produced bundle is byte-identical to the last one. It carries no page-selection info, so `DevAssetPipeline::apply` bypassed the entire render fan-out — a later tick whose page-selection differed from an earlier byte-identical tick silently lost its route staleness.

Fix (Option A): decouple render from prune. The render + write half now runs whenever `!pages.is_empty()` (regardless of `renderer_refresh_skipped`); the deferred-prune loop stays gated on `!renderer_refresh_skipped` (on a skip the route table did not move). `plan.prune_paths` is processed exactly once via the De Morgan-complement "1b" block. The V8 host boot + `paths()` re-expansion (the #940/#956 win) and the P4 staleness code stay full-refresh-only; redundant renders are absorbed by the `WriteCache.last_bytes` byte-dedup. Existing #956 regression tests updated to the new render-on-skip expectations; load-bearing doc comments rewritten; new regression test `skipped_tick_still_renders_differing_page_selection` added.

### #1300 — CSS relative sibling `@import` base (`crates/zfb-css/src/engine.rs`)
A relative sibling `@import './tokens.css';` in the CSS entry `styles/global.css` resolved against the project root instead of the entry's own dir, because the synthesised Tailwind temp entry was written to `working_dir`. Affects both `zfb build` and `zfb dev` (same engine path).

Fix (A): new `entry_dir` helper places the synthesised temp entry in `input_css.parent()` (fallback `working_dir` when `input_css` is `None`), computed once and shared by both the temp-file create site and the relocated stale-entry sweep. `current_dir` stays at `working_dir` (`@source` globs are absolute, so scanning is unaffected). Misleading comment corrected. Four real unit tests cover the helper's branches. `cargo test -p zfb-css` green locally (64 passed).

## Verification

- `zfb-css`: `cargo test -p zfb-css` + clippy + fmt green locally.
- `zfb-build`: cannot be compiled in the web container (the `librusty_v8` download is blocked by the egress policy) — relying on CI (`health.yml`, which compiles V8 and runs `cargo test --workspace`) as the authoritative gate. Reviewed statically by 3 Opus reviewers.

## Follow-up

- #1317 — low-severity dev-only prune hardening found during review (deferred; needs a capable host to compile-verify).

## Review

3-reviewer Opus static review: `plan.prune_paths` exactly-once invariant confirmed; `entry_dir` edge cases confirmed; one narrow deferred finding (→ #1317).

---
_Generated by [Claude Code](https://claude.ai/code/session_017DoFYJfrAgm1nnQNTV8tQj)_