### PR TITLE
Adopt zudo-doc v3.2 in docs

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -28,7 +28,7 @@ All commands run from the **repo root** with the `--filter docs` workspace flag,
 
 ## Key Directories
 
-This site uses **zudo-doc v2 package-owned routes** (`settings.packageOwnedRoutes: true`).
+This site uses **zudo-doc package-owned routes** (`settings.packageOwnedRoutes: true`).
 `@takazudo/zudo-doc/plugins/routes` injects and owns every route — `/docs/[[...slug]]`,
 `/[locale]`, `/[locale]/docs/**`, `/404`, `/sitemap.xml`, `/robots.txt`, tags, versions — and
 renders all page chrome (header/sidebar/TOC/footer) from package defaults, reconstructed from a
@@ -51,7 +51,7 @@ docs/
 ```
 
 The former v1 host-owned route/chrome layer (`pages/lib/**`, `pages/docs/**`, `pages/[locale]/**`,
-`src/components/**`, `src/utils/**`, `src/hooks/**`) was **deleted** when this site adopted v2
+`src/components/**`, `src/utils/**`, `src/hooks/**`) was **deleted** when this site adopted
 package-owned routes — the package now provides all of it. Do not reintroduce those stubs; extend
 via zudo-doc's `hostBindings`/preset seams instead.
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,10 +14,10 @@
     "check:wrangler-pin": "node scripts/check-wrangler-pin.mjs"
   },
   "dependencies": {
-    "@takazudo/zfb": "0.1.0-next.76",
-    "@takazudo/zfb-runtime": "0.1.0-next.76",
-    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.76",
-    "@takazudo/zudo-doc": "^2.5.0",
+    "@takazudo/zfb": "0.1.0-next.78",
+    "@takazudo/zfb-runtime": "0.1.0-next.78",
+    "@takazudo/zfb-adapter-cloudflare": "0.1.0-next.78",
+    "@takazudo/zudo-doc": "^3.2.0",
     "zod": "^4.3.6",
     "preact": "^10.29.1",
     "preact-render-to-string": "^6.6.6",
@@ -26,7 +26,7 @@
     "mermaid": "^11.12.3",
     "katex": "^0.16.38",
     "diff": "^8.0.3",
-    "@takazudo/zudo-doc-history-server": "^2.5.0"
+    "@takazudo/zudo-doc-history-server": "^3.2.0"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.0",

--- a/docs/pages/index.tsx
+++ b/docs/pages/index.tsx
@@ -2,7 +2,7 @@
 /** @jsxImportSource preact */
 // Default-locale (EN) site index — the ONE route the package does not inject.
 //
-// zudo-doc v2 (packageOwnedRoutes) injects /[locale] but not the root "/", so
+// zudo-doc packageOwnedRoutes injects /[locale] but not the root "/", so
 // the host must own this page. We use the package's default home verbatim: it
 // rebuilds the same hero (logo, siteName, description, SiteTreeNav grid, tags)
 // from `settings` via the virtual:zudo-doc-route-context payload the routes

--- a/docs/src/config/color-scheme-utils.ts
+++ b/docs/src/config/color-scheme-utils.ts
@@ -1,0 +1,56 @@
+export {
+  STATE_ROLES,
+  SEMANTIC_CSS_NAMES,
+  SEMANTIC_KEYS,
+  SEMANTIC_RAMP_DEFAULTS,
+  generateCssCustomProperties as generateCssCustomPropertiesFromScheme,
+  generateLightDarkCssProperties as generateLightDarkCssPropertiesFromSchemes,
+  resolveRampRef,
+  resolveSemanticColors,
+  schemeToCssPairs,
+  type ColorScheme,
+  type CssEmitScope,
+  type ModeMap,
+  type OKLCH,
+  type RampRef,
+  type Ramps,
+  type SemanticKey,
+  type StateRole,
+} from "@takazudo/zudo-doc/color-scheme-utils";
+import {
+  generateCssCustomProperties as _generateCssCustomProperties,
+  generateLightDarkCssProperties as _generateLightDarkCssProperties,
+} from "@takazudo/zudo-doc/color-scheme-utils";
+
+import { colorSchemes } from "./color-schemes";
+import { settings } from "./settings";
+
+export const lightDarkPairings = [
+  { light: "Default Light", dark: "Default Dark", label: "Default" },
+];
+
+export function getActiveScheme() {
+  const scheme = colorSchemes[settings.colorScheme];
+  if (!scheme) {
+    throw new Error(
+      `Unknown color scheme: "${settings.colorScheme}". Available: ${Object.keys(colorSchemes).join(", ")}`,
+    );
+  }
+  return scheme;
+}
+
+export function generateCssCustomProperties(): string {
+  return _generateCssCustomProperties(getActiveScheme());
+}
+
+export function generateLightDarkCssProperties(): string {
+  if (!settings.colorMode) {
+    throw new Error("colorMode is not configured");
+  }
+  const { lightScheme, darkScheme } = settings.colorMode;
+  const light = colorSchemes[lightScheme];
+  const dark = colorSchemes[darkScheme];
+  if (!light) throw new Error(`Unknown light scheme: "${lightScheme}"`);
+  if (!dark) throw new Error(`Unknown dark scheme: "${darkScheme}"`);
+  return _generateLightDarkCssProperties(light, dark);
+}

