### PR TITLE
Docs audit: markdown features

### DIFF
--- a/docs/src/content/docs/markdown-features/cjk-friendly.mdx
+++ b/docs/src/content/docs/markdown-features/cjk-friendly.mdx
@@ -5,7 +5,10 @@ tier: Core
 sidebar_position: 50
 ---
 
-`CjkFriendlyPlugin` is always active. It post-processes the parsed markdown AST and re-tokenises emphasis flanking rules for CJK content.
+`CjkFriendlyPlugin` is on by default. It post-processes the parsed markdown
+AST and re-tokenises emphasis flanking rules for CJK content. The same
+`cjkFriendly` gate also controls `CjkAutolinkBoundaryPlugin`, which prevents
+GFM bare URL autolinks from swallowing adjacent CJK text.
 
 ## Why this exists
 
@@ -18,12 +21,19 @@ parser, and renders as literal stars instead of `<strong>`.
 re-tokenises these cases. The result matches the intuitive expectation for
 Japanese, Chinese, and Korean content sites.
 
+GFM autolink literals have a related boundary problem: a URL written flush
+against CJK text, such as `詳細はhttps://example.com参照`, can treat the trailing
+CJK run as part of the link. When `cjkFriendly` is enabled and
+`gfm.autolinkLiteral` is on, `CjkAutolinkBoundaryPlugin` splits the autolink
+at the first adjacent CJK character.
+
 ## Behaviour
 
 **Default:** always on. No configuration key required.
 
 **Opt-out** (rare): set `cjkFriendly: false` in `zfb.config.ts` only when
-you need strict CommonMark output and your content has no CJK emphasis:
+you need strict CommonMark/GFM output and your content has no CJK emphasis
+or bare-URL boundary cases:
 
 ```ts title="zfb.config.ts"
 import { defineConfig } from "zfb/config";
@@ -37,7 +47,12 @@ export default defineConfig({
 
 ## Scope
 
-This plugin handles `**bold**` and `_italic_` adjacent to CJK characters.
+This option handles:
+
+- `**bold**` and `_italic_` adjacent to CJK characters.
+- GFM bare URL autolink boundaries adjacent to CJK characters, when
+  `gfm.autolinkLiteral` is enabled.
+
 GFM strikethrough (`~~foo~~`) does not need the toggle — markdown-rs's GFM
 tokeniser handles `~~` delimiter runs independently, so strikethrough works
 correctly at CJK boundaries in both modes.

--- a/docs/src/content/docs/markdown-features/code-title.mdx
+++ b/docs/src/content/docs/markdown-features/code-title.mdx
@@ -1,13 +1,13 @@
 ---
 title: Code block title
-description: Renders a visible filename or label above a fenced code block from the title= meta attribute.
+description: Wraps a titled fenced code block in a code-block container with a visible filename or label.
 tier: Core
 sidebar_position: 52
 ---
 
 `CodeTitlePlugin` is always active. It reads the `title="…"` token from a
-fenced code block's info string and renders a `<div class="code-title">`
-label immediately above the block.
+fenced code block's info string and wraps the rendered block in a
+`.code-block-container` with a `.code-block-title` followed by the `<pre>`.
 
 ## Usage
 
@@ -24,8 +24,10 @@ export default defineConfig({
 Rendered output:
 
 ```html
