### PR TITLE
Docs audit: crate README API surfaces

### DIFF
--- a/crates/zfb-binfetch/README.md
+++ b/crates/zfb-binfetch/README.md
@@ -1,0 +1,42 @@
+# zfb-binfetch
+
+Small blocking download helper used by zfb build scripts when they need to
+fetch platform tool binaries.
+
+The crate intentionally owns only the HTTP transfer and retry loop. Callers
+remain responsible for choosing a temp path, verifying the downloaded bytes,
+setting permissions, and atomically moving the file into its final slot.
+
+## Public API
+
+- **`FetchOpts`** - retry and timeout knobs:
+  - `attempts` defaults to `3`.
+  - `connect_timeout` defaults to 15 seconds per attempt.
+  - `overall_timeout` defaults to `None`; this avoids aborting a large but
+    healthy slow download. Callers may opt into a whole-request deadline.
+  - `initial_backoff` defaults to 500 ms and doubles after each failed
+    attempt.
+- **`fetch_to_file(url, dest, opts)`** - streams `url` to `dest`, retrying
+  transient send/status/body failures. On success, the full response body is
+  written to `dest`. On failure, any partial `dest` file is removed.
+
+## Usage
+
+```rust,ignore
+use std::path::Path;
+use zfb_binfetch::{fetch_to_file, FetchOpts};
+
+let tmp = Path::new("vendor/bin/esbuild.tmp");
+fetch_to_file("https://example.invalid/esbuild", tmp, &FetchOpts::default())?;
+
+// Caller-owned follow-up: hash, chmod, and rename `tmp` into place.
+```
+
+## Tests
+
+```sh
+cargo test -p zfb-binfetch
+```
+
+The tests use a tiny local HTTP server to cover retry-after-truncation,
+HTTP-status failures, zero-attempt behavior, and cleanup of partial files.

--- a/crates/zfb-build/README.md
+++ b/crates/zfb-build/README.md
@@ -36,8 +36,8 @@ Wiring concrete renderers / engines / bundlers happens in the bin crate
   `ProductionAssetPipeline`, `apply_prod_asset_pipeline`,
   `BuildContext` (legacy transition shim — see below),
   `DevBuildContext`, `ProdBuildContext`, `BuildOutcome`, and the
-  runner types `CssRunner`, `IslandsRunner`, `PageRenderer`,
-  `RendererReloader`.
+  runner types `CssRunner`, `IslandsRunner`, `ClientScriptsRunner`,
+  `PageRenderer`, `RendererReloader`.
 - **Bundler** — `bundle`, `BundleManifest`, `BundleMode`,
   `BundlerInput`, `BundlerOutput`, and related content-collection
   types.
@@ -79,6 +79,7 @@ let ctx = BuildContext {
     }),
     run_css: None,
     run_islands: None,
+    run_client_scripts: None,
     reload_renderer: None,
 };
 

--- a/crates/zfb-config-loader/README.md
+++ b/crates/zfb-config-loader/README.md
@@ -1,0 +1,63 @@
+# zfb-config-loader
+
+`zfb.config.ts` evaluator shared by `zfb` and `zfb-server`.
+
+This crate exists because `zfb` depends on `zfb-server`, so the TypeScript
+config evaluator cannot live in either crate without creating a cycle. The
+loader is config-shape-agnostic: it returns the evaluated default export as
+JSON and leaves deserializing into a concrete config struct to the caller.
+
+## Evaluation model
+
+- Default builds enable `embed_v8`. The config is bundled with the pinned
+  esbuild binary and evaluated in-process with the embedded V8 host from
+  `zfb-render`. No runtime Node process is required.
+- Slim builds (`--no-default-features`) compile out the V8 evaluator and fall
+  back to a `node` subprocess. This path requires `node` on `PATH`.
+- esbuild uses `--platform=neutral`; `node:*` imports in `zfb.config.ts`
+  become bundle-time errors instead of hidden runtime dependencies.
+
+## Public API
+
+- **`load_from_ts_file(ts_path, project_root, opts)`** - bundle, evaluate, and
+  return a `LoadedTsConfig`.
+- **`LoadedTsConfig`** - contains `config: serde_json::Value` plus
+  `resolved_plugins`, one `file://` URL per `config.plugins[]` entry when
+  plugin resolution is enabled.
+- **`LoadOptions`** - optional overrides for esbuild, node, embedded-esbuild
+  extraction, plugin resolution, and a test-only canned JSON path.
+- **`EmbeddedEsbuildGetter`** - callback used by the `zfb` binary to expose
+  its embedded esbuild snapshot as a resolver tier.
+- **`resolve_plugin_path_to_file_url`** and the `node_resolve` exports -
+  plugin/bare-specifier resolution helpers used by the loader and tests.
+- **`output_bounded` / `output_bounded_with`** - subprocess helpers that bound
+  output waits, kill stuck children, and retry `ETXTBSY` spawn races.
+
+## Usage
+
+```rust,ignore
+use zfb_config_loader::{load_from_ts_file, LoadOptions};
+
+let loaded = load_from_ts_file(
+    project_root.join("zfb.config.ts").as_path(),
+    project_root,
+    &LoadOptions::default(),
+)
+.await?;
+
+let value = loaded.config;
+let plugin_urls = loaded.resolved_plugins;
+```
+
+Set `LoadOptions { resolve_plugins: false, ..Default::default() }` for embed
+callers that only need scalar config fields and should not fail when CLI-only
+plugin packages are absent from the deployed app.
+
+## Tests
+
+```sh
+cargo test -p zfb-config-loader
+```
+
+The suite covers node-style bare specifier resolution, plugin URL conversion,
+bounded subprocess behavior, and the loader envelope parsing paths.