--- a/docs/src/config/color-schemes.ts
+++ b/docs/src/config/color-schemes.ts
@@ -1,173 +1,97 @@
-/** A color reference: palette index (number) or direct color value (string) */
-export type ColorRef = number | string;
-
-export interface ColorScheme {
-  background: ColorRef;
-  foreground: ColorRef;
-  cursor: ColorRef;
-  selectionBg: ColorRef;
-  selectionFg: ColorRef;
-  palette: [
-    string,
-    string,
-    string,
-    string,
-    string,
-    string,
-    string,
-    string,
-    string,
-    string,
-    string,
-    string,
-    string,
-    string,
-    string,
-    string,
-  ];
-  /** Optional, vestigial. Carried only in the optional color-scheme config
-   *  envelope consumed by the design token panel tooling (falls back to
-   *  DEFAULT_SHIKI_THEME when omitted), but has no visible effect: that
-   *  tooling's Shiki integration is a no-op stub, and page code highlighting is
-   *  done by syntect (dual-theme, configured via `codeHighlight` in
-   *  zfb.config.ts), not Shiki. */
-  shikiTheme?: string;
-  /** Optional semantic overrides — when omitted, defaults are used:
-   *  surface=p0, muted=p8, accent=p5, accentHover=p14
-   *  codeBg=p10, codeFg=p11, success=p2, danger=p1, warning=p3, info=p4
-   *  Each field accepts a palette index (number) or a direct color value (string). */
-  semantic?: {
-    surface?: ColorRef;
-    muted?: ColorRef;
-    accent?: ColorRef;
-    accentHover?: ColorRef;
-    codeBg?: ColorRef;
-    codeFg?: ColorRef;
-    success?: ColorRef;
-    danger?: ColorRef;
-    warning?: ColorRef;
-    info?: ColorRef;
-    mermaidNodeBg?: ColorRef;
-    mermaidText?: ColorRef;
-    mermaidLine?: ColorRef;
-    mermaidLabelBg?: ColorRef;
-    mermaidNoteBg?: ColorRef;
-    chatUserBg?: ColorRef;
-    chatUserText?: ColorRef;
-    chatAssistantBg?: ColorRef;
-    chatAssistantText?: ColorRef;
-    /** UI chrome over user images — enlarge/close overlay buttons */
-    imageOverlayBg?: ColorRef;
-    imageOverlayFg?: ColorRef;
-    /** <mark> highlight for matched keywords in search results */
-    matchedKeywordBg?: ColorRef;
-    matchedKeywordFg?: ColorRef;
-  };
-}
-
 /**
- * Standard palette index convention (all schemes should follow this):
+ * Ramp-native color schemes (zudo-doc v3).
  *
- * | Index | Role              | Description                              |
- * |-------|-------------------|------------------------------------------|
- * | p0    | Dark surface      | Deepest surface (code blocks, mermaid)   |
- * | p1    | Danger            | Red family — errors, destructive actions  |
- * | p2    | Success           | Green family — confirmations, tips        |
- * | p3    | Warning           | Yellow/amber — caution messages           |
- * | p4    | Info              | Blue family — informational highlights    |
- * | p5    | Accent            | Primary interactive color (links, CTA)    |
- * | p6    | Neutral           | Slate/cyan — borders, secondary elements  |
- * | p7    | Secondary neutral | Gray or muted accent                      |
- * | p8    | Muted             | Gray — borders, secondary text, comments  |
- * | p9    | Background        | Page background                           |
- * | p10   | Surface           | Elevated surface (panels, sidebars)       |
- * | p11   | Text primary      | Main body text                            |
- * | p12   | Accent variant    | Brighter or alternate accent              |
- * | p13   | Decorative        | Purple/lavender — non-semantic decoration  |
- * | p14   | Accent hover      | Hover state for interactive elements      |
- * | p15   | Text secondary    | Secondary text or muted foreground         |
+ * A `ColorScheme` is `{ ramps, map }`:
+ *   - `ramps` is the shared Tier-1 source of truth.
+ *   - `map` is the per-mode wiring from UI roles to ramp stops.
  */