-<div class="code-title">zfb.config.ts</div>
-<pre class="syntect-…"><code>…</code></pre>
+<div class="code-block-container">
+  <div class="code-block-title">zfb.config.ts</div>
+  <pre class="syntect-…"><code>…</code></pre>
+</div>
 ```
 
 ## Config
@@ -38,7 +40,8 @@ Always on, no config key.
 `SyntectPlugin` replaces the entire `<pre>` element with a raw HTML fragment;
 once that happens, the `data-meta` attribute carrying `title="…"` is no
 longer reachable as structured AST. Running `CodeTitlePlugin` first ensures
-it reads the meta before syntect erases it.
+it reads the meta, creates the container, and leaves the inner `<pre>` for
+syntect to highlight afterward.
 
 ## See also
 

--- a/docs/src/content/docs/markdown-features/directives-registry.mdx
+++ b/docs/src/content/docs/markdown-features/directives-registry.mdx
@@ -9,10 +9,14 @@ sidebar_position: 57
 syntax — container (`:::name`), leaf (`::name[label]`), and text
 (`:name[label]`) — to JSX component calls in the compiled output.
 
-It is always active. You interact with it in two ways:
+The primitive exists in Core, but the registry visitor is not added to the
+normal pipeline by default. It runs only when `markdown.features.directives`
+is supplied, or when Rust code inserts a `DirectiveRegistry` manually. You
+interact with it in two ways:
 
 - **From config** — use the opt-in [`directives`](./directives.mdx)
-  feature to register directive names without writing Rust.
+  feature to register directive names without writing Rust. Supplying
+  `directives: {}` still wires an empty registry.
 - **From Rust** — populate a `DirectiveRegistry` directly and insert it into
   the pipeline. See [Custom Directives](../concepts/custom-directives.mdx).
 
@@ -31,8 +35,9 @@ The registry handles three directive shapes:
 The registry ships with **no directive names pre-registered**. Every
 `:::name` you use must be explicitly registered — either via the
 [`directives`](./directives.mdx) feature in `zfb.config.ts` or
-by populating the registry in Rust. An unrecognised directive name emits a
-warning diagnostic and leaves the source paragraph unchanged.
+by populating the registry in Rust. When the registry is active, an
+unrecognised directive name emits a warning diagnostic and leaves the source
+paragraph unchanged.
 
 ## Typed attribute schemas (from #584)
 

--- a/docs/src/content/docs/markdown-features/directives.mdx
+++ b/docs/src/content/docs/markdown-features/directives.mdx
@@ -107,9 +107,24 @@ export default defineConfig({
 - **Leaf** — `::name[label]{attrs}` produces a self-closing component with no children. Used for embeds (video, code playgrounds, etc.).
 - **Text** — `:name[label]{attrs}` is an inline component, mixed into prose.
 
-## Blank-line requirement
+## Fence spacing
 
-Each fence line (`:::name` and the closing `:::`) **must** be separated from surrounding content by blank lines so the Markdown parser treats them as separate paragraphs. Without blank lines the content is not recognised as a directive and a warning diagnostic is emitted at build time.
+Blank lines around container fences are supported but not required. zfb also
+handles the collapsed form that `markdown-rs` produces when an opener, body,
+and closer land in one paragraph:
+
+```md
+:::note
+Body text.
+:::
+:::tip
+Another block.
+:::
+```
+
+Both sibling collapsed directives and nested collapsed directives are
+rewritten when their names are registered. Unknown directive names still emit
+a warning diagnostic and leave their source text unchanged.
 
 ## Registering a directive does not provide a component
 
@@ -127,6 +142,6 @@ The directive-name key follows the directive grammar `[A-Za-z_][A-Za-z0-9_-]*`. 
 
 ## See also
 
-- [Directives registry](./directives-registry.mdx) — the underlying Core primitive (always active, handles parsing).
+- [Directives registry](./directives-registry.mdx) — the underlying Core primitive wired when `markdown.features.directives` is supplied.
 - [Recipe: Admonitions](../recipes/admonitions.mdx) — a worked example registering `note`, `tip`, `info`, `warning`, `danger`, `caution`, and `details` with minimal component stubs and CSS.
 - [Custom Directives](../concepts/custom-directives.mdx) — register directives via the Rust pipeline API.

--- a/docs/src/content/docs/markdown-features/github-autolinks.mdx
+++ b/docs/src/content/docs/markdown-features/github-autolinks.mdx
@@ -10,7 +10,9 @@ This mirrors the autolink behaviour that GitHub renders natively in README files
 
 ## Enable
 
-The `repo` field is required. The feature is silently inactive when it is absent.
+The `repo` field is required. If `githubAutolinks` is configured without
+`repo`, the build emits a config error (`githubAutolinks requires repo:
+"owner/repo"`) instead of silently skipping the feature.
 
 ```ts
 // zfb.config.ts