--- a/crates/zfb-content/README.md
+++ b/crates/zfb-content/README.md
@@ -28,15 +28,31 @@ than an ESTree), the output feeds through the existing SWC pipeline in
 `crates/zfb-render`, keeping JSX → JS codegen in one place.
 
 ```rust,ignore
-use zfb_content::{compile_mdx_to_jsx_module, MdxJsxOptions, MdxModuleCache};
+use std::path::Path;
+use zfb_content::{
+    compile_mdx_to_jsx_module, compile_mdx_to_jsx_module_cached,
+    MdxModuleCache,
+};
 
-let cache = MdxModuleCache::default();
-let compiled: CompiledMdx = compile_mdx_to_jsx_module(
+let compiled = compile_mdx_to_jsx_module(
     source,
-    &MdxJsxOptions::default(),
-    &cache,
+    Path::new("content/docs/intro.mdx"),
+)?;
+
+let cache = MdxModuleCache::new();
+let cached = compile_mdx_to_jsx_module_cached(
+    source,
+    Path::new("content/docs/intro.mdx"),
+    Some(&cache),
+    None,
 )?;
 ```
+
+`compile_mdx_to_jsx_module(input, file_path)` is intentionally the uncached
+convenience wrapper. Opt into the compile cache through
+`compile_mdx_to_jsx_module_cached(input, file_path, cache, pipeline)` or
+`compile_mdx_to_jsx_module_cached_with_deps(...)` when callers need cache
+hits and recorded external dependency paths.
 
 ### 3. Frontmatter extraction (`frontmatter`, `tsx_frontmatter`)
 
@@ -62,7 +78,7 @@ markdown/MDX/TSX entries walking to validated `Entry<T: Validate>` values.
 page modules can call `getCollection("docs")` synchronously during SSR:
 
 ```rust,ignore
-use zfb_content::{build_snapshot, ContentSnapshot, CollectionConfig};
+use zfb_content::{build_snapshot, CollectionConfig, ContentSnapshot};
 
 let snapshot: ContentSnapshot = build_snapshot(&configs)?;
 // snapshot.collections: BTreeMap<String, Vec<EntrySnapshot>>
@@ -92,8 +108,10 @@ preserved inside.
 | `build_snapshot` | `content_bridge` | Build the JS-bridge snapshot |
 | `ContentSnapshot` | `content_bridge` | `BTreeMap`-keyed collection map |
 | `EntrySnapshot` | `content_bridge` | Serializable entry (slug, frontmatter, body, specifier) |
-| `CollectionConfig` | `collection` | Per-collection directory + schema config |
-| `compile_mdx_to_jsx_module` | `mdx_jsx_emit` | MDX → JSX module string |
+| `CollectionConfig` | `content_bridge` | Snapshot collection config: name, root, include/exclude filters, `id_strip_suffix` |
+| `compile_mdx_to_jsx_module` | `mdx_jsx_emit` | Uncached MDX → JSX module convenience wrapper: `(input, file_path)` |
+| `compile_mdx_to_jsx_module_cached` | `mdx_jsx_emit` | Cached MDX → JSX module wrapper with optional `MdxModuleCache` and `Pipeline` |
+| `compile_mdx_to_jsx_module_cached_with_deps` | `mdx_jsx_emit` | Cached wrapper that also returns recorded external dependency paths |
 | `CompiledMdx` | `mdx_jsx_emit` | Output of the MDX emitter |
 | `MdxJsxOptions` | `mdx_jsx_emit` | Options for the JSX emitter |
 | `MdxModuleCache` | `mdx_jsx_emit` | Compilation cache (reuse across files) |

--- a/crates/zfb-md-ast/README.md
+++ b/crates/zfb-md-ast/README.md
@@ -10,11 +10,13 @@ This crate is the dependency boundary that lets `zfb-md-extras` (and other downs
 - **`MdastVisitor`** / **`HastVisitor`** — in-place mutation traits for mdast and hast trees. The pipeline does not auto-recurse; each visitor decides its own traversal strategy.
   - `visit_with_context(&mut node, &mut BuildContext)` — wave-6 seam for visitors that need source path, project root, or diagnostics. Defaults to calling `visit`.
   - `HastVisitor::reset()` — called between documents to clear per-document state (e.g. duplicate-slug counters). Default is a no-op.
-- **`BuildContext<'a>`** — per-document context threaded into pipeline visitors by `Pipeline::run_with_context`. Carries `source_path`, `project_root`, `public_dir`, an optional `HeadingRegistry` reference, and an optional `DiagnosticsSink` reference.
+- **`BuildContext<'a>`** — per-document context threaded into pipeline visitors by `Pipeline::run_with_context`. Carries `source_path`, `project_root`, `public_dir`, an optional `HeadingRegistry` reference, an optional `DiagnosticsSink` reference, and an optional `cross_file_links` buffer.
 - **`diagnostics`** — `MarkdownDiagnostic` enum (`BrokenLink`, `Generic`), `DiagnosticSeverity`, `SourceLocation`, `DiagnosticsSink` trait, and `CollectingSink` (Vec-backed sink for tests and batch processing).
 - **`directives`** — `DirectiveDef`, `DirectiveKind`, `AttrSchema`, `AttrType`, `ValidatedAttrValue`, `AttrValidationResult`, `DirectiveDiagnostic`. Shared between `zfb-content` and `zfb-md-extras` so the latter can produce `Vec<DirectiveDef>` presets without a cycle.
 - **`features_config`** — `MarkdownFeaturesConfig`, `FeatureToggle`, `FeatureOptions`, and supporting types for per-feature markdown pipeline configuration. Re-exported by `zfb` from its `config` module for backwards compatibility.
 - **`heading_registry`** — `HeadingRegistry` (build-scoped heading-ID registry; used by `HeadingLinksPlugin` and link-validation plugins).
