### PR TITLE
Docs audit: getting started

### DIFF
--- a/docs/src/content/docs/getting-started/installation.mdx
+++ b/docs/src/content/docs/getting-started/installation.mdx
@@ -16,8 +16,8 @@ sidebar_position: 2
 
 You will need:
 
-- **Node.js ≥ 22** — the config loader and some build steps invoke Node.
-- **pnpm** — install via the [official installer](https://pnpm.io/installation). zfb scaffolds projects that use pnpm and will run `pnpm install` for you when it can find pnpm on your `PATH`.
+- **Node.js ≥ 22** — required by the npm CLI wrapper and by the `tsc` subprocess that powers `zfb check`. The default TypeScript config loader itself runs inside zfb's embedded V8 runtime, not Node.
+- **pnpm ≥ 11** — install via the [official installer](https://pnpm.io/installation). zfb scaffolds projects that use pnpm and will run `pnpm install` for you when it can find pnpm on your `PATH`.
 
 ## Supported platforms
 

--- a/docs/src/content/docs/getting-started/introduction.mdx
+++ b/docs/src/content/docs/getting-started/introduction.mdx
@@ -13,7 +13,7 @@ If you can read a `pages/` directory tree and write a TSX component, you already
 For the "why this shape" answer — narrow scope, recipes-over-plugins, no middleware layer — see [Design philosophy](../concepts/design-philosophy.mdx).
 
 - **Embedded V8 worker** — pages render through a Rust-embedded V8 runtime. No separate Node process is required at build time.
-- **Atomic writes** — the build never leaves the output directory in a partially-written state. Each `zfb build` run either completes fully or leaves `dist/` unchanged.
+- **Atomic writes** — generated files are written atomically per file, so readers never observe a half-written HTML file. `zfb build` wipes the output directory before it starts writing, so a failed build does not guarantee the previous `dist/` remains intact.
 - **Per-page incremental rebuild** — changing a shared layout touches only the pages that import it, not the whole site. Dev-loop latency stays in the tens of milliseconds even on large sites.
 - **Opt-in islands** — components are server-rendered by default. Add `"use client"` to a component file to opt into client-side hydration. Pages with no islands ship zero JavaScript.
 - **Frontmatter and content collections** — Markdown, MDX, and TypeScript data files in a named directory become a typed collection, queryable from pages via `getCollection()`.

--- a/docs/src/content/docs/getting-started/project-structure.mdx
+++ b/docs/src/content/docs/getting-started/project-structure.mdx
@@ -90,6 +90,8 @@ See [Static Assets](../concepts/static-assets.mdx) for the full reference, inclu
 
 The config file uses a camelCase schema. Common keys include `outDir` (default `"dist"`), `publicDir` (default `"public"`), `host` (default `"localhost"`), `port` (default `3000`), `framework` (`"preact"` or `"react"`, default `"preact"`), `collections`, `tailwind`, and `plugins`. This is not an exhaustive list — see [defineConfig](../api/define-config.mdx) for the full schema reference.
 
+`outDir` is currently honored by `zfb dev` only. `zfb build` and `zfb preview` choose their output directory from the `--outdir` flag, defaulting to `dist/`.
+
 The template scaffolds `zfb.config.json`. If you rename it to `zfb.config.ts`, zfb loads it via the bundled esbuild binary and you get full TypeScript types and IDE completion — the schema is identical in both formats.
 
 ## package.json, tsconfig.json, .gitignore

--- a/docs/src/content/docs/getting-started/your-first-site.mdx
+++ b/docs/src/content/docs/getting-started/your-first-site.mdx
@@ -45,7 +45,7 @@ pnpm zfb dev
 npx zfb dev
 ```
 
-You'll see a "ready" banner with the host and port (defaults: `http://localhost:3000`). zfb watches a fixed set of project roots — `pages/`, `content/`, `components/`, `layouts/`, `styles/`, `data/`, `public/`, and the two config files (`zfb.config.json`, `zfb.config.ts`) — plus any additional paths declared as collection `path` values in your config. Saving any tracked file triggers a live-reload broadcast to connected browsers.
+You'll see a "ready" banner with the host and port (defaults: `http://localhost:3000`). zfb watches a fixed set of project roots — `pages/`, `content/`, `components/`, `layouts/`, `styles/`, `data/`, `src/`, and the two config files (`zfb.config.json`, `zfb.config.ts`) — plus any additional paths declared as collection `path` values or absolute `extraWatchPaths` entries in your config. The default `public/` directory is not watched; those files are served directly from disk. Saving any tracked file triggers a live-reload broadcast to connected browsers.
 
 You can override host and port from the CLI — they always win over `zfb.config.ts`:
 
@@ -67,7 +67,11 @@ npx zfb build
 npx zfb preview
 ```
 
-`zfb build` resolves the output directory (defaulting to `dist/`), enumerates routes via the file-system router, and writes one HTML file per static route. `zfb preview` then serves that directory over HTTP on port `4321` by default. CLI flags (`--outdir`, `--port`) win over the config file in both commands.
+`zfb build` writes to its CLI `--outdir` value, defaulting to `dist/`, then enumerates routes via the file-system router and writes one HTML file per static route. The build command has no `--port` flag because it does not start a server.
+
+`zfb preview` serves its own CLI `--outdir` value, also defaulting to `dist/`, over HTTP on port `4321` by default. Preview's `--port` flag wins over config `port`; if neither is set, preview uses the built-in default.
+
+Today `outDir` in `zfb.config.*` is honored by `zfb dev`, but `zfb build` and `zfb preview` do not read it; pass `--outdir` to those commands when you build or serve a non-default directory. The standalone decision about this split is tracked in [issue #1473](https://github.com/Takazudo/zudo-front-builder/issues/1473).
 
 ## A working example
 


### PR DESCRIPTION
Parent: #1458
Closes #1462

Summary:
- Correct installation, first-site, and project-structure guidance for the current CLI defaults and starter layout.

Validation:
- Covered by the docs audit base-branch validation after integration.
- Local manager checks include docs build, generated HTML validation, repo formatting, TypeScript typecheck, pnpm tests, snippet checks, link checks, and ignored-test inventory.
