### PR TITLE
Docs audit: guides, architecture, install

### DIFF
--- a/docs/src/content/docs/architecture/build-engine.mdx
+++ b/docs/src/content/docs/architecture/build-engine.mdx
@@ -41,7 +41,7 @@ zfb is the orchestrator. It owns the dependency graph, the per-page rebuild cont
 | **esbuild** | Bundles the server-side worker bundle (`zfb-build/bundler.rs`) and the shared islands client bundle (`zfb-islands`). Fast, handles TSX/JSX, MDX loaders, and tree-shaking. | `ClientBundler` (in `zfb-islands`) |
 | **deno_core (V8)** | The embedded V8 isolate that executes the server-side worker bundle for SSG and the dev preview server. Chosen because Tauri distribution requires a single binary with no Node dependency; see [JS runtime](./js-runtime.mdx) for the rationale. | `RenderHost` (in `zfb-render`) |
 | **SWC** | Compiles TSX source to JavaScript before handing it off to esbuild or the render host. Lives inside `zfb-render`. | Internal to `zfb-render`; swappable by replacing that crate's transform step |
-| **lol_html** | Streaming HTML rewriter used to inject hydration entry-point `<script>` tags and island mount markers into the rendered HTML without a full parse. | Used inside `zfb-build/head_inject.rs`; no public trait needed — it is a low-level utility |
+| **lol_html** | Streaming HTML rewriter used where selector-aware mutation matters: island marker processing, base-link rewriting, and dev-server HTML injection. Production head asset injection is a byte-level splice, not a `lol_html` pass. | Used by `zfb-islands/src/html_tree.rs`, `zfb-build/src/link_base_rewrite.rs`, and `zfb-server`; no public trait needed — it is a low-level utility |
 
 ### How the layering works
 
@@ -50,7 +50,11 @@ zfb owns orchestration, the dependency graph, and the per-page contract. The too
 - **esbuild** is called in two places: `zfb-build` (server worker bundle) and `zfb-islands` (shared islands client bundle). Both use it for bundling TypeScript/JSX source trees; neither exposes it to the crates above.
 - **deno_core (V8)** is the JS engine behind `RenderHost`. The renderer in `zfb-render` calls `RenderHost::call_default`; the concrete host (`EmbeddedV8RenderHost`) runs the bundle in an in-process V8 isolate. The orchestrator in `zfb-build` never names the engine — it only receives rendered HTML.
 - **SWC** runs inside `zfb-render` before the module reaches the render host, or inside `zfb-build/bundler.rs` before esbuild sees the source. Either way it is invisible to the orchestrator.
-- **lol_html** runs after the render host returns HTML, inside `zfb-build/head_inject.rs`. The orchestrator sees plain strings in and plain strings out.
+- **lol_html** runs in the HTML mutation utilities that need real element or
+  comment awareness: `zfb-islands/src/html_tree.rs`, `zfb-build/src/link_base_rewrite.rs`,
+  and `zfb-server`'s dev HTML injection path. `zfb-build/src/head_inject.rs`
+  deliberately does not use it; that helper only searches for `</head>` and
+  splices stable CSS / island asset tags before the closing tag.
 
 This structure means the crates above each tool's trait boundary are unaffected when the tool changes. See [Islands](../concepts/islands.mdx) for the `ClientBundler` contract and [Incremental rebuild](../concepts/incremental-rebuild.mdx) for how the dependency graph feeds the per-page policy.
 

--- a/docs/src/content/docs/architecture/why-rust.mdx
+++ b/docs/src/content/docs/architecture/why-rust.mdx
@@ -22,9 +22,9 @@ The visible win is error quality. zfb uses `anyhow` end-to-end, so every error r
 
 ## Concurrency that fits
 
-The build orchestrator schedules across CPUs; the dev server runs an `axum` listener and an SSE broadcast at the same time. Rayon handles parallel-page rendering; tokio handles the async I/O. They coexist without ceremony — Rust's type system enforces the boundaries, so threads never share state they should not share.
+The build orchestrator can do Rust-side bookkeeping, file I/O, and dev-server work without blocking the HTTP listener. Request handling, file serving, and the SSE broadcast live on tokio; heavier render dispatch is isolated from that async edge.
 
