### PR TITLE
Docs audit: contributor docs

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -18,13 +18,18 @@ CI uses Node 22 and Rust stable on `ubuntu-latest`.
 
 The first `cargo build --workspace` on a clean machine takes **15–30 minutes**. The dominant cost is compiling the V8 JavaScript engine (pulled in via `deno_core` by the `zfb-render` crate). This is a one-time cost: subsequent incremental builds are fast because Cargo only recompiles changed crates.
 
-To make the wait productive, start with:
+After installing JS deps, start with the normal workspace build:
 
 ```sh
-cargo build --workspace --tests --no-deps
+pnpm install --frozen-lockfile
+cargo build --workspace
 ```
 
-`--no-deps` skips recompiling external dependencies (useful when you only changed workspace crate code). `--tests` also compiles test harnesses so the first `cargo test` run is faster.
+That command is intentionally plain: it builds every workspace crate for your host target, and the `crates/zfb/build.rs` build script automatically downloads, SHA-256-verifies, and stages the pinned `esbuild` and `tailwindcss` binaries before the `zfb` crate compiles. If you also want to precompile test harnesses after the first dependency install, use:
+
+```sh
+cargo build --workspace --all-targets
+```
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for tips on speeding up local Rust compilation with `sccache`.
 
@@ -34,24 +39,26 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for tips on speeding up local Rust comp
 # 1. Install JS deps
 pnpm install --frozen-lockfile
 