+- **`read_recorder`** — `ReadRecorder`, `ReadOutcome`, and `sha256_hex`; filesystem-reading feature plugins use this to record external file dependencies so `zfb-content` can validate MDX compile-cache hits.
+- **Cross-file links** — `BuildContext::cross_file_links` plus `CrossFileLinkCandidate` and `FileHeadings`; compile side channels used by the post-compile cross-file anchor checker. Paths are normalised with `zfb_types::normalize_path_lexical` so heading-map lookups and deferred link candidates agree.
 - **`hast_text::extract_text`** — utility that extracts plain text content from a `HastNode` subtree.
 
 ## Why this crate exists

--- a/crates/zfb-router/README.md
+++ b/crates/zfb-router/README.md
@@ -82,7 +82,13 @@ Index pages receive a +1 bonus on top of their segment sum.
 `RouterError::AmbiguousShape` — two routes overlap under param-name-insensitive
 comparison (issue #816), catching conflicts that differ only in parameter name.
 
-Both errors carry the conflicting source paths for precise diagnostics.
+`RouterError::OptionalCatchallConflict` — an optional catchall route overlaps
+another route. This catches the zero-segment bare-URL conflict
+(`docs/[[...slug]].tsx` vs `docs/index.tsx`) and full catchall overlap
+(`docs/[[...a]].tsx` vs `docs/[...b].tsx`).
+
+All ambiguity errors carry the conflicting source paths for precise
+diagnostics.
 
 ### Sort parity
 

--- a/crates/zfb-server/README.md
+++ b/crates/zfb-server/README.md
@@ -12,13 +12,16 @@ listens for `page`, `css`, and `islands` events.
 
 | Module | Purpose |
 | -------------------- | -------------------------------------------------------------------- |
+| `assets_containment` | Containment-safe layered asset serving for `/assets/*` |
 | `embed` | `Server` / `ServerBuilder` / `ServerHandle` — embed-as-library API |
 | `embed_handlers` | `EmbedHandler` / `EmbedHandlerSet` — Rust-side request handlers |
+| `host_validation` | Host / Origin allowlist guard for non-loopback binds |
 | `inject` | Byte-level live-reload `<script>` injector |
 | `injected_routes` | `InjectedRouteSet` — pattern registry + request-time matcher for plugin-owned routes |
 | `livereload` | SSE bridge: `ReloadEvent`, `outcome_to_events`, `sse_response` |
 | `middleware` | Tower middleware for request extensions |
 | `plugin_middleware` | `DevMiddlewareDispatcher` — plugin dev-middleware dispatch |
+| `render_hook` | Render-on-request hook handle used by lazy dev rendering |
 | `routes` | Axum router: `build_router`, `AppState`, `PageCache` |
 | `ssr` | `SsrDispatcher` / `SsrRouteSet` — request-time SSR dispatch |
 
@@ -38,14 +41,20 @@ use zfb_server::{
     build_router, AppState, PageCache, CachedPage, DEV_404_BODY,
     content_type_for_extension, resolve_content_type,
     // Plugin middleware
-    DevMiddlewareDispatcher, DevMiddlewareSet, PluginRegistration,
+    path_matches_prefix, DevMiddlewareDispatcher, DevMiddlewareSet,
+    PluginDispatchError, PluginDispatchOutcome, PluginRegistration,
     PluginRequest, PluginResponse, PluginResponseEncoding,
     // Embed handlers
     EmbedHandler, EmbedHandlerFn, EmbedHandlerFuture, EmbedHandlerSet, RouteParams,
+    // Host validation
+    apply_host_validation_layer, HostValidation,
     // Injected routes (InjectedRoute is re-exported from zfb-build)
     InjectedRoute, InjectedRouteSet, pattern_matches,
+    // Render-on-request hook
+    RenderOnRequestHandle, RenderOnRequestHook,
     // SSR
-    SsrDispatcher, SsrRequest, SsrResponse, SsrRouteRecord, SsrRouteSet, SsrRoutesHandle,
+    SsrDispatchError, SsrDispatcher, SsrRequest, SsrResponse, SsrRouteRecord,
+    SsrRouteSet, SsrRoutesHandle,
     // Inject helpers
     inject_livereload, inject_livereload_into_tree, LIVERELOAD_TAG,
     // Bundle URL handles
@@ -81,8 +90,10 @@ All paths must be absolute. Key fields:
 
 | Field | Role |
 | -------------------- | -------------------------------------------------------- |
+| `project_root` | Project root for diagnostics and future middleware |
 | `addr` | Bind address (default `127.0.0.1:3000`) |
 | `dist_root` | Built assets directory (`/assets/*` route root) |
+| `dev_assets_root` | Optional isolated dev-assets root; `/assets/*` checks `<dev_assets_root>/assets/` before `<dist_root>/assets/` |
 | `html_root` | Dev-only HTML root (separate from `dist_root` in `zfb dev`) |
 | `public_root` | Static files at site root (`public/logo.svg` → `/logo.svg`) |
 | `pages` | `PageCache` populated by the orchestrator render loop |
@@ -93,8 +104,15 @@ All paths must be absolute. Key fields:
 | `base` | `zfb.config.ts` `base` value (normalised internally) |
 | `trailing_slash` | `zfb.config.ts` `trailingSlash` value |
 | `mode` | `ServerMode::Dev` / `Preview` / `Embed` |
-| `islands_bundle_url` | `Arc<RwLock<Option<String>>>` — current islands bundle URL |
-| `css_bundle_url` | `Arc<RwLock<Option<String>>>` — current CSS bundle URL |
+| `islands_bundle_url` | `Option<IslandsBundleUrl>` where `IslandsBundleUrl = Arc<RwLock<Option<String>>>`; current dev islands bundle URL |
+| `css_bundle_url` | `Option<CssBundleUrl>` where `CssBundleUrl = Arc<RwLock<Option<String>>>`; current dev CSS bundle URL |
+| `allowed_hosts` | `allowedHosts` config entries for Host validation on non-loopback binds |
+| `bound_host` | Explicit user-bound host string, always allowed by host validation |
+| `render_on_request_hook` | Optional `RenderOnRequestHandle` awaited before page-cache/disk lookup in Dev mode |
+
+`None` for the outer bundle URL handle means the server has no handle to
+consult. `Some(handle)` with an inner `None` means the handle exists but the
+current build has no URL to inject.
 
 ### Route map
 

--- a/crates/zfb-test-utils/README.md
+++ b/crates/zfb-test-utils/README.md
@@ -3,8 +3,8 @@
 Shared test helpers for `zfb` integration tests (std-only, no runtime dependencies).
 
 This crate consolidates utilities used across multiple integration test suites in the
-workspace: esbuild binary location, the compiled `zfb` binary path, and HTML normalization
-for snapshot comparison.
+workspace: esbuild binary location, the compiled `zfb` binary path, HTML normalization,
+SSE parsing, watcher readiness handshakes, and cross-binary e2e serialization.
 
 ## Public API
 
@@ -33,6 +33,10 @@ and `README.md`). Callers should gate with:
 let Some(esbuild) = zfb_test_utils::locate_esbuild() else { return; };
 ```
 
+The lower-level `candidate_workspace_roots()`, `SkipKind`, and
+`classify_failed_lookup()` helpers are public so the lookup policy and its
+panic-vs-skip contract can be tested directly.
+
 ### `zfb_binary!()` macro
 
 ```rust,ignore
@@ -60,6 +64,43 @@ HTML5-spec-compliant normalization for snapshot-based integration tests. Impleme
   inside `<pre>`, `<code>`, `<textarea>`, `<script>`, `<style>` preserved verbatim.
 - **Idempotent**: `normalize_html(normalize_html(s)) == normalize_html(s)`.
 
+### `CrossBinaryE2eLock`
+
+OS-level advisory lock for heavy V8/esbuild e2e tests that must not boot at
+the same time across separate integration-test binaries.
+
+```rust,ignore
+let _e2e_lock = zfb_test_utils::CrossBinaryE2eLock::acquire();
+```
+
+The lock file lives under `<workspace_root>/target/.e2e-serialize.lock`.
+`acquire()` waits up to 360 seconds by default; `acquire_with_timeout(...)`
+exists for focused tests. Dropping the guard releases the OS lock, and process
+death releases it too.
+
+### SSE helpers
+
+- `wait_for_subscribers(tx, min, dur)` waits for a broadcast channel to have
+  enough live receivers using a `Notify`-keyed wake.
+- `wait_for_subscribers_polled(tx, min, dur)` is the legacy 10 ms polling
+  variant for externally-owned senders.
+- `next_sse_event_name(resp, dur)` reads a `text/event-stream` response and
+  returns the first non-empty `event:` name, decoding UTF-8 incrementally so
+  split multibyte characters at chunk boundaries do not drop already-seen
+  lines.
+- `decode_utf8_incremental(...)` is public for unit tests of that decoder.
+
+### Watcher readiness handshake
+
+`watcher_live_handshake(opts, write_marker, signal_seen)` writes fresh marker
+files until a caller-supplied readiness predicate observes the watcher stream
+is live. This replaces fixed warmup sleeps in tests that can otherwise race
+FSEvents/inotify startup dead windows.
+
+`HandshakeOpts` controls the deadline and write/poll cadence. `HandshakeResult`
+reports whether the stream became live, how many markers were written, and the
+elapsed time.
+
 ## Tests
 
 ```sh
@@ -69,3 +110,6 @@ cargo test -p zfb-test-utils
 Tests in `src/html_normalize.rs` cover attribute ordering, entity encoding, boolean
 attribute forms, void elements, whitespace collapse, literal preservation in raw-text
 contexts, and idempotency.
+
+Additional unit tests cover esbuild lookup classification, cross-binary lock
+mutual exclusion, SSE UTF-8 chunk decoding, and watcher-handshake timing.

--- a/crates/zfb-types/README.md
+++ b/crates/zfb-types/README.md
@@ -16,16 +16,32 @@ This crate is a low-dependency leaf that holds types shared by several workspace
 
 - **`dev_mount_prefix(base: Option<&str>) -> Option<String>`** — normalises a `base` config value into the URL-path mount prefix for the dev server. Returns `None` for empty, root-only (`"/"`), or absolute-URL bases (CDN origins); returns `Some("/foo")` — leading slash, no trailing slash — for sub-path bases. Shared so `zfb-server` (mounting) and the build pipeline (href rewriting) always agree on the canonical form.
 
-- **Asset URL constants** — stable public URLs and filenames for the production asset graph, shared between the renderer (head injection) and the islands / CSS emitters (asset registration):
+- **Client-script filename helpers** — the canonical `*.client.{ts,tsx,js,jsx}` contract shared by the router and client-script bundler:
+  - `CLIENT_SCRIPT_INFIX` is `".client."`.
+  - `CLIENT_SCRIPT_EXTENSIONS` is `["ts", "tsx", "js", "jsx"]`.
+  - `is_client_script_file(path)` checks the convention without touching the filesystem.
+  - `client_script_entry_name(path)` returns the entry name, e.g. `search-widget` for `search-widget.client.ts`.
+
+- **Shared helper functions** — small string/path helpers used by generated-code and path-normalisation call sites:
+  - `json_string(s)` emits a safe JSON string literal, including escaping control characters and JS line/paragraph separators.
+  - `escape_html(s)` escapes HTML text/attribute special characters.
+  - `path_to_posix_string(path)` converts Windows separators to `/` for tools that require POSIX-style paths.
+  - `normalize_path_lexical(path)` collapses `.` / `..` components without touching the filesystem.
+
+- **Asset URL constants and helpers** — stable public URLs and filenames for the production asset graph, shared between the renderer (head injection), emitters (asset registration), and client-script pipeline:
 
   | Constant | Value |
   | --- | --- |
   | `STABLE_CSS_URL` | `"/assets/styles.css"` |
   | `STABLE_ISLANDS_URL` | `"/assets/islands.js"` |
   | `STABLE_ASSETS_URL_PREFIX` | `"/assets/"` |
+  | `STABLE_CLIENT_SCRIPTS_URL_PREFIX` | `"/assets/client/"` |
   | `DIST_ASSETS_DIR` | `"assets"` |
+  | `DIST_CLIENT_SCRIPTS_DIR` | `"client"` |
   | `STABLE_CSS_FILENAME` | `"styles.css"` |
   | `STABLE_ISLANDS_FILENAME` | `"islands.js"` |
+
+  `stable_client_script_url(name)`, `stable_client_script_filename(name)`, and `stable_client_script_relative_path(name)` build the stable pre-hash URL / filename / `dist_root`-relative path for a named client-script entry.
 
   Production builds let `ProductionAssetPipeline` rewrite the stable URLs to hashed forms (`/assets/styles-<hash>.css`, etc.). Dev builds keep the stable URLs as-is. The constants live here rather than in `zfb-build` because the renderer cannot depend on `zfb-build` (that would be a cycle), and `zfb-build` already depends on `zfb-render`.
 
@@ -37,3 +53,5 @@ cargo test -p zfb-types
 
 - `src/asset_urls.rs` — stable URL / filename pairing stays in sync; both URLs share the assets prefix; `DIST_ASSETS_DIR` matches `STABLE_ASSETS_URL_PREFIX`.
 - `src/base_prefix.rs` — `dev_mount_prefix` covers `None`, empty string, root slash, multiple trailing slashes, path with/without trailing slash, absolute URL, missing leading slash.
+- `src/client_scripts.rs` — the `.client.*` predicate and entry-name derivation accept all supported extensions and reject bare or non-client files.
+- `src/helpers.rs` — JSON/HTML escaping, platform-gated POSIX path conversion, and lexical path normalization.

--- a/crates/zfb/README.md
+++ b/crates/zfb/README.md
@@ -1,6 +1,7 @@
 # zfb
 
-Frontend build orchestrator — the `zfb` CLI binary and its supporting library crate.
+Frontend build orchestrator - the `zfb` CLI binary and its supporting
+library crate.
 
 ## Subcommands
 
@@ -11,10 +12,16 @@ Scaffold a new project from a template.
 ```sh
 zfb new my-site
 zfb new my-site --template basic-blog
+zfb new my-site --template node-free
 ```
 
-The `basic-blog` template (the only template in v0) is baked into the binary at
-compile time from `crates/zfb/templates/basic-blog/`.
+v0 ships two templates, both baked into the binary at compile time from
+`crates/zfb/templates/<name>/`:
+
+| Template | Role |
+| --- | --- |
+| `basic-blog` | Default starter with a `package.json` and normal Node/pnpm workflow |
+| `node-free` | Starter with no `package.json` / no install step, for environments with no Node or pnpm on `PATH` |
 
 ### `zfb dev`
 
@@ -24,11 +31,22 @@ Run the local development server.
 zfb dev
 zfb dev --port 8080
 zfb dev --host 0.0.0.0
+zfb dev --host
 ```
 
-`--port` and `--host` layer over config: CLI > `zfb.config.json` > built-in
-default (`localhost:3000`). Neither has a clap default value so the command
-body can distinguish "user passed a value" from "user accepted the default".
+`--port` and `--host` layer over config: CLI > `zfb.config.*` > built-in
+default (`localhost:3000`). Both fields stay optional in clap so the command
+body can distinguish "user passed a value" from "use the next fallback".
+Bare `--host` is a Vite-style shortcut for `0.0.0.0`.
+
+Dev-render environment switches:
+
+| Env var | Effect |
+| --- | --- |
+| `ZFB_DEV_EAGER=1` | Disable lazy dev rendering and render affected routes eagerly on every file change |
+| `ZFB_LAZY_DEV_RENDER=0|1` | Precise lazy/eager override; wins over `ZFB_DEV_EAGER` |
+| `ZFB_DEV_BOOT_LAZY=1` | Serve a valid prebuilt `dist/` immediately and render each route on first request |
+| `ZFB_DEV_DEFER_BUNDLE=0` | Opt out of boot-lazy bundle deferral; build the renderer before bind |
 
 ### `zfb build`
 
@@ -37,9 +55,12 @@ Build the project for production.
 ```sh
 zfb build
 zfb build --outdir dist
+zfb build --minify-html
+zfb build --no-minify-html
 ```
 
-Default `--outdir` is `dist`.
+Default `--outdir` is `dist`. `--minify-html` / `--no-minify-html` are an
+explicit tri-state (`BuildMinifyHtml`) layered over `minifyHtml` config.
 
 ### `zfb preview`
 
@@ -48,10 +69,12 @@ Preview a previously built project.
 ```sh
 zfb preview
 zfb preview --port 4321 --outdir dist
+zfb preview --host
 ```
 
-Default port falls back to `zfb.config.json` then to `4321`. Default `--outdir`
-is `dist`. Pass `--host 0.0.0.0` to expose the preview to other LAN devices.
+Default port falls back to `zfb.config.*` then to `4321`. Default `--outdir`
+is `dist`. Bare `--host` is the same LAN shortcut as `zfb dev --host`:
+`0.0.0.0`.
 
 ### `zfb check`
 
@@ -64,87 +87,118 @@ zfb check --skip-tsc
 
 Two failure modes:
 
-1. TypeScript errors — `tsc --noEmit` subprocess. Any error tsc would flag in
+1. TypeScript errors - `tsc --noEmit` subprocess. Any error tsc would flag in
    normal CI is flagged here.
-2. Content collection schema violations — every entry's frontmatter is validated
-   against the JSON Schema in `zfb.config.json`'s `collections[].schema` (when
-   present).
+2. Content collection schema violations - every entry's frontmatter is
+   validated against the JSON Schema in `collections[].schema` when present.
 
