### PR TITLE
Docs audit: crate README sweep

### DIFF
--- a/crates/zfb-css/README.md
+++ b/crates/zfb-css/README.md
@@ -13,19 +13,21 @@ the production emitter, and the native-engine placeholder.
 
 This crate invokes the **Tailwind CSS v4 standalone CLI** as a subprocess.
 
-| Field                 | Value                                                              |
-| --------------------- | ------------------------------------------------------------------ |
-| Pinned version        | **`4.2.0`**                                                        |
-| Major line            | Tailwind CSS v4.x                                                  |
-| Distribution          | Standalone CLI binary (no Node.js required at runtime)             |
-| Expected binary path  | `crates/zfb/binaries/tailwindcss-v4` (in the release tarball)      |
-| Upstream              | <https://github.com/tailwindlabs/tailwindcss/releases>             |
+| Field                 | Value                                                         |
+| --------------------- | ------------------------------------------------------------- |
+| Pinned version        | **`4.2.0`**                                                   |
+| Major line            | Tailwind CSS v4.x                                             |
+| Distribution          | Standalone CLI binary (no Node.js required at runtime)        |
+| Workspace fallback    | `crates/zfb/binaries/tailwindcss-v4` (or `.exe` on Windows)   |
+| Embedded runtime name | `bin/tailwindcss-v4` inside the `include_dir!` vendor snapshot |
+| Upstream              | <https://github.com/tailwindlabs/tailwindcss/releases>        |
 
 > The pin **must be reviewed and refreshed before each `zfb` release**. Bump
 > `4.2.0` to whatever the latest stable Tailwind v4.x is at release-cut time.
-> Update the SHA-256 constants in `crates/zfb/build.rs` and the version
-> constant in `scripts/fetch-tailwind.mjs` in the same commit — both must
-> stay in lockstep with the version line above.
+> Update `TAILWIND_VERSION` and the Tailwind SHA-256 constants in
+> `crates/zfb/build.rs`, plus `TAILWIND_VERSION` in
+> `scripts/fetch-tailwind.mjs`, in the same commit. Both version constants
+> must stay in lockstep with the version line above.
 
 ## Getting the binary
 