--- a/docs/src/content/docs/markdown-features/hard-breaks.mdx
+++ b/docs/src/content/docs/markdown-features/hard-breaks.mdx
@@ -1,0 +1,70 @@
+---
+title: Hard breaks
+description: Convert soft line breaks inside Markdown paragraphs into br elements.
+tier: Opt-in
+sidebar_position: 56
+---
+
+`hardBreaks` is a top-level Markdown parsing option. It defaults to `false`;
+when omitted or set to `false`, soft line breaks follow standard CommonMark
+behavior and collapse into normal whitespace.
+
+Enable it when source newlines should be preserved as line breaks in rendered
+HTML.
+
+## Enable
+
+```ts title="zfb.config.ts"
+import { defineConfig } from "zfb/config";
+
+export default defineConfig({
+  markdown: {
+    hardBreaks: true,
+  },
+});
+```
+
+## Behavior
+
+With `markdown.hardBreaks: true`, every single newline inside a paragraph is
+converted to a hard break:
+
+```md
+first line
+second line
+```
+
+Produces:
+
+```html
+<p>first line<br />second line</p>
+```
+
+Blank-line paragraph separation is unaffected:
+
+```md
+first paragraph
+
+second paragraph
+```
+
+still renders as two paragraphs, not as one paragraph with multiple `<br>`
+elements.
+
+## Scope
+
+The option only rewrites soft line breaks in prose-like Markdown nodes. It
+does not split fenced code, inline code, raw HTML, or MDX JSX/expression
+content.
+
+## Ordering note
+
+`HardBreaksPlugin` runs in the mdast phase after
+[CJK-friendly emphasis](./cjk-friendly.mdx). This lets CJK emphasis
+re-tokenisation inspect intact text nodes before soft line breaks are split
+into explicit break nodes.
+
+## See also
+
+- [CJK-friendly emphasis](./cjk-friendly.mdx) — the mdast pass that runs
+  immediately before hard breaks when both are enabled.

--- a/docs/src/content/docs/markdown-features/index.mdx
+++ b/docs/src/content/docs/markdown-features/index.mdx
@@ -1,14 +1,15 @@
 ---
 title: Markdown Features
-description: "Every feature zfb's Markdown pipeline provides — Core (always-on) and Opt-in (enabled via zfb.config.ts)."
+description: "Every feature and config surface zfb's Markdown pipeline provides, including Core pipeline behavior and opt-in features."
 sidebar_position: 0
 ---
 
 zfb's Markdown pipeline is layered. A set of **Core** features runs
-unconditionally for every content collection, giving you heading anchors,
-server-side syntax highlighting, CJK-friendly emphasis, and more.
-On top of that, a catalog of **Opt-in** features can be enabled one-by-one
-in `zfb.config.ts` under `markdown.features.*`.
+in the engine's main markdown pipeline/config surface, giving you heading
+anchors, server-side syntax highlighting, CJK-friendly handling, and more.
+Some Core rows are always on; others are top-level or `markdown.*` config
+knobs implemented in the core pipeline. The table below is authoritative for
+each row's default and config key.
 
 This page is the map. Each feature has its own page with a usage example,
 config key, and ordering notes.
@@ -27,21 +28,27 @@ traits.
 
 ## Tier convention
 
-- **Core** — active in every build. No config key. Lives in `zfb-content`.
-- **Opt-in** — inactive by default. Enable via `markdown.features.*` in
-  `zfb.config.ts`. Lives in `zfb-md-extras`.
+- **Core** — implemented in `zfb-content` or the top-level markdown config
+  surface. Core does not always mean "unconfigurable"; check the config key
+  and default in the table.
+- **Opt-in** — inactive unless enabled in config. Most opt-in feature entries
+  live under `markdown.features.*`, but `stripMdExt` and
+  `markdown.hardBreaks` are opt-in top-level options.
 
 Each feature page shows a `Core` or `Opt-in` badge near its title.
 
-## Enabling Opt-in features
+## Config shape
 
 ```ts title="zfb.config.ts"
 import { defineConfig } from "zfb/config";
 
 export default defineConfig({
+  stripMdExt: true,
   markdown: {
+    hardBreaks: true,
     features: {
       mermaid: true,
+      githubAutolinks: { repo: "owner/repo" },
       directives: {
         note: "Note",
         tip: "Tip",
@@ -51,39 +58,38 @@ export default defineConfig({
 });
 ```
 
-Pass `true` (use defaults) or a config object (override specific options).
-Omitting a key means the feature is off; no extra bytes are emitted.
+Boolean shorthand is **not universal**. It works only for rows whose value
+shape includes `boolean`. Object-only rows, such as `githubAutolinks`,
+`codeEnrichment`, `tocExport`, `imageDimensions`, `linkValidation`,
+`transclude`, and `headingIds`, require an object. Unknown keys are rejected
+at config load time.
 
-## Core features
+## Feature map
 
