### PR TITLE
DX hardening: require github autolinks repo and escape router selectors

### DIFF
--- a/packages/zfb-runtime/src/__tests__/client-router/router.test.ts
+++ b/packages/zfb-runtime/src/__tests__/client-router/router.test.ts
@@ -83,6 +83,8 @@ import {
 // test environment.
 import type { SyncHistoryEntryOptions } from "../../client-router/index.js";
 
+const PERSIST_ATTR = "data-zfb-transition-persist";
+
 beforeEach(() => {
   resetDocument();
   // Re-inject opt-in meta tag for each test (resetDocument clears head).
@@ -154,6 +156,38 @@ describe("navigate() — happy path with mocked fetch", () => {
     const calls = fetchMock.mock.calls;
     expect(calls).toHaveLength(1);
     expect(String(calls[0]![0])).toContain("/about");
+  });
+
+  it("preloads without throwing when stylesheet persist id and href need CSS escaping", async () => {
+    const persistId = 'style"] [data-x="bad]';
+    const href = '/assets/app"] [data-x="bad].css';
+    const fetchMock = vi.fn(async (url: RequestInfo) => {
+      const u = String(url);
+      if (u.endsWith("/styled")) {
+        return htmlResponse(`<!doctype html><html><head>
+          <meta name="zfb-view-transitions-enabled" content="true">
+          <title>Styled</title>
+          <link rel="stylesheet" data-zfb-transition-persist='${persistId}' href='${href}'>
+        </head><body>
+          <main>styled content</main>
+        </body></html>`);
+      }
+      throw new Error(`unexpected fetch: ${u}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const oldLink = document.createElement("link");
+    oldLink.setAttribute("rel", "stylesheet");
+    oldLink.setAttribute(PERSIST_ATTR, persistId);
+    oldLink.setAttribute("href", href);
+    document.head.append(oldLink);
+
+    await navigate("/styled");
+
+    const stylesheets = document.head.querySelectorAll('link[rel="stylesheet"]');
+    expect(stylesheets).toHaveLength(1);
+    expect(stylesheets[0]).toBe(oldLink);
+    expect(document.querySelector("main")?.textContent).toBe("styled content");
   });
 
   it("dispatches the lifecycle events in order: before-preparation, after-preparation, before-swap, after-swap", async () => {

--- a/packages/zfb-runtime/src/__tests__/client-router/swap-functions.test.ts
+++ b/packages/zfb-runtime/src/__tests__/client-router/swap-functions.test.ts
@@ -62,6 +62,90 @@ describe("swapHeadElements — head dedup", () => {
     expect(metas[0]).toBe(oldMeta);
   });
 
+  it("preserves a persist-id'd head element with selector-special characters", () => {
+    const persistId = 'theme"] [name="injected]';
+    const oldMeta = document.createElement("meta");
+    oldMeta.setAttribute(PERSIST_ATTR, persistId);
+    oldMeta.setAttribute("name", "color-scheme");
+    oldMeta.setAttribute("content", "dark");
+    document.head.append(oldMeta);
+
+    const newDoc = document.implementation.createHTMLDocument();
+    const newMeta = newDoc.createElement("meta");
+    newMeta.setAttribute(PERSIST_ATTR, persistId);
+    newMeta.setAttribute("name", "color-scheme");
+    newMeta.setAttribute("content", "dark");
+    newDoc.head.append(newMeta);
+
+    swapHeadElements(newDoc);
+
+    const metas = document.head.querySelectorAll("meta[name=color-scheme]");
+    expect(metas).toHaveLength(1);
+    expect(metas[0]).toBe(oldMeta);
+  });
+
+  it("keeps an existing stylesheet when the href contains selector-special characters", () => {
+    const href = '/assets/site"] [data-x="bad].css';
+    const oldLink = document.createElement("link");
+    oldLink.setAttribute("rel", "stylesheet");
+    oldLink.setAttribute("href", href);
+    document.head.append(oldLink);
+
+    const newDoc = document.implementation.createHTMLDocument();
+    const newLink = newDoc.createElement("link");
+    newLink.setAttribute("rel", "stylesheet");
+    newLink.setAttribute("href", href);
+    newDoc.head.append(newLink);
+
+    swapHeadElements(newDoc);
+
+    const links = document.head.querySelectorAll('link[rel="stylesheet"]');
+    expect(links).toHaveLength(1);
+    expect(links[0]).toBe(oldLink);
+  });
+
+  it("keeps an existing font preload when the href contains selector-special characters", () => {
+    const href = '/fonts/body"] [data-x="bad].woff2';
+    const oldLink = document.createElement("link");
+    oldLink.setAttribute("rel", "preload");
+    oldLink.setAttribute("as", "font");
+    oldLink.setAttribute("href", href);
+    document.head.append(oldLink);
+
+    const newDoc = document.implementation.createHTMLDocument();
+    const newLink = newDoc.createElement("link");
+    newLink.setAttribute("rel", "preload");
+    newLink.setAttribute("as", "font");
+    newLink.setAttribute("href", href);
+    newDoc.head.append(newLink);
+
+    swapHeadElements(newDoc);
+
+    const links = document.head.querySelectorAll('link[rel="preload"][as="font"]');
+    expect(links).toHaveLength(1);
+    expect(links[0]).toBe(oldLink);
+  });
+
+  it("preserves a Vue scoped dev style when data-vite-dev-id contains selector-special characters", () => {
+    const viteDevId = '/src/App.vue?vue&type=style&scoped=true&path="bad]';
+    const oldStyle = document.createElement("style");
+    oldStyle.dataset["viteDevId"] = viteDevId;
+    oldStyle.textContent = ".old[data-v]{}";
+    document.head.append(oldStyle);
+
+    const newDoc = document.implementation.createHTMLDocument();
+    const newStyle = newDoc.createElement("style");
+    newStyle.dataset["viteDevId"] = viteDevId;
+    newStyle.textContent = ".new[data-v]{}";
+    newDoc.head.append(newStyle);
+
+    swapHeadElements(newDoc);
+
+    const styles = document.head.querySelectorAll("style");
+    expect(styles).toHaveLength(1);
+    expect(styles[0]).toBe(oldStyle);
+  });
+
   it("removes head elements that the new document does not contain", () => {
     document.head.innerHTML = `
       <link rel="stylesheet" href="/old.css">
@@ -135,6 +219,26 @@ describe("swapBodyElement — persist lift", () => {
     // Surrounding markup is the new content.
     expect(document.querySelector("h1")?.textContent).toBe("New Title");
     expect(document.querySelector("main")?.textContent).toBe("new content");
+  });
+
+  it("preserves a persist-id'd body element when the id contains quotes and brackets", () => {
+    const persistId = 'player"] [data-x="bad]';
+    const keptOriginal = document.createElement("div");
+    keptOriginal.setAttribute(PERSIST_ATTR, persistId);
+    keptOriginal.id = "kept";
+    keptOriginal.textContent = "state";
+    document.body.append(keptOriginal);
+
+    const newDoc = document.implementation.createHTMLDocument();
+    const incoming = newDoc.createElement("div");
+    incoming.setAttribute(PERSIST_ATTR, persistId);
+    incoming.id = "incoming";
+    newDoc.body.append(incoming);
+
+    swapBodyElement(newDoc.body, document.body);
+
+    expect(document.getElementById("kept")).toBe(keptOriginal);
+    expect(document.getElementById("incoming")).toBeNull();
   });
 
   it("discards an old persist element when the new body has no matching id", () => {

--- a/packages/zfb-runtime/src/client-router/router.ts
+++ b/packages/zfb-runtime/src/client-router/router.ts
@@ -168,6 +168,24 @@ const announce = () => {
 };
 
 const PERSIST_ATTR = "data-zfb-transition-persist";
+
+const attrValueSelector = (attr: string, value: string): string =>
+  value === "" ? `[${attr}=""]` : `[${attr}=${CSS.escape(value)}]`;
+
+const querySelectorWithAttrValue = (
+  root: ParentNode,
+  selectorPrefix: string,
+  attr: string,
+  value: string,
+): Element | null => {
+  const escapedMatch = root.querySelector(`${selectorPrefix}${attrValueSelector(attr, value)}`);
+  if (escapedMatch) return escapedMatch;
+  return (
+    Array.from(root.querySelectorAll(`${selectorPrefix}[${attr}]`)).find(
+      (el) => el.getAttribute(attr) === value,
+    ) ?? null
+  );
+};
 const DIRECTION_ATTR = "data-zfb-transition";
 const OLD_NEW_ATTR = "data-zfb-transition-fallback";
 
@@ -486,18 +504,27 @@ export function syncHistoryEntry(url: string | URL, options: SyncHistoryEntryOpt
 function preloadStyleLinks(newDocument: Document) {
   const links: Promise<any>[] = [];
   for (const el of newDocument.querySelectorAll("head link[rel=stylesheet]")) {
+    const persistId = el.getAttribute(PERSIST_ATTR);
+    const href = el.getAttribute("href");
+    const existingSelectors = [
+      persistId !== null ? attrValueSelector(PERSIST_ATTR, persistId) : null,
+      href !== null ? `link[rel=stylesheet]${attrValueSelector("href", href)}` : null,
+    ].filter((selector): selector is string => selector !== null);
+    const existingLink =
+      (existingSelectors.length ? document.querySelector(existingSelectors.join(", ")) : null) ??
+      (persistId !== null
+        ? querySelectorWithAttrValue(document, "", PERSIST_ATTR, persistId)
+        : null) ??
+      (href !== null
+        ? querySelectorWithAttrValue(document, "link[rel=stylesheet]", "href", href)
+        : null);
+
     // Do not preload links that are already on the page.
-    if (
-      !document.querySelector(
-        `[${PERSIST_ATTR}="${el.getAttribute(
-          PERSIST_ATTR,
-        )}"], link[rel=stylesheet][href="${el.getAttribute("href")}"]`,
-      )
-    ) {
+    if (href !== null && !existingLink) {
       const c = document.createElement("link");
       c.setAttribute("rel", "preload");
       c.setAttribute("as", "style");
-      c.setAttribute("href", el.getAttribute("href")!);
+      c.setAttribute("href", href);
       links.push(
         new Promise<any>((resolve) => {
           ["load", "error"].forEach((evName) => c.addEventListener(evName, resolve));

--- a/packages/zfb-runtime/src/client-router/swap-functions.ts
+++ b/packages/zfb-runtime/src/client-router/swap-functions.ts
@@ -79,6 +79,24 @@ function consumerPreservedAttrs(): string[] {
   return content ? content.toLowerCase().split(/\s+/).filter(Boolean) : [];
 }
 
+const attrValueSelector = (attr: string, value: string): string =>
+  value === "" ? `[${attr}=""]` : `[${attr}=${CSS.escape(value)}]`;
+
+const querySelectorWithAttrValue = (
+  root: ParentNode,
+  selectorPrefix: string,
+  attr: string,
+  value: string,
+): Element | null => {
+  const escapedMatch = root.querySelector(`${selectorPrefix}${attrValueSelector(attr, value)}`);
+  if (escapedMatch) return escapedMatch;
+  return (
+    Array.from(root.querySelectorAll(`${selectorPrefix}[${attr}]`)).find(
+      (el) => el.getAttribute(attr) === value,
+    ) ?? null
+  );
+};
+
 /*
  * swap attributes of the html element
  * delete all attributes from the current document
@@ -148,7 +166,7 @@ export function swapBodyElement(newElement: Element, oldElement: Element) {
 
   for (const el of oldElement.querySelectorAll(`[${PERSIST_ATTR}]`)) {
     const id = el.getAttribute(PERSIST_ATTR);
-    const newEl = newElement.querySelector(`[${PERSIST_ATTR}="${id}"]`);
+    const newEl = id !== null ? querySelectorWithAttrValue(newElement, "", PERSIST_ATTR, id) : null;
     if (!newEl) continue; // no matching target — leave in old body to be discarded
     persistPairs.push({ old: el, newTarget: newEl });
     if (moveBefore) {
@@ -260,13 +278,15 @@ export const vueScopedStyleId = (el: HTMLStyleElement): string => {
 // either because it has the data attribute or because replacing it would cause avoidable FOUC.
 const persistedHeadElement = (el: HTMLElement, newDoc: Document): Element | null => {
   const id = el.getAttribute(PERSIST_ATTR);
-  const newEl = id && newDoc.head.querySelector(`[${PERSIST_ATTR}="${id}"]`);
+  const newEl = id !== null ? querySelectorWithAttrValue(newDoc.head, "", PERSIST_ATTR, id) : null;
   if (newEl) {
     return newEl;
   }
   if (el.matches("link[rel=stylesheet]")) {
     const href = el.getAttribute("href");
-    return newDoc.head.querySelector(`link[rel=stylesheet][href="${href}"]`);
+    return href !== null
+      ? querySelectorWithAttrValue(newDoc.head, "link[rel=stylesheet]", "href", href)
+      : null;
   }
   // In dev mode, Vite injects <style data-vite-dev-id="..."> elements whose
   // textContent may later be transformed (especially Vue's `:deep()` → `[data-v-xxx]`).
@@ -279,7 +299,7 @@ const persistedHeadElement = (el: HTMLElement, newDoc: Document): Element | null
   if ((import.meta as any).env?.DEV && el instanceof HTMLStyleElement) {
     const viteDevId = vueScopedStyleId(el);
     if (viteDevId) {
-      return newDoc.head.querySelector(`style[data-vite-dev-id="${viteDevId}"]`);
+      return querySelectorWithAttrValue(newDoc.head, "style", "data-vite-dev-id", viteDevId);
     }
   }
   // Preserve inline <style> elements with identical content across navigations.
@@ -297,7 +317,9 @@ const persistedHeadElement = (el: HTMLElement, newDoc: Document): Element | null
   // Preserve font preload links across navigations to avoid re-fetching cached fonts.
   if (el.matches("link[rel=preload][as=font]")) {
     const href = el.getAttribute("href");
-    return newDoc.head.querySelector(`link[rel=preload][as=font][href="${href}"]`);
+    return href !== null
+      ? querySelectorWithAttrValue(newDoc.head, "link[rel=preload][as=font]", "href", href)
+      : null;
   }
   return null;
 };

--- a/packages/zfb/src/config.ts
+++ b/packages/zfb/src/config.ts
@@ -784,7 +784,7 @@ export type GithubAutolinksConfig = {
    * (e.g. `"owner/repo"` renders `#123` as
    * `https://github.com/owner/repo/issues/123`). Required — see above.
    */
-  repo?: string;
+  repo: string;
 };
 
 /**

--- a/packages/zfb/type-tests/config-fixture.ts
+++ b/packages/zfb/type-tests/config-fixture.ts
@@ -1,0 +1,34 @@
+/**
+ * Config type fixture.
+ *
+ * Compiled by `tsc -p tsconfig.preact-fixture.json` through the package's
+ * type-test include. Keep this file compile-only; it proves config
+ * helper types reject invalid shapes without adding runtime test code.
+ */
+
+import { defineConfig } from "../src/config.js";
+
+export const githubAutolinksWithRepo = defineConfig({
+  markdown: {
+    features: {
+      githubAutolinks: {
+        repo: "owner/repo",
+      },
+    },
+  },
+});
+
+export const githubAutolinksOmitted = defineConfig({
+  markdown: {
+    features: {},
+  },
+});
+
+export const githubAutolinksEmptyObject = defineConfig({
+  markdown: {
+    features: {
+      // @ts-expect-error repo is required when githubAutolinks is configured.
+      githubAutolinks: {},
+    },
+  },
+});


### PR DESCRIPTION
## Summary\n- Closes #1418\n- Integrates #1419 by making `GithubAutolinksConfig.repo` required in the TS config type and adding compile-only type coverage\n- Integrates #1420 by escaping client-router selector values for persist ids, stylesheet hrefs, Vite dev style ids, font preloads, and stylesheet preload detection\n- Adds happy-dom regression coverage for special-character selector values\n\n## Topic PRs\n- #1425\n- #1424\n\n## Verification\n- `pnpm -C packages/zfb test`\n- `pnpm -C packages/zfb-runtime test`\n- `pnpm -r --if-present typecheck`\n- `git diff --check main...HEAD`\n- grep verified no in-repo code/demo/template configures `githubAutolinks` without `repo`\n\nNote: Playwright router-chromium was not run locally; CI owns that path-triggered suite.