-`--skip-tsc` skips the tsc subprocess; schema validation still runs. Useful in
-CI lanes that have no TypeScript dependency installed or for schema-only checks.
+`--skip-tsc` skips the tsc subprocess; schema validation still runs.
 
 ## Architecture
 
-```
+```text
 main.rs
-  Cli::parse()                    ← clap (crate::cli)
+  Cli::parse()                    <- clap (crate::cli)
   match Command variant
-    ├── commands::new::run()
-    ├── commands::dev::run()
-    ├── commands::build::run()
-    ├── commands::preview::run()
-    └── commands::check::run()
-  Err → report_error() → stderr + exit(1)
+    |-- commands::new::run()
+    |-- commands::dev::run()
+    |-- commands::build::run()
+    |-- commands::preview::run()
+    `-- commands::check::run()
+  Err -> report_error() -> stderr + exit(1)
 ```
 
-Each `commands/<name>.rs` module exposes one `async fn run(args: &FooArgs) -> anyhow::Result<()>`. Errors propagate with `?` and are rendered once at the top level by `report_error`, avoiding double-printing.
+Each `commands/<name>.rs` module exposes one `async fn run(args: &FooArgs) ->
+anyhow::Result<()>`. Errors propagate with `?` and are rendered once at the
+top level by `report_error`, avoiding double-printing.
 
 ## Configuration
 
 Config is loaded at the start of every command via `Config::load_from_dir()`.
 Resolution order:
 