@@ -39,8 +41,10 @@ When you run `cargo build` (or `cargo install zfb`), the build script
 detects your platform, downloads the pinned `tailwindcss` v4 standalone
 binary from the [tailwindlabs GitHub release](https://github.com/tailwindlabs/tailwindcss/releases),
 verifies its SHA-256, and stages it at `crates/zfb/binaries/tailwindcss-v4`
-(or `tailwindcss-v4.exe` on Windows). Re-runs are a fast no-op when the
-on-disk binary already matches the pinned checksum.
+(or `tailwindcss-v4.exe` on Windows). It then copies the staged executable to
+`$OUT_DIR/vendor/bin/tailwindcss-v4` so `include_dir!` embeds it in the
+compiled `zfb` executable. Re-runs are a fast no-op when the on-disk binary
+already matches the pinned checksum.
 
 The script `scripts/fetch-tailwind.mjs` (invoked via `pnpm fetch:tailwind`)
 performs the same download for developer convenience — useful when you
@@ -82,8 +86,9 @@ with the package directory as CWD; the engine's default relative path
 
 - **Reproducible builds.** A fixed Tailwind version means the same source tree
   produces byte-identical CSS regardless of when or where it is built.
-- **Bundled binary.** The release tarball ships the exact binary `zfb-css`
-  expects — no `npx`, no `node_modules`, no network calls at user build time.
+- **Embedded binary.** The compiled `zfb` executable embeds the exact binary
+  `zfb-css` expects and extracts it to a tempdir at runtime — no `npx`, no
+  `node_modules`, no network calls while building a user site.
 - **Subprocess contract.** The CLI flags this crate calls (`--input`,
   `--output`, `--watch`, content-scan globs) are the v4 surface area; locking
   the version prevents flag drift from breaking the wrapper.
@@ -100,18 +105,19 @@ behind an internal `CssEngine` trait. The `tailwindcss-v4` binary is one
 implementation; a hypothetical Rust-native crate would be another, with no
 changes required at call sites.
 
-### Why the binary lives at `crates/zfb/binaries/tailwindcss-v4`
+### Why the workspace fallback lives at `crates/zfb/binaries/tailwindcss-v4`
 
-The `zfb` CLI is the single user-facing executable; bundled tooling needs to
-sit in a path the `zfb` runtime can locate relative to its own executable.
-Placing the binary inside `crates/zfb/` keeps the release-tarball layout
-colocated with the crate that owns the runtime contract. See
-`crates/zfb/binaries/README.md` for the slot-level details.
+The `zfb` CLI owns both the Cargo build script that downloads helper binaries
+and the `include_dir!` snapshot that embeds them. Placing the workspace
+fallback under `crates/zfb/` keeps download, checksum, embedding, and runtime
+extraction details colocated with the crate that owns the runtime contract.
+See `crates/zfb/binaries/README.md` for the staging-path details.
 
 The binary file itself is **not** committed to git — `.gitignore` excludes it.
 `crates/zfb/build.rs` downloads and SHA-verifies it at `cargo build` /
-`cargo install` time; `pnpm fetch:tailwind` provides the same binary for
-local development without a full build.
+`cargo install` time, embeds it via `$OUT_DIR/vendor/bin/`, and leaves the
+workspace copy as the direct-development fallback. `pnpm fetch:tailwind`
+provides the same workspace copy for local development without a full build.
 
 ---
 

--- a/crates/zfb-islands/README.md
+++ b/crates/zfb-islands/README.md
@@ -14,28 +14,31 @@ and code-splitting. The `NativeRustBundler` placeholder lives in
 
 This crate invokes the **esbuild standalone CLI** as a subprocess.
 
-| Field                | Value                                                          |
-| -------------------- | -------------------------------------------------------------- |
-| Pinned version       | **`0.25.12`**                                                  |
-| Major line           | esbuild 0.25.x                                                 |
-| Distribution         | Standalone CLI binary (Go-built; no Node.js required)          |
-| Expected binary path | `crates/zfb/binaries/esbuild` (in the release tarball)         |
-| Upstream             | <https://github.com/evanw/esbuild/releases>                    |
+| Field                 | Value                                                        |
+| --------------------- | ------------------------------------------------------------ |
+| Pinned version        | **`0.25.12`**                                                |
+| Major line            | esbuild 0.25.x                                               |
+| Distribution          | Standalone CLI binary (Go-built; no Node.js required)        |
+| Version source        | `EXPECTED_ESBUILD_VERSION` in `crates/zfb-toolchain-pins`    |
+| Workspace fallback    | `crates/zfb/binaries/esbuild/esbuild` (or `.exe` on Windows) |
+| Embedded runtime name | `bin/esbuild` inside the `include_dir!` vendor snapshot       |
+| Upstream              | <https://github.com/evanw/esbuild/releases>                  |
 
 > The pin **must be reviewed and refreshed before each `zfb` release**.
 > Bump `0.25.12` to whatever the latest stable esbuild 0.x is at
-> release-cut time. Update the SHA-256 constants in `crates/zfb/build.rs`
-> and the `EXPECTED_ESBUILD_VERSION` / `EXPECTED_ESBUILD_SHA256` constants
-> in `crates/zfb-islands/src/esbuild.rs` in the same commit.
+> release-cut time. Update `EXPECTED_ESBUILD_VERSION` in
+> `crates/zfb-toolchain-pins/src/lib.rs`, `EXPECTED_ESBUILD_SHA256` in
+> `crates/zfb-islands/src/esbuild.rs`, and the esbuild SHA-256 table in
+> `crates/zfb/build.rs` in the same commit.
 
 ### Why a pinned version
 
 - **Reproducible builds.** A fixed esbuild version means the same source
   tree produces byte-identical bundles regardless of when or where it is
   built — the SHA-256 hash that drives `islands-{hash}.js` depends on this.
-- **Bundled binary.** The release tarball ships the exact binary
-  `zfb-islands` expects — no `npx`, no `node_modules`, no network calls at
-  user build time.
+- **Embedded binary.** The compiled `zfb` executable embeds the exact binary
+  `zfb-islands` expects and extracts it to a tempdir at runtime — no `npx`,
+  no `node_modules`, no network calls while building a user site.
 - **Subprocess contract.** The CLI flags this crate calls for the shared
   bundle path (`--bundle`, `--format=esm`, `--splitting=true`,
   `--tree-shaking=true`, `--entry-names=islands`,
@@ -57,16 +60,16 @@ implementation; a hypothetical Rust-native crate would be another, with no
 changes required at call sites. See `src/future_rust_native.rs` for the
 `NativeRustBundler` stub.
 
-### Why the binary lives at `crates/zfb/binaries/esbuild`
+### Why the workspace fallback lives at `crates/zfb/binaries/esbuild/esbuild`
 
-The `zfb` CLI is the single user-facing executable; bundled tooling needs
-to sit in a path the `zfb` runtime can locate relative to its own
-executable. Placing the binary inside `crates/zfb/` keeps the
-release-tarball layout colocated with the crate that owns the runtime
-contract. See `crates/zfb/binaries/README.md` for the slot-level details
-(this slot mirrors the Tailwind v4 slot reserved by Epic 4 / Sub 4).
+The `zfb` CLI owns both the Cargo build script that downloads helper binaries
+and the `include_dir!` snapshot that embeds them. Placing the workspace
+fallback under `crates/zfb/` keeps download, checksum, embedding, and runtime
+extraction details colocated with the crate that owns the runtime contract.
+See `crates/zfb/binaries/README.md` for the staging-path details.
 
 The binary file itself is **not** committed to git — `.gitignore` excludes
 it. `crates/zfb/build.rs` downloads and SHA-verifies the esbuild binary
-from the npm registry at `cargo build` / `cargo install` time, so no
-manual fetch step is needed for a standard build.
+from the npm registry at `cargo build` / `cargo install` time, embeds it via
+`$OUT_DIR/vendor/bin/`, and leaves the workspace copy as the
+direct-development fallback.

--- a/crates/zfb-md-extras/README.md
+++ b/crates/zfb-md-extras/README.md
@@ -47,8 +47,14 @@ the committed file — `gen-fixture.mjs` is never called by CI.
 ### Running the integration test
 
 ```sh
-cargo test --package zfb-md-extras
+cargo test -p zfb-md-extras --features test-utils
 ```
+
+The fixture integration tests in `Cargo.toml` declare
+`required-features = ["test-utils"]` because they import
+`zfb_md_extras::test_harness::run_fixture`. Without `--features test-utils`,
+Cargo compiles the crate's ordinary tests but skips those fixture test
+binaries, so the snapshot fixtures are not exercised.
 
 ### Writing a new fixture test
 

--- a/crates/zfb-toolchain-pins/README.md
+++ b/crates/zfb-toolchain-pins/README.md
@@ -1,10 +1,13 @@
-# zfb-toolchain-pins
+# zfb-toolchain-pins — EXPECTED_WRANGLER_VERSION, EXPECTED_WORKERD_VERSION, EXPECTED_ESBUILD_VERSION
 
-Single source of truth for pinned external tool versions (`wrangler`, `workerd`).
+Single source of truth for pinned external tool versions (`wrangler`,
+`workerd`, `esbuild`).
 
 All crates that need to compare or display these version strings import from here rather
-than duplicating them. `zfb preview` runs `pnpm exec wrangler --version` at startup and
-aborts with a clear error if the reported version does not match.
+than duplicating them. `zfb preview` runs `pnpm exec wrangler --version` at
+startup and aborts with a clear error if the reported version does not match;
+`zfb-islands` and `crates/zfb/build.rs` import the esbuild version pin from
+this crate.
 
 ## Constants
 
@@ -12,18 +15,27 @@ aborts with a clear error if the reported version does not match.
 | --------------------------- | --------------- | ----------------------------------------------------------------- |
 | `EXPECTED_WRANGLER_VERSION` | `"4.85.0"` | Checked by `zfb preview` against the live `wrangler` CLI version |
 | `EXPECTED_WORKERD_VERSION` | `"1.20260424.1"` | Documents the locked `workerd` transitive dependency |
+| `EXPECTED_ESBUILD_VERSION` | `"0.25.12"` | Used by `zfb-islands` version checks and by `crates/zfb/build.rs` download URLs |
 
 `EXPECTED_WRANGLER_VERSION` is kept in lock-step with the exact-pinned `wrangler` entry in
 the root `package.json`. `EXPECTED_WORKERD_VERSION` is not controlled directly (workerd is
 a transitive dependency of wrangler); its constant here makes a single `grep` surface both
-pins together.
+pins together. `EXPECTED_ESBUILD_VERSION` is the esbuild version source of
+truth; `crates/zfb-islands/src/esbuild.rs` re-exports it for callers that
+previously imported the pin from the islands crate.
 
 ## Bump procedure
 
-1. Update the two constants in `src/lib.rs`.
-2. Bring the root `package.json` `devDependencies` in sync (wrangler pin).
-3. Run `cargo build --workspace` to catch any compile-time consumers that relied on the
-   old string value.
+1. Update the relevant constants in `src/lib.rs`.
+2. For a wrangler bump, bring the root `package.json` `devDependencies` and
+   lockfile in sync; confirm the resolved `workerd` version and update
+   `EXPECTED_WORKERD_VERSION` if it changed.
+3. For an esbuild bump, update `EXPECTED_ESBUILD_VERSION` here,
+   `EXPECTED_ESBUILD_SHA256` in `crates/zfb-islands/src/esbuild.rs`, and the
+   platform-specific esbuild SHA-256 table in `crates/zfb/build.rs` in the
+   same commit.
+4. Run `cargo build --workspace` to catch any compile-time consumers that
+   relied on the old string value.
 
 See [CONTRIBUTING.md](../../CONTRIBUTING.md) "External tool version pins" for the full
 runbook.
@@ -34,6 +46,8 @@ runbook.
 cargo test -p zfb-toolchain-pins
 ```
 
-This crate contains only constants — the command compiles the crate and runs zero unit
-tests. The pins are exercised by consumer crates (for example, `zfb preview` checks
-`wrangler --version` against `EXPECTED_WRANGLER_VERSION` at runtime).
+This crate contains only constants — the command compiles the crate and runs
+zero unit tests. The pins are exercised by consumer crates: `zfb preview`
+checks `wrangler --version` against `EXPECTED_WRANGLER_VERSION`, while
+`zfb-islands` checks the esbuild subprocess version against
+`EXPECTED_ESBUILD_VERSION`.

--- a/crates/zfb/binaries/README.md
+++ b/crates/zfb/binaries/README.md
@@ -1,38 +1,47 @@
-# `crates/zfb/binaries/` — Bundled binary distribution slot
+# `crates/zfb/binaries/` — Workspace staging paths for embedded helper binaries
 
-This directory reserves placement for third-party binaries that ship inside the
-`zfb` release tarball. The binaries are invoked at runtime as subprocesses by
-the `zfb` CLI (and by sibling crates that depend on `zfb`'s runtime layout).
+This directory records the workspace staging paths for third-party helper
+binaries that `zfb` invokes as subprocesses. The binaries themselves are not
+committed. During a `zfb` crate build, `crates/zfb/build.rs` downloads and
+verifies the platform-specific files, stages them here for local reuse, then
+copies them into `$OUT_DIR/vendor/bin/` so `include_dir!` embeds them into the
+compiled `zfb` executable.
+
+An installed `zfb` binary does not rely on an executable-adjacent `binaries/`
+directory. At runtime, `zfb` extracts embedded helper binaries to a fresh
+tempdir via `crates/zfb/src/render_pipeline.rs::embedded_binary`.
 
 ## Why this lives here
 
-The `zfb` crate is the user-facing CLI binary. When we package a release
-tarball for distribution, this `binaries/` directory is included alongside the
-`zfb` executable so that, at runtime, `zfb` can locate the bundled tools using
-a path relative to its own executable. Keeping the slot inside `crates/zfb/`
-(rather than at the workspace root) keeps the release-tarball layout colocated
-with the crate that owns the runtime contract.
+The `zfb` crate owns the Cargo build script and the `include_dir!` snapshot
+that embeds helper binaries. Keeping the staging paths inside `crates/zfb/`
+keeps the download, checksum, embedding, and runtime extraction contract
+colocated with the user-facing CLI crate.
 
-## Expected slots
+Sibling crates still expose workspace-relative fallback paths for direct
+in-repo development and focused package tests. The production `zfb` command
+path wires in the embedded extraction tier before those fallbacks are needed.
 
-| Path                              | Purpose                                                       | Owner crate     |
-| --------------------------------- | ------------------------------------------------------------- | --------------- |
-| `tailwindcss-v4`                  | Tailwind CSS v4 standalone CLI binary (subprocess invocation) | `zfb-css`       |
-| `esbuild/esbuild`                 | esbuild standalone CLI binary (subprocess invocation)         | `zfb-islands`   |
+## Expected staged files
+
+| Path                              | Purpose                                                       | Owner crate   |
+| --------------------------------- | ------------------------------------------------------------- | ------------- |
+| `tailwindcss-v4`                  | Tailwind CSS v4 standalone CLI binary (subprocess invocation) | `zfb-css`     |
+| `esbuild/esbuild`                 | esbuild standalone CLI binary (subprocess invocation)         | `zfb-islands` |
 
 See `crates/zfb-css/README.md` for the pinned Tailwind version and rationale.
 See `crates/zfb-islands/README.md` for the pinned esbuild version and rationale,
-and `crates/zfb/binaries/esbuild/README.md` for the slot-shape rationale
-(the esbuild slot uses a subdirectory rather than a single file path).
+and `crates/zfb/binaries/esbuild/README.md` for the esbuild subdirectory
+rationale.
 
-## Embedded npm packages (no on-disk slot)
+## Embedded npm packages
 
 In addition to the binaries above, `crates/zfb/build.rs` snapshots three
 groups of npm packages directly **into the compiled `zfb` binary** via
-`include_dir!`. They have no `binaries/` slot — they ride inside the
-executable bytes themselves and are extracted to a tempdir at `zfb build`
-/ `zfb dev` time so esbuild can resolve framework imports without a
-consumer-side `node_modules/`.
+`include_dir!`. They are not staged under `crates/zfb/binaries/`; they ride
+inside the executable bytes themselves and are extracted to a tempdir at
+`zfb build` / `zfb dev` time so esbuild can resolve framework imports without
+a consumer-side `node_modules/`.
 
 | Embedded package(s)                      | Sub  | Source                                                                  |
 | ---------------------------------------- | ---- | ----------------------------------------------------------------------- |
@@ -54,14 +63,15 @@ committed to this repository. Instead:
 
 - `.gitignore` excludes the actual binary file paths (e.g. `tailwindcss-v4`,
   `tailwindcss-v4.exe`).
-- The slot directory is preserved in git via `.gitkeep`.
+- The staging directories are preserved in git via `.gitkeep`.
 - **The Cargo build script (`crates/zfb/build.rs`) is the authoritative
   population path.** When you run `cargo build` or `cargo install --path
   crates/zfb`, the build script detects the current platform, downloads the
-  pinned binary from the upstream release (esbuild from the npm registry,
-  tailwindcss from GitHub releases), verifies its SHA-256 against pinned
-  constants in `build.rs`, and stages the binary here atomically. Re-runs are
-  no-ops when the on-disk binary already matches the pinned checksum.
+  pinned binary (esbuild from the npm registry, tailwindcss from GitHub
+  releases), verifies its SHA-256 against pinned constants, stages the binary
+  here atomically, then copies it to `$OUT_DIR/vendor/bin/` for embedding.
+  Re-runs are no-ops when the on-disk binary already matches the pinned
+  checksum.
 - `scripts/fetch-tailwind.mjs` at the repo root is kept as a **developer
   convenience** (superseded by the build script) — it can still be run via
   `pnpm fetch:tailwind` in environments that already have Node.js available.
@@ -70,14 +80,17 @@ committed to this repository. Instead:
   binaries or have no network access. When either is set, the build script
   skips the corresponding download step entirely.
 
-## Runtime contract (sketch)
+## Runtime resolution
 
-At runtime, sibling crates (e.g. `zfb-css`) resolve the binary path roughly as:
+Production callers should use the resolver wiring in the `zfb` crate. The
+effective precedence is:
 
 ```text
-<dir-of-zfb-executable>/binaries/<binary-name>
+explicit path on the config
+-> ZFB_ESBUILD_BIN / ZFB_TAILWIND_BIN
+-> embedded binary under $OUT_DIR/vendor/bin/ extracted to a tempdir
+-> workspace staging path under crates/zfb/binaries/
 ```
 
-Resolution helpers will live in the `zfb` crate when the release-engineering
-epic lands. Until then, downstream crates should treat the path as
-implementation-defined and access it only through a `zfb`-provided API.
+The last tier exists for direct workspace development. It is not the installed
+distribution model.

--- a/crates/zfb/binaries/esbuild/README.md
+++ b/crates/zfb/binaries/esbuild/README.md
@@ -1,60 +1,59 @@
-# `crates/zfb/binaries/esbuild/` — esbuild binary slot
+# `crates/zfb/binaries/esbuild/` — esbuild workspace staging directory
 
-This directory reserves placement for the **esbuild standalone CLI binary**
-that the `zfb-islands` crate invokes as a subprocess (see
-`crates/zfb-islands/README.md` for the version pin).
+This directory is the workspace staging location for the **esbuild standalone
+CLI binary** that `zfb-islands` invokes as a subprocess (see
+`crates/zfb-islands/README.md` for the version pin). The production `zfb`
+binary embeds the staged esbuild file from `$OUT_DIR/vendor/bin/` via
+`include_dir!` and extracts it to a tempdir at runtime.
 
-## Slot layout
+## Staging layout
 
-The release-tarball layout looks like this:
+The workspace staging layout is:
 
 ```text
-zfb/                      # release tarball root
-├── zfb                   # the user-facing CLI executable
-└── binaries/
-    ├── tailwindcss-v4    # bundled Tailwind v4 CLI (zfb-css)
-    └── esbuild/          # this directory
-        └── esbuild       # bundled esbuild CLI (zfb-islands)
+crates/zfb/binaries/
+├── tailwindcss-v4        # staged Tailwind v4 CLI (zfb-css)
+└── esbuild/              # this directory
+    └── esbuild           # staged esbuild CLI (zfb-islands)
 ```
 
 The `esbuild` binary file itself is **never** committed to this repo.
 `.gitignore` excludes the actual binary path; this directory is preserved
 in git via `.gitkeep`.
 
-## Why a subdirectory rather than a single file slot
+## Why a subdirectory rather than a single file
 
-`crates/zfb/binaries/tailwindcss-v4` is a single-file slot because Tailwind
-ships exactly one CLI binary per platform. esbuild also ships a single CLI
-binary per platform — a subdirectory is used here so that platform-specific
-release tooling (a future epic) has room to drop a sidecar (e.g. a checksum
-manifest or a `LICENSE.md`) without polluting the parent `binaries/`
-namespace. The runtime path the subprocess code resolves to is
-`crates/zfb/binaries/esbuild` — that path is interpreted as the *binary
-file itself*, not as a directory; see the override env var
-`ZFB_ESBUILD_BIN`.
+`crates/zfb/binaries/tailwindcss-v4` is a single-file staging path because
+Tailwind ships exactly one CLI binary per platform. esbuild also ships a
+single CLI binary per platform, but this directory keeps the workspace path
+unambiguous: the staged executable is `crates/zfb/binaries/esbuild/esbuild`
+(or `esbuild.exe` on Windows), while `crates/zfb/binaries/esbuild/` is only
+the parent directory.
 
-> If the subdirectory shape proves to be unnecessary at release-engineering
-> time, this slot may be flattened back to a single file path. The
-> subprocess code reads the path verbatim, so the call site is unaffected.
+Set `ZFB_ESBUILD_BIN` or call `EsbuildSubprocessConfig::with_binary_path` to
+use a different executable path.
 
-## Why this slot is reserved now
+## Build and embedding flow
 
-Sub 2 of [issue #6](https://github.com/Takazudo/zudo-front-builder/issues/6)
-implements the subprocess wrapper. The wrapper needs a deterministic
-default path for the binary so that user code can construct an
-`EsbuildSubprocessConfig::default()` without environment fiddling. The
-binary itself will be downloaded and verified by a future
-release-engineering epic — this sub-task only **reserves the slot**.
+`crates/zfb/build.rs` downloads the pinned esbuild package for the current
+platform, extracts the CLI binary, verifies its SHA-256, and stages it at this
+workspace path. The same build script then copies the executable to
+`$OUT_DIR/vendor/bin/esbuild` so `include_dir!` embeds it in the compiled
+`zfb` executable. Runtime callers in the `zfb` crate prefer that embedded
+copy and keep the extraction tempdir alive while the subprocess runs.
 
 ## Runtime resolution
 
-The `EsbuildSubprocessConfig::default()` constructor resolves the binary
-path as follows:
+The `zfb` command path resolves esbuild as follows:
 
-1. If the `ZFB_ESBUILD_BIN` env var is set, use that path verbatim.
-2. Otherwise, default to `crates/zfb/binaries/esbuild/esbuild` (i.e. the
-   `esbuild` executable file inside this slot directory; relative to the
-   current working directory at engine construction time).
+1. An explicit `esbuild_binary` / `EsbuildSubprocessConfig::with_binary_path`
+   value wins.
+2. If `ZFB_ESBUILD_BIN` is set, use that path verbatim.
+3. Otherwise, extract the embedded `bin/esbuild` file to a tempdir and use
+   that path.
+4. If the embedded tier is unavailable in a direct workspace flow, fall back
+   to `crates/zfb/binaries/esbuild/esbuild` relative to the current working
+   directory at config construction time.
 
 A clear error message is returned if the binary is not present at the
 resolved path.


### PR DESCRIPTION
Parent: #1458
Closes #1466

Summary:
- Refresh crate README coverage for binary staging, toolchain pinning, CSS/content/islands/server/router behavior, and workspace notes.

Validation:
- Covered by the docs audit base-branch validation after integration.
- Local manager checks include docs build, generated HTML validation, repo formatting, TypeScript typecheck, pnpm tests, snippet checks, link checks, and ignored-test inventory.
