### PR TITLE
cargo-advisories: resolve 5 cargo-deny advisories, harden zfb-graph, reconcile deny.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2112,12 +2112,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4171,7 +4165,6 @@ dependencies = [
  "serde_json",
  "thiserror",
  "walkdir",
- "yaml-rust",
 ]
 
 [[package]]
@@ -5419,15 +5412,6 @@ dependencies = [
  "log",
  "mac",
  "markup5ever",
-]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arrayvec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,15 +588,14 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1885,14 +1884,14 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.18.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
 dependencies = [
  "console",
- "number_prefix",
  "portable-atomic",
  "unicode-width",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -2430,12 +2429,6 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
@@ -4642,6 +4635,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1217,12 +1217,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2958,19 +2952,6 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
@@ -2997,21 +2978,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -3046,15 +3012,6 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -3114,15 +3071,6 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
 
 [[package]]
 name = "rend"
@@ -4209,16 +4157,6 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
-]
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
 ]
 
 [[package]]
@@ -5739,7 +5677,7 @@ dependencies = [
  "imagesize",
  "markdown",
  "roxmltree",
- "tempdir",
+ "tempfile",
  "zfb-content",
  "zfb-md-ast",
  "zfb-test-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,6 +251,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
+dependencies = [
+ "bincode_derive",
+ "serde",
+ "unty",
+]
+
+[[package]]
+name = "bincode_derive"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
+dependencies = [
+ "virtue",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,7 +842,7 @@ checksum = "2c1dbe504b49d3df8182331ff4c8cc80a5aec65d2e7c190ee9d82b7192d0eceb"
 dependencies = [
  "anyhow",
  "az",
- "bincode",
+ "bincode 1.3.3",
  "bit-set",
  "bit-vec",
  "boxed_error",
@@ -4159,7 +4179,7 @@ version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
 dependencies = [
- "bincode",
+ "bincode 1.3.3",
  "flate2",
  "fnv",
  "once_cell",
@@ -4656,6 +4676,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "unty"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4761,6 +4787,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "virtue"
+version = "0.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vlq"
@@ -5689,7 +5721,7 @@ dependencies = [
 name = "zfb-graph"
 version = "0.0.0"
 dependencies = [
- "bincode",
+ "bincode 2.0.1",
  "serde",
  "sha2",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ serde_yaml = "0.9"
 serde_json = "1"
 anyhow = "1"
 thiserror = "2"
-syntect = "5"
+syntect = { version = "5", default-features = false, features = ["default-syntaxes", "default-themes", "html", "regex-onig", "plist-load"] }
 garde = { version = "0.22", features = ["derive"] }
 tempfile = "3"
 walkdir = "2"

--- a/crates/zfb-graph/Cargo.toml
+++ b/crates/zfb-graph/Cargo.toml
@@ -10,7 +10,7 @@ description = "zfb dependency graph: tracks which pages depend on which sources 
 [dependencies]
 thiserror = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-bincode = "1"
+bincode = { version = "2", features = ["serde"] }
 sha2 = "0.10"
 walkdir = { workspace = true }
 tracing = "0.1"

--- a/crates/zfb-graph/src/error.rs
+++ b/crates/zfb-graph/src/error.rs
@@ -11,7 +11,11 @@ pub enum GraphError {
     #[error("graph persistence IO error: {0}")]
     Io(#[from] std::io::Error),
 
-    /// Binary (de)serialisation failed.
-    #[error("graph persistence codec error: {0}")]
-    Codec(#[from] bincode::Error),
+    /// Binary serialisation failed.
+    #[error("graph persistence encode error: {0}")]
+    Encode(#[from] bincode::error::EncodeError),
+
+    /// Binary deserialisation failed.
+    #[error("graph persistence decode error: {0}")]
+    Decode(#[from] bincode::error::DecodeError),
 }

--- a/crates/zfb-graph/src/persist.rs
+++ b/crates/zfb-graph/src/persist.rs
@@ -10,9 +10,13 @@
 //! without misreading bytes as a graph. The digest is checked against
 //! the caller's freshly-computed [`ManifestDigest`] before any
 //! deserialisation work happens; if they disagree, the file is
-//! discarded. Bincode (1.x) is used because it's already tiny, fast,
-//! and serde-native — no extra ceremony needed for the graph types
-//! that already derive `Serialize`/`Deserialize`.
+//! discarded. Bincode is used because it's already tiny, fast, and
+//! serde-native — no extra ceremony needed for the graph types that
+//! already derive `Serialize`/`Deserialize`. The codec was migrated
+//! from bincode 1 to bincode 2's serde integration (`bincode::serde`)
+//! since bincode 1 is unmaintained (RUSTSEC-2025-0141); [`VERSION`]
+//! was bumped alongside so old on-disk caches are a graceful
+//! cache-miss rather than a decode error.
 //!
 //! ## Manifest digest — what invalidates the graph
 //!
@@ -56,7 +60,17 @@ const MAGIC: &[u8; 4] = b"ZFBG";
 
 /// On-disk format version. Bump on any backwards-incompatible
 /// change to the wire format or to fields that bincode round-trips.
-const VERSION: u16 = 1;
+/// Bumped 1 -> 2 for the bincode 1 -> bincode 2 codec migration (the
+/// wire encoding differs even though the Rust types didn't change);
+/// see [`bincode_config`].
+const VERSION: u16 = 2;
+
+/// Shared bincode 2 configuration for both [`save_to_disk`] and
+/// [`load_from_disk`] — encode and decode must agree on this or
+/// round-trips silently corrupt.
+fn bincode_config() -> impl bincode::config::Config {
+    bincode::config::standard()
+}
 
 /// Stable hash over the inputs that determine graph identity.
 ///
@@ -284,7 +298,7 @@ pub fn save_to_disk(
         }
     }
 
-    let body = bincode::serialize(graph)?;
+    let body = bincode::serde::encode_to_vec(graph, bincode_config())?;
     let mut buf: Vec<u8> = Vec::with_capacity(4 + 2 + 32 + body.len());
     buf.extend_from_slice(MAGIC);
     buf.extend_from_slice(&VERSION.to_le_bytes());
@@ -360,7 +374,8 @@ pub fn load_from_disk(
 
     let mut body = Vec::new();
     f.read_to_end(&mut body)?;
-    let graph: DependencyGraph = bincode::deserialize(&body)?;
+    let (graph, _): (DependencyGraph, usize) =
+        bincode::serde::decode_from_slice(&body, bincode_config())?;
     Ok(Some(graph))
 }
 
@@ -426,6 +441,27 @@ mod tests {
         assert!(load_from_disk(&path, &written_digest).unwrap().is_some());
         // Wrong digest → discarded; caller will rebuild.
         assert!(load_from_disk(&path, &other_digest).unwrap().is_none());
+    }
+
+    #[test]
+    fn old_version_cache_is_a_graceful_miss_not_an_error() {
+        // Regression for the bincode 1 -> 2 migration: a cache file
+        // written by the old VERSION (1, bincode-1-encoded body)
+        // must be rejected as a cache-miss (Ok(None)) rather than
+        // failing to decode as bincode 2, since the version check
+        // happens before the body is ever touched.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("graph.bin");
+        let digest = ManifestDigest::from_bytes([9u8; 32]);
+
+        let mut buf: Vec<u8> = Vec::new();
+        buf.extend_from_slice(MAGIC);
+        buf.extend_from_slice(&1u16.to_le_bytes()); // old, pre-migration VERSION
+        buf.extend_from_slice(digest.as_bytes());
+        buf.extend_from_slice(b"stale bincode-1-encoded body, never read");
+        std::fs::write(&path, &buf).unwrap();
+
+        assert!(load_from_disk(&path, &digest).unwrap().is_none());
     }
 
     #[test]

--- a/crates/zfb-md-extras/Cargo.toml
+++ b/crates/zfb-md-extras/Cargo.toml
@@ -72,7 +72,7 @@ required-features = ["test-utils"]
 # context.  The optional flag ensures zero production-binary cost when the
 # feature is off.
 [features]
-test-utils = ["dep:zfb-test-utils", "dep:tempdir"]
+test-utils = ["dep:zfb-test-utils", "dep:tempfile"]
 
 [dependencies]
 markdown = { workspace = true }
@@ -90,14 +90,14 @@ roxmltree = { workspace = true }
 # test_harness.rs via cfg(test)) can resolve them without activating the
 # feature flag.
 zfb-test-utils = { path = "../zfb-test-utils", optional = true }
-tempdir = { version = "0.3", optional = true }
+tempfile = { workspace = true, optional = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
 # Keep here for cfg(test) builds of this crate's own tests (test_harness tests
 # compile via cfg(test), not via the test-utils feature flag).
 zfb-test-utils = { path = "../zfb-test-utils" }
-tempdir = "0.3"
+tempfile = { workspace = true }
 # Dev-dep cycle is intentional and Cargo-supported: zfb-md-extras integration
 # tests need to run content through the full pipeline (which lives in
 # zfb-content). The workspace already uses this pattern elsewhere (e.g.

--- a/crates/zfb-md-extras/src/image_dimensions.rs
+++ b/crates/zfb-md-extras/src/image_dimensions.rs
@@ -858,8 +858,14 @@ mod tests {
         {
             use std::os::unix::fs::symlink;
 
-            let outer = tempdir::TempDir::new("imgdim_symlink_outer").unwrap();
-            let inner = tempdir::TempDir::new("imgdim_symlink_inner").unwrap();
+            let outer = tempfile::Builder::new()
+                .prefix("imgdim_symlink_outer")
+                .tempdir()
+                .unwrap();
+            let inner = tempfile::Builder::new()
+                .prefix("imgdim_symlink_inner")
+                .tempdir()
+                .unwrap();
 
             // Create a real file outside the project root.
             let outside_file = outer.path().join("secret.png");
@@ -920,7 +926,10 @@ mod tests {
 
     #[test]
     fn probed_image_records_full_content_hash() {
-        let dir = tempdir::TempDir::new("imgdim_rec_ok").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("imgdim_rec_ok")
+            .tempdir()
+            .unwrap();
         // Not a real image — the probe fails with a warning, but the READ
         // is still recorded with the full-content hash: the warning
         // outcome depends on these bytes too.
@@ -938,7 +947,10 @@ mod tests {
 
     #[test]
     fn missing_image_records_missing_outcome() {
-        let dir = tempdir::TempDir::new("imgdim_rec_missing").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("imgdim_rec_missing")
+            .tempdir()
+            .unwrap();
         let source = dir.path().join("page.mdx");
         let reads = record_reads_for_src("./absent.png", dir.path(), &source);
         assert_eq!(
@@ -951,7 +963,10 @@ mod tests {
 
     #[test]
     fn remote_and_data_srcs_record_nothing() {
-        let dir = tempdir::TempDir::new("imgdim_rec_remote").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("imgdim_rec_remote")
+            .tempdir()
+            .unwrap();
         let source = dir.path().join("page.mdx");
         for src in [
             "https://example.com/x.png",
@@ -971,7 +986,10 @@ mod tests {
         // The per-plugin mtime cache may skip the header sniff, but the
         // compile-cache manifest still needs the dependency recorded on
         // every compile — the OUTPUT depends on the file each time.
-        let dir = tempdir::TempDir::new("imgdim_rec_cachehit").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("imgdim_rec_cachehit")
+            .tempdir()
+            .unwrap();
         let bytes = b"bytes";
         std::fs::write(dir.path().join("pic.png"), bytes).unwrap();
         let source = dir.path().join("page.mdx");
@@ -1044,7 +1062,10 @@ mod tests {
 
     #[test]
     fn plugin_injects_svg_viewbox_dimensions() {
-        let dir = tempdir::TempDir::new("imgdim_svg_vb").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("imgdim_svg_vb")
+            .tempdir()
+            .unwrap();
         std::fs::write(
             dir.path().join("diagram.svg"),
             r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 100"></svg>"#,
@@ -1060,7 +1081,10 @@ mod tests {
     fn plugin_skips_undimensionable_svg_without_warning() {
         // The core of #1083: an SVG with no width/height/viewBox is left
         // unchanged and emits NO diagnostic (was: one warning per SVG).
-        let dir = tempdir::TempDir::new("imgdim_svg_none").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("imgdim_svg_none")
+            .tempdir()
+            .unwrap();
         std::fs::write(
             dir.path().join("plain.svg"),
             r#"<svg xmlns="http://www.w3.org/2000/svg"><rect/></svg>"#,
@@ -1081,7 +1105,10 @@ mod tests {
 
         // Regression guard: a non-SVG file imagesize cannot decode must STILL
         // warn — the #1083 silence is scoped to SVGs only.
-        let dir = tempdir::TempDir::new("imgdim_raster_bad").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("imgdim_raster_bad")
+            .tempdir()
+            .unwrap();
         std::fs::write(dir.path().join("broken.png"), b"not a real png").unwrap();
         let (img, diags) = run_plugin_collecting("broken.png", dir.path());
         assert_eq!(get_attr(&img, "width"), None);
@@ -1096,7 +1123,10 @@ mod tests {
         // A missing `.svg` is a broken reference, not an undimensionable SVG —
         // the `fs::metadata` stat fails before the SVG branch, so it still
         // warns (it is NOT swallowed by the silent-skip path).
-        let dir = tempdir::TempDir::new("imgdim_svg_missing").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("imgdim_svg_missing")
+            .tempdir()
+            .unwrap();
         let (img, diags) = run_plugin_collecting("absent.svg", dir.path());
         assert_eq!(get_attr(&img, "width"), None);
         assert_eq!(diags.len(), 1, "a missing SVG must still warn");
@@ -1107,7 +1137,10 @@ mod tests {
     fn plugin_caches_svg_on_second_reference() {
         // The SVG path participates in the mtime cache + read_count
         // instrumentation, exactly like the raster path.
-        let dir = tempdir::TempDir::new("imgdim_svg_cache").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("imgdim_svg_cache")
+            .tempdir()
+            .unwrap();
         std::fs::write(
             dir.path().join("d.svg"),
             r#"<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 10"></svg>"#,

--- a/crates/zfb-md-extras/src/link_validation.rs
+++ b/crates/zfb-md-extras/src/link_validation.rs
@@ -631,10 +631,12 @@ mod tests {
     /// BrokenLink diagnostic even when `icon-x` is not a heading in any registry.
     #[test]
     fn img_src_with_svg_sprite_fragment_no_broken_link() {
-        use tempdir::TempDir;
         use zfb_md_ast::{diagnostics::CollectingSink, HastVisitor};
 
-        let dir = TempDir::new("link_val_img_fragment").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("link_val_img_fragment")
+            .tempdir()
+            .unwrap();
         let sprite_path = dir.path().join("sprite.svg");
         // File must exist so validate_file_exists passes.
         std::fs::write(&sprite_path, "<svg/>").unwrap();
@@ -707,8 +709,10 @@ mod tests {
 
     #[test]
     fn linked_file_probe_records_full_content_hash() {
-        use tempdir::TempDir;
-        let dir = TempDir::new("linkval_rec_ok").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("linkval_rec_ok")
+            .tempdir()
+            .unwrap();
         std::fs::write(dir.path().join("other.md"), b"# Other\n").unwrap();
         let source = dir.path().join("page.md");
 
@@ -722,8 +726,10 @@ mod tests {
 
     #[test]
     fn missing_link_target_records_missing_outcome() {
-        use tempdir::TempDir;
-        let dir = TempDir::new("linkval_rec_missing").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("linkval_rec_missing")
+            .tempdir()
+            .unwrap();
         let source = dir.path().join("page.md");
 
         let reads = record_reads_for_href("./absent.md", dir.path(), &source);
@@ -737,8 +743,10 @@ mod tests {
 
     #[test]
     fn file_with_fragment_records_the_target_file() {
-        use tempdir::TempDir;
-        let dir = TempDir::new("linkval_rec_frag").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("linkval_rec_frag")
+            .tempdir()
+            .unwrap();
         std::fs::write(dir.path().join("other.md"), b"# Heading\n").unwrap();
         let source = dir.path().join("page.md");
 
@@ -752,8 +760,10 @@ mod tests {
 
     #[test]
     fn non_filesystem_hrefs_record_nothing() {
-        use tempdir::TempDir;
-        let dir = TempDir::new("linkval_rec_none").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("linkval_rec_none")
+            .tempdir()
+            .unwrap();
         let source = dir.path().join("page.md");
 
         for href in [
@@ -804,10 +814,12 @@ mod tests {
     /// MUST report when the target is missing.
     #[test]
     fn cross_file_fragment_with_none_registry_checks_existence_only() {
-        use tempdir::TempDir;
         use zfb_md_ast::{diagnostics::CollectingSink, HastVisitor};
 
-        let dir = TempDir::new("lv_none_reg").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("lv_none_reg")
+            .tempdir()
+            .unwrap();
         let source_path = dir.path().join("page.md");
         std::fs::write(&source_path, "").unwrap();
         let other_path = dir.path().join("other.md");
@@ -926,8 +938,10 @@ mod tests {
     /// must emit NO diagnostic (the verdict is deferred, not broken).
     #[test]
     fn degrade_branch_records_cross_file_candidate() {
-        use tempdir::TempDir;
-        let dir = TempDir::new("cand_degrade").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("cand_degrade")
+            .tempdir()
+            .unwrap();
         std::fs::write(dir.path().join("other.md"), b"## Target\n").unwrap();
         // `sub/..` in the source spelling collapses lexically during
         // target resolution — the candidate target key must come out in
@@ -964,8 +978,10 @@ mod tests {
     /// an in-compile verdict would have.
     #[test]
     fn fail_on_broken_candidate_carries_error_severity() {
-        use tempdir::TempDir;
-        let dir = TempDir::new("cand_severity").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("cand_severity")
+            .tempdir()
+            .unwrap();
         std::fs::write(dir.path().join("other.md"), b"x\n").unwrap();
         let source = dir.path().join("page.md");
 
@@ -987,8 +1003,10 @@ mod tests {
     /// the target) must not record a candidate — valid and broken alike.
     #[test]
     fn locally_settled_fragment_records_no_candidate() {
-        use tempdir::TempDir;
-        let dir = TempDir::new("cand_local").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("cand_local")
+            .tempdir()
+            .unwrap();
         std::fs::write(dir.path().join("other.md"), b"## Target\n").unwrap();
         let source = dir.path().join("page.md");
 
@@ -1033,8 +1051,10 @@ mod tests {
     /// empty / percent-encoded fragments.
     #[test]
     fn non_degrading_hrefs_record_no_candidate() {
-        use tempdir::TempDir;
-        let dir = TempDir::new("cand_none").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("cand_none")
+            .tempdir()
+            .unwrap();
         std::fs::write(dir.path().join("other.md"), b"x\n").unwrap();
         std::fs::write(dir.path().join("sprite.svg"), b"<svg/>").unwrap();
         let source = dir.path().join("page.md");
@@ -1068,10 +1088,12 @@ mod tests {
     /// pre-#977 unarmed behaviour, byte-for-byte.
     #[test]
     fn missing_channel_keeps_degrade_branch_silent() {
-        use tempdir::TempDir;
         use zfb_md_ast::{diagnostics::CollectingSink, HastVisitor};
 
-        let dir = TempDir::new("cand_no_channel").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("cand_no_channel")
+            .tempdir()
+            .unwrap();
         std::fs::write(dir.path().join("other.md"), b"x\n").unwrap();
         let source = dir.path().join("page.md");
 

--- a/crates/zfb-md-extras/src/test_harness.rs
+++ b/crates/zfb-md-extras/src/test_harness.rs
@@ -124,8 +124,11 @@ fn is_verbatim(dir: &Path) -> bool {
 mod tests {
     use super::*;
     /// Helper: create a temporary fixture directory with given files.
-    fn make_fixture_dir(files: &[(&str, &str)]) -> tempdir::TempDir {
-        let dir = tempdir::TempDir::new("zfb_fixture_test").expect("tempdir");
+    fn make_fixture_dir(files: &[(&str, &str)]) -> tempfile::TempDir {
+        let dir = tempfile::Builder::new()
+            .prefix("zfb_fixture_test")
+            .tempdir()
+            .expect("tempdir");
         for (name, content) in files {
             let path = dir.path().join(name);
             std::fs::write(&path, content).expect("write fixture file");

--- a/crates/zfb-md-extras/src/transclude.rs
+++ b/crates/zfb-md-extras/src/transclude.rs
@@ -883,8 +883,6 @@ mod tests {
 
     // ── Integration: file resolution (using tempdir) ──────────────────────
 
-    use tempdir::TempDir;
-
     fn run_transclude(
         input_md: &str,
         source_path: PathBuf,
@@ -910,7 +908,10 @@ mod tests {
 
     #[test]
     fn simple_include_inlines_content() {
-        let dir = TempDir::new("transclude_test").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("transclude_test")
+            .tempdir()
+            .unwrap();
         let snippet_path = dir.path().join("snippet.md");
         std::fs::write(&snippet_path, "# Hello\n\nWorld.\n").unwrap();
 
@@ -941,7 +942,10 @@ mod tests {
 
     #[test]
     fn include_with_code_true_wraps_in_code_block() {
-        let dir = TempDir::new("transclude_code").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("transclude_code")
+            .tempdir()
+            .unwrap();
         let snippet_path = dir.path().join("foo.rs");
         std::fs::write(&snippet_path, "fn main() {}\n").unwrap();
 
@@ -969,7 +973,10 @@ mod tests {
 
     #[test]
     fn include_with_lines_slices_correctly() {
-        let dir = TempDir::new("transclude_lines").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("transclude_lines")
+            .tempdir()
+            .unwrap();
         let snippet_path = dir.path().join("nums.md");
         std::fs::write(&snippet_path, "line1\nline2\nline3\nline4\nline5\n").unwrap();
 
@@ -996,7 +1003,10 @@ mod tests {
     #[test]
     fn cycle_detection_emits_error() {
         // A→A direct self-reference.
-        let dir = TempDir::new("transclude_cycle").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("transclude_cycle")
+            .tempdir()
+            .unwrap();
         let input = r#":::include{file="./cycle.md"}"#;
         // cycle.md includes itself
         let cycle_content = r#":::include{file="./cycle.md"}"#;
@@ -1025,7 +1035,10 @@ mod tests {
     #[test]
     fn max_depth_exceeded_emits_error() {
         // With maxDepth=1 a chain A→B→C is rejected at B→C level.
-        let dir = TempDir::new("transclude_depth").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("transclude_depth")
+            .tempdir()
+            .unwrap();
         // c.md is a leaf (no includes)
         std::fs::write(dir.path().join("c.md"), "leaf\n").unwrap();
         // b.md includes c.md (depth 1 — allowed)
@@ -1050,7 +1063,10 @@ mod tests {
 
     #[test]
     fn absolute_path_rejected() {
-        let dir = TempDir::new("transclude_abs").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("transclude_abs")
+            .tempdir()
+            .unwrap();
         let input = r#":::include{file="/etc/passwd"}"#;
         let source = dir.path().join("input.md");
         std::fs::write(&source, input).unwrap();
@@ -1073,8 +1089,14 @@ mod tests {
 
     #[test]
     fn path_outside_project_root_rejected() {
-        let outer = TempDir::new("transclude_outer").unwrap();
-        let inner = TempDir::new("transclude_inner").unwrap();
+        let outer = tempfile::Builder::new()
+            .prefix("transclude_outer")
+            .tempdir()
+            .unwrap();
+        let inner = tempfile::Builder::new()
+            .prefix("transclude_inner")
+            .tempdir()
+            .unwrap();
         // outer/secret.md exists but project_root is inner/
         std::fs::write(outer.path().join("secret.md"), "secret\n").unwrap();
 
@@ -1107,7 +1129,10 @@ mod tests {
     #[test]
     fn two_level_chain_inlines_both() {
         // A → B → (nothing), verify both levels resolve.
-        let dir = TempDir::new("transclude_chain").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("transclude_chain")
+            .tempdir()
+            .unwrap();
         std::fs::write(dir.path().join("b.md"), "From B.\n").unwrap();
         std::fs::write(dir.path().join("a.md"), r#":::include{file="./b.md"}"#).unwrap();
 
@@ -1162,7 +1187,10 @@ mod tests {
 
     #[test]
     fn successful_include_records_full_content_hash() {
-        let dir = TempDir::new("transclude_rec_ok").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("transclude_rec_ok")
+            .tempdir()
+            .unwrap();
         let snippet = dir.path().join("snippet.md");
         std::fs::write(&snippet, "shared text\n").unwrap();
         let source = dir.path().join("input.md");
@@ -1181,7 +1209,10 @@ mod tests {
 
     #[test]
     fn missing_include_records_missing_outcome() {
-        let dir = TempDir::new("transclude_rec_missing").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("transclude_rec_missing")
+            .tempdir()
+            .unwrap();
         let source = dir.path().join("input.md");
         let input = r#":::include{file="./not-yet.md"}"#;
         std::fs::write(&source, input).unwrap();
@@ -1202,7 +1233,10 @@ mod tests {
 
     #[test]
     fn nested_chain_records_every_level() {
-        let dir = TempDir::new("transclude_rec_chain").unwrap();
+        let dir = tempfile::Builder::new()
+            .prefix("transclude_rec_chain")
+            .tempdir()
+            .unwrap();
         std::fs::write(dir.path().join("c.md"), "leaf\n").unwrap();
         std::fs::write(dir.path().join("b.md"), r#":::include{file="./c.md"}"#).unwrap();
         let source = dir.path().join("a.md");

--- a/crates/zfb-md-extras/tests/cross_feature_integration.rs
+++ b/crates/zfb-md-extras/tests/cross_feature_integration.rs
@@ -63,7 +63,10 @@ use zfb_md_ast::{
 /// broken link from the snippet is visible to the validator.
 #[test]
 fn transclude_link_validation_broken_link_in_snippet() {
-    let tmpdir = tempdir::TempDir::new("zfb-cross-transclude-lv").expect("tempdir");
+    let tmpdir = tempfile::Builder::new()
+        .prefix("zfb-cross-transclude-lv")
+        .tempdir()
+        .expect("tempdir");
     let project_root = tmpdir.path().to_path_buf();
 
     // Write the snippet containing a broken anchor reference.
@@ -340,7 +343,10 @@ fn code_enrichment_and_code_tabs_coexist_documented_limitation() {
 /// transclusion, not to link validation.
 #[test]
 fn transclude_cycle_produces_generic_not_broken_link() {
-    let tmpdir = tempdir::TempDir::new("zfb-cross-cycle").expect("tempdir");
+    let tmpdir = tempfile::Builder::new()
+        .prefix("zfb-cross-cycle")
+        .tempdir()
+        .expect("tempdir");
     let project_root = tmpdir.path().to_path_buf();
 
     // A and B include each other — classic cycle.
@@ -472,7 +478,10 @@ fn all_features_on_does_not_crash() {
         "/tests/fixtures/image_dimensions"
     ));
 
-    let tmpdir = tempdir::TempDir::new("zfb-cross-all-features").expect("tempdir");
+    let tmpdir = tempfile::Builder::new()
+        .prefix("zfb-cross-all-features")
+        .tempdir()
+        .expect("tempdir");
     let project_root = tmpdir.path().to_path_buf();
 
     // Copy the fixture image into tmpdir so image_dimensions can resolve it.

--- a/crates/zfb-md-extras/tests/link_validation.rs
+++ b/crates/zfb-md-extras/tests/link_validation.rs
@@ -153,7 +153,10 @@ fn bare_anchor_missing_heading_emits_warning() {
 #[test]
 fn cross_file_known_anchor_no_diagnostic() {
     // Create a real tempdir so the filesystem-existence and project-root checks pass.
-    let tmpdir = tempdir::TempDir::new("zfb-link-val-test").expect("tempdir");
+    let tmpdir = tempfile::Builder::new()
+        .prefix("zfb-link-val-test")
+        .tempdir()
+        .expect("tempdir");
     let project_root = tmpdir.path().to_path_buf();
     let source_path = tmpdir.path().join("page.md");
     let other_path = tmpdir.path().join("other.md");
@@ -190,7 +193,10 @@ fn cross_file_known_anchor_no_diagnostic() {
 /// `[foo](./other.md#missing-heading)` → warning.
 #[test]
 fn cross_file_missing_anchor_emits_warning() {
-    let tmpdir = tempdir::TempDir::new("zfb-link-val-test").expect("tempdir");
+    let tmpdir = tempfile::Builder::new()
+        .prefix("zfb-link-val-test")
+        .tempdir()
+        .expect("tempdir");
     let project_root = tmpdir.path().to_path_buf();
     let source_path = tmpdir.path().join("page.md");
     let other_path = tmpdir.path().join("other.md");
@@ -230,7 +236,10 @@ fn cross_file_missing_anchor_emits_warning() {
 /// `[foo](./missing.md)` where the file does not exist → warning.
 #[test]
 fn missing_file_emits_warning() {
-    let tmpdir = tempdir::TempDir::new("zfb-link-val-test").expect("tempdir");
+    let tmpdir = tempfile::Builder::new()
+        .prefix("zfb-link-val-test")
+        .tempdir()
+        .expect("tempdir");
     let project_root = tmpdir.path().to_path_buf();
     let source_path = tmpdir.path().join("page.md");
     std::fs::write(&source_path, "").expect("write page.md");
@@ -352,7 +361,10 @@ fn multiple_broken_links_all_emitted() {
 /// `[foo](./existing.md)` where the file exists → no diagnostic.
 #[test]
 fn existing_file_no_anchor_no_diagnostic() {
-    let tmpdir = tempdir::TempDir::new("zfb-link-val-test").expect("tempdir");
+    let tmpdir = tempfile::Builder::new()
+        .prefix("zfb-link-val-test")
+        .tempdir()
+        .expect("tempdir");
     let project_root = tmpdir.path().to_path_buf();
     let source_path = tmpdir.path().join("page.md");
     let target_path = tmpdir.path().join("existing.md");
@@ -380,7 +392,10 @@ fn existing_file_no_anchor_no_diagnostic() {
 /// the file happens to exist on disk.
 #[test]
 fn path_traversal_outside_project_root_emits_diagnostic() {
-    let tmpdir = tempdir::TempDir::new("zfb-link-val-test").expect("tempdir");
+    let tmpdir = tempfile::Builder::new()
+        .prefix("zfb-link-val-test")
+        .tempdir()
+        .expect("tempdir");
     // Create a sub-directory as the project root; source is inside it.
     let project_root = tmpdir.path().join("project");
     std::fs::create_dir_all(&project_root).expect("create project dir");
@@ -439,7 +454,10 @@ fn site_absolute_href_skipped() {
 /// absent → one BrokenLink.
 #[test]
 fn cross_file_fragment_without_target_entry_degrades_to_existence_only() {
-    let tmpdir = tempdir::TempDir::new("zfb-link-val-test").expect("tempdir");
+    let tmpdir = tempfile::Builder::new()
+        .prefix("zfb-link-val-test")
+        .tempdir()
+        .expect("tempdir");
     let project_root = tmpdir.path().to_path_buf();
     let source_path = tmpdir.path().join("page.md");
     let other_path = tmpdir.path().join("other.md");
@@ -581,7 +599,10 @@ fn empty_and_percent_encoded_fragments_skipped() {
 /// `[x](./other.md?x=1)`, target on disk → no diagnostic (query stripped).
 #[test]
 fn query_string_file_link_validates_path_only() {
-    let tmpdir = tempdir::TempDir::new("zfb-link-val-test").expect("tempdir");
+    let tmpdir = tempfile::Builder::new()
+        .prefix("zfb-link-val-test")
+        .tempdir()
+        .expect("tempdir");
     let project_root = tmpdir.path().to_path_buf();
     let source_path = tmpdir.path().join("page.md");
     let other_path = tmpdir.path().join("other.md");
@@ -820,7 +841,10 @@ fn heading_file_with_element_id_both_accepted() {
 /// validation, not just bare same-file fragments.
 #[test]
 fn cross_file_link_to_explicit_element_id_no_diagnostic() {
-    let tmpdir = tempdir::TempDir::new("zfb-link-val-test").expect("tempdir");
+    let tmpdir = tempfile::Builder::new()
+        .prefix("zfb-link-val-test")
+        .tempdir()
+        .expect("tempdir");
     let project_root = tmpdir.path().to_path_buf();
     let source_path = tmpdir.path().join("page.md");
     let other_path = tmpdir.path().join("other.md");
@@ -851,7 +875,10 @@ fn cross_file_link_to_explicit_element_id_no_diagnostic() {
 /// anchor in a headingless file must still emit `BrokenLink`.
 #[test]
 fn cross_file_link_broken_anchor_in_headingless_file_emits_diagnostic() {
-    let tmpdir = tempdir::TempDir::new("zfb-link-val-test").expect("tempdir");
+    let tmpdir = tempfile::Builder::new()
+        .prefix("zfb-link-val-test")
+        .tempdir()
+        .expect("tempdir");
     let project_root = tmpdir.path().to_path_buf();
     let source_path = tmpdir.path().join("page.md");
     let other_path = tmpdir.path().join("other.md");

--- a/crates/zfb/Cargo.toml
+++ b/crates/zfb/Cargo.toml
@@ -54,7 +54,7 @@ axum = "0.8"
 clap = { version = "4", features = ["derive"] }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 include_dir = "0.7"
-indicatif = "0.17"
+indicatif = "0.18"
 # Issue #228's HTML link rewriter (`<a href>` / `<form action>`
 # prefix-stamp) used to live here with its own `lol_html` dep. After
 # the post-merge review caught that the dev server also needs to apply

--- a/deny.toml
+++ b/deny.toml
@@ -36,33 +36,30 @@ feature-depth = 1
 db-path = "$CARGO_HOME/advisory-dbs"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
-# Every entry below was found on the FIRST `cargo deny check advisories` run
-# when this config was added (issue #1334) — tracked, not silently dropped,
-# in issue #1351: https://github.com/Takazudo/zudo-front-builder/issues/1351
+# Adoption history: these entries were first recorded on the FIRST `cargo
+# deny check advisories` run when this config was added (issue #1334).
+# The 5 entries that have since cleared (anyhow, remove_dir_all, tempdir,
+# number_prefix, yaml-rust — see epic #1365) were removed from this list.
+# The entries below are still blocked; the live tracker for all of them is
+# issue #1373: https://github.com/Takazudo/zudo-front-builder/issues/1373
+# (supersedes the original per-entry #1351 links, now closed).
 # Remove an entry once its underlying dependency is upgraded/replaced and the
 # advisory no longer appears.
 # Note: this cargo-deny release's ignore-entry schema only accepts `id` and
 # `reason` (no separate `url` key), so the tracking-issue link is folded into
 # each `reason` string instead.
 ignore = [
-    # anyhow has a safe upgrade (>=1.0.103) — kept ignored only because
-    # `cargo update` is out of scope for the cargo-deny adoption PR itself;
-    # see the tracking issue for the trivial follow-up.
-    { id = "RUSTSEC-2026-0190", reason = "unsound Error::downcast_mut() in anyhow 1.0.102, pulled in via deno_core and swc_common; safe upgrade to >=1.0.103 available. Tracked: https://github.com/Takazudo/zudo-front-builder/issues/1351" },
-    # quick-xml 0.39.4 via plist -> syntect; needs >=0.41.0.
-    { id = "RUSTSEC-2026-0194", reason = "quadratic-runtime DoS parsing XML with duplicate attribute names in quick-xml 0.39.4, pulled in via plist -> syntect; needs quick-xml >=0.41.0. Tracked: https://github.com/Takazudo/zudo-front-builder/issues/1351" },
-    { id = "RUSTSEC-2026-0195", reason = "unbounded namespace-declaration allocation (memory-exhaustion DoS) in quick-xml 0.39.4, same dependency path as RUSTSEC-2026-0194. Tracked: https://github.com/Takazudo/zudo-front-builder/issues/1351" },
-    # tempdir + its remove_dir_all dep are a dev-only path (zfb-md-extras
-    # tests); fix is swapping to the already-in-workspace `tempfile` crate.
-    { id = "RUSTSEC-2023-0018", reason = "TOCTOU race in remove_dir_all 0.5.3, pulled in via the dev-dependency tempdir in zfb-md-extras; fix is swapping tempdir for the workspace's existing tempfile dep. Tracked: https://github.com/Takazudo/zudo-front-builder/issues/1351" },
-    { id = "RUSTSEC-2018-0017", reason = "tempdir 0.3.7 is deprecated in favor of tempfile; direct dev-dependency of zfb-md-extras, no runtime impact. Tracked: https://github.com/Takazudo/zudo-front-builder/issues/1351" },
+    # quick-xml 0.39.4 via plist -> syntect's plist-load feature, kept for
+    # the documented codeHighlight.themesDir .tmTheme loading product
+    # feature; needs plist to release with quick-xml >=0.41.0 (latest plist
+    # 1.9.0 still pins quick_xml ^0.39.2).
+    { id = "RUSTSEC-2026-0194", reason = "quadratic-runtime DoS parsing XML with duplicate attribute names in quick-xml 0.39.4, pulled in via plist -> syntect's plist-load feature (kept for the documented codeHighlight.themesDir .tmTheme loading support); needs a plist release allowing quick-xml >=0.41.0 (latest plist 1.9.0 still pins quick_xml ^0.39.2). Tracked: https://github.com/Takazudo/zudo-front-builder/issues/1373" },
+    { id = "RUSTSEC-2026-0195", reason = "unbounded namespace-declaration allocation (memory-exhaustion DoS) in quick-xml 0.39.4, same dependency path as RUSTSEC-2026-0194 (plist -> syntect's plist-load feature, kept for codeHighlight.themesDir .tmTheme support); same fix condition. Tracked: https://github.com/Takazudo/zudo-front-builder/issues/1373" },
     # Transitive "unmaintained" findings with no safe upgrade path today —
     # each pinned by an upstream crate we don't control directly.
-    { id = "RUSTSEC-2025-0141", reason = "bincode 1.3.3 unmaintained, pulled in transitively via deno_core; no safe upgrade available. Tracked: https://github.com/Takazudo/zudo-front-builder/issues/1351" },
-    { id = "RUSTSEC-2025-0119", reason = "number_prefix 0.4.0 unmaintained, pulled in transitively via indicatif; no safe upgrade available. Tracked: https://github.com/Takazudo/zudo-front-builder/issues/1351" },
-    { id = "RUSTSEC-2024-0436", reason = "paste 1.0.15 unmaintained, pulled in transitively via v8/deno_core; no safe upgrade available. Tracked: https://github.com/Takazudo/zudo-front-builder/issues/1351" },
-    { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 2.0.1 unmaintained, pulled in transitively via local-ip-address; no safe upgrade available. Tracked: https://github.com/Takazudo/zudo-front-builder/issues/1351" },
-    { id = "RUSTSEC-2024-0320", reason = "yaml-rust 0.4.5 unmaintained, pulled in transitively via syntect's .sublime-syntax YAML loading; no safe upgrade available. Tracked: https://github.com/Takazudo/zudo-front-builder/issues/1351" },
+    { id = "RUSTSEC-2025-0141", reason = "bincode 1.3.3 unmaintained, pulled in transitively via deno_core and syntect's dump features; no safe upgrade available until deno_core moves off bincode 1.x (a deno_core bump is V8-scale and tracked separately). zfb-graph itself was migrated to bincode 2 (#1370) — this only covers the remaining transitive deno_core/syntect usage. Tracked: https://github.com/Takazudo/zudo-front-builder/issues/1373" },
+    { id = "RUSTSEC-2024-0436", reason = "paste 1.0.15 unmaintained, pulled in transitively via v8/deno_core; no safe upgrade available until deno_core/v8 moves (same V8-scale bump as the bincode entry above). Tracked: https://github.com/Takazudo/zudo-front-builder/issues/1373" },
+    { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 2.0.1 unmaintained, pulled in transitively via local-ip-address -> neli -> getset; no safe upgrade available until movement happens upstream in that chain. Tracked: https://github.com/Takazudo/zudo-front-builder/issues/1373" },
 ]
 
 # Lenient to start: an explicit allow-list keeps `cargo deny check`


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1365

---

## Summary

Implements epic #1365 (supersedes #1351): resolves **5 of the 10** cargo-deny advisory findings, migrates zfb-graph off its direct `bincode 1` dependency (hardening), and reconciles `deny.toml` so the remaining 5 blocked advisories carry corrected reasons and a live tracking link (#1373).

### Resolved advisories

| Advisory | Fix |
|---|---|
| RUSTSEC-2026-0190 (anyhow unsound) | `cargo update -p anyhow` → 1.0.103 |
| RUSTSEC-2023-0018 (remove_dir_all TOCTOU) | tempdir → tempfile swap in zfb-md-extras dev-deps |
| RUSTSEC-2018-0017 (tempdir unmaintained) | same swap; tempdir + rand 0.4 subtree gone from lock |
| RUSTSEC-2025-0119 (number_prefix unmaintained) | indicatif 0.17 → 0.18.6 (0.18 dropped number_prefix) |
| RUSTSEC-2024-0320 (yaml-rust unmaintained) | syntect `default-features = false`, explicit feature list drops `yaml-load` (`plist-load` kept for the documented `codeHighlight.themesDir` .tmTheme support) |

### Hardening

- zfb-graph's on-disk dependency-graph cache migrated from unmaintained bincode 1 to bincode 2 (serde mode); wire-format `VERSION` bumped 1 → 2, old caches gracefully rebuild (regression test added). RUSTSEC-2025-0141 stays ignored — bincode 1.3.3 remains via deno_core + syntect dump features.

### deny.toml reconciliation

- 5 cleared `[advisories.ignore]` entries removed.
- 5 surviving entries (quick-xml ×2, bincode, paste, proc-macro-error2) re-confirmed blocked with corrected dependency paths and re-linked to the new tracking issue #1373 (#1351 is closed as superseded).
- `cargo deny check advisories` → **advisories ok**, zero unmatched-ignore warnings.

## Verification

- `cargo check --workspace` ✓, `cargo check -p zfb --all-targets` ✓
- `cargo test -p zfb-md-extras` 304 ✓ and `--features test-utils` 421 ✓ (required-features lane)
- `cargo test -p zfb-content` 685 ✓ (syntect trim incl. .tmTheme + dual-theme tests)
- `cargo test -p zfb-graph` 63 ✓ (incl. new old-version-cache graceful-miss test)
- `cargo tree`: yaml-rust / number_prefix / tempdir gone; plist retained; zfb-graph on bincode 2.0.1
- Codex review: no actionable correctness issues

## Topic PRs

Topic branches were merged locally into the base branch (per the /x-wt-teams flow); no separate topic PRs were opened since the base already contained their commits.
- anyhow-bump → 4913aa6 (#1366)
- tempdir-swap → 89d497d (#1367)
- syntect-trim → 7276cc7 (#1368)
- indicatif-bump → bee8d53 (#1369)
- zfb-graph-bincode2 → a091391 (#1370)
- deny-reconcile → d5ee98a (#1371)