### PR TITLE
Harden islands shadow reachability and symlink mode (#1429)

### DIFF
--- a/crates/zfb-build/src/glob_expand.rs
+++ b/crates/zfb-build/src/glob_expand.rs
@@ -29,7 +29,8 @@
 //!     is an explicit `Err` — silently mis-expanding user code is the failure
 //!     mode this whole task exists to avoid.
 
-use std::path::Path;
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
 
 use anyhow::{anyhow, bail, Result};
 use walkdir::WalkDir;
@@ -63,6 +64,18 @@ pub struct GlobCallCollector {
     pub base: u32,
     /// Every `import.meta.glob(...)` call found so far, in source order.
     pub calls: Vec<GlobCall>,
+}
+
+/// Result of expanding `import.meta.glob(...)` in one source file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GlobExpansion {
+    /// Source with supported eager string-literal glob calls rewritten into
+    /// namespace imports plus object literals.
+    pub expanded_source: String,
+    /// Absolute paths of every file matched by any expanded glob call, sorted
+    /// and deduped. Shadow materialisers use this to mirror the target graph
+    /// without parsing generated import strings.
+    pub matched_files: Vec<PathBuf>,
 }
 
 impl swc_core::ecma::visit::Visit for GlobCallCollector {
@@ -293,12 +306,29 @@ pub fn expand_import_meta_glob(
     file_dir: &Path,
     is_excluded: &dyn Fn(&Path) -> bool,
 ) -> Result<String> {
+    Ok(expand_import_meta_glob_with_matches(source, file_dir, is_excluded)?.expanded_source)
+}
+
+/// Expand Vite's eager `import.meta.glob(...)` macro and return the matched
+/// target files alongside the rewritten source.
+///
+/// See [`expand_import_meta_glob`] for the supported syntax and error
+/// contract. This richer form exists for callers that need to mirror the
+/// expanded target graph into a shadow tree.
+pub fn expand_import_meta_glob_with_matches(
+    source: &str,
+    file_dir: &Path,
+    is_excluded: &dyn Fn(&Path) -> bool,
+) -> Result<GlobExpansion> {
     let calls = collect_import_meta_glob_calls(source)?;
 
     if calls.is_empty() {
         // The substring was present but only inside strings/comments — no
         // real call. Return the source unchanged.
-        return Ok(source.to_string());
+        return Ok(GlobExpansion {
+            expanded_source: source.to_string(),
+            matched_files: Vec::new(),
+        });
     }
 
     // Calls are collected in source order (visit is pre-order, left-to-right
@@ -309,6 +339,7 @@ pub fn expand_import_meta_glob(
     // (lo, hi, replacement_object_literal) per call, source order.
     let mut replacements: Vec<(usize, usize, String)> = Vec::new();
     let mut glob_counter: usize = 0;
+    let mut matched_files: BTreeSet<PathBuf> = BTreeSet::new();
 
     for call in &calls {
         let pattern = match &call.parsed {
@@ -323,6 +354,9 @@ pub fn expand_import_meta_glob(
         // already sorted + deduped by `glob_match_relative`.
         let mut entries: Vec<String> = Vec::with_capacity(matches.len());
         for rel in &matches {
+            let rel_path = rel.strip_prefix("./").unwrap_or(rel.as_str());
+            matched_files.insert(file_dir.join(rel_path));
+
             let ident = format!("__glob_{glob_counter}");
             glob_counter += 1;
             // serde_json string-quotes the specifier/key so any exotic char
@@ -368,17 +402,23 @@ pub fn expand_import_meta_glob(
     // shebang (`#!…`) MUST stay on line 1, so insert the imports AFTER it
     // rather than before — prepending before a shebang would break a Node
     // script. (Rare for a bundled module, but cheap to get right.)
-    if import_decls.is_empty() {
-        return Ok(out);
-    }
-    let decls = import_decls.join("\n");
-    if out.starts_with("#!") {
-        let nl = out.find('\n').map(|i| i + 1).unwrap_or(out.len());
-        let (shebang, rest) = out.split_at(nl);
-        Ok(format!("{shebang}{decls}\n{rest}"))
+    let expanded_source = if import_decls.is_empty() {
+        out
     } else {
-        Ok(format!("{decls}\n{out}"))
-    }
+        let decls = import_decls.join("\n");
+        if out.starts_with("#!") {
+            let nl = out.find('\n').map(|i| i + 1).unwrap_or(out.len());
+            let (shebang, rest) = out.split_at(nl);
+            format!("{shebang}{decls}\n{rest}")
+        } else {
+            format!("{decls}\n{out}")
+        }
+    };
+
+    Ok(GlobExpansion {
+        expanded_source,
+        matched_files: matched_files.into_iter().collect(),
+    })
 }
 
 /// Walk `file_dir` and return the POSIX `./`-prefixed relative paths of every
@@ -513,7 +553,8 @@ mod tests {
     fn import_meta_glob_one_match_expands_with_namespace_import() {
         let dir = fixture_dir(&[("widgets/a.tsx", "export const a = 1;")]);
         let src = r#"const m = import.meta.glob('./widgets/*.tsx', { eager: true });"#;
-        let out = expand_import_meta_glob(src, dir.path(), &no_exclude).unwrap();
+        let expansion = expand_import_meta_glob_with_matches(src, dir.path(), &no_exclude).unwrap();
+        let out = &expansion.expanded_source;
         assert!(!out.contains("import.meta.glob("), "macro removed:\n{out}");
         assert!(
             out.contains(r#"import * as __glob_0 from "./widgets/a.tsx";"#),
@@ -522,6 +563,11 @@ mod tests {
         assert!(
             out.contains(r#""./widgets/a.tsx": __glob_0"#),
             "object key → namespace mapping:\n{out}"
+        );
+        assert_eq!(
+            expansion.matched_files,
+            vec![dir.path().join("widgets/a.tsx")],
+            "matched target paths are exposed for shadow materialisation"
         );
     }
 

--- a/crates/zfb-islands/src/bundler.rs
+++ b/crates/zfb-islands/src/bundler.rs
@@ -207,21 +207,30 @@ pub struct BundleConfig {
     /// keeps every importer anchored at its on-disk location instead of
     /// canonicalising symlinks back to their real target (issue #1404).
     ///
-    /// This is the load-bearing flag of the islands shadow: the shadow
-    /// tree symlinks plain source files and writes REAL expanded copies of
-    /// `import.meta.glob`-using files. Without `--preserve-symlinks`,
-    /// esbuild would resolve a symlinked island file to its real project
-    /// path and then resolve THAT file's relative imports against the real
-    /// tree — skipping the in-shadow expanded glob copy entirely and
-    /// shipping the raw `import.meta.glob(` call to the browser again. With
-    /// the flag, esbuild stays at `<shadow>/…` so the expanded copies win.
+    /// This is the load-bearing flag for the islands shadow's symlink mode:
+    /// that shadow symlinks plain source files and writes REAL expanded
+    /// copies of `import.meta.glob`-using files. Without
+    /// `--preserve-symlinks`, esbuild would resolve a symlinked island file
+    /// to its real project path and then resolve THAT file's relative imports
+    /// against the real tree — skipping the in-shadow expanded glob copy
+    /// entirely and shipping the raw `import.meta.glob(` call to the browser
+    /// again. With the flag, esbuild stays at `<shadow>/…` so the expanded
+    /// copies win.
+    ///
+    /// Some islands shadows use copy-mode instead: project-local source files
+    /// are real copied files, so the expanded copies remain visible without
+    /// this flag. That mirrors the SSR bundler's fallback for project
+    /// `node_modules` plus tsconfig `paths`, where preserving symlinks can
+    /// pin workspace-package importers under `<shadow>/node_modules/...` and
+    /// break non-hoisted pnpm resolution.
     ///
     /// Default `false` — the no-shadow path (no `import.meta.glob` reachable
     /// from an island, the overwhelming common case) never sets it, so the
     /// esbuild argv and bundle bytes are byte-identical to a pre-#1404
     /// build. Only `build_default_islands_payload` sets it, and only after
     /// it has materialised a shadow and remapped the island `source_path`s
-    /// into it.
+    /// into it, and only when that shadow used symlink mode rather than
+    /// copy-mode.
     pub preserve_symlinks: bool,
 }
 
@@ -300,7 +309,7 @@ impl BundleConfig {
     /// Toggle `--preserve-symlinks` on the esbuild invocation (chainable).
     ///
     /// See [`BundleConfig::preserve_symlinks`] — set by the islands-shadow
-    /// path (#1404) and left `false` everywhere else.
+    /// path (#1404/#1413) and left `false` everywhere else.
     pub fn with_preserve_symlinks(mut self, preserve_symlinks: bool) -> Self {
         self.preserve_symlinks = preserve_symlinks;
         self

--- a/crates/zfb-islands/src/esbuild.rs
+++ b/crates/zfb-islands/src/esbuild.rs
@@ -1338,12 +1338,12 @@ pub(crate) fn build_esbuild_args_with_entry_name(
     if config.sourcemap {
         args.push(OsString::from("--sourcemap=linked"));
     }
-    // Issue #1404: keep esbuild anchored at each importer's on-disk
-    // location instead of canonicalising symlinks. Set ONLY by the
-    // islands-shadow path (`BundleConfig::preserve_symlinks`), so the
-    // default no-shadow argv is byte-identical to a pre-#1404 build. See
-    // [`crate::bundler::BundleConfig::preserve_symlinks`] for why the
-    // shadow's expanded-glob copies would otherwise be bypassed.
+    // Issue #1404/#1413: keep esbuild anchored at each importer's on-disk
+    // location when the islands shadow uses symlink mode. Copy-mode shadows
+    // omit this flag because their source files are real shadow copies,
+    // mirroring the SSR bundler's project-node_modules + tsconfig-paths
+    // fallback. The default no-shadow argv remains byte-identical to a
+    // pre-#1404 build.
     if config.preserve_symlinks {
         args.push(OsString::from("--preserve-symlinks"));
     }

--- a/crates/zfb-islands/src/lib.rs
+++ b/crates/zfb-islands/src/lib.rs
@@ -61,8 +61,8 @@ pub use hydration::{
 };
 pub use manifest::{manifest_json, write_manifest, Collision, Manifest};
 pub use scanner::{
-    is_bare_specifier, scan_islands, scan_islands_with_meta, FsResolver, InMemoryResolver,
-    IslandsSet, Resolver, ScanError, ScanMeta, ScanResult,
+    is_bare_specifier, scan_islands, scan_islands_with_meta, scan_reachable_modules, FsResolver,
+    InMemoryResolver, IslandsSet, Resolver, ScanError, ScanMeta, ScanResult,
 };
 // Re-export from zfb-types so downstream crates get a stable path.
 pub use zfb_types::normalize_path_lexical;

--- a/crates/zfb-islands/src/scanner.rs
+++ b/crates/zfb-islands/src/scanner.rs
@@ -70,7 +70,7 @@
 //! the `(source_path, component_name)` pair via a `BTreeMap`, which also
 //! gives us the sort order on output for free.
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::{Component, Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
@@ -1364,6 +1364,57 @@ impl Resolver for InMemoryResolver {
 /// on it stay unchanged.
 pub fn scan_islands<R: Resolver>(pages: &[PathBuf], resolver: &R) -> ScanResult<IslandsSet> {
     scan_islands_with_meta(pages, resolver).map(|(islands, _meta)| islands)
+}
+
+/// Walk ordinary JS/TS module imports from arbitrary roots and return the
+/// sorted, deduped resolved module closure.
+///
+/// This intentionally reuses the same import-edge collector as
+/// [`scan_islands_with_meta`] (`import`, `export ... from`, `export *`, and
+/// string-literal dynamic `import()`). It does not inspect `"use client"` or
+/// collect island metadata; callers use it when they need the esbuild-reachable
+/// closure for generated entry roots such as expanded `import.meta.glob`
+/// targets.
+pub fn scan_reachable_modules<R: Resolver>(
+    roots: &[PathBuf],
+    resolver: &R,
+) -> ScanResult<Vec<PathBuf>> {
+    let mut reachable: BTreeSet<PathBuf> = BTreeSet::new();
+    let mut visited: HashSet<PathBuf> = HashSet::new();
+    let mut stack: Vec<PathBuf> = roots.to_vec();
+
+    while let Some(current) = stack.pop() {
+        if !visited.insert(current.clone()) {
+            continue;
+        }
+        reachable.insert(current.clone());
+
+        if !is_scannable_source(&current) {
+            continue;
+        }
+
+        let source = resolver
+            .read(&current)
+            .map_err(|message| ScanError::Resolver {
+                path: current.clone(),
+                message,
+            })?;
+        let module = parse_module(&current, &source)?;
+        let importer_dir = current
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."));
+
+        for specifier in collect_import_specifiers(&module) {
+            if let Some(resolved) = resolver.resolve(&importer_dir, &specifier) {
+                if !visited.contains(&resolved) {
+                    stack.push(resolved);
+                }
+            }
+        }
+    }
+
+    Ok(reachable.into_iter().collect())
 }
 
 /// Like [`scan_islands`], but also returns [`ScanMeta`] — side-channel
@@ -7130,6 +7181,60 @@ mod tests {
                 "dynamic import literal {want} must be an edge: {out:?}"
             );
         }
+    }
+
+    #[test]
+    fn scan_reachable_modules_walks_import_closure_from_arbitrary_roots() {
+        let resolver = InMemoryResolver::new()
+            .with_file(
+                root().join("components/widgets/a.tsx"),
+                r#"import { shared } from "../shared";
+                   export * from "../barrel";
+                   export async function load() { return import("../lazy"); }
+                   import type { OnlyType } from "../types";
+                   export const a = shared;
+                "#,
+            )
+            .with_file(
+                root().join("components/shared.ts"),
+                "export const shared = 1;\n",
+            )
+            .with_file(
+                root().join("components/barrel.ts"),
+                "export { value } from './value';\n",
+            )
+            .with_file(
+                root().join("components/value.ts"),
+                "export const value = 2;\n",
+            )
+            .with_file(
+                root().join("components/lazy.ts"),
+                "export const lazy = 3;\n",
+            )
+            .with_file(
+                root().join("components/types.ts"),
+                "export type OnlyType = string;\n",
+            );
+
+        let out =
+            scan_reachable_modules(&[root().join("components/widgets/a.tsx")], &resolver).unwrap();
+
+        for want in [
+            "components/widgets/a.tsx",
+            "components/shared.ts",
+            "components/barrel.ts",
+            "components/value.ts",
+            "components/lazy.ts",
+        ] {
+            assert!(
+                out.contains(&root().join(want)),
+                "reachable closure missing {want}: {out:?}"
+            );
+        }
+        assert!(
+            !out.contains(&root().join("components/types.ts")),
+            "type-only imports must not be runtime reachability edges: {out:?}"
+        );
     }
 
     #[test]

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -66,8 +66,8 @@ use zfb_css::{
 };
 use zfb_islands::{
     build_production_client_scripts, build_production_islands_asset, discover_client_scripts,
-    scan_islands_with_meta, BundleConfig, EsbuildSubprocessBundler, EsbuildSubprocessConfig,
-    FrameworkKind, FsResolver,
+    scan_islands_with_meta, scan_reachable_modules, BundleConfig, EsbuildSubprocessBundler,
+    EsbuildSubprocessConfig, FrameworkKind, FsResolver,
 };
 use zfb_router::Router;
 
@@ -1160,16 +1160,19 @@ pub(crate) enum IslandsGlobPolicy {
 /// Built by [`materialise_islands_shadow`] only when `import.meta.glob` is
 /// reachable from a `"use client"` island. It mirrors the project's source
 /// tree under a throwaway `TempDir` keyed by project-root-relative path:
-/// plain files are symlinked, files that call `import.meta.glob` are written
-/// as REAL, expanded copies (the Vite macro expanded Rust-side via
-/// `zfb_build::glob_expand`, the same trick the SSR bundler's
-/// `materialise_source_file` uses), and `node_modules` is symlinked as a
-/// whole. The island `source_path`s are then remapped into the shadow so
-/// esbuild — invoked with `--preserve-symlinks` — resolves each island's
-/// transitive imports through the shadow, reaching the expanded glob copies
-/// instead of the raw project files. Raw-mirrored JS-like glob target/subtree
-/// files are scanned before materialisation so a nested `import.meta.glob`
-/// that would otherwise ship unexpanded keeps the stopgap instead.
+/// files that call `import.meta.glob` are written as REAL, expanded copies
+/// (the Vite macro expanded Rust-side via `zfb_build::glob_expand`, the same
+/// trick the SSR bundler's `materialise_source_file` uses), and `node_modules`
+/// is symlinked as a whole. Plain source files are symlinked when esbuild will
+/// run with `--preserve-symlinks`; in the project-`node_modules` + tsconfig
+/// `paths` shape they are copied instead, mirroring the SSR bundler's
+/// copy-mode fallback so non-hoisted pnpm/workspace resolution is not pinned
+/// under `<shadow>/node_modules/...`. The island `source_path`s are then
+/// remapped into the shadow so esbuild resolves transitive imports through the
+/// materialised tree, reaching the expanded glob copies instead of the raw
+/// project files. Raw-mirrored JS-like glob target/subtree files are scanned
+/// before materialisation so a nested `import.meta.glob` that would otherwise
+/// ship unexpanded keeps the stopgap instead.
 struct IslandsShadow {
     /// Kept alive so the tempdir (and every symlink / real file inside it)
     /// survives until esbuild has finished bundling. Dropping it deletes the
@@ -1182,6 +1185,10 @@ struct IslandsShadow {
     /// absent — left pointing at the real file, resolved through the shadow's
     /// `node_modules` symlink.
     remap: std::collections::HashMap<PathBuf, PathBuf>,
+    /// Whether the islands esbuild invocation must receive
+    /// `--preserve-symlinks` for this shadow. False only when source files were
+    /// copied into the shadow instead of symlinked.
+    preserve_symlinks: bool,
 }
 
 /// Outcome of attempting to build the islands shadow for a project whose
@@ -1338,6 +1345,11 @@ fn shadow_symlink(from: &Path, to: &Path) -> std::io::Result<()> {
     }
 }
 
+fn shadow_copy_file(from: &Path, to: &Path) -> std::io::Result<()> {
+    let _ = std::fs::remove_file(to);
+    std::fs::copy(from, to).map(|_| ())
+}
+
 /// Materialise the islands shadow tree for a project whose scan reported
 /// `import.meta.glob` reachable from a `"use client"` island (issue #1404).
 ///
@@ -1388,6 +1400,7 @@ fn materialise_islands_shadow(
     // the walk below.
     let mut offenders: Vec<String> = Vec::new();
     let mut expanded_by_path: HashMap<PathBuf, String> = HashMap::new();
+    let mut matched_glob_targets: BTreeSet<PathBuf> = BTreeSet::new();
     for g in &scan_meta.glob_reachable_from_islands {
         if project_local_shadow_rel(g, root).is_none() {
             offenders.push(format!(
@@ -1409,13 +1422,14 @@ fn materialise_islands_shadow(
         // materialise. See `matched_target_under_pruned_build_output`.
         let exclude_build_output =
             |abs: &Path| matched_target_under_pruned_build_output(abs, file_dir);
-        match zfb_build::glob_expand::expand_import_meta_glob(
+        match zfb_build::glob_expand::expand_import_meta_glob_with_matches(
             &source,
             file_dir,
             &exclude_build_output,
         ) {
-            Ok(expanded) => {
-                expanded_by_path.insert(g.clone(), expanded);
+            Ok(expansion) => {
+                matched_glob_targets.extend(expansion.matched_files);
+                expanded_by_path.insert(g.clone(), expansion.expanded_source);
             }
             Err(e) => offenders.push(format!("{}: {e:#}", g.display())),
         }
@@ -1443,6 +1457,47 @@ fn materialise_islands_shadow(
             if entry.file_type().is_file() && project_local_shadow_rel(entry.path(), root).is_some()
             {
                 to_mirror.insert(entry.path().to_path_buf());
+            }
+        }
+    }
+    // (c) every project-local module reachable from each expanded glob target.
+    //     These are real esbuild edges after macro expansion, but they are not
+    //     present in the page/island scanner graph and may live outside the
+    //     glob module's own directory subtree.
+    if !matched_glob_targets.is_empty() {
+        let target_roots: Vec<PathBuf> = matched_glob_targets.iter().cloned().collect();
+        let resolver = FsResolver::new();
+        match scan_reachable_modules(&target_roots, &resolver) {
+            Ok(modules) => {
+                for m in modules {
+                    if project_local_shadow_rel(&m, root).is_some() {
+                        to_mirror.insert(m);
+                    }
+                }
+            }
+            Err(zfb_islands::ScanError::Parse { path, message }) => {
+                let bytes = std::fs::read(&path).with_context(|| {
+                    format!(
+                        "read parse-error islands shadow glob target {}",
+                        path.display()
+                    )
+                })?;
+                if bytes_contain_import_meta_glob(&bytes)
+                    && project_local_shadow_rel(&path, root).is_some()
+                {
+                    // Let the raw-mirrored nested-glob preflight below produce
+                    // the intended #1412 KeepStopgap message, including the
+                    // parse-error detail, instead of turning this into an IO-ish
+                    // shadow materialisation failure.
+                    to_mirror.insert(path);
+                } else {
+                    return Err(zfb_islands::ScanError::Parse { path, message }.into());
+                }
+            }
+            Err(e) => {
+                return Err(anyhow!(
+                    "scan imports reachable from islands shadow glob targets: {e}"
+                ));
             }
         }
     }
@@ -1495,6 +1550,9 @@ fn materialise_islands_shadow(
         .tempdir()
         .context("failed to allocate islands shadow tempdir")?;
     let shadow_root = tempdir.path();
+    let project_node_modules = detect_project_node_modules(root);
+    let source_copy_mode = project_node_modules.is_some() && !read_tsconfig_paths(root).is_empty();
+    let preserve_symlinks = !source_copy_mode;
 
     for from in &to_mirror {
         let rel = match project_local_shadow_rel(from, root) {
@@ -1507,10 +1565,15 @@ fn materialise_islands_shadow(
                 .with_context(|| format!("create shadow dir {}", parent.display()))?;
         }
         if let Some(expanded) = expanded_by_path.get(from) {
-            // Real expanded copy — NOT a symlink, so esbuild (under
-            // --preserve-symlinks) reads the expanded macro from the shadow.
+            // Real expanded copy — NOT a symlink, so esbuild reads the
+            // expanded macro from the shadow in both preserve-symlinks and
+            // copy-mode branches.
             std::fs::write(&to, expanded.as_bytes())
                 .with_context(|| format!("write expanded glob module {}", to.display()))?;
+        } else if source_copy_mode {
+            shadow_copy_file(from, &to).with_context(|| {
+                format!("copy shadow file {} -> {}", from.display(), to.display())
+            })?;
         } else {
             shadow_symlink(from, &to).with_context(|| {
                 format!("symlink shadow file {} -> {}", from.display(), to.display())
@@ -1521,7 +1584,7 @@ fn materialise_islands_shadow(
     // Symlink node_modules as a whole so shadow files' bare imports
     // (`preact`, `@takazudo/zfb/runtime`, …) resolve — esbuild walks up from
     // each shadow file to `<shadow>/node_modules`.
-    if let Some(nm) = detect_project_node_modules(root) {
+    if let Some(nm) = project_node_modules {
         let shadow_nm = shadow_root.join("node_modules");
         shadow_symlink(&nm, &shadow_nm).with_context(|| {
             format!(
@@ -1531,13 +1594,12 @@ fn materialise_islands_shadow(
             )
         })?;
     }
-    // Note: the user's `tsconfig.json` / `jsconfig.json` need no special
-    // handling — they are ordinary project-root files, already symlinked
-    // into the shadow root by the mirror walk when the project has them, so
-    // esbuild's upward walk from a shadow source file finds them (with
-    // `baseUrl: "."` resolving relative to the shadow root, whose mirror of
-    // the project tree makes relative `compilerOptions.paths` targets resolve
-    // in-shadow).
+    // Note: the user's `tsconfig.json` / `jsconfig.json` are not source files
+    // in this mirror set. Islands esbuild still runs with `project_root` as its
+    // working dir, and its synthetic-tsconfig path (when plugin aliases or
+    // virtual modules require one) is seeded from that project config. The
+    // shadow only controls whether project source files are symlinked or real
+    // copies before esbuild follows their relative imports.
 
     // --- Remap island source_paths into the shadow. ----------------------
     let mut remap: HashMap<PathBuf, PathBuf> = HashMap::new();
@@ -1550,6 +1612,7 @@ fn materialise_islands_shadow(
     Ok(IslandsShadowOutcome::Ready(IslandsShadow {
         _tempdir: tempdir,
         remap,
+        preserve_symlinks,
     }))
 }
 
@@ -1683,8 +1746,11 @@ pub(crate) fn build_default_islands_payload(
     // the island graph mirrored under a TempDir with the Vite macro expanded
     // Rust-side (the islands esbuild pipeline cannot expand it itself), the
     // same trick the SSR bundler already uses — and remap the island
-    // `source_path`s into it so esbuild (run with `--preserve-symlinks`)
-    // bundles the expanded copies. Supported forms (eager + string-literal)
+    // `source_path`s into it so esbuild bundles the expanded copies. Most
+    // shadows run with `--preserve-symlinks`; the project-node_modules +
+    // tsconfig-paths shape copies source files instead and omits the flag,
+    // mirroring the SSR bundler's copy-mode fallback. Supported forms (eager
+    // + string-literal)
     // now WORK; unsupported forms (lazy/default, non-literal, `import()`
     // mode) and glob modules outside the mirrorable tree keep the #1387
     // stopgap below. The no-glob common case takes the fast path (this whole
@@ -1702,7 +1768,7 @@ pub(crate) fn build_default_islands_payload(
     if !scan_meta.glob_reachable_from_islands.is_empty() {
         match materialise_islands_shadow(project_root, &islands_set, &scan_meta)? {
             IslandsShadowOutcome::Ready(shadow) => {
-                islands_preserve_symlinks = true;
+                islands_preserve_symlinks = shadow.preserve_symlinks;
                 _islands_shadow = Some(shadow);
             }
             IslandsShadowOutcome::KeepStopgap(offenders) => {
@@ -1913,9 +1979,10 @@ pub(crate) fn build_default_islands_payload(
         .with_outdir(outdir.to_path_buf())
         .with_jsx_import_source(islands_jsx_import_source)
         .with_client_router(scan_meta.uses_client_router)
-        // Issue #1404: `--preserve-symlinks` iff a glob-expanding shadow was
-        // materialised above — keeps esbuild anchored at the shadow's
-        // expanded copies. `false` on the fast path ⇒ byte-identical argv.
+        // Issue #1413: the shadow carries the exact symlink-mode decision.
+        // Most shadows need `--preserve-symlinks`; copy-mode shadows use real
+        // source copies and deliberately omit it to mirror the SSR bundler.
+        // `false` on the no-shadow fast path keeps byte-identical argv.
         .with_preserve_symlinks(islands_preserve_symlinks);
 
     // Issue #1404: remap island `source_path`s into the shadow ONLY for the
@@ -5349,6 +5416,10 @@ mod tests {
                 panic!("supported eager glob must NOT keep the stopgap; offenders: {o:?}")
             }
         };
+        assert!(
+            shadow.preserve_symlinks,
+            "default islands shadow uses symlinked source files plus --preserve-symlinks"
+        );
 
         // The island's source_path was remapped into the shadow.
         let shadow_island = shadow
@@ -5505,6 +5576,204 @@ mod tests {
         assert!(
             std::fs::symlink_metadata(shadow_root.join("components/dist/generated.tsx")).is_err(),
             "build output under dist/ must be pruned from the shadow (matched set ⊆ mirrored set)"
+        );
+    }
+
+    #[test]
+    fn materialise_islands_shadow_mirrors_glob_target_transitive_project_imports() {
+        let tmp = tempdir().unwrap();
+        let project_root = tmp.path();
+        let (island_src, glob_src, target) = write_basic_glob_shadow_project(project_root);
+        std::fs::write(
+            &target,
+            "import { helper } from '../shared/helper';\nexport const a = helper;\n",
+        )
+        .unwrap();
+        write_shadow_fixture(
+            project_root,
+            "components/shared/helper.ts",
+            "export const helper = 1;\n",
+        );
+
+        let (islands, scan_meta) = basic_shadow_inputs(
+            project_root,
+            vec![glob_src.clone()],
+            vec![island_src.clone(), glob_src],
+        );
+        let outcome = materialise_islands_shadow(project_root, &islands, &scan_meta)
+            .expect("shadow materialisation must not IO-error");
+        let shadow = match outcome {
+            IslandsShadowOutcome::Ready(s) => s,
+            IslandsShadowOutcome::KeepStopgap(o) => {
+                panic!("supported glob target closure must NOT keep stopgap: {o:?}")
+            }
+        };
+        let shadow_island = shadow
+            .remap
+            .get(&island_src)
+            .expect("island source_path must be remapped into the shadow");
+        let shadow_root = shadow_island.parent().unwrap().parent().unwrap();
+        assert!(
+            std::fs::symlink_metadata(shadow_root.join("components/shared/helper.ts")).is_ok(),
+            "project-local helper imported only by a glob target must be mirrored"
+        );
+    }
+
+    #[test]
+    fn materialise_islands_shadow_mirrors_glob_target_tsconfig_alias_imports() {
+        let tmp = tempdir().unwrap();
+        let project_root = tmp.path();
+        std::fs::write(
+            project_root.join("tsconfig.json"),
+            r#"{"compilerOptions":{"baseUrl":".","paths":{"@/*":["components/*"]}}}"#,
+        )
+        .unwrap();
+        let (island_src, glob_src, target) = write_basic_glob_shadow_project(project_root);
+        std::fs::write(
+            &target,
+            "import { helper } from '@/shared/helper';\nexport const a = helper;\n",
+        )
+        .unwrap();
+        write_shadow_fixture(
+            project_root,
+            "components/shared/helper.ts",
+            "export const helper = 1;\n",
+        );
+
+        let (islands, scan_meta) = basic_shadow_inputs(
+            project_root,
+            vec![glob_src.clone()],
+            vec![island_src.clone(), glob_src],
+        );
+        let outcome = materialise_islands_shadow(project_root, &islands, &scan_meta)
+            .expect("shadow materialisation must not IO-error");
+        let shadow = match outcome {
+            IslandsShadowOutcome::Ready(s) => s,
+            IslandsShadowOutcome::KeepStopgap(o) => {
+                panic!("supported alias import closure must NOT keep stopgap: {o:?}")
+            }
+        };
+        let shadow_island = shadow
+            .remap
+            .get(&island_src)
+            .expect("island source_path must be remapped into the shadow");
+        let shadow_root = shadow_island.parent().unwrap().parent().unwrap();
+        assert!(
+            std::fs::symlink_metadata(shadow_root.join("components/shared/helper.ts")).is_ok(),
+            "tsconfig-aliased helper imported only by a glob target must be mirrored"
+        );
+    }
+
+    #[test]
+    fn materialise_islands_shadow_flags_glob_in_transitive_target_import() {
+        let tmp = tempdir().unwrap();
+        let project_root = tmp.path();
+        let (island_src, glob_src, target) = write_basic_glob_shadow_project(project_root);
+        std::fs::write(
+            &target,
+            "import { helper } from '../shared/helper';\nexport const a = helper;\n",
+        )
+        .unwrap();
+        write_shadow_fixture(
+            project_root,
+            "components/shared/helper.ts",
+            "export const helper = import.meta.glob('./nested/*.tsx', { eager: true });\n",
+        );
+
+        let (islands, scan_meta) = basic_shadow_inputs(
+            project_root,
+            vec![glob_src.clone()],
+            vec![island_src, glob_src],
+        );
+        let outcome = materialise_islands_shadow(project_root, &islands, &scan_meta)
+            .expect("shadow materialisation must not IO-error");
+        let offenders = match outcome {
+            IslandsShadowOutcome::KeepStopgap(o) => o,
+            IslandsShadowOutcome::Ready(_) => {
+                panic!("transitive raw-mirrored target glob must keep stopgap")
+            }
+        };
+        let message = offenders.join("\n");
+        assert!(
+            message.contains("components/shared/helper.ts"),
+            "names transitive helper offender: {message}"
+        );
+        assert!(
+            message.contains("raw-mirrored glob target/subtree"),
+            "preserves #1412 loudness language: {message}"
+        );
+    }
+
+    #[test]
+    fn materialise_islands_shadow_keeps_symlink_mode_with_project_node_modules_without_paths() {
+        let tmp = tempdir().unwrap();
+        let project_root = tmp.path();
+        std::fs::create_dir_all(project_root.join("node_modules")).unwrap();
+        let (island_src, glob_src, _target) = write_basic_glob_shadow_project(project_root);
+
+        let (islands, scan_meta) = basic_shadow_inputs(
+            project_root,
+            vec![glob_src.clone()],
+            vec![island_src.clone(), glob_src],
+        );
+        let outcome = materialise_islands_shadow(project_root, &islands, &scan_meta)
+            .expect("shadow materialisation must not IO-error");
+        let shadow = match outcome {
+            IslandsShadowOutcome::Ready(s) => s,
+            IslandsShadowOutcome::KeepStopgap(o) => panic!("supported glob must be ready: {o:?}"),
+        };
+        let shadow_island = shadow
+            .remap
+            .get(&island_src)
+            .expect("island source_path must be remapped into the shadow");
+        assert!(
+            shadow.preserve_symlinks,
+            "project node_modules without tsconfig paths keeps --preserve-symlinks"
+        );
+        assert!(
+            std::fs::symlink_metadata(shadow_island)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "plain source remains symlinked when preserve-symlinks is safe"
+        );
+    }
+
+    #[test]
+    fn materialise_islands_shadow_uses_copy_mode_with_project_node_modules_and_paths() {
+        let tmp = tempdir().unwrap();
+        let project_root = tmp.path();
+        std::fs::create_dir_all(project_root.join("node_modules")).unwrap();
+        std::fs::write(
+            project_root.join("tsconfig.json"),
+            r#"{"compilerOptions":{"baseUrl":".","paths":{"@/*":["src/*"]}}}"#,
+        )
+        .unwrap();
+        let (island_src, glob_src, _target) = write_basic_glob_shadow_project(project_root);
+
+        let (islands, scan_meta) = basic_shadow_inputs(
+            project_root,
+            vec![glob_src.clone()],
+            vec![island_src.clone(), glob_src],
+        );
+        let outcome = materialise_islands_shadow(project_root, &islands, &scan_meta)
+            .expect("shadow materialisation must not IO-error");
+        let shadow = match outcome {
+            IslandsShadowOutcome::Ready(s) => s,
+            IslandsShadowOutcome::KeepStopgap(o) => panic!("supported glob must be ready: {o:?}"),
+        };
+        let shadow_island = shadow
+            .remap
+            .get(&island_src)
+            .expect("island source_path must be remapped into the shadow");
+        let meta = std::fs::symlink_metadata(shadow_island).unwrap();
+        assert!(
+            !shadow.preserve_symlinks,
+            "project node_modules plus tsconfig paths uses copy-mode and omits --preserve-symlinks"
+        );
+        assert!(
+            meta.file_type().is_file() && !meta.file_type().is_symlink(),
+            "plain source is a real copied file in copy-mode"
         );
     }
 


### PR DESCRIPTION
Closes #1429.
Part of #1428.
Supersedes #1413.

## Summary

- exposes `zfb_build::glob_expand::expand_import_meta_glob_with_matches` so the islands shadow can use real matched target paths instead of parsing generated imports;
- adds `zfb_islands::scan_reachable_modules` and uses it to mirror project-local modules reachable from expanded glob targets, including tsconfig-alias imports outside the glob module directory;
- preserves #1412 loudness for raw mirrored target/subtree globs, including parse-error cases;
- mirrors the SSR bundler's symlink/copy-mode split for islands shadow source files: project `node_modules` + tsconfig `paths` copies source files and omits `--preserve-symlinks`, while the normal shadow path keeps symlinked source plus the flag.

## Tests

- `cargo test -p zfb-build glob_expand`
- `cargo test -p zfb-islands scanner`
- `cargo test -p zfb materialise_islands_shadow`
- `cargo fmt --check`
- `git diff --check`

## Notes

Client scripts remain out of scope; unsupported glob forms still keep the existing targeted stopgap.