-The same code in Node would need worker threads or child processes for equivalent isolation. Workers do not share modules; child processes do not share memory. Either way, you pay coordination overhead on every page that the Rust version does for free.
+Page rendering itself is not Rayon-parallel today. User TSX runs through a single embedded V8 isolate thread, both for build-time SSG and dev-side `prerender = false` dispatch. The concurrency win is the clean boundary around that isolate and the rest of the Rust pipeline, not parallel execution of multiple page renders in one build.
 
 ## Distribution
 

--- a/docs/src/content/docs/guides/desktop-deployment.mdx
+++ b/docs/src/content/docs/guides/desktop-deployment.mdx
@@ -133,7 +133,16 @@ integration — IPC, filesystem access, hot content reload — without the sidec
 lifecycle plumbing of Mode B.
 
 **What's involved.** Add `zfb-server` as a Cargo dependency and call
-`Server::builder()` inside Tauri's synchronous `setup` callback:
+`Server::builder()` inside Tauri's synchronous `setup` callback.
+
+`zfb-server` is not published to crates.io yet; that packaging work is tracked
+in [issue #1475](https://github.com/Takazudo/zudo-front-builder/issues/1475).
+Until then, depend on the workspace crate from git and pin a tag or commit:
+
+```toml
+[dependencies]
+zfb-server = { git = "https://github.com/Takazudo/zudo-front-builder", package = "zfb-server", rev = "<commit>" }
+```
 
 ```rust
 use zfb_server::{Server, ServerMode};

--- a/docs/src/content/docs/guides/embed-as-library.mdx
+++ b/docs/src/content/docs/guides/embed-as-library.mdx
@@ -8,6 +8,18 @@ The `zfb-server` crate ships a small builder API so a Rust host can run zfb's HT
 
 This guide covers the public builder shape, the request-extension injection point, and the host-handler seam (`with_ssr_handler`).
 
+<Note title="Crate availability">
+
+`zfb-server` is not published to crates.io yet, so `docs.rs/zfb-server` links
+do not resolve. Depend on the workspace crate from git and pin a tag or commit:
+
+```toml
+[dependencies]
+zfb-server = { git = "https://github.com/Takazudo/zudo-front-builder", package = "zfb-server", rev = "<commit>" }
+```
+
+</Note>
+
 ## When to reach for this
 
 Pick the embed-as-library path when the host needs to:
@@ -176,7 +188,7 @@ If instead the host needs to push content into the server at runtime — a `Page
 
 ### Level 1: seed a `PageCache` through the builder
 
-`ServerBuilder::with_page_cache(cache)` hands the server a [`PageCache`](https://docs.rs/zfb-server) you own instead of the empty one `build()` allocates by default. `PageCache` is `Clone` (internally an `Arc<RwLock<…>>`), so you keep a handle, give a clone to the builder, and then write into the *same* shared map at runtime — the running server sees every insert:
+`ServerBuilder::with_page_cache(cache)` hands the server a `PageCache` you own instead of the empty one `build()` allocates by default. `PageCache` is `Clone` (internally an `Arc<RwLock<…>>`), so you keep a handle, give a clone to the builder, and then write into the *same* shared map at runtime — the running server sees every insert:
 
 ```rust
 use zfb_server::{Server, ServerMode, PageCache};
@@ -203,7 +215,7 @@ This is enough when all you need is dynamic page bytes. What it does **not** giv
 
 ### Level 2: drop to `ServeOpts` + `serve_with_listener`
 
-When you need more than a page cache — a live livereload `broadcast` channel, request-time SSR routes (`SsrRoutesHandle`), plugin dev-middleware — the builder is deliberately not the entry point. Construct a [`ServeOpts`](https://docs.rs/zfb-server) yourself and call the lower-level `serve_with_listener(opts, listener, shutdown)` (or `serve(opts, shutdown)`, which binds the listener for you). Both are public and stable — they are the same entry points `zfb dev` itself uses.
+When you need more than a page cache — a live livereload `broadcast` channel, request-time SSR routes (`SsrRoutesHandle`), plugin dev-middleware — the builder is deliberately not the entry point. Construct a `ServeOpts` yourself and call the lower-level `serve_with_listener(opts, listener, shutdown)` (or `serve(opts, shutdown)`, which binds the listener for you). Both are public and stable — they are the same entry points `zfb dev` itself uses.
 
 `ServeOpts` is a plain struct you fill in directly. The fields relevant to live content are:
 
@@ -222,6 +234,7 @@ let (broadcast, _rx) = tokio::sync::broadcast::channel::<ReloadEvent>(64);
 let opts = ServeOpts {
     project_root: project_root.clone(),
     dist_root: dist_root.clone(),
+    dev_assets_root: None,
     html_root: dist_root.clone(), // embed/preview callers alias dist_root
     public_root,
     addr: "127.0.0.1:0".parse()?,

--- a/docs/src/content/docs/guides/extending-the-markdown-pipeline.mdx
+++ b/docs/src/content/docs/guides/extending-the-markdown-pipeline.mdx
@@ -47,10 +47,15 @@ The pipeline runs two distinct passes over two different ASTs:
    markdown-rs with MDX-aware options.
 2. **mdast visitors** — `MdastVisitor` implementations rewrite the
    markdown AST in place. Run first because some transforms only
-   make sense before HTML structure exists. The directive registry
-   is a mdast visitor: it folds runs of paragraphs delimited by
-   `:::name` / `:::` into a single MDX JSX element, which is much
-   easier on mdast than after `<p>` tags have appeared.
+   make sense before HTML structure exists. The default mdast visitors
+   are `CjkAutolinkBoundaryPlugin` (when GFM autolink literals are
+   enabled) and `CjkFriendlyPlugin`; configured extras such as
+   `TranscludePlugin`, `CodeTabsPlugin`, `GithubAlertsPlugin`,
+   `ReadingTimePlugin`, `RubyPlugin`, and `DirectiveRegistry` are
+   inserted in this phase when their feature flags are enabled. The
+   directive registry folds runs of paragraphs delimited by `:::name`
+   / `:::` into a single MDX JSX element, which is much easier on
+   mdast than after `<p>` tags have appeared.
 3. **Convert** mdast → hast via `mdast_to_hast`. hast is zfb's
    minimal HTML AST (`HastNode`).
 4. **hast visitors** — `HastVisitor` implementations rewrite the
@@ -68,16 +73,27 @@ heading level, an `<img>` with a width attribute), hast.
 
 ## Visitor trait shape
 
-Both visitor traits are intentionally small — one method, called
-once on a node, mutate in place:
+The visitor traits live in the `zfb-md-ast` crate and are re-exported from
+`zfb_content::pipeline` for local callers. Both traits are intentionally
+small: implement `visit` for context-free transforms, and override
+`visit_with_context` only when the plugin needs source paths, project roots,
+diagnostics, or heading registries from `BuildContext`.
 
 ```rust
 pub trait MdastVisitor {
     fn visit(&mut self, node: &mut MdastNode);
+
+    fn visit_with_context(&mut self, node: &mut MdastNode, _ctx: &mut BuildContext<'_>) {
+        self.visit(node);
+    }
 }
 
 pub trait HastVisitor {
     fn visit(&mut self, node: &mut HastNode);
+
+    fn visit_with_context(&mut self, node: &mut HastNode, _ctx: &mut BuildContext<'_>) {
+        self.visit(node);
+    }
 }
 ```
 
@@ -86,7 +102,7 @@ Recursion is the visitor's responsibility — there is no auto-walk.
 A typical hast visitor looks like:
 
 ```rust
-use crate::pipeline::{HastNode, HastVisitor};
+use zfb_md_ast::{HastNode, HastVisitor};
 
 pub struct MyPlugin;
 
@@ -119,8 +135,8 @@ consumers need them.
 
 **Core (wire into `Pipeline::with_defaults`)** when the behaviour is
 universal: every content-collection consumer would want it the same way,
-with no legitimate reason to opt out. Examples: `HeadingLinksPlugin`,
-`CodeTitlePlugin`, `SyntectPlugin`.
+with no legitimate reason to opt out. Examples: `CjkFriendlyPlugin`,
+`HeadingLinksPlugin`, `CodeTitlePlugin`, `SyntectPlugin`.
 
 **Opt-in (wire into `Pipeline::with_defaults_and_features`)** when the
 feature is valuable but not universally needed, or when it requires
@@ -139,6 +155,7 @@ one file per feature:
 
 ```
 crates/zfb-content/src/plugins/
+├── cjk_autolink.rs
 ├── cjk_friendly.rs
 ├── code_title.rs
 ├── directives.rs
@@ -192,18 +209,22 @@ Adding your visitor there means every caller that uses the defaults
 picks it up automatically. Append it in the right phase:
 
 ```rust
-// in crates/zfb-content/src/pipeline.rs, inside Pipeline::with_defaults()
-let mut p = Self::with_mdx();
+// in crates/zfb-content/src/pipeline.rs, inside the defaults builder
+let mut p = Self::with_resolved_gfm_constructs(resolved);
 
 // mdast phase
-p.add_mdast_visitor(Box::new(AdmonitionsPlugin::new()));
+if resolved.autolink_literal {
+    p.push_config_derived_mdast_visitor(Box::new(CjkAutolinkBoundaryPlugin::new()));
+}
+p.push_config_derived_mdast_visitor(Box::new(CjkFriendlyPlugin::new()));
+p.push_config_derived_mdast_visitor(Box::new(MyMdastPlugin::new())); // <-- new, if mdast
 
 // hast phase
-p.add_hast_visitor(Box::new(HeadingLinksPlugin::new()));
-p.add_hast_visitor(Box::new(CodeTitlePlugin::new()));
-p.add_hast_visitor(Box::new(MyPlugin));     // <-- new
-p.add_hast_visitor(Box::new(MermaidPlugin::new()));
-p.add_hast_visitor(Box::new(SyntectPlugin::new(highlighter)));
+p.push_config_derived_hast_visitor(Box::new(HeadingLinksPlugin::new()));
+p.push_config_derived_hast_visitor(Box::new(CodeTitlePlugin::new()));
+p.push_config_derived_hast_visitor(Box::new(MyPlugin)); // <-- new
+p.push_config_derived_hast_visitor(Box::new(MermaidPlugin::new()));
+p.push_config_derived_hast_visitor(Box::new(SyntectPlugin::new(highlighter)));
 p
 ```
 
@@ -223,6 +244,11 @@ rules that bite most often:
 - **`HeadingLinksPlugin` runs first in the hast phase.** Anything
   that mutates headings later sees the slugified `id` attributes.
   `TocPlugin` and `TocExportPlugin` depend on these `id` values.
+- **`CjkAutolinkBoundaryPlugin` runs before `CjkFriendlyPlugin`** when
+  GFM autolink literals are enabled. It splits over-consumed bare URLs
+  before CJK emphasis retokenisation changes the surrounding text nodes.
+- **`CjkFriendlyPlugin` runs early in the mdast phase.** Visitors that
+  depend on CJK-adjacent emphasis being tokenised should run after it.
 - **`CodeTitlePlugin` runs before `SyntectPlugin`.** SyntectPlugin
   replaces the entire `<pre>` element with a `HastNode::Raw` HTML
   fragment; once that happens, the `data-meta` attribute that
@@ -237,9 +263,9 @@ rules that bite most often:
 - **`ImageDimensionsPlugin`** runs in the hast phase before `SyntectPlugin`.
   It only touches `<img>` elements and is order-independent relative to
   heading / code-block visitors.
-- **`GithubAlertsPlugin` runs in the mdast phase**, before the mdast
-  → hast conversion. It rewrites blockquote nodes; the `AdmonitionsPlugin`
-  (which also runs in the mdast phase) reads the results independently.
+- **`GithubAlertsPlugin` runs in the mdast phase**, before the directive
+  registry and before the mdast → hast conversion. It rewrites blockquote
+  nodes into MDX JSX elements.
 - **`TranscludePlugin` runs first in the mdast phase.** Included
   content must be merged into the AST before any other visitor sees it.
 
@@ -305,9 +331,10 @@ changes when the rest of the codebase moves.
 - [Customizing Markdown](./customizing-markdown.mdx) — what the
   Markdown rendering pipeline looks like from a content-collection
   consumer's perspective.
-- `crates/zfb-content/src/pipeline.rs` — `Pipeline`, `MdastVisitor`
-  / `HastVisitor` traits, and the `Pipeline::with_defaults()`
-  ordering rationale in its doc comment.
+- `crates/zfb-md-ast/src/lib.rs` — `MdastVisitor`, `HastVisitor`,
+  `BuildContext`, and the `visit_with_context` default methods.
+- `crates/zfb-content/src/pipeline.rs` — `Pipeline` construction and the
+  `Pipeline::with_defaults()` ordering rationale in its doc comment.
 - `crates/zfb-content/src/plugins/code_title.rs` — small, stateless
   `HastVisitor` example.
 - `crates/zfb-content/src/plugins/heading_links.rs` — stateful

--- a/docs/src/content/docs/guides/migrating-from-astro.mdx
+++ b/docs/src/content/docs/guides/migrating-from-astro.mdx
@@ -54,7 +54,8 @@ const posts = getCollection("blog");  // synchronous — no await
 ```
 
 The return shape is similar — each entry exposes `slug`, `data`
-(frontmatter), and `body`. See /api/get-collection for the full surface.
+(frontmatter), and `body`. See
+[`getCollection`](../api/get-collection.mdx) for the full surface.
 
 Schemas move from inline Zod to declarative config. Declare collections in
 `zfb.config.ts` using `defineConfig`:
@@ -76,6 +77,8 @@ Valid `type` values are `"string"`, `"number"`, `"integer"`, `"boolean"`,
 `"array"`, `"object"`, and `"null"` (no `"date"`, no trailing `?` for
 optional). The schema is validated for structure at config load time but
 frontmatter fields are not currently enforced against it at build time.
+Run `zfb check` to validate collection frontmatter against the declared
+schemas; that is the enforcement gate for CI.
 See [`defineConfig`](../api/define-config.mdx) for the full shape.
 
 ## Islands
@@ -94,7 +97,7 @@ export default function Counter() {
 ```
 
 Anything imported from a `"use client"` file becomes an island
-automatically. See /api/island.
+automatically. See [`island`](../api/island.mdx).
 
 ## Slots and layouts
 
@@ -142,7 +145,8 @@ When set, `globalThis.__zfb.site` is available at render time so layouts can
 build canonical `<link>` tags and OpenGraph meta. See
 [`defineConfig`](../api/define-config.mdx).
 
-**Plugin lifecycle: `setup`, `addAlias`, `addVirtualModule`, `injectRoute`**
+**Plugin lifecycle: `setup`, `addAlias`, `addVirtualModule`, `injectRoute`,
+`addClientEntry`**
 
 Astro integrations expose `updateConfig`, `addWatchFile`, and `injectRoute`
 during the `astro:config:setup` hook. zfb's equivalent is the `setup` hook in
@@ -153,11 +157,13 @@ import { definePlugin } from "@takazudo/zfb/plugins";
 
 export default definePlugin({
   name: "my-plugin",
-  setup({ command, addAlias, addVirtualModule, injectRoute }) {
+  setup({ command, addAlias, addVirtualModule, injectRoute, addClientEntry }) {
     addAlias("@/components/foo", "./src/components/foo.tsx");
     addVirtualModule("virtual:my-data", () =>
       `export default ${JSON.stringify({ key: "value" })}`,
     );
+    injectRoute("/preset-page", "./pages/preset-page.tsx");
+    addClientEntry("./client/analytics.client.ts");
     if (command === "dev") {
       injectRoute("/api/dev/x", "./scripts/dev-x.ts");
     }
@@ -167,7 +173,13 @@ export default definePlugin({
 
 `addAlias` performs exact-match import rewrites (prefix matching is a future
 revision). `addVirtualModule` exposes a synthetic ESM module by specifier.
-`injectRoute` is dev-only; calling it during `zfb build` is an error.
+`injectRoute` is not dev-only: during `zfb build`, package-owned routes are
+materialised into the build overlay and prerendered through the normal route
+pipeline; during `zfb dev`, they are synthetic routes served by the dev
+renderer. Gate a route on `command === "dev"` only when you intentionally want
+that route to exist in dev but not in production. `addClientEntry` registers a
+package-owned `*.client.{ts,tsx,js,jsx}` side-effect entry for the client
+bundle.
 See [Plugins](../concepts/plugins.mdx) for the full contract.
 
 **Route manifest in `postBuild` (`ctx.routes`)**

--- a/docs/src/content/docs/guides/migrating-from-eleventy.mdx
+++ b/docs/src/content/docs/guides/migrating-from-eleventy.mdx
@@ -15,7 +15,7 @@ they differ is the templating story. Read the
 `layout:` keys. zfb reads layouts from `layouts/` and you import them
 directly into your page TSX:
 
-```tsx
+```ts
 import BlogLayout from "../../layouts/blog-layout.tsx";
 
 export default function Page({ post }) {
@@ -70,17 +70,32 @@ export function paths() {
 ## Pagination
 
 11ty's `pagination` front-matter key becomes a `paginate()` helper inside
-`paths()`. See /api/paginate for the full surface, but the shape is:
+`paths()`. See [`paginate`](../api/paginate.mdx) for the full surface, but
+the shape is:
 
-```ts
+```tsx
+import { getCollection } from "zfb/content";
+import { paginate } from "zfb/paginate";
+
 export function paths() {
   const posts = getCollection("blog");  // synchronous — no await
-  return paginate(posts, { pageSize: 10 });
+  return paginate(posts, { pageSize: 10, param: "page" });
+}
+
+export default function BlogPage({ page }) {
+  const { data, page: currentPage, lastPage, pageSize, total } = page;
+  return (
+    <p>
+      Page {currentPage} of {lastPage}; showing {data.length} of {total}
+      posts at {pageSize} per page.
+    </p>
+  );
 }
 ```
 
-You get one route per page, plus the standard `currentPage`,
-`totalPages`, and `data` props.
+The `param` value must match your dynamic route segment (`[page].tsx` in
+this example). Each generated route receives `props.page` with the shape
+`{ data, page, lastPage, pageSize, total }`.
 
 ## Markdown front matter
 
@@ -88,6 +103,10 @@ This part is largely unchanged. Use `---` as a separator at the top of
 your `.md` files; zfb-content parses the front matter into `entry.data`
 and the body into `entry.body`. The fields available depend on the
 collection schema you declared in `zfb.config`.
+
+Content collections only enumerate `.md`, `.mdx`, and `.tsx` entries.
+Other files in the collection directory are ignored rather than surfaced
+through `getCollection()`.
 
 ## Honest caveat
 

--- a/docs/src/content/docs/guides/ssr-and-cloudflare-bindings.mdx
+++ b/docs/src/content/docs/guides/ssr-and-cloudflare-bindings.mdx
@@ -367,10 +367,10 @@ There are two ways to run the app locally, and they answer different questions:
   `prerender = false` routes through the embedded V8 isolate (see
   [dev-prod parity for `prerender = false`](#dev-prod-parity-for-prerender-false)
   above), but it exposes **no Worker bindings**: calling
-  `getCloudflareContext<Env>()` from an SSR route under `zfb dev` yields no
-  `env`, so any route that reads `env.DB` (or any other binding) cannot work
-  here. Use this for layout, styling, and routing iteration on routes that do
-  **not** touch bindings.
+  `getCloudflareContext<Env>()` from an SSR route under `zfb dev` throws
+  because there is no Cloudflare request scope, so any route that reads
+  `env.DB` (or any other binding) cannot work here. Use this for layout,
+  styling, and routing iteration on routes that do **not** touch bindings.
 - **`wrangler dev`** — binding-realistic loop. Runs the built `_worker.js`
   against a **local** D1 database (a SQLite file under `.wrangler/`), serves
   your real `compatibility_flags`, and surfaces real binding bugs. It

--- a/docs/src/content/docs/install/node-free.mdx
+++ b/docs/src/content/docs/install/node-free.mdx
@@ -5,15 +5,15 @@ sidebar_position: 1
 ---
 
 zfb ships as a self-contained Rust binary. **Node.js is not required to
-install or run it** — esbuild and Tailwind ship as standalone native binaries
-alongside the `zfb` executable (in the release tarball's `binaries/` slot)
-and are invoked as subprocesses located relative to the `zfb` executable
-itself. You only need Node as an opt-in escape hatch for specific features
-(see [When Node is still needed](#when-node-is-still-needed) below).
+install or run it** — esbuild and Tailwind are embedded into the `zfb`
+executable's vendor snapshot and extracted at runtime before they are invoked
+as subprocesses. They are not shipped as separate release-tarball binaries
+next to `zfb`. You only need Node as an opt-in escape hatch for specific
+features (see [When Node is still needed](#when-node-is-still-needed) below).
 
 The Node-free path supports the full feature set for content sites: Markdown,
 MDX, HTML pages, **and islands** — esbuild and Tailwind run as standalone
-native binaries shipped with `zfb`, so client-side hydration and CSS processing
+native binaries extracted by `zfb`, so client-side hydration and CSS processing
 work with zero Node involvement.
 
 ## Supported platforms


### PR DESCRIPTION
Parent: #1458
Closes #1463

Summary:
- Refresh guide, architecture, and install coverage for embedding, desktop deployment, SSR bindings, migrations, and node-free install flows.

Validation:
- Covered by the docs audit base-branch validation after integration.
- Local manager checks include docs build, generated HTML validation, repo formatting, TypeScript typecheck, pnpm tests, snippet checks, link checks, and ignored-test inventory.
