### PR TITLE
Fix persist remount pending/deferred edges

### DIFF
--- a/packages/zfb-runtime/docs/client-router/port-spec.md
+++ b/packages/zfb-runtime/docs/client-router/port-spec.md
@@ -383,9 +383,16 @@ For islands specifically (Astro's branch around line 124–132 detects `astro-is
   > The original Astro port set a bare `ssr` attribute here that nothing consumed
   > (zfb islands are marker divs, not `<astro-island>` custom elements) — #1389
   > replaces it with the namespaced `data-zfb-island-remount` flag and wires the
-  > consumer. Two v1 limitations remain for this niche path (tracked as a
-  > follow-up issue): a persisted island still mid-import at swap time, or one with
-  > deferred `data-when`, does not remount seamlessly with fresh props.
+  > consumer.
+  >
+  > **Post-spec update (2026-07, issue #1432):** the niche mid-import/deferred
+  > gaps in that consumer are fixed. If a URL-bundle island is still importing
+  > when the swap refreshes `data-props`, the pending import consumes the flag
+  > after resolution and re-reads the refreshed props before mounting. If an
+  > already-mounted deferred island is flagged for a props-change remount,
+  > `mountNewIslands()` bypasses the deferred scheduler for the replacement mount
+  > so the island is not left blank while waiting for idle/visible/media to fire
+  > again. Ordinary first-time deferred hydration remains deferred.
 
 #### 12.3.2 Boundary table (W3D pins this)
 

--- a/packages/zfb/src/__tests__/runtime.test.ts
+++ b/packages/zfb/src/__tests__/runtime.test.ts
@@ -920,6 +920,128 @@ describe("scheduleHydrate", () => {
         expect(el.hasAttribute("data-zfb-island-remount")).toBe(false);
       });
 
+      it("pending URL remount keeps the flag until import resolves and mounts with refreshed props", async () => {
+        document.body.innerHTML = `
+          <div ${PERSIST}="panel" data-zfb-island="Panel" data-props='{"v":1}' data-when="load"></div>
+        `;
+        const el = document.querySelector(`[${PERSIST}="panel"]`)!;
+        const mount = vi.fn();
+
+        let resolveImport: ((mod: { mount: typeof mount }) => void) | undefined;
+        const importPromise = new Promise<{ mount: typeof mount }>((resolve) => {
+          resolveImport = resolve;
+        });
+        restoreImporter = __setIslandImporterForTests(() => importPromise);
+
+        mountIslands({ Panel: "/islands/panel.js" });
+        expect(mount).not.toHaveBeenCalled();
+
+        // Simulate swapBodyElement refreshing props while the URL import is still pending.
+        el.setAttribute("data-props", '{"v":2}');
+        el.setAttribute("data-zfb-island-remount", "");
+
+        mountNewIslands();
+
+        // The pending import owns the eventual mount, so the flag must not be
+        // consumed before that import can re-read fresh data-props.
+        expect(el.hasAttribute("data-zfb-island-remount")).toBe(true);
+        expect(mount).not.toHaveBeenCalled();
+
+        resolveImport!({ mount });
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(mount).toHaveBeenCalledTimes(1);
+        expect(mount.mock.calls[0]![0]).toEqual({ v: 2 });
+        expect(el.hasAttribute("data-zfb-island-remount")).toBe(false);
+
+        mountNewIslands();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(mount).toHaveBeenCalledTimes(1);
+      });
+
+      it("mounted inline deferred remount bypasses the scheduler and runs synchronously", () => {
+        vi.useFakeTimers();
+        try {
+          vi.stubGlobal("requestIdleCallback", undefined);
+          document.body.innerHTML = `
+            <div ${PERSIST}="panel" data-zfb-island="Panel" data-props='{"v":1}' data-when="idle"></div>
+          `;
+          const el = document.querySelector(`[${PERSIST}="panel"]`)!;
+          const mount = vi.fn();
+          const unmount = vi.fn();
+
+          mountIslands({ Panel: { mount, unmount } });
+          expect(mount).not.toHaveBeenCalled();
+
+          vi.advanceTimersByTime(0);
+          expect(mount).toHaveBeenCalledTimes(1);
+          expect(mount.mock.calls[0]![0]).toEqual({ v: 1 });
+
+          el.setAttribute("data-props", '{"v":2}');
+          el.setAttribute("data-zfb-island-remount", "");
+
+          mountNewIslands();
+
+          // No second timer advance: a persisted props-change remount must not
+          // wait for idle again after the old instance has been unmounted.
+          expect(unmount).toHaveBeenCalledTimes(1);
+          expect(mount).toHaveBeenCalledTimes(2);
+          expect(mount.mock.calls[1]![0]).toEqual({ v: 2 });
+          expect(el.hasAttribute("data-zfb-island-remount")).toBe(false);
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it("mounted URL deferred remount starts immediately instead of waiting for idle again", async () => {
+        vi.useFakeTimers();
+        try {
+          vi.stubGlobal("requestIdleCallback", undefined);
+          document.body.innerHTML = `
+            <div ${PERSIST}="panel" data-zfb-island="Panel" data-props='{"v":1}' data-when="idle"></div>
+          `;
+          const el = document.querySelector(`[${PERSIST}="panel"]`)!;
+          const mount = vi.fn();
+          const unmount = vi.fn();
+          const importer = vi.fn(async () => ({ mount, unmount }));
+          restoreImporter = __setIslandImporterForTests(importer);
+
+          mountIslands({ Panel: "/islands/panel.js" });
+          expect(importer).not.toHaveBeenCalled();
+
+          vi.advanceTimersByTime(0);
+          await Promise.resolve();
+          await Promise.resolve();
+
+          expect(importer).toHaveBeenCalledTimes(1);
+          expect(mount).toHaveBeenCalledTimes(1);
+          expect(mount.mock.calls[0]![0]).toEqual({ v: 1 });
+
+          el.setAttribute("data-props", '{"v":2}');
+          el.setAttribute("data-zfb-island-remount", "");
+
+          mountNewIslands();
+
+          // No second timer advance: the replacement URL import should start
+          // immediately even though the actual mount remains promise-timed.
+          expect(unmount).toHaveBeenCalledTimes(1);
+          expect(importer).toHaveBeenCalledTimes(2);
+
+          await Promise.resolve();
+          await Promise.resolve();
+
+          expect(mount).toHaveBeenCalledTimes(2);
+          expect(mount.mock.calls[1]![0]).toEqual({ v: 2 });
+          expect(el.hasAttribute("data-zfb-island-remount")).toBe(false);
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
       it("mountNewIslands leaves a persisted island with unchanged props (no remount flag) mounted — no unmount, no re-mount", () => {
         document.body.innerHTML = `
           <div ${PERSIST}="chrome" data-zfb-island="Sidebar" data-props='{"open":true}' data-when="load"></div>

--- a/packages/zfb/src/runtime.ts
+++ b/packages/zfb/src/runtime.ts
@@ -416,9 +416,9 @@ export function mountNewIslands(): void {
     // for remount by swap-functions.swapBodyElement. Clear its surviving mounted
     // entry BEFORE scheduleMount's already-mounted guard so it re-mounts fresh
     // with the refreshed data-props. No-op for every other element.
-    clearMountedForRemount(el);
+    const forceRemount = clearMountedForRemount(el);
     warnIfNestedIsland(el, name);
-    scheduleMount(manifest, el, name, "hydrate");
+    scheduleMount(manifest, el, name, "hydrate", { force: forceRemount });
   }
 
   const skipSsrIslands = document.querySelectorAll<HTMLElement>("[data-zfb-island-skip-ssr]");
@@ -440,31 +440,38 @@ export function mountNewIslands(): void {
  * in-memory "needs-remount" queue between the two packages is impossible; the
  * live DOM node carrying the flag IS the queue.
  *
- * On a flagged element: fire the old instance's unmount thunk (so its
+ * On a flagged mounted element: fire the old instance's unmount thunk (so its
  * useEffect/framework cleanups run against the still-connected node), drop the
- * `mounted` entry so `scheduleMount`'s guard no longer short-circuits, and strip
- * the flag so the remount happens exactly once. A no-op for elements without the
- * flag (the common case: fresh markers and props-unchanged persisted islands).
+ * `mounted` entry so `scheduleMount`'s guard no longer short-circuits, strip the
+ * flag, and ask the caller to force the replacement mount through immediately
+ * instead of re-entering any deferred scheduler. This keeps a deferred persisted
+ * island from blanking while it waits for idle/visible/media to fire again.
+ *
+ * On a flagged element whose URL import is still pending, leave the flag in
+ * place. The already-running import's success handler consumes it after the
+ * module resolves and re-reads `data-props` at that point, so a props refresh
+ * that happened during the import wins without starting a duplicate import.
+ *
+ * A no-op for elements without the flag (the common case: fresh markers and
+ * props-unchanged persisted islands).
  *
  * Scope: only the `[data-zfb-island]` (hydrated) loop calls this, mirroring the
  * writer side — swapBodyElement sets the flag only for `newTarget.matches(
- * "[data-zfb-island]")`, never for skip-ssr islands. Known v1 limitations for the
- * niche props-changed hybrid path (tracked as a follow-up): (1) if the island's
- * per-island bundle import is still in `pending` at swap time, the follow-up
- * scheduleMount is blocked by the pending guard and the eventual mount uses the
- * props captured before the swap; (2) a deferred (`data-when` idle/visible/media)
- * island is unmounted synchronously here but re-mounts only when its scheduler
- * next fires, so it can briefly blank. Both require the rare persist-props path
- * plus a deferred/in-flight island; the common `data-when="load"` case is exact.
+ * "[data-zfb-island]")`, never for skip-ssr islands.
  */
-function clearMountedForRemount(el: Element): void {
-  if (!el.hasAttribute(ISLAND_REMOUNT_ATTR)) return;
-  el.removeAttribute(ISLAND_REMOUNT_ATTR);
+function clearMountedForRemount(el: Element): boolean {
+  if (!el.hasAttribute(ISLAND_REMOUNT_ATTR)) return false;
+  if (pending.has(el)) return false;
+
   const thunk = mounted.get(el);
   if (thunk) {
     thunk();
     mounted.delete(el);
+    el.removeAttribute(ISLAND_REMOUNT_ATTR);
+    return true;
   }
+  el.removeAttribute(ISLAND_REMOUNT_ATTR);
+  return false;
 }
 
 /**
@@ -521,6 +528,7 @@ function scheduleMount(
   element: Element,
   componentName: string,
   mode: "hydrate" | "render",
+  options: { force?: boolean } = {},
 ): void {
   // Skip elements already mounted OR currently importing — the latter
   // prevents two concurrent `mountIslands` calls from each firing a
@@ -550,7 +558,7 @@ function scheduleMount(
   //     constructed a mount function for it. Skip the dynamic import
   //     and call the supplied function directly.
   if (typeof entry !== "string") {
-    fireInlineMount(element, entry, mode);
+    fireInlineMount(element, entry, mode, options);
     return;
   }
 
@@ -619,6 +627,9 @@ function scheduleMount(
           pending.delete(element);
           return;
         }
+        const shouldRefreshProps = element.hasAttribute(ISLAND_REMOUNT_ATTR);
+        const propsForMount = shouldRefreshProps ? readProps(element) : props;
+        if (shouldRefreshProps) element.removeAttribute(ISLAND_REMOUNT_ATTR);
         const unmountThunk = mod.unmount
           ? () => mod.unmount!(element)
           : () => {
@@ -626,7 +637,7 @@ function scheduleMount(
             };
         mounted.set(element, unmountThunk);
         pending.delete(element);
-        fn(props, element, mode);
+        fn(propsForMount, element, mode);
       },
       (err: unknown) => {
         // Surface the error in dev so the user notices, then clear
@@ -644,6 +655,11 @@ function scheduleMount(
     // SSR-skip islands ignore data-when: there is nothing to defer
     // hydration of, just an empty container we paint into. Mount
     // immediately so the user sees output.
+    fire();
+    return;
+  }
+
+  if (options.force) {
     fire();
     return;
   }
@@ -667,7 +683,12 @@ function scheduleMount(
  * coordinate around — we just call `mount` / `default` directly,
  * gated by the same `data-when` semantics as the URL path.
  */
-function fireInlineMount(element: Element, mod: IslandModule, mode: "hydrate" | "render"): void {
+function fireInlineMount(
+  element: Element,
+  mod: IslandModule,
+  mode: "hydrate" | "render",
+  options: { force?: boolean } = {},
+): void {
   const fn = mod.mount ?? mod.default;
   if (typeof fn !== "function") {
     if (typeof process !== "undefined" && process.env && process.env["NODE_ENV"] !== "production") {
@@ -702,6 +723,11 @@ function fireInlineMount(element: Element, mod: IslandModule, mode: "hydrate" | 
   };
 
   if (mode === "render") {
+    fire();
+    return;
+  }
+
+  if (options.force) {
     fire();
     return;
   }


### PR DESCRIPTION
Closes #1432.
Part of #1431.
Supersedes #1409.

## Summary

- Keep `data-zfb-island-remount` on pending URL imports until the import resolves, then re-read refreshed `data-props` before mounting.
- Force already-mounted persisted islands with changed props through the replacement mount path without waiting for idle/visible/media again.
- Add regressions for pending URL imports, inline deferred remounts, and URL deferred remounts, and update the client-router port-spec note to describe the fixed behavior.

## Test plan

- `pnpm --filter @takazudo/zfb test`
- `pnpm --filter @takazudo/zfb-runtime test`
- `pnpm --filter @takazudo/zfb typecheck`