-1. `zfb.config.ts` — bundled by pinned esbuild, evaluated in-process by V8 (default build) or by a node subprocess (slim build).
-2. `zfb.config.json` — parsed directly by serde.
-3. `Config::default()` — built-in defaults (see below).
+1. `zfb.config.ts` - bundled by pinned esbuild and evaluated by
+   `zfb-config-loader` (embedded V8 in default builds, node subprocess in
+   slim builds).
+2. `zfb.config.json` - parsed directly by serde.
+3. `Config::default()` - built-in defaults.
+
+TypeScript wins over JSON when both files are present.
 
 ### Key `Config` fields and defaults
 
-| Field | Default | Notes |
-|---|---|---|
-| `out_dir` | `"dist"` | Production output directory |
-| `public_dir` | `"public"` | Static assets directory |
-| `host` | — | Dev/preview host; CLI flag takes precedence |
-| `port` | — | Dev/preview port; CLI flag takes precedence |
-| `framework` | `Preact` | `Preact` or `React` |
-| `collections` | `[]` | Content collection definitions |
-| `output` | `Auto` | `Static`, `Hybrid`, or `Auto` |
-| `base` | — | Base path prefix for all URLs |
-| `strip_md_ext` | — | Strip `.md`/`.mdx` from generated links |
-| `trailing_slash` | — | Add/remove trailing slashes |
-| `emit_routes_manifest` | — | Write a JSON routes manifest to dist |
-| `plugin_hook_timeout_secs` | — | Max time per plugin hook |
+| Rust field | Config key | Default | Notes |
+| --- | --- | --- | --- |
+| `out_dir` | `outDir` | `"dist"` | Production output directory |
+| `public_dir` | `publicDir` | `"public"` | Static assets directory |
+| `host` | `host` | `None` | Dev/preview bind host; CLI flag takes precedence |
+| `port` | `port` | `None` | Dev/preview port; CLI flag takes precedence |
+| `allowed_hosts` | `allowedHosts` | `[]` | DNS-rebinding allowlist for non-loopback binds |
+| `framework` | `framework` | `Preact` | `Preact` or `React` |
+| `collections` | `collections` | `[]` | Content collection definitions |
+| `tailwind` | `tailwind` | enabled | `enabled: false` opts out of Tailwind |
+| `prefetch` | `prefetch` | `None` | `disabled: true` disables runtime prefetch wiring |
+| `minify_html` | `minifyHtml` | `false` | Can be overridden per build by CLI flags |
+| `bundle` | `bundle` | `None` | `exclude` globs for files kept out of the esbuild graph |
+| `plugins` | `plugins` | `[]` | User plugin entries, with resolved module URLs on the TS path |
+| `adapter` | `adapter` | `None` | Deploy-target adapter package; `None` / `"none"` means static |
+| `strip_md_ext` | `stripMdExt` | `false` | Rewrite authored `.md` / `.mdx` links to route URLs |
+| `code_highlight` | `codeHighlight` | `None` | Syntect theme / theme directory options |
+| `resolve_markdown_links` | `resolveMarkdownLinks` | `None` | Markdown link resolver and broken-link policy |
+| `base` | `base` | `None` | URL prefix for emitted asset/page URLs |
+| `trailing_slash` | `trailingSlash` | `false` | Append `/` to extensionless rewritten hrefs |
+| `markdown` | `markdown` | `None` | GFM, TOC, external-link, CJK, and feature plugin options |
+| `site` | `site` | `None` | Absolute canonical site origin emitted to runtime globals |
+| `emit_routes_manifest` | `emitRoutesManifest` | `None` (emit) | `false` skips `<outDir>/__zfb/routes.json` |
+| `extra_watch_paths` | `extraWatchPaths` | `[]` | Absolute external directories watched by `zfb dev` |
+| `output` | `output` | `Auto` | `Static`, `Hybrid`, or detection-driven `Auto` |
+| `plugin_hook_timeout_secs` | `pluginHookTimeoutSecs` | `None` | Overrides env/built-in plugin hook timeout |
+| `copy_public_with_base` | `copyPublicWithBase` | `true` | Copy `public/` under the base path in production output |
+| `presets` | `presets` | `[]` | Partial config presets merged before validation |
 