+
+import type { ColorScheme, ModeMap, Ramps } from "./color-scheme-utils";
+
+export type { ColorScheme } from "./color-scheme-utils";
+
+const ramps: Ramps = {
+  base: [
+    "oklch(.965 .004 65)",
+    "oklch(.705 .008 65)",
+    "oklch(.480 .008 65)",
+    "oklch(.300 .006 65)",
+    "oklch(.185 .005 65)",
+  ],
+  accent: ["oklch(.755 .130 64)", "oklch(.700 .158 62)", "oklch(.470 .120 56)"],
+  state: {
+    danger: "oklch(.640 .170 25)",
+    success: "oklch(.680 .145 145)",
+    warning: "oklch(.760 .135 82)",
+    info: "oklch(.680 .130 245)",
+  },
+};
+
+const darkMap: ModeMap = {
+  bg: { base: 4 },
+  fg: { base: 0 },
+  selectionBg: { base: 2 },
+  selectionFg: { base: 0 },
+  semantic: {
+    surface: { base: 4 },
+    muted: { base: 1 },
+    accent: { accent: 1 },
+    accentHover: { accent: 0 },
+    codeBg: { base: 3 },
+    codeFg: { base: 0 },
+    success: { state: "success" },
+    danger: "oklch(.655 .170 25)",
+    warning: { state: "warning" },
+    info: { state: "info" },
+    mermaidNodeBg: { base: 3 },
+    mermaidText: { base: 0 },
+    mermaidLine: { base: 1 },
+    mermaidLabelBg: { base: 3 },
+    mermaidNoteBg: { base: 2 },
+    chatUserBg: { accent: 1 },
+    chatUserText: { base: 4 },
+    chatAssistantBg: { base: 4 },
+    chatAssistantText: { base: 0 },
+    imageOverlayBg: { base: 4 },
+    imageOverlayFg: { base: 0 },
+    matchedKeywordBg: "oklch(.700 .158 62)",
+    matchedKeywordFg: "oklch(.300 .003 65)",
+  },
+};
+
+const lightMap: ModeMap = {
+  bg: { base: 0 },
+  fg: { base: 4 },
+  selectionBg: { base: 1 },
+  selectionFg: { base: 4 },
+  semantic: {
+    surface: { base: 0 },
+    muted: { base: 2 },
+    accent: { accent: 2 },
+    accentHover: "oklch(.400 .096 56)",
+    codeBg: { base: 0 },
+    codeFg: { base: 4 },
+    success: "oklch(.470 .140 145)",
+    danger: "oklch(.505 .170 25)",
+    warning: "oklch(.490 .100 82)",
+    info: "oklch(.485 .122 245)",
+    mermaidNodeBg: { base: 1 },
+    mermaidText: { base: 4 },
+    mermaidLine: { base: 2 },
+    mermaidLabelBg: { base: 1 },
+    mermaidNoteBg: { base: 1 },
+    chatUserBg: { accent: 1 },
+    chatUserText: { base: 4 },
+    chatAssistantBg: { base: 0 },
+    chatAssistantText: { base: 4 },
+    imageOverlayBg: { base: 4 },
+    imageOverlayFg: { base: 0 },
+    matchedKeywordBg: "oklch(.700 .158 62)",
+    matchedKeywordFg: "oklch(.300 .003 65)",
+  },
+};
+
 export const colorSchemes: Record<string, ColorScheme> = {
-  "Default Light": {
-    background: 9,
-    foreground: 11,
-    cursor: 6,
-    selectionBg: 11,
-    selectionFg: 10,
-    palette: [
-      "#303030",
-      "#a01515",
-      "#1f5429",
-      "#903030", // p0-3: dark surface, danger, success, warning — darkened for WCAG AA (#2298)
-      "#174fa0",
-      "#7d470b",
-      "#90a1b9",
-      "#7a5218", // p4-7: info, accent, neutral, secondary — darkened for WCAG AA (#2298)
-      "#6b6b6b",
-      "#e2ddda",
-      "#ece9e9",
-      "#303030", // p8-11: muted, background, surface, text
-      "#5b99dc",
-      "#b89ee7",
-      "#8590a0",
-      "#654516", // p12-15: accent variant, decorative, hover, muted foreground
-    ],
-    semantic: {
-      surface: 10,
-      muted: 8,
-      accent: 5,
-      accentHover: 14,
-      codeBg: 10,
-      codeFg: 11,
-      success: 2,
-      danger: 1,
-      warning: 3,
-      info: 4,
-      imageOverlayBg: 11,
-      imageOverlayFg: 10,
-      matchedKeywordBg: "#fff59d",
-      matchedKeywordFg: "#000000",
-    },
-  },
-  "Default Dark": {
-    background: 9,
-    foreground: 15,
-    cursor: 6,
-    selectionBg: 10,
-    selectionFg: 11,
-    palette: [
-      "#1c1c1c",
-      "#da6871",
-      "#93bb77",
-      "#dfbb77", // p0-3: dark surface, danger, success, warning
-      "#5caae9",
-      "#c074d6",
-      "#90a1b9",
-      "#a0a0a0", // p4-7: info, accent, neutral, secondary
-      "#888888",
-      "#181818",
-      "#383838",
-      "#e0e0e0", // p8-11: muted, background, surface, text
-      "#d69a66",
-      "#c074d6",
-      "#a7c0e3",
-      "#b8b8b8", // p12-15: accent variant, decorative, hover, text secondary
-    ],
-    semantic: {
-      surface: 0,
-      muted: 8,
-      accent: 12,
-      accentHover: 14,
-      codeBg: 10,
-      codeFg: 11,
-      success: 2,
-      danger: 1,
-      warning: 3,
-      info: 4,
-      imageOverlayBg: 0,
-      imageOverlayFg: 11,
-      matchedKeywordBg: "#fff59d",
-      matchedKeywordFg: "#000000",
-    },
-  },
+  "Default Light": { ramps, map: lightMap },
+  "Default Dark": { ramps, map: darkMap },
 };

