### PR TITLE
runtime: same-page traverse fast-path + syncHistoryEntry history API

### DIFF
--- a/docs/src/content/docs/concepts/client-side-routing.mdx
+++ b/docs/src/content/docs/concepts/client-side-routing.mdx
@@ -156,7 +156,7 @@ Some viewers deep-link to a real path segment instead of a hash — a photo ligh
 ```ts
 import { syncHistoryEntry } from "@takazudo/zfb-runtime/client-router";
 
-function openPhoto(slug: string) {
+function openPhotoLightbox(slug: string) {
   syncHistoryEntry(`/photos/${slug}/`);
 }
 ```

--- a/docs/src/content/docs/concepts/client-side-routing.mdx
+++ b/docs/src/content/docs/concepts/client-side-routing.mdx
@@ -130,13 +130,24 @@ type SyncHistoryEntryOptions = {
 ```tsx
 import { syncHistoryEntry } from "@takazudo/zfb-runtime/client-router";
 
-function PhotoModal({ id }: { id: string }) {
-  const open = () => syncHistoryEntry(`${location.pathname}#photo-${id}`);
-  return <button onClick={open}>View photo</button>;
+function PhotoModal({ id, onClose }: { id: string; onClose: () => void }) {
+  useEffect(() => {
+    const onPopState = () => {
+      if (location.hash !== `#photo-${id}`) onClose();
+    };
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, [id, onClose]);
+
+  return <div className="modal">{/* photo content */}</div>;
+}
+
+function openPhoto(id: string) {
+  syncHistoryEntry(`${location.pathname}#photo-${id}`);
 }
 ```
 
-Because the pushed entry shares the current `pathname` and `search` (only the hash changes), pressing Back afterwards is served by the same-page traversal fast-path (see below): no fetch, no swap — the modal just closes as the live DOM, and any other island state on the page, is left untouched.
+Because the pushed entry shares the current `pathname` and `search` (only the hash changes), pressing Back afterwards is served by the same-page traversal fast-path (see below): no fetch, no swap, no full-page remount. The browser still fires its normal `popstate` event, though — `syncHistoryEntry()` does not close the modal for you. The modal listens for `popstate` (or `hashchange`) itself and closes when the hash no longer matches; without that listener the URL would change but the modal would stay open.
 
 ### Example: a dialog with its own pathname
 
@@ -286,7 +297,7 @@ document.addEventListener("zfb:before-preparation", (e) => {
 
 A Back or Forward press that lands on a history entry sharing the current page's `pathname` and `search` — only the hash or router-tracked state differs — is served entirely from the live DOM. The router does not fetch, does not swap `<head>`/`<body>`, and does not remount anything: it restores the entry's tracked scroll position and leaves the page exactly as it is. Island/client state (open dropdowns, form input, video playback, etc.) survives untouched.
 
-This is the mechanism behind the modal examples above: opening a hash-based modal with `syncHistoryEntry()` and later pressing Back closes it for free, with no round trip to the server. (The router already skipped the fetch for a plain same-page `#anchor` link before a traversal was even involved — this fast-path extends the same idea to Back/Forward.)
+This is the mechanism behind the hash-modal example above: pressing Back after `syncHistoryEntry()` is handled with no round trip to the server and no disruption to the rest of the page — the modal component itself still has to react to the URL change (via `popstate`/`hashchange`) to close. (The router already skipped the fetch for a plain same-page `#anchor` link before a traversal was even involved — this fast-path extends the same idea to Back/Forward.)
 
 ### Lifecycle events and the route announcer are skipped
 

--- a/docs/src/content/docs/concepts/client-side-routing.mdx
+++ b/docs/src/content/docs/concepts/client-side-routing.mdx
@@ -35,6 +35,7 @@ Importing `<ClientRouter />` registers the click and form-submit intercepts as a
 |---|---|---|---|
 | `fallback` | `"none" \| "animate" \| "swap"` | `"animate"` | Behaviour when the browser does not support native View Transitions. |
 | `prefetchAll` | `boolean` | `false` | When `true`, every same-origin link is opted into the `"hover"` prefetch strategy automatically. |
+| `traverseRefetch` | `boolean` | `false` | Opt this page out of the same-page Back/Forward fast-path, forcing a re-fetch on every traversal — see [Same-page traversal](#same-page-traversal). |
 
 ### Fallback modes
 
@@ -94,6 +95,62 @@ Add `data-zfb-reload` to any `<a>` or `<form>` to force a full browser reload fo
 ```html
 <a href="/admin" data-zfb-reload>Admin (full reload)</a>
 ```
+
+## Deep-linking transient UI state with `syncHistoryEntry()`
+
+Modals, dialogs, and viewers often want their own URL — so Back closes them, and the state is shareable and bookmarkable — without performing a real page navigation. Don't reach for raw `history.pushState()` / `history.replaceState()` for this: the router tracks its own history index and the URL it navigated *from* to detect Back/Forward direction and same-page traversals (see [Same-page traversal](#same-page-traversal) below), and a hand-rolled history entry desyncs that bookkeeping.
+
+`syncHistoryEntry()` writes a router-managed history entry without navigating — no fetch, no swap, no DOM or scroll changes:
+
+```ts
+import { syncHistoryEntry } from "@takazudo/zfb-runtime/client-router";
+
+function openModal(id: string) {
+  syncHistoryEntry(`#photo-${id}`);
+}
+```
+
+```ts
+function syncHistoryEntry(url: string | URL, options?: SyncHistoryEntryOptions): void;
+
+type SyncHistoryEntryOptions = {
+  replace?: boolean; // use replaceState instead of pushState (no new Back entry)
+  state?: any;       // merged into history.state; the router's own keys win on collision
+};
+```
+
+- **Push by default** — creates a new history entry, so Back returns to whatever the user was looking at before. Pass `{ replace: true }` to overwrite the current entry instead (no new Back stop).
+- **`state` is merged, router keys win** — your own keys survive, but the router's bookkeeping keys (`index`, `scrollX`, `scrollY`) always take precedence if your `state` object happens to reuse those names.
+- **Throws on a cross-origin URL** — never silently falls back to a full-page load; a mistaken cross-origin call is a bug you want to see immediately.
+- **No-ops during SSR**, emitting the same one-time console warning as calling `navigate()` on the server.
+- **Never touches the DOM, scroll position, or `document.title`** — it is pure history bookkeeping. Your component is responsible for rendering the modal/dialog itself based on the current URL.
+
+### Example: a hash-based modal
+
+```tsx
+import { syncHistoryEntry } from "@takazudo/zfb-runtime/client-router";
+
+function PhotoModal({ id }: { id: string }) {
+  const open = () => syncHistoryEntry(`${location.pathname}#photo-${id}`);
+  return <button onClick={open}>View photo</button>;
+}
+```
+
+Because the pushed entry shares the current `pathname` and `search` (only the hash changes), pressing Back afterwards is served by the same-page traversal fast-path (see below): no fetch, no swap — the modal just closes as the live DOM, and any other island state on the page, is left untouched.
+
+### Example: a dialog with its own pathname
+
+Some viewers deep-link to a real path segment instead of a hash — a photo lightbox at `/photos/<slug>/`, say, reachable from a shareable link:
+
+```ts
+import { syncHistoryEntry } from "@takazudo/zfb-runtime/client-router";
+
+function openPhoto(slug: string) {
+  syncHistoryEntry(`/photos/${slug}/`);
+}
+```
+
+This changes `pathname`, so the pushed entry no longer matches the page the user came from — pressing Back falls through to a normal cross-page traversal (fetch + swap of the previous page), not the fast-path. `syncHistoryEntry()` only edits the URL bar and the router's bookkeeping; it never fetches or renders anything itself, so an island reading `location.pathname` is what actually shows the lightbox contents while the URL carries it.
 
 ## Prefetch strategies
 
@@ -165,6 +222,8 @@ document.addEventListener("zfb:before-preparation", (e) => {
 });
 ```
 
+One exception: none of these six events fire for a same-page Back/Forward traversal — see [Same-page traversal](#same-page-traversal) below.
+
 ### Event reference
 
 | Event name | Cancellable | When it fires |
@@ -222,6 +281,30 @@ document.addEventListener("zfb:before-preparation", (e) => {
   }
 });
 ```
+
+## Same-page traversal
+
+A Back or Forward press that lands on a history entry sharing the current page's `pathname` and `search` — only the hash or router-tracked state differs — is served entirely from the live DOM. The router does not fetch, does not swap `<head>`/`<body>`, and does not remount anything: it restores the entry's tracked scroll position and leaves the page exactly as it is. Island/client state (open dropdowns, form input, video playback, etc.) survives untouched.
+
+This is the mechanism behind the modal examples above: opening a hash-based modal with `syncHistoryEntry()` and later pressing Back closes it for free, with no round trip to the server. (The router already skipped the fetch for a plain same-page `#anchor` link before a traversal was even involved — this fast-path extends the same idea to Back/Forward.)
+
+### Lifecycle events and the route announcer are skipped
+
+Because nothing is fetched or swapped, none of the six `zfb:*` [lifecycle events](#navigation-lifecycle-events) — from `zfb:before-preparation` through `zfb:page-load` — fire for a same-page traversal. The ARIA route announcer (the offscreen `.zfb-route-announcer` element that speaks the new page's title to screen readers after every SPA navigation) is not updated either, since it's only written as part of the fetch/swap flow.
+
+If you hook lifecycle events to run per-navigation side effects (analytics, re-initializing a widget, etc.), those hooks will not run for a Back/Forward press between two same-page history entries.
+
+### Opting back in with `traverseRefetch`
+
+Static and prerendered pages don't need to know about any of this — their content can't change between visits, so serving the fast-path from the live DOM is always correct. A per-request SSR page (`export const prerender = false`) is different: its server-rendered output can legitimately differ between two visits to the *same* URL — session-dependent markup, a CSRF token, live data — so pinning the first-render content on every subsequent traversal would be wrong.
+
+Opt such a page back into the fetch with the `traverseRefetch` prop:
+
+```tsx
+<ClientRouter traverseRefetch />
+```
+
+This emits `<meta name="zfb-traverse-refetch" content="true">`, which the router checks on the current (target) page before taking the fast-path — when present, a same-page traversal falls through to a normal fetch and swap instead. Mount `<ClientRouter />` with the same `traverseRefetch` value on every page that participates in SPA navigation, since the meta is read from whichever page is currently live.
 
 ## View Transitions
 

--- a/packages/zfb-runtime/src/__tests__/client-router.test.ts
+++ b/packages/zfb-runtime/src/__tests__/client-router.test.ts
@@ -137,6 +137,41 @@ describe("ClientRouter — preserveHtmlAttrs", () => {
   });
 });
 
+describe("ClientRouter — traverseRefetch", () => {
+  it("does not emit a zfb-traverse-refetch meta when the prop is omitted", () => {
+    const nodes = ClientRouter();
+    const meta = nodes.find((n) => n.type === "meta" && n.props["name"] === "zfb-traverse-refetch");
+    expect(meta).toBeUndefined();
+    // Byte-identical baseline: still exactly the three base nodes.
+    expect(nodes).toHaveLength(3);
+  });
+
+  it("does not emit the meta when traverseRefetch is false", () => {
+    const nodes = ClientRouter({ traverseRefetch: false });
+    const meta = nodes.find((n) => n.type === "meta" && n.props["name"] === "zfb-traverse-refetch");
+    expect(meta).toBeUndefined();
+    expect(nodes).toHaveLength(3);
+  });
+
+  it("appends a zfb-traverse-refetch meta VNode when traverseRefetch is true", () => {
+    const nodes = ClientRouter({ traverseRefetch: true });
+    const meta = nodes.find((n) => n.type === "meta" && n.props["name"] === "zfb-traverse-refetch");
+    expect(meta).toBeDefined();
+    // Pin the exact attribute values — this is the contract the router reads.
+    expect(meta?.props["name"]).toBe("zfb-traverse-refetch");
+    expect(meta?.props["content"]).toBe("true");
+    expect(nodes).toHaveLength(4);
+  });
+
+  it("the traverse-refetch meta is a real JSX-runtime element (carries the $$typeof brand)", () => {
+    const nodes = ClientRouter({ traverseRefetch: true });
+    const meta = nodes.find((n) => n.type === "meta" && n.props["name"] === "zfb-traverse-refetch");
+    expect(meta).toBeDefined();
+    const brand = (meta as { $$typeof?: unknown } | undefined)?.$$typeof;
+    expect(typeof brand).toBe("symbol");
+  });
+});
+
 describe("ClientRouter — baseline nodes are always present", () => {
   it("always emits a style VNode first", () => {
     const nodes = ClientRouter();

--- a/packages/zfb-runtime/src/__tests__/client-router/router.test.ts
+++ b/packages/zfb-runtime/src/__tests__/client-router/router.test.ts
@@ -66,8 +66,14 @@ import {
   init,
   navigate,
   supportsViewTransitions,
+  syncHistoryEntry,
   transitionEnabledOnThisPage,
 } from "../../client-router/router.js";
+// Type-only import from the PUBLIC barrel — proves SyncHistoryEntryOptions is
+// re-exported from @takazudo/zfb-runtime/client-router. `import type` is erased
+// at runtime, so it does not drag the barrel's <ClientRouter> module into the
+// test environment.
+import type { SyncHistoryEntryOptions } from "../../client-router/index.js";
 
 beforeEach(() => {
   resetDocument();
@@ -1056,5 +1062,272 @@ describe("route announcer — timer lifecycle (#1063)", () => {
       setTimeoutSpy.mockRestore();
       clearTimeoutSpy.mockRestore();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// syncHistoryEntry() — public history bookkeeping API (#1377)
+// ---------------------------------------------------------------------------
+//
+// syncHistoryEntry(url, { replace?, state? }) writes a router-managed history
+// entry (push/replace) WITHOUT any navigation, DOM, scroll, or lifecycle side
+// effect — the supported path for consumers deep-linking transient UI state
+// (dialogs/modals, a photo viewer's /photos/<slug>/ URL) that would otherwise
+// hand-roll raw history.pushState and desync originalLocation + the index
+// bookkeeping.
+//
+// `currentHistoryIndex` is module-global and monotonic across THIS whole file
+// (every prior navigate() bumped it), so these tests read the resulting index
+// back from history.state and assert RELATIVE deltas — never an absolute value.
+//
+// BLIND SPOT (documented): happy-dom models neither a real history stack nor a
+// real fetch/paint, so popstate-driven assertions hand-feed the target entry's
+// state and prove the router's BRANCH LOGIC (fetch vs. fast-path, direction),
+// not real-browser back/forward behavior. Definitive proof is the Wave-3
+// chromium harness (#1378).
+describe("syncHistoryEntry() — public history bookkeeping API (#1377)", () => {
+  // Earlier tests in this file shim `location.href` via Object.defineProperty and
+  // never restore it, leaving a frozen own-property getter that would stop
+  // history.push/replaceState(state, "", path) from reflecting into
+  // `location.href`. Delete any leaked own-property so happy-dom's native getter —
+  // which DOES track push/replaceState — is back in effect.
+  beforeEach(() => {
+    if (Object.getOwnPropertyDescriptor(location, "href")) {
+      delete (location as unknown as Record<string, unknown>)["href"];
+    }
+    // A well-formed router-managed base entry so history.state is never null.
+    history.replaceState({ index: 0, scrollX: 0, scrollY: 0 }, "", "/sync-base");
+  });
+
+  const drain = () => new Promise((r) => setTimeout(r, 0));
+
+  function fetchPages() {
+    const fetchMock = vi.fn(async (url: RequestInfo) => {
+      const u = String(url);
+      if (u.includes("/base")) return htmlResponse(pageHtml("Base", "base content"));
+      if (u.includes("/photos")) return htmlResponse(pageHtml("Photos", "photos content"));
+      if (u.includes("/gallery")) return htmlResponse(pageHtml("Gallery", "gallery content"));
+      throw new Error(`unexpected fetch: ${u}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  // Fire the popstate a browser would fire for a history entry. happy-dom's
+  // history.replaceState(state, "", path) updates BOTH history.state and
+  // location.href (same-origin path) — exactly what onPopState reads. State MUST
+  // be non-null (onPopState ignores ev.state === null).
+  function dispatchPopstate(path: string, state: Record<string, unknown>) {
+    history.replaceState(state, "", path);
+    window.dispatchEvent(new PopStateEvent("popstate", { state }));
+  }
+
+  // Capture the Direction the router classified for a popstate-driven transition,
+  // read off the zfb:before-preparation event.
+  function captureDirection(): { get: () => string | undefined; dispose: () => void } {
+    let seen: string | undefined;
+    const handler = (ev: Event) => {
+      seen = (ev as unknown as { direction: string }).direction;
+    };
+    document.addEventListener("zfb:before-preparation", handler);
+    return {
+      get: () => seen,
+      dispose: () => document.removeEventListener("zfb:before-preparation", handler),
+    };
+  }
+
+  it("push: writes a new same-page entry with a finite index and scroll reset to 0", () => {
+    syncHistoryEntry("/sync-base/modal-a");
+    const first = history.state;
+    expect(location.pathname).toBe("/sync-base/modal-a");
+    expect(Number.isFinite(first.index)).toBe(true);
+    expect(first.scrollX).toBe(0);
+    expect(first.scrollY).toBe(0);
+
+    // A second push increments the tracked index by exactly 1 — the bookkeeping
+    // popstate direction detection relies on.
+    syncHistoryEntry("/sync-base/modal-b");
+    const second = history.state;
+    expect(location.pathname).toBe("/sync-base/modal-b");
+    expect(second.index).toBe(first.index + 1);
+  });
+
+  it("replace: keeps the current entry's index (no increment) and swaps the URL in place", () => {
+    syncHistoryEntry("/sync-base/page-1"); // establishes a known current index
+    const before = history.state.index;
+
+    syncHistoryEntry("/sync-base/page-1-replaced", { replace: true });
+    expect(location.pathname).toBe("/sync-base/page-1-replaced");
+    // Replace must NOT advance the index.
+    expect(history.state.index).toBe(before);
+  });
+
+  it("replace: falls back to the tracked index when history.state.index is missing/invalid", () => {
+    syncHistoryEntry("/sync-base/anchor"); // tracked index := N (module currentHistoryIndex)
+    const tracked = history.state.index;
+
+    // A raw-History consumer left the current entry with NO valid index.
+    history.replaceState({ foo: "bar" }, "", "/sync-base/anchor");
+
+    syncHistoryEntry("/sync-base/anchor-2", { replace: true });
+    // The fallback stamped the tracked index, not NaN/undefined.
+    expect(history.state.index).toBe(tracked);
+    expect(history.state.foo).toBeUndefined(); // consumer's stale key not carried over
+  });
+
+  it("merges consumer state, with router keys (index/scrollX/scrollY) winning", () => {
+    syncHistoryEntry("/sync-base/dialog", {
+      state: { modal: "photo", index: 999, scrollX: 555, scrollY: 777 },
+    });
+    const s = history.state;
+    // Consumer's own (non-colliding) key is preserved.
+    expect(s.modal).toBe("photo");
+    // Router bookkeeping keys override the consumer's colliding values.
+    expect(s.index).not.toBe(999);
+    expect(Number.isFinite(s.index)).toBe(true);
+    expect(s.scrollX).toBe(0);
+    expect(s.scrollY).toBe(0);
+  });
+
+  it("throws on a cross-origin target (never a silent full-page load)", () => {
+    const before = history.state;
+    expect(() => syncHistoryEntry("https://evil.example.com/x")).toThrow(/cross-origin/i);
+    // The throw happens before any history write.
+    expect(history.state).toBe(before);
+    expect(location.pathname).toBe("/sync-base");
+  });
+
+  it("is a no-op with a console warning when called during SSR (no document)", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const pushSpy = vi.spyOn(history, "pushState");
+    // Only this test exercises the server path, so the module's one-time
+    // `syncHistoryEntryOnServerWarned` flag is still false on the first call here.
+    vi.stubGlobal("document", undefined);
+    try {
+      syncHistoryEntry("/sync-base/should-not-run");
+      const afterFirst = warnSpy.mock.calls.length;
+      // Second call: no-op AND once-only (no additional warning).
+      syncHistoryEntry("/sync-base/still-nothing");
+      expect(warnSpy.mock.calls.length).toBe(afterFirst);
+      expect(afterFirst).toBe(1);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+    // No history entry was written on the server path.
+    expect(pushSpy).not.toHaveBeenCalled();
+    // The warning mirrors navigate()'s shape: an Error named "Warning".
+    const warnedWith = warnSpy.mock.calls[0]?.[0] as Error | undefined;
+    expect(warnedWith?.name).toBe("Warning");
+
+    warnSpy.mockRestore();
+    pushSpy.mockRestore();
+  });
+
+  it("push: persists the outgoing entry's live scroll before pushing the new entry", () => {
+    syncHistoryEntry("/sync-base/list"); // outgoing entry
+    const outgoingIndex = history.state.index;
+
+    // The user scrolled since the last scrollend flush.
+    vi.stubGlobal("scrollX", 24);
+    vi.stubGlobal("scrollY", 480);
+
+    const replaceSpy = vi.spyOn(history, "replaceState");
+    syncHistoryEntry("/sync-base/detail");
+
+    // updateScrollPosition() rewrote the OUTGOING entry's state with the live
+    // scroll (a replaceState) before the new entry was pushed.
+    expect(replaceSpy).toHaveBeenCalled();
+    const replaced = replaceSpy.mock.calls.at(-1)?.[0] as {
+      index: number;
+      scrollX: number;
+      scrollY: number;
+    };
+    expect(replaced.scrollX).toBe(24);
+    expect(replaced.scrollY).toBe(480);
+    // It updated the outgoing entry (same index), not a fresh one.
+    expect(replaced.index).toBe(outgoingIndex);
+    // The freshly pushed entry itself starts at scroll (0,0).
+    expect(history.state.scrollX).toBe(0);
+    expect(history.state.scrollY).toBe(0);
+
+    replaceSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  it("updates originalLocation: a subsequent same-page Back takes the traverse fast path (no fetch)", async () => {
+    const fetchMock = fetchPages();
+
+    // Router-managed base so originalLocation === /base.
+    await navigate("/base");
+
+    // A photo viewer opens a NEW pathname, then a modal within it — both via
+    // syncHistoryEntry, which re-points originalLocation each time.
+    syncHistoryEntry("/photos/slug/");
+    syncHistoryEntry("/photos/slug/#modal");
+    const modalIndex = history.state.index; // finite, stamped by syncHistoryEntry
+
+    fetchMock.mockClear();
+    const beforePrep = vi.fn();
+    document.addEventListener("zfb:before-preparation", beforePrep);
+
+    // Back to /photos/slug/. originalLocation is /photos/slug/#modal (updated by
+    // the last sync push), so samePage(from, to) holds → traverse fast path.
+    // Had originalLocation NOT been updated it would still be /base, samePage
+    // would be false, and this Back would FETCH.
+    dispatchPopstate("/photos/slug/", { index: modalIndex - 1, scrollX: 0, scrollY: 0 });
+    await drain();
+
+    document.removeEventListener("zfb:before-preparation", beforePrep);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(beforePrep).not.toHaveBeenCalled();
+  });
+
+  it("pathname-changed traverse still fetches normally (not a false fast-path), direction classified 'back'", async () => {
+    const fetchMock = fetchPages();
+
+    await navigate("/base");
+    const baseIndex = history.state.index;
+
+    // syncHistoryEntry pushes a DIFFERENT pathname (photo viewer) and re-points
+    // originalLocation to it — and increments currentHistoryIndex, so the entry
+    // carries a finite index that derivePopDirection can use.
+    syncHistoryEntry("/gallery/");
+
+    fetchMock.mockClear();
+    const dir = captureDirection();
+
+    // Back to /base: samePage(/gallery/, /base) is false → cross-page traverse
+    // must fall through to a real fetch, with the direction correctly "back".
+    dispatchPopstate("/base", { index: baseIndex, scrollX: 0, scrollY: 0 });
+    await drain();
+
+    expect(fetchMock.mock.calls.some((c) => String(c[0]).includes("/base"))).toBe(true);
+    expect(dir.get()).toBe("back");
+    dir.dispose();
+  });
+
+  it("never scrolls or mutates the DOM (push and replace are side-effect free)", () => {
+    const scrollToSpy = vi.spyOn(window, "scrollTo");
+    document.body.innerHTML = `<main id="marker">original</main>`;
+    const bodyBefore = document.body.innerHTML;
+    const titleBefore = document.title;
+
+    syncHistoryEntry("/sync-base/quiet-push");
+    syncHistoryEntry("/sync-base/quiet-replace", { replace: true });
+
+    // No scroll side effect (no fragment-scroll, no scroll-to-top).
+    expect(scrollToSpy).not.toHaveBeenCalled();
+    // No DOM mutation: body and title untouched.
+    expect(document.body.innerHTML).toBe(bodyBefore);
+    expect(document.title).toBe(titleBefore);
+
+    scrollToSpy.mockRestore();
+  });
+
+  it("exported SyncHistoryEntryOptions type is usable by consumers", () => {
+    // Compile-time proof that the public option type covers { replace, state }.
+    const opts: SyncHistoryEntryOptions = { replace: true, state: { modal: "x" } };
+    expect(() => syncHistoryEntry("/sync-base/typed", opts)).not.toThrow();
   });
 });

--- a/packages/zfb-runtime/src/__tests__/client-router/router.test.ts
+++ b/packages/zfb-runtime/src/__tests__/client-router/router.test.ts
@@ -726,6 +726,224 @@ describe("pageshow / bfcache re-sync — WebKit Back-history (#1076)", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// Same-page traverse fast-path (#1374 / #1376)
+// ---------------------------------------------------------------------------
+//
+// A Back/Forward (popstate) traversal between two history entries sharing the
+// same pathname+search is served from the live DOM — no re-fetch, no re-swap,
+// no zfb:* lifecycle events. This is the #1374 fix: before it, a traversal over
+// a raw `history.pushState('#slug')` entry fell through to a full fetch + swap
+// of the byte-identical page (overlay flash, wasted fetch, island-state loss),
+// because the old hash-gate only saw router-managed navigation.
+//
+// The fast path routes through moveToLocation (scroll restore + originalLocation
+// self-heal), NOT a bare early return — see the acceptance criteria in #1376.
+//
+// A per-page opt-out (`<ClientRouter traverseRefetch />` →
+// meta[name="zfb-traverse-refetch"]) forces the fetch back on for per-request
+// SSR pages whose content can differ between two visits to the same URL.
+//
+// BLIND SPOT (documented): happy-dom models neither a real fetch/paint nor
+// bfcache, so this proves the gate's BRANCH LOGIC, not the real-browser
+// no-flash behavior. Definitive proof is the Wave-3 chromium harness (#1378).
+describe("same-page traverse fast-path (#1374 / #1376)", () => {
+  // Earlier tests in this file shim `location.href` via Object.defineProperty
+  // and never restore it, leaving a frozen own-property getter that would stop
+  // `history.push/replaceState(state, "", path)` from reflecting into
+  // `location.href` (which onPopState reads via `new URL(location.href)`).
+  // Delete any leaked own-property so happy-dom's native prototype getter — which
+  // DOES track push/replaceState — is back in effect for these tests.
+  beforeEach(() => {
+    if (Object.getOwnPropertyDescriptor(location, "href")) {
+      delete (location as unknown as Record<string, unknown>)["href"];
+    }
+  });
+
+  const drain = () => new Promise((r) => setTimeout(r, 0));
+
+  function fetchPages() {
+    const fetchMock = vi.fn(async (url: RequestInfo) => {
+      const u = String(url);
+      if (u.includes("/base")) return htmlResponse(pageHtml("Base", "base content"));
+      if (u.includes("/other")) return htmlResponse(pageHtml("Other", "other content"));
+      throw new Error(`unexpected fetch: ${u}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    return fetchMock;
+  }
+
+  // Add the opt-out meta to the CURRENT (live) document — i.e. AFTER a navigate()
+  // swap has replaced the head, since the router reads it on the target page.
+  function injectTraverseRefetchMeta() {
+    const meta = document.createElement("meta");
+    meta.setAttribute("name", "zfb-traverse-refetch");
+    meta.setAttribute("content", "true");
+    document.head.appendChild(meta);
+  }
+
+  // Fire the popstate a browser would fire for a history entry. happy-dom's
+  // history.replaceState(state, "", path) updates BOTH history.state and
+  // location.href (same-origin path) — exactly what onPopState reads. The state
+  // MUST be non-null: onPopState ignores `ev.state === null` (:814-816).
+  function dispatchPopstate(path: string, state: Record<string, unknown>) {
+    history.replaceState(state, "", path);
+    window.dispatchEvent(new PopStateEvent("popstate", { state }));
+  }
+
+  // Seed one router-managed entry at /base through production code so
+  // originalLocation === /base and history.state carries a finite index. The
+  // module index is monotonic across the whole file, so read the resulting
+  // index back rather than assuming an absolute value.
+  async function seedBase(): Promise<number> {
+    await navigate("/base");
+    expect(document.title).toBe("Base");
+    return (history.state as { index: number }).index;
+  }
+
+  it("(a) raw pushState('#modal') + Back popstate → no fetch, no before-preparation, originalLocation self-heals", async () => {
+    const fetchMock = fetchPages();
+    const baseIndex = await seedBase();
+
+    // Consumer opens a modal via RAW history.pushState — NOT through the router,
+    // so originalLocation stays /base and the module index is unchanged. This is
+    // the #1374 trigger: the old hash-gate could not see this entry.
+    history.pushState({ ...history.state }, "", "/base#modal");
+
+    const beforePrep = vi.fn();
+    document.addEventListener("zfb:before-preparation", beforePrep);
+    fetchMock.mockClear();
+
+    // User presses Back: the browser pops to the /base entry and fires popstate.
+    dispatchPopstate("/base", { index: baseIndex, scrollX: 0, scrollY: 0 });
+    await drain();
+
+    document.removeEventListener("zfb:before-preparation", beforePrep);
+
+    // Fast path: byte-identical same-page traverse never fetches or swaps, and
+    // skips ALL zfb:* lifecycle events (intentional — same as the hash fast-path).
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(beforePrep).not.toHaveBeenCalled();
+
+    // originalLocation self-healed by moveToLocation (NOT a bare early return):
+    // a subsequent cross-page navigation behaves normally.
+    await navigate("/other");
+    expect(document.title).toBe("Other");
+    expect(fetchMock.mock.calls.some((c) => String(c[0]).includes("/other"))).toBe(true);
+  });
+
+  it("(b) same scenario WITH the zfb-traverse-refetch meta → fetch IS called (opt-out preserved)", async () => {
+    const fetchMock = fetchPages();
+    const baseIndex = await seedBase();
+
+    // Opt this page back INTO the fetch (per-request SSR). The router reads the
+    // meta on the CURRENT document, so inject it after the navigate() swap.
+    injectTraverseRefetchMeta();
+
+    history.pushState({ ...history.state }, "", "/base#modal");
+
+    fetchMock.mockClear();
+    dispatchPopstate("/base", { index: baseIndex, scrollX: 0, scrollY: 0 });
+    await drain();
+
+    // The opt-out disables the traverse clause, so the same-page traverse falls
+    // through to a full fetch (today's pre-fast-path behavior, preserved).
+    expect(fetchMock.mock.calls.some((c) => String(c[0]).includes("/base"))).toBe(true);
+  });
+
+  it("(c) forward hash fast-path is unaffected by the gate restructure", async () => {
+    const fetchMock = fetchPages();
+    await seedBase();
+
+    fetchMock.mockClear();
+    const beforePrep = vi.fn();
+    document.addEventListener("zfb:before-preparation", beforePrep);
+
+    // Forward same-page hash nav via navigate() — hits `(direction !== "back" &&
+    // to.hash)`, which the new traverse clause must not disturb.
+    await navigate(`${location.pathname}#section-2`);
+
+    document.removeEventListener("zfb:before-preparation", beforePrep);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(beforePrep).not.toHaveBeenCalled();
+    expect(location.hash).toBe("#section-2");
+  });
+
+  it("(c) back-direction hash clause (from.hash) still fast-paths even with the traverse clause opted out", async () => {
+    const fetchMock = fetchPages();
+    await seedBase();
+
+    // Move forward into a hash entry so originalLocation carries a hash
+    // (`from.hash` for the subsequent Back). This goes through the router.
+    await navigate(`${location.pathname}#section`);
+    const hashIndex = (history.state as { index: number }).index;
+
+    // Opt OUT of the traverse fast-path so the traverse clause is disabled — the
+    // back-direction hash clause `(direction === "back" && from.hash)` is then
+    // the ONLY thing that can short-circuit the fetch, proving it is still live.
+    injectTraverseRefetchMeta();
+
+    fetchMock.mockClear();
+    const beforePrep = vi.fn();
+    document.addEventListener("zfb:before-preparation", beforePrep);
+
+    // Browser Back from /base#section to /base: to.hash empty, from.hash "#section".
+    dispatchPopstate("/base", { index: hashIndex - 1, scrollX: 0, scrollY: 0 });
+    await drain();
+
+    document.removeEventListener("zfb:before-preparation", beforePrep);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(beforePrep).not.toHaveBeenCalled();
+  });
+
+  it("(d) cross-page popstate still fetches (the traverse clause is gated on samePage)", async () => {
+    const fetchMock = fetchPages();
+
+    // Two DIFFERENT pages so the traverse is cross-page (samePage false).
+    await navigate("/base");
+    const baseIdx = (history.state as { index: number }).index;
+    await navigate("/other");
+
+    fetchMock.mockClear();
+    // Browser Back to /base (lower index) — cross-page traverse must still fetch.
+    dispatchPopstate("/base", { index: baseIdx, scrollX: 0, scrollY: 0 });
+    await drain();
+
+    expect(fetchMock.mock.calls.some((c) => String(c[0]).includes("/base"))).toBe(true);
+  });
+
+  it("(e) incomplete non-null state ({}) + Back → no fetch, no crash, no scroll jump", async () => {
+    const fetchMock = fetchPages();
+    await seedBase();
+
+    // Consumer opens a modal via RAW pushState with EMPTY (incomplete) state.
+    history.pushState({}, "", "/base#modal");
+
+    // User presses Back. In this raw-History flow the popstate delivers a
+    // non-null but INCOMPLETE state (no index/scrollX/scrollY). The fast path
+    // must tolerate it: no crash, and it must NEVER call scrollTo(undefined, …)
+    // — scroll is left where it is rather than jumping to (0,0).
+    const scrollSpy = vi.spyOn(window, "scrollTo");
+    fetchMock.mockClear();
+    const beforePrep = vi.fn();
+    document.addEventListener("zfb:before-preparation", beforePrep);
+
+    dispatchPopstate("/base", {});
+    await drain();
+
+    document.removeEventListener("zfb:before-preparation", beforePrep);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(beforePrep).not.toHaveBeenCalled();
+    // Partial-state hardening: no scrollTo call at all on this path.
+    expect(scrollSpy).not.toHaveBeenCalled();
+
+    scrollSpy.mockRestore();
+  });
+});
+
 describe("island lifecycle ordering during navigate()", () => {
   it("calls cancelPendingIslands then unmountIslands then mountNewIslands in that order", async () => {
     vi.stubGlobal(

--- a/packages/zfb-runtime/src/client-router.ts
+++ b/packages/zfb-runtime/src/client-router.ts
@@ -79,6 +79,23 @@ export interface ClientRouterProps {
    * @see https://github.com/Takazudo/zudo-front-builder/issues/1103
    */
   preserveHtmlAttrs?: string[];
+  /**
+   * Opt this page OUT of the same-page traverse fast-path (default `false` —
+   * fast-path ON). By default a Back/Forward traversal between two history
+   * entries sharing the same `pathname + search` is served instantly from the
+   * live DOM — no re-fetch, no re-swap, so island/client state is preserved.
+   *
+   * Set this on a **per-request SSR page** (`prerender = false`) whose
+   * server-rendered content can legitimately differ between two visits to the
+   * same URL: with the fast-path skipped such a traverse would pin the stale
+   * first-render content. Emitted as
+   * `<meta name="zfb-traverse-refetch" content="true">`, which the router reads
+   * on the current (target) page to force the fetch back on. Mount with the
+   * **same value on every page** that participates in SPA navigation, mirroring
+   * the `preserveHtmlAttrs` guidance.
+   * @see https://github.com/Takazudo/zudo-front-builder/issues/1376
+   */
+  traverseRefetch?: boolean;
 }
 
 /**
@@ -150,6 +167,7 @@ export function ClientRouter({
   fallback = "animate",
   prefetchAll: prefetchAllProp = false,
   preserveHtmlAttrs = [],
+  traverseRefetch = false,
 }: ClientRouterProps = {}): readonly ClientRouterElement[] {
   // Bootstrap prefetch exactly once on the client when prefetchAll is true.
   // The initialized flag inside prefetchInit() provides a second safety layer
@@ -207,6 +225,19 @@ export function ClientRouter({
         { name: "zfb-preserve-html-attrs", content: preserveList.join(" ") },
         "zfb-preserve-html-attrs",
       ),
+    );
+  }
+
+  // Traverse-refetch opt-out meta (#1376). A same-page Back/Forward traversal
+  // skips the re-fetch/re-swap by default (the router's traverse fast-path);
+  // this meta opts a per-request SSR page (`prerender = false`) back INTO the
+  // fetch, since skipping it would pin stale server-rendered content. Emitted
+  // only when opted in, so non-opt-in output stays byte-identical. Same
+  // conditional-emission shape as the prefetch-disabled / preserve-html-attrs
+  // metas; the router reads meta[name="zfb-traverse-refetch"][content="true"].
+  if (traverseRefetch) {
+    nodes.push(
+      makeVNode("meta", { name: "zfb-traverse-refetch", content: "true" }, "zfb-traverse-refetch"),
     );
   }
 

--- a/packages/zfb-runtime/src/client-router/index.ts
+++ b/packages/zfb-runtime/src/client-router/index.ts
@@ -18,7 +18,13 @@ export {
   isTransitionBeforeSwapEvent,
 } from "./events.js";
 
-export type { Direction, Fallback, NavigationTypeString, Options } from "./types.js";
+export type {
+  Direction,
+  Fallback,
+  NavigationTypeString,
+  Options,
+  SyncHistoryEntryOptions,
+} from "./types.js";
 
 export { swapFunctions, swap } from "./swap-functions.js";
 
@@ -26,7 +32,14 @@ export { swapFunctions, swap } from "./swap-functions.js";
 //   - W3C1: `supportsViewTransitions`, `transitionEnabledOnThisPage`.
 //   - W3C2: `navigate()` (public navigation entry).
 //   - W3C3: `init()` (idempotent bootstrap: registers click + form intercept listeners).
-export { navigate, supportsViewTransitions, transitionEnabledOnThisPage, init } from "./router.js";
+//   - W2 (#1377): `syncHistoryEntry()` (history bookkeeping without navigation).
+export {
+  navigate,
+  supportsViewTransitions,
+  transitionEnabledOnThisPage,
+  init,
+  syncHistoryEntry,
+} from "./router.js";
 export type { InitOptions } from "./router.js";
 
 // Prefetch public surface (#276).

--- a/packages/zfb-runtime/src/client-router/router.ts
+++ b/packages/zfb-runtime/src/client-router/router.ts
@@ -59,7 +59,7 @@ import {
   type TransitionBeforePreparationEvent,
 } from "./events.js";
 import { detectScriptExecuted } from "./swap-functions.js";
-import type { Direction, Fallback, Options } from "./types.js";
+import type { Direction, Fallback, Options, SyncHistoryEntryOptions } from "./types.js";
 // Island re-bootstrap and deferred-cancel after body swap (W1B §12.2, §12.5).
 // mountNewIslands() is called after runScripts() and before onPageLoad().
 // cancelPendingIslands() is called before doSwap() so deferred callbacks
@@ -372,6 +372,81 @@ const moveToLocation = (
     history.scrollRestoration = "manual";
   }
 };
+
+let syncHistoryEntryOnServerWarned = false;
+
+// Public: write a router-managed history entry (push or replace) WITHOUT any
+// navigation, DOM, scroll, or lifecycle side effect. This is the supported path
+// for consumers deep-linking transient UI state (dialogs/modals, a photo
+// viewer's /photos/<slug>/ URL). Hand-rolled raw history.pushState desyncs
+// `originalLocation` and the index bookkeeping that popstate direction detection
+// (derivePopDirection) and the same-page traverse fast-path depend on; navigate()
+// can't be used because it forces a fetch. See #1377 / #1374.
+export function syncHistoryEntry(url: string | URL, options: SyncHistoryEntryOptions = {}): void {
+  // SSR guard: no window/history to touch. Mirror navigate()'s server no-op +
+  // one-time console warning. Checked at call time via `typeof document` (not the
+  // module-eval `inBrowser` const) so the branch is reachable and behavior is
+  // identical in a real environment (document is always present in a browser).
+  if (typeof document === "undefined") {
+    if (!syncHistoryEntryOnServerWarned) {
+      // instantiate an error for the stacktrace to show to user.
+      const warning = new Error(
+        "syncHistoryEntry() was called during a server side render. This may be unintentional as it is expected to be called in response to a client-side user interaction. Please make sure that your usage is correct.",
+      );
+      warning.name = "Warning";
+      // biome-ignore lint/suspicious/noConsole: allowed
+      console.warn(warning);
+      syncHistoryEntryOnServerWarned = true;
+    }
+    return;
+  }
+
+  const to = new URL(url, location.href);
+
+  // Cross-origin is not ours to manage. The History API would throw a native
+  // SecurityError for a cross-origin URL, but we guard explicitly so the failure
+  // is a clear, documented contract violation rather than an opaque platform
+  // error — and never a silent full-page load. #1377.
+  if (to.origin !== location.origin) {
+    throw new Error(
+      `syncHistoryEntry(): refusing to write a cross-origin history entry for "${to.href}" (current origin: ${location.origin}).`,
+    );
+  }
+
+  if (options.replace) {
+    // Replace keeps the current entry's index. A consumer migrating from raw
+    // history.pushState may have left a missing/invalid index, so fall back to
+    // the tracked index rather than stamping NaN/undefined.
+    const current = history.state;
+    const index =
+      current != null && Number.isFinite(current.index) ? current.index : currentHistoryIndex;
+    history.replaceState(
+      {
+        ...options.state,
+        index,
+        scrollX: Number.isFinite(current?.scrollX) ? current.scrollX : scrollX,
+        scrollY: Number.isFinite(current?.scrollY) ? current.scrollY : scrollY,
+      },
+      "",
+      to.href,
+    );
+  } else {
+    // Persist the CURRENT (outgoing) entry's latest scroll before pushing, so a
+    // later Back restoration can't lose scroll that `scrollend` hasn't flushed
+    // yet — the same guard transition() applies before a non-traverse push.
+    updateScrollPosition({ scrollX, scrollY });
+    history.pushState(
+      { ...options.state, index: ++currentHistoryIndex, scrollX: 0, scrollY: 0 },
+      "",
+      to.href,
+    );
+  }
+
+  // Always re-point originalLocation so the next transition()/onPopState uses the
+  // correct "from" URL. Skipping this is exactly what makes a raw pushState
+  // desync the router (a same-page Back would miss the traverse fast path).
+  originalLocation = to;
+}
 
 function preloadStyleLinks(newDocument: Document) {
   const links: Promise<any>[] = [];

--- a/packages/zfb-runtime/src/client-router/router.ts
+++ b/packages/zfb-runtime/src/client-router/router.ts
@@ -96,6 +96,19 @@ export const supportsViewTransitions = inBrowser && !!document.startViewTransiti
 export const transitionEnabledOnThisPage = () =>
   inBrowser && !!document.querySelector('[name="zfb-view-transitions-enabled"]');
 
+// A same-page Back/Forward traversal (two history entries sharing pathname +
+// search) is served from the live DOM by the fast-path in transition() — no
+// re-fetch, no re-swap, no lifecycle events. A per-request SSR page
+// (`prerender = false`) whose server output can differ between two visits to
+// the SAME url opts back INTO the fetch by emitting
+// <meta name="zfb-traverse-refetch" content="true"> (via <ClientRouter
+// traverseRefetch />); skipping the fetch on such a page would pin the stale
+// first-render content. Read from the CURRENT document — for a same-page
+// traverse the current document IS the target page. Mirrors the
+// zfb-prefetch-disabled meta reader. (#1376)
+const traverseRefetchOptedOut = () =>
+  inBrowser && !!document.querySelector('meta[name="zfb-traverse-refetch"][content="true"]');
+
 const samePage = (thisLocation: URL, otherLocation: URL) =>
   thisLocation.pathname === otherLocation.pathname && thisLocation.search === otherLocation.search;
 
@@ -331,7 +344,12 @@ const moveToLocation = (
   }
 
   if (historyState) {
-    scrollTo(historyState.scrollX, historyState.scrollY);
+    // Raw-History consumers may push partial/empty state (`{}`), so the tracked
+    // scroll fields can be absent or non-finite. Never scrollTo(undefined, …) —
+    // leave scroll where it is rather than jumping to (0,0). #1376.
+    if (Number.isFinite(historyState.scrollX) && Number.isFinite(historyState.scrollY)) {
+      scrollTo(historyState.scrollX, historyState.scrollY);
+    }
   } else {
     if (to.hash) {
       // because we are already on the target page ...
@@ -494,7 +512,13 @@ async function transition(
     updateScrollPosition({ scrollX, scrollY });
   }
   if (samePage(from, to) && !options.formData) {
-    if ((direction !== "back" && to.hash) || (direction === "back" && from.hash)) {
+    if (
+      // Same-page Back/Forward: serve from the live DOM (no re-fetch/re-swap)
+      // unless this page opted back into the fetch (per-request SSR). #1374/#1376.
+      (navigationType === "traverse" && !traverseRefetchOptedOut()) ||
+      (direction !== "back" && to.hash) ||
+      (direction === "back" && from.hash)
+    ) {
       moveToLocation(to, from, options, document.title, historyState);
       if (currentNavigation === mostRecentNavigation) mostRecentNavigation = undefined;
       return;

--- a/packages/zfb-runtime/src/client-router/types.ts
+++ b/packages/zfb-runtime/src/client-router/types.ts
@@ -9,3 +9,12 @@ export type Options = {
   formData?: FormData;
   sourceElement?: Element; // more than HTMLElement, e.g. SVGAElement
 };
+
+// Public options for syncHistoryEntry() (#1377).
+export type SyncHistoryEntryOptions = {
+  // Replace the current history entry instead of pushing a new one.
+  replace?: boolean;
+  // Consumer state merged into the entry; the router's bookkeeping keys
+  // (index/scrollX/scrollY) always take precedence over colliding keys.
+  state?: any;
+};

--- a/packages/zfb-runtime/src/index.ts
+++ b/packages/zfb-runtime/src/index.ts
@@ -43,6 +43,7 @@ export {
   navigate,
   supportsViewTransitions,
   transitionEnabledOnThisPage,
+  syncHistoryEntry,
 } from "./client-router/router.js";
 
 // Prefetch public surface (#276).
@@ -67,7 +68,13 @@ export {
   isTransitionBeforeSwapEvent,
 } from "./client-router/events.js";
 export { swapFunctions, swap } from "./client-router/swap-functions.js";
-export type { Direction, Fallback, NavigationTypeString, Options } from "./client-router/types.js";
+export type {
+  Direction,
+  Fallback,
+  NavigationTypeString,
+  Options,
+  SyncHistoryEntryOptions,
+} from "./client-router/types.js";
 
 // Plugin lifecycle types (#255). The runtime package re-exports the
 // `@takazudo/zfb/plugins` surface so consumers writing plugins from a

--- a/tests/router-chromium/fixture/sync-dialog.html
+++ b/tests/router-chromium/fixture/sync-dialog.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="zfb-view-transitions-enabled" content="" />
+    <meta name="zfb-view-transitions-fallback" content="animate" />
+    <title>Sync Dialog</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        margin: 0;
+      }
+      nav {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        display: flex;
+        gap: 1rem;
+        padding: 0.75rem 1rem;
+        background: #fff;
+        border-bottom: 1px solid #ccc;
+        z-index: 10;
+      }
+      main {
+        padding: 4rem 1rem 1rem;
+      }
+    </style>
+    <script type="importmap">
+      {
+        "imports": {
+          "@takazudo/zfb/runtime": "/island-stubs.js"
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <nav>
+      <a href="/index.html" id="to-home">Home</a>
+      <a href="/page-a.html" id="to-page-a">Page A</a>
+      <a href="/page-b.html" id="to-page-b">Page B</a>
+    </nav>
+    <main>
+      <h1>Sync Dialog</h1>
+      <!-- Stands in for a photo-viewer's deep-linkable "dialog" URL. -->
+      <button id="open-dialog">Open Photo</button>
+    </main>
+    <script type="module">
+      import { init } from "/dist/client-router/router.js";
+      import { init as prefetchInit } from "/dist/client-router/prefetch.js";
+      // syncHistoryEntry lives in router.js itself, NOT the client-router/index.js
+      // barrel. The barrel re-exports <ClientRouter /> from client-router.ts, which
+      // imports the bare specifier "react/jsx-runtime" at module scope — this
+      // fixture has no import-map entry for it (no bundler here), so pulling in
+      // the barrel would throw a browser module-resolution error. router.js has no
+      // such dependency, so importing straight from it is both correct and safe.
+      import { syncHistoryEntry } from "/dist/client-router/router.js";
+      init();
+      prefetchInit();
+
+      // A pathname-style "dialog" deep link (photo viewer pattern, #1377): pushes
+      // a NEW pathname via the public bookkeeping API — no navigation, no DOM/
+      // scroll/lifecycle side effect, just a router-managed history entry.
+      document.getElementById("open-dialog").addEventListener("click", () => {
+        syncHistoryEntry("/photos/photo-1/");
+      });
+    </script>
+  </body>
+</html>

--- a/tests/router-chromium/fixture/traverse-modal-optout.html
+++ b/tests/router-chromium/fixture/traverse-modal-optout.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="zfb-view-transitions-enabled" content="" />
+    <meta name="zfb-view-transitions-fallback" content="animate" />
+    <!--
+      Per-request SSR opt-out (<ClientRouter traverseRefetch /> in a real zfb
+      site): forces the same-page traverse fast-path back OFF, so a Back/Forward
+      over this page's own URL re-fetches instead of serving the live DOM. #1376.
+    -->
+    <meta name="zfb-traverse-refetch" content="true" />
+    <title>Traverse Modal (opt-out)</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        margin: 0;
+      }
+      nav {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        display: flex;
+        gap: 1rem;
+        padding: 0.75rem 1rem;
+        background: #fff;
+        border-bottom: 1px solid #ccc;
+        z-index: 10;
+      }
+      main {
+        padding: 4rem 1rem 1rem;
+      }
+    </style>
+    <script type="importmap">
+      {
+        "imports": {
+          "@takazudo/zfb/runtime": "/island-stubs.js"
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <nav>
+      <a href="/index.html" id="to-home">Home</a>
+      <a href="/page-a.html" id="to-page-a">Page A</a>
+      <a href="/page-b.html" id="to-page-b">Page B</a>
+    </nav>
+    <main>
+      <h1>Traverse Modal (opt-out)</h1>
+      <button id="open-modal">Open Modal</button>
+      <div id="counter">0</div>
+    </main>
+    <script type="module">
+      import { init } from "/dist/client-router/router.js";
+      import { init as prefetchInit } from "/dist/client-router/prefetch.js";
+      init();
+      prefetchInit();
+
+      let count = 0;
+      const counterEl = document.getElementById("counter");
+      document.getElementById("open-modal").addEventListener("click", () => {
+        count += 1;
+        counterEl.textContent = String(count);
+        history.pushState({ ...history.state }, "", `${location.pathname}#modal`);
+      });
+    </script>
+  </body>
+</html>

--- a/tests/router-chromium/fixture/traverse-modal.html
+++ b/tests/router-chromium/fixture/traverse-modal.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Required by ClientRouter: enables SPA mode + real View Transitions on this page. -->
+    <meta name="zfb-view-transitions-enabled" content="" />
+    <meta name="zfb-view-transitions-fallback" content="animate" />
+    <title>Traverse Modal</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        margin: 0;
+      }
+      nav {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        display: flex;
+        gap: 1rem;
+        padding: 0.75rem 1rem;
+        background: #fff;
+        border-bottom: 1px solid #ccc;
+        z-index: 10;
+      }
+      main {
+        padding: 4rem 1rem 1rem;
+      }
+    </style>
+    <script type="importmap">
+      {
+        "imports": {
+          "@takazudo/zfb/runtime": "/island-stubs.js"
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <nav>
+      <a href="/index.html" id="to-home">Home</a>
+      <a href="/page-a.html" id="to-page-a">Page A</a>
+      <a href="/page-b.html" id="to-page-b">Page B</a>
+    </nav>
+    <main>
+      <h1>Traverse Modal</h1>
+      <button id="open-modal">Open Modal</button>
+      <!--
+        Client-state marker for the traverse fast-path specs (#1378). Incremented
+        only by the click handler below — NOT derived from the URL/hash — so it
+        proves the fast path preserves the live DOM/JS across Back/Forward. This
+        catches a DIFFERENT regression than the harness's __docId: __docId only
+        detects a full page reload (a new document), whereas a regression that
+        fell through to a real body swap (doSwap) would NOT mint a new document
+        but WOULD reset this counter back to "0", since the swap re-parses and
+        re-executes the fetched page's own <script>.
+      -->
+      <div id="counter">0</div>
+    </main>
+    <script type="module">
+      import { init } from "/dist/client-router/router.js";
+      import { init as prefetchInit } from "/dist/client-router/prefetch.js";
+      init();
+      prefetchInit();
+
+      let count = 0;
+      const counterEl = document.getElementById("counter");
+      document.getElementById("open-modal").addEventListener("click", () => {
+        count += 1;
+        counterEl.textContent = String(count);
+        // Raw history.pushState — deliberately NOT routed through the router —
+        // mirrors a hand-rolled modal-open pattern (the #1374 trigger). Non-null
+        // state is required: onPopState ignores `ev.state === null` entries
+        // (client-router/router.ts, onPopState).
+        history.pushState({ ...history.state }, "", `${location.pathname}#modal`);
+      });
+    </script>
+  </body>
+</html>

--- a/tests/router-chromium/traverse.chromium.spec.mjs
+++ b/tests/router-chromium/traverse.chromium.spec.mjs
@@ -1,0 +1,284 @@
+/**
+ * traverse.chromium.spec.mjs — Level-4 (real browser) confirm gate for the
+ * Traverse Fastpath epic (issue #1375, sub-issue #1378).
+ *
+ * ============================================================
+ * WHY THIS SUITE EXISTS
+ * ============================================================
+ * The two deliverables this suite proves are documented, at the Level-2
+ * (happy-dom) layer, as having a real-browser blind spot:
+ *   - packages/zfb-runtime/src/__tests__/client-router/router.test.ts's
+ *     "same-page traverse fast-path (#1374 / #1376)" describe block hand-feeds
+ *     `dispatchPopstate()` — it proves the gate's BRANCH LOGIC (fetch vs.
+ *     fast-path), not that a REAL Back/Forward gesture in a real browser hits
+ *     that branch, that no reload occurs, and that live DOM/JS state survives.
+ *   - the same file's "syncHistoryEntry() — public history bookkeeping API
+ *     (#1377)" describe block has the identical blind spot for the pathname-
+ *     dialog case.
+ * Both describe blocks say so explicitly: "Definitive proof is the Wave-3
+ * chromium harness (#1378)." This file is that proof.
+ *
+ * ============================================================
+ * DEFLAKING DISCIPLINE (issue #1346) — same rules as router.chromium.spec.mjs
+ * ============================================================
+ * Every wait is keyed on the router's OWN lifecycle events or on state the
+ * router itself sets — NO bare `waitForTimeout`, NO `networkidle`. The harness
+ * below (init script + helpers) is intentionally a byte-for-byte copy of
+ * router.chromium.spec.mjs's, mirroring the tests/webkit-back-history vs.
+ * tests/router-chromium precedent of deliberately duplicating shared harness
+ * plumbing across sibling Level-4 suites rather than coupling them through a
+ * shared module (see serve-fixture.mjs's header comment in this directory).
+ *
+ * The fast-path specs (1-3 below) have NO `zfb:page-load` (or any zfb:* event)
+ * to await on the happy path — that is the entire point of the fast path. Per
+ * the issue's required wait shape: wait on router-owned/user-visible state
+ * that MUST change (`location.hash` reaching the expected value, plus the
+ * DOM-rendered counter marker), THEN assert the seq counter is unchanged since
+ * the pre-trigger baseline. Spec 4 (syncHistoryEntry pathname dialog) is the
+ * mirror image: pathname changes, so the FULL lifecycle fires and is awaited
+ * the normal way (waitForNavDone).
+ */
+
+// @ts-check
+import { test, expect } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// Harness installed before every document, before any page script runs.
+// (Copied from router.chromium.spec.mjs — see that file's header for the full
+// rationale of each piece; only the parts these specs need are exercised.)
+// ---------------------------------------------------------------------------
+const HARNESS_INIT = () => {
+  // @ts-expect-error - test-only globals
+  if (window.__zfbHarness) return;
+  // @ts-expect-error
+  window.__zfbHarness = true;
+
+  const uuid =
+    typeof crypto !== "undefined" && crypto.randomUUID
+      ? crypto.randomUUID()
+      : String(Math.random());
+  // @ts-expect-error
+  window.__docId = uuid;
+
+  const NAMES = [
+    "zfb:before-preparation",
+    "zfb:after-preparation",
+    "zfb:before-swap",
+    "zfb:after-swap",
+    "zfb:page-load",
+    "zfb:navigation-aborted",
+  ];
+  const rec = { events: [], seq: 0 };
+  // @ts-expect-error
+  window.__zfb = rec;
+  for (const name of NAMES) {
+    document.addEventListener(name, (ev) => {
+      rec.events.push({
+        name,
+        seq: ++rec.seq,
+        direction:
+          ev && typeof (/** @type {any} */ (ev).direction) === "string"
+            ? /** @type {any} */ (ev).direction
+            : null,
+      });
+    });
+  }
+};
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(HARNESS_INIT);
+});
+
+// ---------------------------------------------------------------------------
+// Event-keyed wait helpers (no bare timeouts, no networkidle).
+// ---------------------------------------------------------------------------
+
+/** Current lifecycle sequence counter — capture BEFORE triggering a navigation. */
+async function seqNow(page) {
+  return page.evaluate(() => /** @type {any} */ (window).__zfb?.seq ?? 0);
+}
+
+/** Wait until a lifecycle event `name` has been recorded with seq > `after`. */
+async function waitForZfbEvent(page, name, after, timeout = 8000) {
+  await page.waitForFunction(
+    ({ name, after }) =>
+      /** @type {any} */ (window.__zfb?.events ?? []).some((e) => e.name === name && e.seq > after),
+    { name, after },
+    { timeout },
+  );
+}
+
+/**
+ * Wait until a navigation is fully finished AND quiescent — see
+ * router.chromium.spec.mjs's `waitForNavDone` for the full rationale (the
+ * `data-zfb-transition` absence check keeps the next step from starting
+ * mid-animation, one of the 5 deflaking root causes).
+ */
+async function waitForNavDone(page, after, timeout = 8000) {
+  await waitForZfbEvent(page, "zfb:page-load", after, timeout);
+  await page.waitForFunction(
+    () => !document.documentElement.hasAttribute("data-zfb-transition"),
+    undefined,
+    { timeout },
+  );
+}
+
+/** Wait for the initial full-page load's `zfb:page-load` (router booted). */
+async function waitForInitialLoad(page) {
+  await page.waitForFunction(() =>
+    /** @type {any} */ (window.__zfb?.events ?? []).some((e) => e.name === "zfb:page-load"),
+  );
+}
+
+/** Names (in seq order) of lifecycle events recorded with seq > `after`. */
+async function eventNamesSince(page, after) {
+  return page.evaluate((after) => {
+    const rec = /** @type {any} */ (window).__zfb;
+    return rec.events.filter((e) => e.seq > after).map((e) => e.name);
+  }, after);
+}
+
+/** Direction of the last `name` event recorded with seq > `after` (or null). */
+async function lastDirectionSince(page, name, after) {
+  return page.evaluate(
+    ({ name, after }) => {
+      const rec = /** @type {any} */ (window).__zfb;
+      const evs = rec.events.filter((e) => e.name === name && e.seq > after);
+      return evs.length ? evs[evs.length - 1].direction : null;
+    },
+    { name, after },
+  );
+}
+
+// ===========================================================================
+// Spec 1 — raw pushState modal + Back takes the same-page traverse fast path:
+// no lifecycle event, no reload, live DOM/JS state preserved. (#1374 / #1376)
+// ===========================================================================
+test("raw pushState modal + Back takes the traverse fast path (no lifecycle event, no reload, state preserved)", async ({
+  page,
+}) => {
+  await page.goto("/traverse-modal.html");
+  await waitForInitialLoad(page);
+
+  const docId = await page.evaluate(() => /** @type {any} */ (window).__docId);
+
+  // Open the modal: a raw (non-router) pushState with a non-null state object.
+  await page.click("#open-modal");
+  await page.waitForFunction(() => location.hash === "#modal");
+  await expect(page.locator("#counter")).toHaveText("1");
+
+  const s = await seqNow(page);
+  await page.goBack();
+  // Deterministic wait shape (#1378): there is no zfb:* event to await on the
+  // fast path, so wait on the one piece of router-owned/user-visible state
+  // that MUST change — the hash clearing back to "".
+  await page.waitForFunction(() => location.hash === "");
+
+  // No lifecycle event fired for this Back at all: the fast path returns via
+  // moveToLocation() before doPreparation() (which would dispatch
+  // zfb:before-preparation) ever runs.
+  expect(await eventNamesSince(page, s)).toEqual([]);
+  // No full reload: same JS context, same __docId.
+  expect(await page.evaluate(() => /** @type {any} */ (window).__docId)).toBe(docId);
+  // No body swap either (a swap would re-execute the page's <script> and reset
+  // the counter to "0") — the counter marker proves the live DOM/JS survived.
+  await expect(page.locator("#counter")).toHaveText("1");
+});
+
+// ===========================================================================
+// Spec 2 — Forward-reopen after the fast-path Back: same fast path, same
+// guarantees, hash restored.
+// ===========================================================================
+test("Forward after the fast-path Back reopens the modal via the fast path too (no lifecycle event, no reload, state preserved)", async ({
+  page,
+}) => {
+  await page.goto("/traverse-modal.html");
+  await waitForInitialLoad(page);
+  const docId = await page.evaluate(() => /** @type {any} */ (window).__docId);
+
+  await page.click("#open-modal");
+  await page.waitForFunction(() => location.hash === "#modal");
+
+  let s = await seqNow(page);
+  await page.goBack();
+  await page.waitForFunction(() => location.hash === "");
+  expect(await eventNamesSince(page, s)).toEqual([]);
+
+  s = await seqNow(page);
+  await page.goForward();
+  await page.waitForFunction(() => location.hash === "#modal");
+
+  expect(await eventNamesSince(page, s)).toEqual([]);
+  expect(await page.evaluate(() => /** @type {any} */ (window).__docId)).toBe(docId);
+  await expect(page.locator("#counter")).toHaveText("1");
+});
+
+// ===========================================================================
+// Spec 3 — the zfb-traverse-refetch opt-out meta forces the FULL lifecycle
+// back on for the identical Back gesture: opt-out respected. (#1376)
+// ===========================================================================
+test("the traverseRefetch opt-out meta forces the full lifecycle on Back (opt-out respected)", async ({
+  page,
+}) => {
+  await page.goto("/traverse-modal-optout.html");
+  await waitForInitialLoad(page);
+  const docId = await page.evaluate(() => /** @type {any} */ (window).__docId);
+
+  await page.click("#open-modal");
+  await page.waitForFunction(() => location.hash === "#modal");
+
+  const s = await seqNow(page);
+  await page.goBack();
+  // Opted out: this Back falls through to the normal fetch + swap pipeline, so
+  // (unlike specs 1-2) there IS a zfb:before-preparation to await.
+  await waitForZfbEvent(page, "zfb:before-preparation", s);
+  await waitForNavDone(page, s);
+
+  expect(await page.evaluate(() => location.hash)).toBe("");
+  // Still a client-side swap, not a full browser reload: same JS context.
+  expect(await page.evaluate(() => /** @type {any} */ (window).__docId)).toBe(docId);
+});
+
+// ===========================================================================
+// Spec 4 — syncHistoryEntry()-driven pathname dialog: Back is a cross-page
+// traverse (different pathname), so it is a NORMAL soft navigation — full
+// lifecycle fires, correct direction, no stuck transition overlay, and
+// history.state.index stays finite. (#1377)
+// ===========================================================================
+test("syncHistoryEntry pathname dialog: Back triggers a normal soft navigation with the correct direction", async ({
+  page,
+}) => {
+  await page.goto("/sync-dialog.html");
+  await waitForInitialLoad(page);
+
+  const indexBefore = await page.evaluate(() => /** @type {any} */ (history.state)?.index);
+  expect(Number.isFinite(indexBefore)).toBe(true);
+
+  const s0 = await seqNow(page);
+  await page.click("#open-dialog");
+  await page.waitForFunction(() => location.pathname === "/photos/photo-1/");
+  // syncHistoryEntry() is side-effect free: no lifecycle event, no DOM/scroll
+  // change, just a router-managed history entry (#1377 contract).
+  expect(await eventNamesSince(page, s0)).toEqual([]);
+  const indexAfterPush = await page.evaluate(() => /** @type {any} */ (history.state)?.index);
+  expect(indexAfterPush).toBe(indexBefore + 1);
+
+  const s = await seqNow(page);
+  await page.goBack();
+  // The pathname changed (/photos/photo-1/ -> the dialog's own page), so
+  // samePage() is false and this Back is a REAL cross-page traverse — unlike
+  // specs 1-3, the full lifecycle fires and is awaited the normal way.
+  await waitForNavDone(page, s);
+
+  // Correct direction reported on zfb:before-swap.
+  expect(await lastDirectionSince(page, "zfb:before-swap", s)).toBe("back");
+  // Landed back on the dialog's own page, not stuck on the virtual photo URL.
+  expect(new URL(page.url()).pathname).not.toBe("/photos/photo-1/");
+  // No overlay anomaly: waitForNavDone already asserts data-zfb-transition is
+  // gone; the page's own DOM is live and interactive again.
+  await expect(page.locator("#open-dialog")).toBeVisible();
+  // history.state.index is finite (a real, monotonic entry) — not NaN/
+  // undefined, which a raw-pushState desync would have produced.
+  const indexAfterBack = await page.evaluate(() => /** @type {any} */ (history.state)?.index);
+  expect(Number.isFinite(indexAfterBack)).toBe(true);
+});


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1375

---

## Summary

- **Same-page traverse fast-path (#1376, fixes the #1374 bug):** a Back/Forward (`popstate`) traversal between two history entries sharing the same `pathname + search` no longer re-fetches and re-swaps the page. Previously, any app that deep-linked transient UI state via raw `history.pushState('#slug')` (e.g. a modal) got a loading-overlay flash, a wasted network round-trip, and island/client state loss on Back. The fast path routes through `moveToLocation` — scroll restores from the history entry and the stale `originalLocation` self-heals (deliberately NOT the bare-return shape of unmerged Astro PR withastro/astro#17020).
- **`traverseRefetch` opt-out (`<ClientRouter traverseRefetch />` → `<meta name="zfb-traverse-refetch">`):** escape hatch for per-request SSR (`prerender = false`) pages participating in soft-nav, whose same-URL content can change between visits. Mirrors the `zfb-prefetch-disabled` meta pattern. Default is fast-path ON (matches bfcache semantics and zfb's SSG-first posture).
- **`syncHistoryEntry(url, { replace?, state? })` public API (#1377):** the supported way to deep-link transient UI state without hand-rolling raw History. Performs the router's history + `originalLocation` bookkeeping with zero navigation/DOM/scroll side effects; also fixes the **pathname-changing** dialog case the fast path can't reach. Exported from both `@takazudo/zfb-runtime/client-router` and the root barrel (mirror kept complete per codex review).
- **Hardening:** partial/empty raw-History state (`pushState({})`) can no longer cause `scrollTo(undefined, …)` — non-finite scroll fields leave scroll untouched.

## Changes

- `packages/zfb-runtime/src/client-router/router.ts` — traverse clause in the same-page fast-path gate; `traverseRefetchOptedOut()` meta reader; `syncHistoryEntry()`; scroll-restore finite-guard in `moveToLocation`.
- `packages/zfb-runtime/src/client-router.ts` — `traverseRefetch?: boolean` prop emitting the opt-out meta.
- `packages/zfb-runtime/src/client-router/{index,types}.ts`, `src/index.ts` — public exports (`syncHistoryEntry`, `SyncHistoryEntryOptions`) on both barrels.
- `packages/zfb-runtime/src/__tests__/` — 20 new L2 happy-dom tests (traverse fast-path cases a–e, opt-out meta emission, full `syncHistoryEntry` contract incl. cross-origin throw, server no-op, state-merge precedence, replace-index fallback).
- `tests/router-chromium/` — 4 new L4 specs + 3 fixture pages (pushState-modal Back, Forward-reopen, `traverseRefetch` opt-out, `syncHistoryEntry` pathname dialog), following the #1346 event-keyed deflaking discipline.
- `docs/src/content/docs/concepts/client-side-routing.mdx` — documents the traverse behavior (incl. lifecycle/route-announcer suppression), `traverseRefetch`, and `syncHistoryEntry` with hash-modal + pathname-dialog examples.

## Test Plan

- L2 (required T1 gate): `pnpm -r test` — 168/168 zfb-runtime tests green locally, incl. the 20 new ones.
- L4: `pnpm test:router-chromium` — 12/12 green locally (8 pre-existing + 4 new), 0 retries; the path-filtered `router-chromium (L4)` CI job runs on this PR.
- Docs: `pnpm docs:check` green; `Build docs site` CI job validates the build.
- Release-day note: `tests/webkit-back-history` (T4, Mac-only) sits on this code path — RELEASE_DAY_CHECKLIST.md already mandates running it before any release touching router code.