-# 2. Fetch the pinned tailwindcss v4 standalone CLI binary into
-#    crates/zfb/binaries/tailwindcss-v4 (idempotent — fast no-op on re-run)
-pnpm fetch:tailwind
-
-# 3. Build the Rust workspace (first run: 15-30 min; subsequent runs: fast)
+# 2. Build the Rust workspace (first run: 15-30 min; subsequent runs: fast).
+#    This also provisions the pinned esbuild and tailwindcss binaries.
 cargo build --workspace
 ```
 
-## The Tailwind binary
+## Provisioned external binaries
 
-The CSS pipeline shells out to the Tailwind v4 standalone CLI as a subprocess. The binary file is **not** committed to git — it is materialized on demand.
+The islands bundler shells out to `esbuild`, and the CSS pipeline shells out to the Tailwind v4 standalone CLI. These binary files are **not** committed to git; they are materialized on demand.
 
-There are two supported ways to provide it:
+The default path is Cargo-driven. Any normal build that compiles `crates/zfb` runs [`crates/zfb/build.rs`](./crates/zfb/build.rs), which:
 
-1. **Default — `pnpm fetch:tailwind`**: downloads the pinned asset from the upstream GitHub release, verifies SHA-256 against `sha256sums.txt`, and places it at `crates/zfb/binaries/tailwindcss-v4` (or `tailwindcss-v4.exe` on Windows). Supported platforms: `darwin-x64`, `darwin-arm64`, `linux-x64`, `linux-arm64`, `win32-x64`. For musl-libc Linux, use the override below.
-2. **Override — `ZFB_TAILWIND_BIN`**: set this env var to an absolute path of any tailwindcss v4 standalone binary you already have on disk. The engine uses it directly and `pnpm fetch:tailwind` becomes a no-op. This is the right choice for CI images that already bundle tailwind, or for musl-libc systems.
+- downloads the pinned platform-specific `@esbuild/*` npm tarball, extracts the standalone `esbuild` binary, verifies it against the `ESBUILD_SHA256_*` constants, and stages it under `crates/zfb/binaries/esbuild/`;
+- downloads the pinned Tailwind v4 standalone binary from the upstream GitHub release, verifies it against the `TAILWIND_SHA256_*` constants, and stages it as `crates/zfb/binaries/tailwindcss-v4` (or `.exe` on Windows);
+- copies both verified binaries into the embedded vendor snapshot so installed `zfb` binaries can run without a workspace checkout.
 
-See [`crates/zfb-css/README.md`](./crates/zfb-css/README.md) ("Getting the binary") for the full contract and the [`crates/zfb/binaries/README.md`](./crates/zfb/binaries/README.md) for the runtime resolution layout.
+Supported build platforms are `darwin-x64`, `darwin-arm64`, `linux-x64-gnu`, `linux-arm64-gnu`, and `win32-x64-msvc`. For unsupported targets such as musl-libc Linux, set both `ZFB_ESBUILD_BIN` and `ZFB_TAILWIND_BIN` to absolute paths for pre-verified binaries.
+
+`pnpm fetch:tailwind` still exists as a Tailwind-only developer convenience, but it is not part of first-build setup. Plain `cargo build --workspace` provisions both binaries.
+
+See [`crates/zfb-css/README.md`](./crates/zfb-css/README.md) ("Getting the binary") for the Tailwind runtime contract and the [`crates/zfb/binaries/README.md`](./crates/zfb/binaries/README.md) for the runtime resolution layout.
 
 ## Embedded npm packages
 
@@ -74,7 +81,7 @@ To bump a framework-runtime version:
 ## Running tests
 
 ```sh
-# Default — fast, mock-only, no external binary required
+# Default — non-ignored workspace suite; Cargo provisions host binaries as needed
 cargo test --workspace
 
 # Heavyweight — runs the previously-`#[ignore]`-gated tests that exercise
@@ -97,7 +104,7 @@ pnpm format               # apply
 ```sh
 pnpm docs:dev             # zfb dev server for the docs site
 pnpm docs:build           # static build into docs/dist/
-pnpm fetch:tailwind       # (re-)materialize the Tailwind v4 binary
+pnpm fetch:tailwind       # optional Tailwind-only prefetch; cargo build is authoritative
 ```
 
 ## Release builds and cross-compilation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,12 +14,17 @@ The first `cargo build --workspace` on a clean machine takes **15–30 minutes**
 To minimise the wait on your first checkout:
 
 ```sh
-# Compile workspace crates + test harnesses, skip recompiling
-# third-party deps that haven't changed.
-cargo build --workspace --tests --no-deps
+pnpm install --frozen-lockfile
+cargo build --workspace
 ```
 
-After this, incremental rebuilds and `cargo test` runs are fast.
+This is executable as written and is the supported first build. It also runs `crates/zfb/build.rs`, which downloads, SHA-256-verifies, and stages the pinned host-platform `esbuild` and `tailwindcss` binaries. After this, incremental rebuilds and test runs are fast.
+
+If you want to compile test harnesses during the warm-up build, use Cargo's all-targets mode:
+
+```sh
+cargo build --workspace --all-targets
+```
 
 ### Cargo feature gate — `embed_v8`
 
@@ -49,11 +54,17 @@ Add the exports to your shell profile to persist them.
 
 ### Faster test runs with cargo-nextest
 
-If the workspace test suite becomes slow, [cargo-nextest](https://nexte.st/) is a drop-in replacement for `cargo test` that runs tests in parallel and streams output efficiently:
+[cargo-nextest](https://nexte.st/) is the adopted CI runner for Rust tests. It runs tests in parallel, applies the repo's retry/timeout policy from [`.config/nextest.toml`](./.config/nextest.toml), and emits JUnit telemetry.
 
 ```sh
 cargo install cargo-nextest
 cargo nextest run --workspace
+```
+
+nextest does not run doctests, so run the doctest lane separately when you need local parity with CI:
+
+```sh
+cargo test --workspace --doc
 ```
 
 ## Workspace layout
@@ -71,8 +82,8 @@ cargo run -p zfb
 
 - Branch off `main` (or the relevant base branch for an in-flight epic).
 - Keep commits focused; conventional commit-style messages are appreciated but not strictly enforced.
-- `lefthook` runs the pre-commit pipeline: Prettier over JS/TS/JSON/YAML (no Rust) and `@takazudo/mdx-formatter` over MD/MDX. Rust formatting is not enforced automatically — run `cargo fmt` and `cargo clippy --workspace` manually before opening a PR.
-- Open a PR against `main` (or the relevant epic base branch). CI is a strict superset of the pre-commit pipeline: it also runs `cargo build`, `cargo clippy -D warnings`, the full test suite, and actionlint.
+- `lefthook` runs the pre-commit pipeline: Prettier over JS/TS/JSON/YAML (no Rust) and `@takazudo/mdx-formatter` over MD/MDX. Rust formatting is not enforced automatically — run `cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings` manually before opening a PR.
+- Open a PR against `main` (or the relevant epic base branch). CI is a strict superset of the pre-commit pipeline. The main PR gate includes `cargo fmt --all --check`, `pnpm -r --if-present typecheck`, `pnpm -r test`, `pnpm format:check`, `cargo build --workspace --all-targets`, `cargo clippy --workspace --all-targets -- -D warnings`, the env-gated binary integration tests, `cargo nextest run --workspace --profile ci`, `cargo test --workspace --doc`, and actionlint.
 
 ## Formatting
 
@@ -110,16 +121,14 @@ The Cloudflare Workers deploy workflows expect the following GitHub Actions secr
 
 zfb shells out to a small set of third-party tools (esbuild for the islands bundler, wrangler/workerd for Cloudflare Workers preview, Tailwind v4 for the CSS engine). Every one of those tools is **exact-pinned** so that the same source tree produces byte-identical output regardless of when or where it is built — this matters for asset-hash stability and for keeping the SSR pipeline from drifting under our feet when upstream cuts a patch release.
 
-The pin lives in two places that **must move together**:
+The pin sources are:
 
-1. The npm-side declaration in [`package.json`](./package.json) (no `^`/`~` for these entries).
-2. The Rust-side constant that the subprocess wrapper checks against at startup.
-
-| Tool        | Rust constant                                                                                       | Where                                          | npm-side pin                          |
-| ----------- | --------------------------------------------------------------------------------------------------- | ---------------------------------------------- | ------------------------------------- |
-| esbuild     | `EXPECTED_ESBUILD_VERSION`, `EXPECTED_ESBUILD_SHA256`                                               | `crates/zfb-islands/src/esbuild.rs`            | (binary; populated by release engineering into `crates/zfb/binaries/esbuild/esbuild`) |
-| wrangler    | `EXPECTED_WRANGLER_VERSION`                                                                         | `crates/zfb-toolchain-pins/src/lib.rs`         | `wrangler` in `package.json`          |
-| workerd     | `EXPECTED_WORKERD_VERSION` (informational; pinned transitively via wrangler → `pnpm-lock.yaml`)     | `crates/zfb-toolchain-pins/src/lib.rs`         | (transitive; resolved in `pnpm-lock.yaml`) |
+| Tool        | Version source                                                                                  | Checksum / lock source                                                                                                      | Package-side pin                                      |
+| ----------- | ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| esbuild     | `EXPECTED_ESBUILD_VERSION` in `crates/zfb-toolchain-pins/src/lib.rs`                            | `EXPECTED_ESBUILD_SHA256` 5-platform `cfg` block in `crates/zfb-islands/src/esbuild.rs`; matching `ESBUILD_SHA256_*` constants in `crates/zfb/build.rs` | No root `package.json` pin; `build.rs` downloads the matching `@esbuild/<platform>` tarball |
+| tailwindcss | `TAILWIND_VERSION` in `crates/zfb/build.rs`; mirrored by `TAILWIND_VERSION` in `scripts/fetch-tailwind.mjs` | `TAILWIND_SHA256_*` constants in `crates/zfb/build.rs`                                                                       | No root `package.json` pin; `build.rs` downloads the standalone GitHub release asset |
+| wrangler    | `EXPECTED_WRANGLER_VERSION` in `crates/zfb-toolchain-pins/src/lib.rs`                           | `pnpm-lock.yaml`                                                                                                            | Exact `wrangler` devDependency in root `package.json` |
+| workerd     | `EXPECTED_WORKERD_VERSION` in `crates/zfb-toolchain-pins/src/lib.rs`                            | `pnpm-lock.yaml` transitive dependency from wrangler                                                                         | Transitive only                                       |
 
 ### Bumping wrangler / workerd
 
@@ -134,16 +143,28 @@ If you ever need to bypass the wrangler version gate (e.g. while a bump is mid-f
 
 ### Bumping esbuild
 
-esbuild is shipped as a Go-built standalone CLI binary that release engineering downloads into `crates/zfb/binaries/esbuild/esbuild` at release-tarball assembly time — the binary is **not** committed to this repo. To bump:
+esbuild is shipped as a Go-built standalone CLI binary. The binary is **not** committed to this repo; `crates/zfb/build.rs` downloads the platform-specific `@esbuild/*` tarball during Cargo builds, verifies the extracted binary, and stages it under `crates/zfb/binaries/esbuild/`. To bump:
 
 1. Pick the new esbuild version (the latest stable 0.x at release-cut time; see <https://github.com/evanw/esbuild/releases>).
-2. Edit `EXPECTED_ESBUILD_VERSION` in `crates/zfb-islands/src/esbuild.rs`.
-3. Compute the SHA-256 of the platform-specific binary you intend to ship (e.g. `sha256sum esbuild` on Linux, `shasum -a 256 esbuild` on macOS) and edit `EXPECTED_ESBUILD_SHA256` to that lowercase hex digest. Leave the constant as the empty string (`""`) only if you are explicitly handing the SHA-pin step off to the next release-engineering pass — the version gate still runs in that case, but the checksum gate is skipped (with a clear log line).
-4. Update the `## esbuild Version` table in `crates/zfb-islands/README.md`.
-5. Run `cargo test -p zfb-islands` — the unit tests use the mock-subprocess code path and do not require the real binary.
-6. Drop the new binary into `crates/zfb/binaries/esbuild/esbuild` locally to test the end-to-end gate, but do not commit it (`.gitignore` already excludes the path).
+2. Edit `EXPECTED_ESBUILD_VERSION` in `crates/zfb-toolchain-pins/src/lib.rs`.
+3. Compute the SHA-256 of the extracted binary in each supported `@esbuild/*` package (`linux-x64`, `linux-arm64`, `darwin-arm64`, `darwin-x64`, `win32-x64`) and update the corresponding entries in the `EXPECTED_ESBUILD_SHA256` 5-platform `cfg` block in `crates/zfb-islands/src/esbuild.rs`.
+4. Update the matching `ESBUILD_SHA256_LINUX_X64`, `ESBUILD_SHA256_LINUX_ARM64`, `ESBUILD_SHA256_MACOS_ARM64`, `ESBUILD_SHA256_MACOS_X64`, and `ESBUILD_SHA256_WIN_X64` constants in `crates/zfb/build.rs` in the same commit.
+5. Update the `## esbuild Version` table in `crates/zfb-islands/README.md`.
+6. Run `cargo build --workspace --all-targets` so the host-platform binary is downloaded, SHA-256-verified, and staged by `build.rs`.
+7. Run `cargo test -p zfb-islands` — the unit tests use the mock-subprocess code path and do not require the real binary.
 
 The verification gate is implemented in `ensure_binary_verified` in `crates/zfb-islands/src/esbuild.rs` and runs once per binary path per process: it spawns `esbuild --version`, asserts the reported version equals `EXPECTED_ESBUILD_VERSION`, and (when populated) hashes the binary and asserts the SHA-256 equals `EXPECTED_ESBUILD_SHA256`. A mismatch on either gate aborts with a clear, actionable error pointing back at this section.
+
+### Bumping Tailwind
+
+Tailwind v4 is shipped as the upstream standalone CLI binary. The binary is **not** committed to this repo; `crates/zfb/build.rs` downloads the platform-specific GitHub release asset during Cargo builds, verifies it, and stages it as `crates/zfb/binaries/tailwindcss-v4` (or `.exe` on Windows). To bump:
+
+1. Pick the new Tailwind v4 version from <https://github.com/tailwindlabs/tailwindcss/releases>.
+2. Edit `TAILWIND_VERSION` in `crates/zfb/build.rs`.
+3. Edit the mirrored `TAILWIND_VERSION` in `scripts/fetch-tailwind.mjs` so the optional Tailwind-only prefetch helper stays aligned.
+4. Update the `TAILWIND_SHA256_LINUX_X64`, `TAILWIND_SHA256_LINUX_ARM64`, `TAILWIND_SHA256_MACOS_ARM64`, `TAILWIND_SHA256_MACOS_X64`, and `TAILWIND_SHA256_WIN_X64` constants in `crates/zfb/build.rs` from the release's `sha256sums.txt`.
+5. Update any Tailwind version tables in `crates/zfb-css/README.md`.
+6. Run `cargo build --workspace --all-targets` so the host-platform binary is downloaded, SHA-256-verified, and staged by `build.rs`.
 
 ## Supply chain
 

--- a/SECURITY-DEPS.md
+++ b/SECURITY-DEPS.md
@@ -6,27 +6,49 @@ Every runtime dep on a publishable package is a supply-chain liability for downs
 Add deps only when a Node built-in cannot do the job, document the reason here, and prefer
 `pnpm dlx` / `npx` for build-time-only tools.
 
-## Intended-public packages and their runtime deps
+## Published packages and their runtime deps
 
-The four packages intended for publication are `@takazudo/zfb`, `@takazudo/zfb-runtime`,
-`@takazudo/zfb-adapter-cloudflare`, and `create-zfb`. Their `dependencies` fields (NOT
-`devDependencies`) are audited here.
+The release pipeline publishes nine npm packages:
 
-### `@takazudo/zfb`
+- five first-party platform binary packages: `@takazudo/zfb-darwin-arm64`,
+  `@takazudo/zfb-darwin-x64`, `@takazudo/zfb-linux-arm64-gnu`,
+  `@takazudo/zfb-linux-x64-gnu`, and `@takazudo/zfb-win32-x64-msvc`;
+- four non-platform packages: `@takazudo/zfb`, `@takazudo/zfb-runtime`,
+  `@takazudo/zfb-adapter-cloudflare`, and `create-zfb`.
+
+Their `dependencies` fields (NOT `devDependencies`) are audited here. First-party
+workspace links and optional platform packages still matter for publication integrity, but
+they are not third-party runtime supply-chain surface in the same way a registry dependency
+is.
+
+### Platform binary packages
 
 **Runtime deps:** none.
 
-`@takazudo/zfb` has no `dependencies` field — only `devDependencies` (TypeScript, Vitest,
-`@types/node`). All of those are build/test tooling that is never installed by downstream
-users of the package.
+The five `@takazudo/zfb-<platform>` packages carry the built `zfb` binary, `README.md`, and
+license metadata. They do not declare `dependencies`.
+
+### `@takazudo/zfb`
+
+**Third-party runtime deps:** none.
+
+`@takazudo/zfb` does not declare a `dependencies` field. It does declare:
+
+- `optionalDependencies` on the five first-party platform binary packages, so package managers
+  install the matching native `zfb` executable when available;
+- an optional `react` peer, used only by consumers that opt into React-facing APIs;
+- `devDependencies` for local build/test/typecheck fixtures, including TypeScript, Vitest,
+  `happy-dom`, `preact`, `react`, and type packages.
+
+Those fields are intentionally separate from third-party production `dependencies`.
 
 ### `@takazudo/zfb-runtime`
 
 **Runtime deps:**
 
-| Package | Version range | Rationale |
-| ------- | ------------- | --------- |
-| `hono`  | `^4.12.23`    | Hono is the page-router runtime — it is the entire point of this package. `zfb-runtime` wraps Hono's routing primitives to provide file-system-based page routing, content snapshots, and SSR for Cloudflare Workers. A Node built-in cannot replace a full HTTP routing framework. The dep is retained. Floor raised from `^4.7.0` to clear 9 advisories patched at >=4.12.21 (#813). |
+| Package | Version source | Rationale |
+| ------- | -------------- | --------- |
+| `hono`  | `packages/zfb-runtime/package.json` | Hono is the page-router runtime — it is the entire point of this package. `zfb-runtime` wraps Hono's routing primitives to provide file-system-based page routing, content snapshots, and SSR for Cloudflare Workers. A Node built-in cannot replace a full HTTP routing framework. The dep is retained. Keep the package manifest and this rationale in sync when the range changes. |
 
 ### `@takazudo/zfb-adapter-cloudflare`
 
@@ -42,21 +64,37 @@ deps — see SECURITY-DEPS.md` comment to make this contractual.
 
 **Runtime deps:**
 
-| Package          | Version range                  | Rationale |
-| ---------------- | ------------------------------ | --------- |
-| `@takazudo/zfb`  | `workspace:0.1.0-next.31`      | Scaffold tool uses the first-party `@takazudo/zfb` package. `@takazudo/zfb` itself has no external runtime deps (see above), so `create-zfb` introduces no third-party transitive runtime surface. |
+| Package         | Version source | Rationale |
+| --------------- | -------------- | --------- |
+| `@takazudo/zfb` | `packages/create-zfb/package.json` | Scaffold tool uses the first-party `@takazudo/zfb` package. pnpm rewrites the workspace specifier to the concrete package version at publish time. `@takazudo/zfb` itself has no third-party production `dependencies` field (see above), so `create-zfb` introduces no third-party transitive runtime surface. |
 
 ## Audit policy
 
-CI runs `pnpm audit --prod --audit-level=high`. `high`+ findings fail PRs. `moderate` and
-`low` findings are intentionally informational — track them here, file issues for real fixes.
-So "CI audit green" means no high/critical CVEs, not zero findings.
+There are two supply-chain audit lanes:
+
+- **npm production deps:** PR CI and the weekly [`.github/workflows/security-audit.yml`](./.github/workflows/security-audit.yml)
+  workflow run `pnpm audit --prod --audit-level=high`. `high`+ findings fail. `moderate`
+  and `low` findings are intentionally informational — track them here and file issues for
+  real fixes. "npm audit green" means no high/critical CVEs in production dependency graphs,
+  not zero findings.
+- **Rust deps:** the weekly security audit also runs `cargo deny check` using
+  [`deny.toml`](./deny.toml). The `[advisories]` section is deny-on-finding for known
+  vulnerabilities and yanked crates; licenses, bans, and sources currently report warnings
+  rather than failing the job. The weekly workflow files or closes a tracking issue when
+  either audit lane changes state.
+
+Run the same checks locally with:
+
+```sh
+pnpm audit --prod --audit-level=high
+cargo deny check
+```
 
 ## Known moderate / low findings
 
-_None at the time of this audit (2026-05-20). Update this section whenever a non-gated
-finding is observed, with the advisory ID, affected package, severity, and the tracking
-issue number._
+_None currently recorded in this document. Update this section whenever a non-gated npm
+finding or warning-only Rust finding is observed, with the advisory ID, affected package or
+crate, severity, and the tracking issue number._
 
 ## Before adding a runtime dep
 


### PR DESCRIPTION
Parent: #1458
Closes #1465

Summary:
- Update contributor and maintainer docs for current build, security, Claude skill, and contribution workflows.

Validation:
- Covered by the docs audit base-branch validation after integration.
- Local manager checks include docs build, generated HTML validation, repo formatting, TypeScript typecheck, pnpm tests, snippet checks, link checks, and ignored-test inventory.