-`OutputMode::Auto` selects `Static` or `Hybrid` based on what the project uses.
+`OutputMode::Auto` selects the V8/SSR topology from detected
+`prerender = false` routes, while `Static` and `Hybrid` are explicit
+precondition choices.
 
 ### `embed_v8` feature flag
 
-The default build enables the `embed_v8` cargo feature, which compiles in
-`deno_core` / V8 for in-process config evaluation and SSR. Without this
-feature the binary is lighter ("slim build") but falls back to a node
-subprocess for config loading and fails loudly if any code path requires SSR.
-The two code paths gated behind the feature are `ssr_adapter` and
-`v8_host_adapter`.
+The default build enables `embed_v8`, which propagates to `zfb-render`,
+`zfb-build`, `zfb-server`, and `zfb-config-loader`. It compiles in
+`deno_core` / V8 for in-process TS-config evaluation and SSR dispatch.
+
+`cargo build --no-default-features -p zfb` produces the slim build. In that
+mode, TS config evaluation falls back to a `node` subprocess and SSR-required
+paths fail loudly. The V8-bearing adapter modules gated in this crate are
+`lazy_render_adapter`, `ssr_adapter`, and `v8_host_adapter`.
 
 ## Public library surface
 
-The library crate (`lib.rs`) exposes the following items to adapter authors
-and integration tests:
+The library crate (`lib.rs`) exposes the CLI parser, command modules,
+configuration types, diagnostics, render-planning helpers, and the top-level
+error renderer:
 
 ```rust,ignore
 use zfb::{
-    // CLI parsing
-    cli::{Cli, Command, NewArgs, DevArgs, BuildArgs, PreviewArgs, CheckArgs},
-    // Command dispatch
+    bounded_join,
+    cli::{
+        BuildArgs, BuildMinifyHtml, CheckArgs, Cli, Command, DevArgs, NewArgs,
+        PreviewArgs,
+    },
     commands,
-    // Configuration
-    config::Config,
-    // Dynamic-route planning (for adapter authors)
+    config::{
+        BundleConfig, CodeHighlightConfig, CollectionDef, Config, Framework,
+        JsonSchema, MarkdownConfig, OutputMode, PluginConfig, PrefetchConfig,
+        ResolveMarkdownLinksConfig, TailwindConfig,
+    },
+    diagnostics,
+    render_pipeline,
     DeferredDynamicRoute, PendingDynamicRoute,
-    // Top-level error renderer
     report_error,
 };
 ```
+
+`render_pipeline` also defines the dynamic-route expansion and SSR dispatch
+planning types used by adapter-facing code.
 
 ## Tests
 
@@ -152,7 +206,6 @@ use zfb::{
 cargo test -p zfb
 ```
 
-Integration tests live in `crates/zfb/tests/` and cover build lifecycle
-(`build_cleans_outdir`, `build_terminates`), the `check` command, content
-snapshot behaviour (`content_snapshot_no_deferred`), CSS module components,
-framework package resolution, and version stamping.
+Integration tests live in `crates/zfb/tests/` and cover build lifecycle,
+`check`, content snapshots, CSS module components, framework package
+resolution, dev-server behavior, and version stamping.


### PR DESCRIPTION
Parent: #1458
Closes #1467

Summary:
- Add and update crate READMEs for binfetch, config-loader, test-utils, zfb-types, and public API surface notes.

Validation:
- Covered by the docs audit base-branch validation after integration.
- Local manager checks include docs build, generated HTML validation, repo formatting, TypeScript typecheck, pnpm tests, snippet checks, link checks, and ignored-test inventory.