-These always-on plugins ship as part of `zfb-content`'s default pipeline.
-
-- [CJK-friendly emphasis](./cjk-friendly.mdx) — re-tokenises bold/italic adjacent to CJK ideographs and kana.
-- [Heading links](./heading-links.mdx) — slugified `id` attributes and self-referencing anchor links on every heading.
-- [Code block title](./code-title.mdx) — renders a filename label above a fenced code block from `title="…"`.
-- [External links](./external-links.mdx) — adds `target` and `rel` attributes to outbound links (configurable).
-- [Resolve links](./resolve-links.mdx) — rewrites internal link targets using the content source map.
-- [Strip .md extension](./strip-md-ext.mdx) — removes `.md`/`.mdx` suffixes from internal link hrefs.
-- [Syntax highlighting](./syntax-highlighting.mdx) — server-side highlighting via syntect; always on, theme-configurable.
-- [Directives registry](./directives-registry.mdx) — maps `:::name`/`::name`/`:name` directive syntax to JSX components.
-
-## Opt-in features
-
-Enable each in `markdown.features.*`. All live in `zfb-md-extras`.
-
-- [Directives](./directives.mdx) — register `:::name` / `::name` / `:name` directive syntax that maps to your own JSX components (zero defaults — you supply the vocabulary).
-- [Mermaid diagrams](./mermaid.mdx) — renders Mermaid flowcharts from fenced code blocks.
-- [Heading-marker TOC](./heading-marker-toc.mdx) — auto-inserts a table of contents after a designated heading.
-- [GitHub alerts](./github-alerts.mdx) — renders `> [!NOTE]` / `> [!WARNING]` blockquotes as styled components.
-- [Reading time](./reading-time.mdx) — computes estimated reading time and injects it into frontmatter.
-- [GitHub autolinks](./github-autolinks.mdx) — links GitHub issue/PR/commit references (`#123`, `org/repo#456`, `abc1234`) automatically.
-- [Code-block enrichment](./code-enrichment.mdx) — adds diff markers and per-line highlighting to fenced code blocks.
-- [Code tabs](./code-tabs.mdx) — groups consecutive fenced code blocks into a tabbed switcher.
-- [Ruby annotation](./ruby.mdx) — renders `{これは}^{これ}` (caret, primary) or `{漢字|かんじ}` (pipe, legacy alias) syntax as HTML `<ruby>` elements.
-- [TOC export](./toc-export.mdx) — exports a structured heading tree into the compiled JSX module for framework-side rendering.
-- [Image dimensions](./image-dimensions.mdx) — injects `width` and `height` attributes on `<img>` elements from the actual file.
-- [Link validation](./link-validation.mdx) — warns on broken internal links by default; hard build errors with `failOnBroken: true`.
-- [Transclusion](./transclude.mdx) — inlines the content of another file using the `:::include` directive.
+| Feature | Tier | Config key | Value shape | Default / gating |
+|---|---|---|---|---|
+| [CJK-friendly emphasis](./cjk-friendly.mdx) | Core | `markdown.cjkFriendly` | `boolean` | `true`; set `false` to opt out. |
+| [Heading links](./heading-links.mdx) | Core | `markdown.features.headingIds` | `{ strategy?: "flat" \| "hierarchical" }` | Plugin always on; default strategy is `"flat"`. |
+| [Code block title](./code-title.mdx) | Core | none | n/a | Always on. |
+| [External links](./external-links.mdx) | Core | `markdown.externalLinks` | `{ target?: string; rel?: string[] }` | Off unless supplied. |
+| [Resolve links](./resolve-links.mdx) | Core | `resolveMarkdownLinks` | `{ enabled?: boolean; docsDir?: string; dirs?: { dir: string; routePrefix: string }[]; onBrokenLinks?: "warn" \| "error" \| "ignore" }` | Off unless `enabled: true`. |
+| [Strip .md extension](./strip-md-ext.mdx) | Opt-in | `stripMdExt` | `boolean` | `false`; when `true`, strips `.md`/`.mdx` and appends `/`. |
+| [Hard breaks](./hard-breaks.mdx) | Opt-in | `markdown.hardBreaks` | `boolean` | `false`; when `true`, soft line breaks become `<br>`. |
+| [Syntax highlighting](./syntax-highlighting.mdx) | Core | `codeHighlight` | `{ theme?: string; themesDir?: string; themeLight?: string; themeDark?: string }` | On with the default syntect theme. |
+| [Directives registry](./directives-registry.mdx) | Core primitive | `markdown.features.directives` or Rust API | `Record<string, DirectiveSpec>` | Registry visitor runs only when supplied; zero default names. |
+| [Directives](./directives.mdx) | Opt-in | `markdown.features.directives` | `Record<string, string \| { component: string; kind?: "container" \| "leaf" \| "text"; titleFromLabel?: boolean }>` | Off when absent; `{}` wires an empty registry. |
+| [Mermaid diagrams](./mermaid.mdx) | Opt-in | `markdown.features.mermaid` | `boolean \| {}` | Off when absent or `false`; marks blocks as `<div class="mermaid">`. |
+| [Heading-marker TOC](./heading-marker-toc.mdx) | Opt-in | `markdown.features.headingMarkerToc` | `boolean \| { heading?: string; maxDepth?: number }` | Off when absent or `false`. |
+| [GitHub alerts](./github-alerts.mdx) | Opt-in | `markdown.features.githubAlerts` | `boolean \| {}` | Off when absent or `false`. |
+| [Reading time](./reading-time.mdx) | Opt-in | `markdown.features.readingTime` | `boolean \| { wpm?: number }` | Off when absent or `false`; emits `export const readingTimeMinutes`. |
+| [GitHub autolinks](./github-autolinks.mdx) | Opt-in | `markdown.features.githubAutolinks` | `{ repo: string }` | Off when absent; missing `repo` is a build-blocking config error. |
+| [Code-block enrichment](./code-enrichment.mdx) | Opt-in | `markdown.features.codeEnrichment` | `{ diffMarkers?: boolean; lineHighlight?: boolean }` | Off when absent; object form enables it, with both subfeatures on by default. |
+| [Code tabs](./code-tabs.mdx) | Opt-in | `markdown.features.codeTabs` | `boolean \| {}` | Off when absent or `false`. |
+| [Ruby annotation](./ruby.mdx) | Opt-in | `markdown.features.ruby` | `boolean \| {}` | Off when absent or `false`. |
+| [TOC export](./toc-export.mdx) | Opt-in | `markdown.features.tocExport` | `{ maxDepth?: number }` | Off when absent; default `maxDepth` is `3`. |
+| [Image dimensions](./image-dimensions.mdx) | Opt-in | `markdown.features.imageDimensions` | `{ skipRemote?: boolean }` | Off when absent; `skipRemote` defaults to `true`. |
+| [Link validation](./link-validation.mdx) | Opt-in | `markdown.features.linkValidation` | `{ failOnBroken?: boolean }` | Off when absent; warns by default, errors with `failOnBroken: true`. |
+| [Transclusion](./transclude.mdx) | Opt-in | `markdown.features.transclude` | `{ maxDepth?: number }` | Off when absent; default `maxDepth` is `5`. |
 
 ## See also
 

