### PR TITLE
Lift RUSTSEC-2026-0173 ignore: getset 0.1.7 drops proc-macro-error2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,11 +1413,10 @@ dependencies = [
 
 [[package]]
 name = "getset"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf0fc11e47561d47397154977bc219f4cf809b2974facc3ccb3b89e2436f912"
+checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
 dependencies = [
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -2812,28 +2811,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
  "syn 2.0.117",
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -59,7 +59,6 @@ ignore = [
     # each pinned by an upstream crate we don't control directly.
     { id = "RUSTSEC-2025-0141", reason = "bincode 1.3.3 unmaintained, pulled in transitively via deno_core and syntect's dump features; no safe upgrade available until deno_core moves off bincode 1.x (a deno_core bump is V8-scale and tracked separately). zfb-graph itself was migrated to bincode 2 (#1370) — this only covers the remaining transitive deno_core/syntect usage. Tracked: https://github.com/Takazudo/zudo-front-builder/issues/1373" },
     { id = "RUSTSEC-2024-0436", reason = "paste 1.0.15 unmaintained, pulled in transitively via v8/deno_core; no safe upgrade available until deno_core/v8 moves (same V8-scale bump as the bincode entry above). Tracked: https://github.com/Takazudo/zudo-front-builder/issues/1373" },
-    { id = "RUSTSEC-2026-0173", reason = "proc-macro-error2 2.0.1 unmaintained, pulled in transitively via local-ip-address -> neli -> getset; no safe upgrade available until movement happens upstream in that chain. Tracked: https://github.com/Takazudo/zudo-front-builder/issues/1373" },
 ]
 
 # Lenient to start: an explicit allow-list keeps `cargo deny check`


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1373

---

## Summary

- Lifts the RUSTSEC-2026-0173 (`proc-macro-error2` unmaintained) advisory ignore from `deny.toml` — the first entry cleared from the 5-advisory tracker #1373.
- getset 0.1.7 (released 2026-06-10) dropped its `proc-macro-error2` dependency; the only path into the workspace graph was `local-ip-address` → `neli` → `getset`.
- Refs #1373 (living tracker for the 4 remaining blocked advisories — intentionally NOT closed by this PR).

## Changes

- `Cargo.lock`: `cargo update -p getset` bumps getset 0.1.6 → 0.1.7, removing `proc-macro-error2` 2.0.1 and `proc-macro-error-attr2` 2.0.0 from the dependency graph entirely.
- `deny.toml`: removed the now-unneeded `RUSTSEC-2026-0173` entry from `[advisories.ignore]` (4 entries remain, all tracked in #1373).

## Test Plan

- [x] `cargo deny check advisories` (cargo-deny 0.19.9): `advisories ok` — 4 remaining ignores, zero `advisory-not-detected` warnings
- [x] Full `cargo deny check` (what the weekly security-audit job runs): exit 0, only pre-existing warn-only `[bans]` duplicate warnings
- [x] `grep proc-macro-error Cargo.lock` → no matches
- [x] `cargo check -p zfb --no-default-features`: compiles clean against getset 0.1.7 (covers the `local-ip-address` → `neli` → `getset` proc-macro path)
- [x] PR CI (health.yml full workspace suite + required checks): all 12 checks green
- Post-merge: dispatch `security-audit.yml` on `main` to confirm the cargo-deny job is green with the updated config