### PR TITLE
chore(format): ignore docs/.zudo-doc/ local build artifacts in prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,6 +10,7 @@ docs/dist/
 # these dirs exist, even though CI — a fresh checkout — never sees them.
 .playwright-cli/
 __inbox/
+docs/.zudo-doc/
 # Snapshot fixture for the .d.ts emitter — must match the emitter's
 # byte-exact output, so prettier (which would re-flow the inline
 # interfaces) is not allowed to touch it.


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1329

---

## Summary

Adds `docs/.zudo-doc/` to the "Gitignored local artifacts" section of `.prettierignore`. The zudo-doc docs-site build emits gitignored `docs/.zudo-doc/routes-src/*.ts(x)` artifacts that prettier's glob picks up, false-failing `pnpm format:check` / `pnpm b4push` on any dev tree with a local docs build — same class as the existing `.playwright-cli/` and `__inbox/` entries. CI (fresh checkout) never sees these files, so this is a local-DX-only fix.

Closes #1329

## Test Plan

- Verified locally: with `docs/.zudo-doc/routes-src/` artifacts present, `pnpm format:check:ts` failed on 5 files before the change and passes after.
- Codex review: no findings.

---
*Auto-fix from the `/x-as-pr` session for #1327 (agent-found issue #1329).*