--- a/docs/src/content/docs/markdown-features/mermaid.mdx
+++ b/docs/src/content/docs/markdown-features/mermaid.mdx
@@ -4,7 +4,10 @@ description: Render Mermaid flowcharts and diagrams directly in Markdown.
 tier: Opt-in
 ---
 
-The `mermaid` feature renders [Mermaid](https://mermaid.js.org/) diagrams from fenced code blocks at build time.
+The `mermaid` feature marks [Mermaid](https://mermaid.js.org/) fenced code
+blocks at build time. zfb replaces the code block with a `<div
+class="mermaid">`; diagram rendering happens client-side when your Mermaid
+runtime processes that element.
 
 ## Enable
 
@@ -33,13 +36,17 @@ graph TD;
 ```
 ````
 
-The plugin replaces the `<pre><code class="language-mermaid">` block with:
+At build time, the plugin replaces the `<pre><code class="language-mermaid">`
+block with:
 
 ```html
 <div class="mermaid" data-mermaid="">graph TD; ...</div>
 ```
 
-The `data-mermaid` attribute signals a client-side Mermaid renderer to process the block. The raw diagram source is embedded verbatim (angle brackets and other characters are NOT HTML-escaped) so the renderer receives the unmodified Mermaid DSL.
+The `data-mermaid` attribute and `mermaid` class signal a client-side Mermaid
+renderer to process the block. The raw diagram source is embedded verbatim
+(angle brackets and other characters are NOT HTML-escaped) so the renderer
+receives the unmodified Mermaid DSL.
 
 ## Visitor ordering
 

--- a/docs/src/content/docs/markdown-features/reading-time.mdx
+++ b/docs/src/content/docs/markdown-features/reading-time.mdx
@@ -63,6 +63,8 @@ The plugin combines two passes:
    as one word, because CJK text does not use spaces between words:
    - CJK Unified Ideographs + Extension A (U+3400–U+9FFF)
    - CJK Compatibility Ideographs (U+F900–U+FAFF)
+   - CJK supplementary-plane ideographs, including Extensions B and later
+     plus the Compatibility Ideographs Supplement (U+20000–U+2FA1F)
    - Hiragana (U+3040–U+309F)
    - Katakana (U+30A0–U+30FF)
    - Hangul Syllables (U+AC00–U+D7AF)

--- a/docs/src/content/docs/markdown-features/strip-md-ext.mdx
+++ b/docs/src/content/docs/markdown-features/strip-md-ext.mdx
@@ -1,41 +1,64 @@
 ---
 title: Strip .md extension
-description: Removes the .md or .mdx suffix from internal link hrefs at build time.
-tier: Core
+description: Opt-in top-level config that removes .md or .mdx suffixes from internal link hrefs at build time.
+tier: Opt-in
 sidebar_position: 55
 ---
 
-`StripMdExtensionPlugin` removes the `.md` or `.mdx` suffix from internal
-link `href` values so that links authored as `[page](./other.md)` produce
-clean output URLs like `/docs/other`.
+`stripMdExt` is an opt-in top-level `zfb.config.ts` field, not a
+`markdown.features` entry. It defaults to `false`; when omitted or set to
+`false`, author-written `.md` and `.mdx` hrefs are preserved.
+
+When enabled, `StripMdExtensionPlugin` removes the `.md` or `.mdx` suffix
+from internal link `href` values and appends a trailing slash, so links
+authored as `[page](./other.md)` produce clean output URLs like
+`./other/`.
 
 ## What it does
 
-In the hast phase, the plugin walks every `<a>` element. For each link whose
-`href` ends with `.md` or `.mdx`:
+In the hast phase, the plugin walks every `<a>` element. For each internal
+link whose path ends with `.md` or `.mdx`:
 
 1. Strips the extension.
-2. Leaves the rest of the path, query string, and fragment intact.
+2. Appends a trailing `/` to the stripped path.
+3. Preserves the query string and fragment after the slash.
 
-The plugin only touches relative and root-relative paths — absolute URLs
-(`https://…`) and non-link elements are left unchanged.
+The plugin touches internal relative and root-relative paths. Absolute URLs
+(`https://…`), anchor-only links (`#section`), non-link elements, and hrefs
+with non-markdown file extensions are left unchanged. In trailing-slash mode,
+extensionless relative hrefs such as `./guide` and `../guide` also become
+`./guide/` and `../guide/`.
 
 ## Config
 
-Always on when a source map is available, no config key. The plugin runs
-after `ResolveLinksPlugin` so it sees the already-resolved paths.
+Enable it at the top level:
+
+```ts title="zfb.config.ts"
+import { defineConfig } from "zfb/config";
+
+export default defineConfig({
+  stripMdExt: true,
+});
+```
+
+The plugin runs after `ResolveLinksPlugin` when both are configured, so it
+sees already-resolved paths before cleaning up any remaining markdown
+extensions.
 
 ## Example
 
 ```md
-See [setup](./installation.mdx) for details.
+See [setup](./installation.mdx#requirements) for details.
 ```
 
-Produces:
+With `stripMdExt: true`, produces:
 
 ```html
-<a href="./installation">See setup for details.</a>
+<p>See <a href="./installation/#requirements">setup</a> for details.</p>
 ```
+
+With `stripMdExt: false` or an omitted config field, the authored
+`./installation.mdx#requirements` href is preserved.
 
 ## See also
 


### PR DESCRIPTION
Parent: #1458
Closes #1461

Summary:
- Refresh markdown feature docs, add the hard-breaks page, and align feature index support/status language.

Validation:
- Covered by the docs audit base-branch validation after integration.
- Local manager checks include docs build, generated HTML validation, repo formatting, TypeScript typecheck, pnpm tests, snippet checks, link checks, and ignored-test inventory.