--- a/docs/src/config/settings-types.ts
+++ b/docs/src/config/settings-types.ts
@@ -26,6 +26,8 @@ export type {
   FrontmatterPreviewConfig,
   TagPlacement,
   VersionConfig,
+  ChangelogConfig,
   MetaTagsConfig,
+  SiteHeadConfig,
   Settings,
 } from "@takazudo/zudo-doc/settings";

--- a/docs/src/config/settings.ts
+++ b/docs/src/config/settings.ts
@@ -43,6 +43,7 @@ export const settings = {
     "The Rust engine under your content-site framework — router, renderer, content pipeline. Author in TypeScript/JSX, runs as a single binary." as string,
   base: "/",
   trailingSlash: false as boolean,
+  minifyHtml: true as boolean,
   noindex: false as boolean,
   editUrl: false as string | false,
   githubUrl: "https://github.com/Takazudo/zudo-front-builder" as string | false,

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -68,18 +68,10 @@
  * Tight token strategy: import preflight + utilities only (no default theme).
  * Only project-specific tokens are available.
  *
- * Raw palette: --zd-0 to --zd-15 + bg/fg/sel (injected by ColorSchemeProvider)
+ * Base roles: --zd-bg/--zd-fg/--zd-selection-bg/--zd-selection-fg + ramps
+ * (--palette-base-0..4 / --palette-accent-0..2 / --palette-state-*) +
+ * 23 --zd-{role} semantic tokens, all injected by ColorSchemeProvider.
  * Tailwind tokens: registered below via @theme
- *
- * Palette slots:
- *   0/8:  black / bright-black (surfaces, muted text, borders)
- *   1/9:  red / bright-red
- *   2/10: green / bright-green
- *   3/11: yellow / bright-yellow
- *   4/12: blue / bright-blue
- *   5/13: magenta / bright-magenta
- *   6/14: cyan / bright-cyan
- *   7/15: white / bright-white
  * ======================================== */
 
 @theme {
@@ -104,26 +96,8 @@
   /* ── Base ── */
   --color-bg: var(--zd-bg);
   --color-fg: var(--zd-fg);
-  --color-sel-bg: var(--zd-sel-bg);
-  --color-sel-fg: var(--zd-sel-fg);
-
-  /* ── Raw palette (p0–p15) ── */
-  --color-p0: var(--zd-0);
-  --color-p1: var(--zd-1);
-  --color-p2: var(--zd-2);
-  --color-p3: var(--zd-3);
-  --color-p4: var(--zd-4);
-  --color-p5: var(--zd-5);
-  --color-p6: var(--zd-6);
-  --color-p7: var(--zd-7);
-  --color-p8: var(--zd-8);
-  --color-p9: var(--zd-9);
-  --color-p10: var(--zd-10);
-  --color-p11: var(--zd-11);
-  --color-p12: var(--zd-12);
-  --color-p13: var(--zd-13);
-  --color-p14: var(--zd-14);
-  --color-p15: var(--zd-15);
+  --color-sel-bg: var(--zd-selection-bg);
+  --color-sel-fg: var(--zd-selection-fg);
 
   /* ── Semantic aliases ── */
   --color-surface: var(--zd-surface);
@@ -138,12 +112,17 @@
   --color-info: var(--zd-info);
   /* Overlay is intentionally theme-independent (always dark, not scheme-driven) */
   --color-overlay: #000;
+  --color-page-loading-overlay: color-mix(in oklch, var(--color-overlay) 60%, transparent);
   --color-image-overlay-bg: var(--zd-image-overlay-bg);
   --color-image-overlay-fg: var(--zd-image-overlay-fg);
   /* --color-mermaid-* aliases removed: mermaid-init-script reads --zd-mermaid-* directly;
-     these @theme registrations were unused (no Tailwind utility references). Under zudo-doc
-     v2 package-owned routes, --zd-* (incl. --zd-mermaid-*) are injected by the package
-     HeadWithDefaults from the `colorSchemes` passed to zudoDocPreset. */
+     these @theme registrations were unused (no Tailwind utility references). Under package-owned
+     routes, --zd-* (incl. --zd-mermaid-*) are injected by the package HeadWithDefaults from the
+     `colorSchemes` passed to zudoDocPreset. */
+  --color-chat-user-bg: var(--zd-chat-user-bg);
+  --color-chat-user-text: var(--zd-chat-user-text);
+  --color-chat-assistant-bg: var(--zd-chat-assistant-bg);
+  --color-chat-assistant-text: var(--zd-chat-assistant-text);
   --color-matched-keyword-bg: var(--zd-matched-keyword-bg);
   --color-matched-keyword-fg: var(--zd-matched-keyword-fg);
 

--- a/docs/zfb.config.ts
+++ b/docs/zfb.config.ts
@@ -6,7 +6,7 @@ import { translations } from "./src/config/i18n";
 import { colorSchemes } from "./src/config/color-schemes";
 
 // The canonical seven directives for this showcase. Keys are directive names;
-// values are the JSX component names — under zudo-doc v2 package-owned routes,
+// values are the JSX component names — under zudo-doc package-owned routes,
 // these all resolve to package-provided mdx-components (deriveMdxComponents),
 // so the host no longer registers them. "details" is a collapsible, NOT an
 // admonition.
@@ -25,7 +25,7 @@ export default defineConfig({
   tailwind: { enabled: true },
   base: settings.base,
   adapter: "@takazudo/zfb-adapter-cloudflare",
-  // translations + colorSchemes are consumed by zudo-doc v2's package-owned
+  // translations + colorSchemes are consumed by zudo-doc package-owned
   // routes (packageOwnedRoutes) so /404 etc. inherit host i18n/theme; optional
   // in v1, required-in-practice once packageOwnedRoutes is on (zudo-doc #2404).
   ...zudoDocPreset({ settings, buildDocsSchema, directiveVocabulary, translations, colorSchemes }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,20 +44,20 @@ importers:
   docs:
     dependencies:
       '@takazudo/zfb':
-        specifier: 0.1.0-next.76
-        version: 0.1.0-next.76(react@19.2.6)
+        specifier: 0.1.0-next.78
+        version: 0.1.0-next.78(react@19.2.6)
       '@takazudo/zfb-adapter-cloudflare':
-        specifier: 0.1.0-next.76
-        version: 0.1.0-next.76
+        specifier: 0.1.0-next.78
+        version: 0.1.0-next.78
       '@takazudo/zfb-runtime':
-        specifier: 0.1.0-next.76
-        version: 0.1.0-next.76(@takazudo/zfb@0.1.0-next.76(react@19.2.6))(react@19.2.6)
+        specifier: 0.1.0-next.78
+        version: 0.1.0-next.78(@takazudo/zfb@0.1.0-next.78(react@19.2.6))(react@19.2.6)
       '@takazudo/zudo-doc':
-        specifier: ^2.5.0
-        version: 2.5.0(@takazudo/zfb-runtime@0.1.0-next.76(@takazudo/zfb@0.1.0-next.76(react@19.2.6))(react@19.2.6))(@takazudo/zfb@0.1.0-next.76(react@19.2.6))(@takazudo/zudo-doc-history-server@2.5.0)(diff@8.0.4)(katex@0.16.45)(preact@10.29.1)(shiki@4.2.0)(zod@4.4.3)
+        specifier: ^3.2.0
+        version: 3.2.0(@takazudo/zfb-runtime@0.1.0-next.78(@takazudo/zfb@0.1.0-next.78(react@19.2.6))(react@19.2.6))(@takazudo/zfb@0.1.0-next.78(react@19.2.6))(@takazudo/zudo-doc-history-server@3.2.0)(diff@8.0.4)(katex@0.16.45)(preact@10.29.1)(shiki@4.2.0)(zod@4.4.3)
       '@takazudo/zudo-doc-history-server':
-        specifier: ^2.5.0
-        version: 2.5.0
+        specifier: ^3.2.0
+        version: 3.2.0
       diff:
         specifier: ^8.0.3
         version: 8.0.4
@@ -1229,48 +1229,48 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.76':
-    resolution: {integrity: sha512-hcBbG23lismCVW9Caq4xfCKc3lVIAVvcs5N6ZdMlZRXELPt5GceQycAQ+Dc4CkSC+Sdvi4lt7rjzaTYMKjd95g==}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.78':
+    resolution: {integrity: sha512-g9KyrzOEN0NTmJi7GqR9Q6mal1O4H5ja+2JhKKHzk2CiGwUBAuNNzH0pJvfwcc15K0wm6aIC2VcUx5iRUzhMjQ==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.76':
-    resolution: {integrity: sha512-fy7Ff0LGmPbpnLeZcTAzY3X4Hup4YkGYxboVMw7bKWq7AZr6DJ25rKSfGcGSOdQnPdrdFIXMoPkR/G3WBfWZdQ==}
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.78':
+    resolution: {integrity: sha512-F1VsKrilKgF0qEAtO7JQyi5PO50jGHep3UGzPKFfrSDlMzbfh6hiKeNp0SMekeKE0tuTfIXVDZqFLP06nGVf6Q==}
     cpu: [arm64]
     os: [darwin]
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.76':
-    resolution: {integrity: sha512-fq1KTz9WmPqTsRD/86iyKsvjaZVwO8NlhNcPxinKyFm8Z/QdD4U/mpPQuc57nV7Aor7zRfAVAK8EWgdngUCuSA==}
+  '@takazudo/zfb-darwin-x64@0.1.0-next.78':
+    resolution: {integrity: sha512-JtE4CfUY6gqdzMiuP6q4JuFW0GVVqqjL1vFjY/uFVroelTmwiSgjSAyeI6G+kUnhJDbG8F2m0eGjd9mEh5rAlQ==}
     cpu: [x64]
     os: [darwin]
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.76':
-    resolution: {integrity: sha512-ZO2TAHXL18cGpQohFuje4oXjOC9CieJeDH93nMJyhphxI9lBy+AuyvfDeI1GTxOClRpH8pUqCluqvZsQRXuUHw==}
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.78':
+    resolution: {integrity: sha512-YgVgdBYk1/LgsmhJIHqlPeTItV10BkooVnbs3UTmPYvKMu8vrOsrfqLcw60tF5dx6hZxXtWX+a2Jv6dCc/F28g==}
     cpu: [arm64]
     os: [linux]
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.76':
-    resolution: {integrity: sha512-P1O6b+edKagWCaTSGl56KD20WRpN9AKnVzDvIYpgHiKK4DYWUQzqbPcQ/4LJIppXgseaZNNfFr9IomHFX17ubQ==}
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.78':
+    resolution: {integrity: sha512-JS4vJBunnc5s9LSghl55Pvs/nDToFnPVmOMbOS6Mgq/8T1dEsoDe0wP8288xxXTv8RbxJk2YJ0eg9JLxxeATMQ==}
     cpu: [x64]
     os: [linux]
 
-  '@takazudo/zfb-runtime@0.1.0-next.76':
-    resolution: {integrity: sha512-k/3fsAjMNKucLO+kamspKB/W/x//9y/yJSuAZd52gnZdHWK2wMDxhu5akLjF5m2KpypvEBiYD6Wh3QmPVNw7lw==}
+  '@takazudo/zfb-runtime@0.1.0-next.78':
+    resolution: {integrity: sha512-YG8py9ce0dfpCzv5rinUYFCUVeZalpyaaL53aSo1diQASEbT7Wh3gOEdHdF6+1fB8UHlukQlBaVdW7Z9pQ+iTA==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     peerDependencies:
-      '@takazudo/zfb': 0.1.0-next.76
+      '@takazudo/zfb': 0.1.0-next.78
       react: ^19.2.3
     peerDependenciesMeta:
       react:
         optional: true
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.76':
-    resolution: {integrity: sha512-qFwwExYsfYbrX0mr6lcCLnqQy10Vzogp9OGkEnJE65QI81OuiwO4XqdhlSuGZzqxsQ/G7DkgR0x4GcMvE8nfUw==}
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.78':
+    resolution: {integrity: sha512-yy2lD2eRMQQ7g23JJYBPacCyqBvjyWGhwb/sndCXlixUBVI1rga3ZA7MbVNfAuOGmN0Ak3BCFAeM3TCKBILuHg==}
     cpu: [x64]
     os: [win32]
 
-  '@takazudo/zfb@0.1.0-next.76':
-    resolution: {integrity: sha512-4k1Z0GPSuDIJw9pKzpJWVeLVKrUIOW2eTGA4/M/URj1zkBwo8KRtRFQ2jldBCjvdWkiz3nJK0MUNjwZJgq8bSA==}
+  '@takazudo/zfb@0.1.0-next.78':
+    resolution: {integrity: sha512-wwY1sLCKZznq/aNidOO0oYbw5f/gy+jRVqC5ntbTH2CdVl9EdjnuRBCuEAb2qSUHYOKaeYUDbevUMmqP5E5Zyw==}
     engines: {node: '>=22.0.0', pnpm: '>=10.0.0'}
     hasBin: true
     peerDependencies:
@@ -1279,18 +1279,18 @@ packages:
       react:
         optional: true
 
-  '@takazudo/zudo-doc-history-server@2.5.0':
-    resolution: {integrity: sha512-GgOxoE7wmJCQL63ogmtm81hOMjsf/dbaifoC/4Ps8zSoBL5lBMgYB2Ua++FuAa6TvOysUApDimggrbeHX2McYw==}
+  '@takazudo/zudo-doc-history-server@3.2.0':
+    resolution: {integrity: sha512-+B45OfwxrZbcHU0GkZq9v1AiB3CsP2U520eOqveqYZsOJBqi1ZSFKGdepe84/TMfA2zes/JvBIRSYzvrxwnNKA==}
     hasBin: true
 
-  '@takazudo/zudo-doc@2.5.0':
-    resolution: {integrity: sha512-gvefYyfRx0indPdOj3tAuTastBS0ZOXhIFAha8mYBqyYqxHmGtAlZX60hXqKTNhKag1z8833LYctwO87H4yICA==}
+  '@takazudo/zudo-doc@3.2.0':
+    resolution: {integrity: sha512-r6Nk98/cURHvUZ4p5WLdtIdpgdeCXRJJPajeYbQ4NyhS0DmWWFDj6i+b3gkBzUdYKZnvlFkiFjPg0JvCG/oztA==}
     hasBin: true
     peerDependencies:
-      '@takazudo/zdtp': ^0.4.2
-      '@takazudo/zfb': ^0.1.0-next.76
-      '@takazudo/zfb-runtime': ^0.1.0-next.76
-      '@takazudo/zudo-doc-history-server': ^2.2.1
+      '@takazudo/zdtp': ^0.4.5
+      '@takazudo/zfb': ^0.1.0-next.78
+      '@takazudo/zfb-runtime': ^0.1.0-next.78
+      '@takazudo/zudo-doc-history-server': ^3.1.0
       diff: ^8.0.0
       katex: ^0.16.0
       preact: ^10.29.1
@@ -3150,45 +3150,45 @@ snapshots:
       tailwindcss: 4.2.4
       vite: 7.3.5(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)
 
-  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.76': {}
+  '@takazudo/zfb-adapter-cloudflare@0.1.0-next.78': {}
 
-  '@takazudo/zfb-darwin-arm64@0.1.0-next.76':
+  '@takazudo/zfb-darwin-arm64@0.1.0-next.78':
     optional: true
 
-  '@takazudo/zfb-darwin-x64@0.1.0-next.76':
+  '@takazudo/zfb-darwin-x64@0.1.0-next.78':
     optional: true
 
-  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.76':
+  '@takazudo/zfb-linux-arm64-gnu@0.1.0-next.78':
     optional: true
 
-  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.76':
+  '@takazudo/zfb-linux-x64-gnu@0.1.0-next.78':
     optional: true
 
-  '@takazudo/zfb-runtime@0.1.0-next.76(@takazudo/zfb@0.1.0-next.76(react@19.2.6))(react@19.2.6)':
+  '@takazudo/zfb-runtime@0.1.0-next.78(@takazudo/zfb@0.1.0-next.78(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.76(react@19.2.6)
+      '@takazudo/zfb': 0.1.0-next.78(react@19.2.6)
       hono: 4.12.25
     optionalDependencies:
       react: 19.2.6
 
-  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.76':
+  '@takazudo/zfb-win32-x64-msvc@0.1.0-next.78':
     optional: true
 
-  '@takazudo/zfb@0.1.0-next.76(react@19.2.6)':
+  '@takazudo/zfb@0.1.0-next.78(react@19.2.6)':
     optionalDependencies:
-      '@takazudo/zfb-darwin-arm64': 0.1.0-next.76
-      '@takazudo/zfb-darwin-x64': 0.1.0-next.76
-      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.76
-      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.76
-      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.76
+      '@takazudo/zfb-darwin-arm64': 0.1.0-next.78
+      '@takazudo/zfb-darwin-x64': 0.1.0-next.78
+      '@takazudo/zfb-linux-arm64-gnu': 0.1.0-next.78
+      '@takazudo/zfb-linux-x64-gnu': 0.1.0-next.78
+      '@takazudo/zfb-win32-x64-msvc': 0.1.0-next.78
       react: 19.2.6
 
-  '@takazudo/zudo-doc-history-server@2.5.0': {}
+  '@takazudo/zudo-doc-history-server@3.2.0': {}
 
-  '@takazudo/zudo-doc@2.5.0(@takazudo/zfb-runtime@0.1.0-next.76(@takazudo/zfb@0.1.0-next.76(react@19.2.6))(react@19.2.6))(@takazudo/zfb@0.1.0-next.76(react@19.2.6))(@takazudo/zudo-doc-history-server@2.5.0)(diff@8.0.4)(katex@0.16.45)(preact@10.29.1)(shiki@4.2.0)(zod@4.4.3)':
+  '@takazudo/zudo-doc@3.2.0(@takazudo/zfb-runtime@0.1.0-next.78(@takazudo/zfb@0.1.0-next.78(react@19.2.6))(react@19.2.6))(@takazudo/zfb@0.1.0-next.78(react@19.2.6))(@takazudo/zudo-doc-history-server@3.2.0)(diff@8.0.4)(katex@0.16.45)(preact@10.29.1)(shiki@4.2.0)(zod@4.4.3)':
     dependencies:
-      '@takazudo/zfb': 0.1.0-next.76(react@19.2.6)
-      '@takazudo/zfb-runtime': 0.1.0-next.76(@takazudo/zfb@0.1.0-next.76(react@19.2.6))(react@19.2.6)
+      '@takazudo/zfb': 0.1.0-next.78(react@19.2.6)
+      '@takazudo/zfb-runtime': 0.1.0-next.78(@takazudo/zfb@0.1.0-next.78(react@19.2.6))(react@19.2.6)
       fs-extra: 11.3.5
       gray-matter: 4.0.3
       minimist: 1.2.8
@@ -3196,7 +3196,7 @@ snapshots:
       preact: 10.29.1
       zod: 4.4.3
     optionalDependencies:
-      '@takazudo/zudo-doc-history-server': 2.5.0
+      '@takazudo/zudo-doc-history-server': 3.2.0
       diff: 8.0.4
       katex: 0.16.45
       shiki: 4.2.0


### PR DESCRIPTION
Closes #1445.
Part of #1444.

## Summary

- Bumped the docs app from `@takazudo/zudo-doc` `^2.5.0` to `^3.2.0`, `@takazudo/zudo-doc-history-server` to `^3.2.0`, and the peer-coupled zfb docs packages to `0.1.0-next.78` using `/dev-bump-zudo-deps`.
- Ported docs color schemes to zudo-doc v3's ramp-native `{ ramps, map }` model and added the local `color-scheme-utils` helper/re-export used by v3 generated projects.
- Updated docs CSS tokens for the v3 package contract: selection variables, page-loading overlay, chat aliases, and removal of legacy `--zd-0..15` / `--color-p0..p15` assumptions.
- Aligned settings/type forwarding with v3 (`minifyHtml`, `ChangelogConfig`, `SiteHeadConfig`) and removed stale current-integration `v2` wording.

## Verification

- `pnpm install`
- `pnpm docs:check`
- `pnpm docs:build`
- `pnpm --filter docs check:html`
- `rg -- '--zd-[0-9]|--color-p' docs/src` (only valid `--color-page-loading-overlay` matched)
- `rg -- '--zd-[0-9]|--color-p[0-9]' docs/src` (no legacy numeric palette matches)
- Browser smoke against `docs/dist` on `/`, `/docs/getting-started/`, and `/ja/docs/getting-started/`: all 200, non-empty content, no page/console errors, and resolved `--zd-selection-bg`, `--color-chat-user-bg`, `--color-page-loading-overlay`.

## Notes

- `@takazudo/zdtp` remains absent because it is an optional peer and `settings.designTokenPanel` is still `false`.
- The docs now use the zudo-doc v3 reference ramp palette; this is intentional for following the latest implementation shape.
