### PR TITLE
fix(build): make published sourcemaps self-contained (#1325)

### DIFF
--- a/packages/zfb-adapter-cloudflare/tsconfig.json
+++ b/packages/zfb-adapter-cloudflare/tsconfig.json
@@ -5,8 +5,12 @@
     "exactOptionalPropertyTypes": true,
     "verbatimModuleSyntax": true,
     "declaration": true,
-    "declarationMap": true,
+    // Published tarball ships dist/ but not src/ (see package.json "files"), so maps that point at
+    // ../src/*.ts dangle in consumers (issue #1325). inlineSources embeds the .ts into .js.map so JS
+    // maps are self-contained; declarationMap is off because .d.ts.map can't inline sources.
+    "declarationMap": false,
     "sourceMap": true,
+    "inlineSources": true,
     "types": ["node"],
     "rootDir": "./src",
     "outDir": "./dist",

--- a/packages/zfb-runtime/tsconfig.json
+++ b/packages/zfb-runtime/tsconfig.json
@@ -5,8 +5,12 @@
     "exactOptionalPropertyTypes": true,
     "verbatimModuleSyntax": true,
     "declaration": true,
-    "declarationMap": true,
+    // Published tarball ships dist/ but not src/ (see package.json "files"), so maps that point at
+    // ../src/*.ts dangle in consumers (issue #1325). inlineSources embeds the .ts into .js.map so JS
+    // maps are self-contained; declarationMap is off because .d.ts.map can't inline sources.
+    "declarationMap": false,
     "sourceMap": true,
+    "inlineSources": true,
     "types": ["node"],
     "rootDir": "./src",
     "outDir": "./dist"

--- a/packages/zfb/tsconfig.json
+++ b/packages/zfb/tsconfig.json
@@ -5,8 +5,12 @@
     "exactOptionalPropertyTypes": true,
     "verbatimModuleSyntax": true,
     "declaration": true,
-    "declarationMap": true,
+    // Published tarball ships dist/ but not src/ (see package.json "files"), so maps that point at
+    // ../src/*.ts dangle in consumers (issue #1325). inlineSources embeds the .ts into .js.map so JS
+    // maps are self-contained; declarationMap is off because .d.ts.map can't inline sources.
+    "declarationMap": false,
     "sourceMap": true,
+    "inlineSources": true,
     "jsx": "react-jsx",
     "jsxImportSource": "react",
     "types": ["node"],


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1325

---

## Summary

The three published packages (`zfb`, `zfb-runtime`, `zfb-adapter-cloudflare`) build with `tsc` using `sourceMap` + `declarationMap` but **no** `inlineSources`. Every emitted `dist/*.js.map` referenced `../src/*.ts` with empty `sourcesContent`, and `src/` is excluded from the tarball via the `files` allowlist — so the maps dangle in consumers. Vite/vitest logs `points to missing source files` (~16 lines of noise per test run in every consuming repo), burying real warnings. The `.d.ts.map` files dangled the same way (quieter).

Fixed per the issue's **preferred** option: enable `inlineSources` so each `.js.map` embeds the `.ts` source (maps stay useful for debugging and become self-contained), and turn `declarationMap` off — `.d.ts.map` cannot inline sources and would keep dangling at the unshipped `src/`, so it is dead weight for published consumers.

## Changes

- `packages/zfb/tsconfig.json`, `packages/zfb-runtime/tsconfig.json`, `packages/zfb-adapter-cloudflare/tsconfig.json`:
  - add `"inlineSources": true`
  - change `"declarationMap": true` → `"declarationMap": false`
  - short comment on each explaining the packaging constraint (dist shipped, src not) and linking #1325

`declaration: true` and `sourceMap: true` are unchanged, so `.d.ts` files and `.js.map` references are still emitted.

## Test Plan

Level-3 (build output) verification — rebuilt all three packages from a clean `dist`:

- every `.js.map` now carries non-empty `sourcesContent` (self-contained): `zfb` 12/12, `zfb-runtime` 13/13, `zfb-adapter-cloudflare` 2/2
- zero `.d.ts.map` files emitted across all three (was: one per module)
- `.d.ts` declarations still emitted; `.js` still carry `//# sourceMappingURL=*.js.map`; no `//# sourceMappingURL=*.d.ts.map` comments remain
- `pnpm typecheck`, `pnpm test`, and `prettier --check` pass for all three packages

Not tested: publishing an actual tarball and consuming it in a downstream Vite/vitest project (would require a real publish); the emitted-map inspection above is the direct proxy for the reported symptom.

---
_Generated by [Claude Code](https://claude.ai/code/session_01N4vTLkGc9kF9kwZd8a7j1V)_