### PR TITLE
Make GithubAutolinksConfig repo required

### DIFF
--- a/packages/zfb/src/config.ts
+++ b/packages/zfb/src/config.ts
@@ -784,7 +784,7 @@ export type GithubAutolinksConfig = {
    * (e.g. `"owner/repo"` renders `#123` as
    * `https://github.com/owner/repo/issues/123`). Required — see above.
    */
-  repo?: string;
+  repo: string;
 };
 
 /**

--- a/packages/zfb/type-tests/config-fixture.ts
+++ b/packages/zfb/type-tests/config-fixture.ts
@@ -1,0 +1,34 @@
+/**
+ * Config type fixture.
+ *
+ * Compiled by `tsc -p tsconfig.preact-fixture.json` through the package's
+ * type-test include. Keep this file compile-only; it proves config
+ * helper types reject invalid shapes without adding runtime test code.
+ */
+
+import { defineConfig } from "../src/config.js";
+
+export const githubAutolinksWithRepo = defineConfig({
+  markdown: {
+    features: {
+      githubAutolinks: {
+        repo: "owner/repo",
+      },
+    },
+  },
+});
+
+export const githubAutolinksOmitted = defineConfig({
+  markdown: {
+    features: {},
+  },
+});
+
+export const githubAutolinksEmptyObject = defineConfig({
+  markdown: {
+    features: {
+      // @ts-expect-error repo is required when githubAutolinks is configured.
+      githubAutolinks: {},
+    },
+  },
+});


### PR DESCRIPTION
## Summary\n- Closes #1419\n- Makes `GithubAutolinksConfig.repo` required in the public TS config type\n- Adds a compile-only config type fixture proving `githubAutolinks: {}` is rejected while omitting the feature remains valid\n\n## Verification\n- `pnpm -C packages/zfb test`\n- `pnpm -r --if-present typecheck`\n- grep verified no in-repo code/demo/template configures `githubAutolinks` without `repo`\n\nParent epic: #1418\nTargets base branch: `base/dx-hardening`