### PR TITLE
[Hygiene Batch] Wire outDir into build and preview

### DIFF
--- a/crates/zfb/README.md
+++ b/crates/zfb/README.md
@@ -59,7 +59,8 @@ zfb build --minify-html
 zfb build --no-minify-html
 ```
 
-Default `--outdir` is `dist`. `--minify-html` / `--no-minify-html` are an
+Output-directory precedence is CLI `--outdir` > `outDir` in `zfb.config.*` >
+the built-in `dist` default. `--minify-html` / `--no-minify-html` are an
 explicit tri-state (`BuildMinifyHtml`) layered over `minifyHtml` config.
 
 ### `zfb preview`
@@ -72,9 +73,9 @@ zfb preview --port 4321 --outdir dist
 zfb preview --host
 ```
 
-Default port falls back to `zfb.config.*` then to `4321`. Default `--outdir`
-is `dist`. Bare `--host` is the same LAN shortcut as `zfb dev --host`:
-`0.0.0.0`.
+Port and host fall back to `zfb.config.*`, then to `4321` and `localhost`.
+Output-directory precedence matches build: CLI `--outdir` > config `outDir` >
+`dist`. Bare `--host` is the same LAN shortcut as `zfb dev --host`: `0.0.0.0`.
 
 ### `zfb check`
 
@@ -129,7 +130,7 @@ TypeScript wins over JSON when both files are present.
 
 | Rust field | Config key | Default | Notes |
 | --- | --- | --- | --- |
-| `out_dir` | `outDir` | `"dist"` | Production output directory |
+| `out_dir` | `outDir` | `"dist"` | Build/preview output and dev's prebuilt seed; build/preview CLI flag takes precedence |
 | `public_dir` | `publicDir` | `"public"` | Static assets directory |
 | `host` | `host` | `None` | Dev/preview bind host; CLI flag takes precedence |
 | `port` | `port` | `None` | Dev/preview port; CLI flag takes precedence |

--- a/crates/zfb/src/cli.rs
+++ b/crates/zfb/src/cli.rs
@@ -107,9 +107,10 @@ pub struct DevArgs {
 /// Arguments for `zfb build`.
 #[derive(Debug, Args)]
 pub struct BuildArgs {
-    /// Output directory for the production build.
-    #[arg(long, default_value = "dist")]
-    pub outdir: PathBuf,
+    /// Output directory for the production build. Falls back to `outDir`
+    /// from `zfb.config.*`, then to `dist`.
+    #[arg(long)]
+    pub outdir: Option<PathBuf>,
 
     /// Enable production HTML minification for this build.
     #[arg(
@@ -165,11 +166,9 @@ impl BuildMinifyHtml {
 
 /// Arguments for `zfb preview`.
 ///
-/// `port` and `host` are `Option<_>` for the same reason as the `DevArgs`
-/// fields — see the doc-comment there — so the command body can layer
-/// "CLI > config > built-in default" cleanly. `outdir` keeps a clap default
-/// because the preview command does not consult config for it today (config's
-/// `outDir` is already wired through the build command).
+/// `port`, `host`, and `outdir` are `Option<_>` for the same reason as the
+/// `DevArgs` fields — see the doc-comment there — so the command body can
+/// layer "CLI > config > built-in default" cleanly.
 #[derive(Debug, Args)]
 pub struct PreviewArgs {
     /// Port to bind the preview server to. Falls back to `port` from
@@ -186,12 +185,13 @@ pub struct PreviewArgs {
     #[arg(long, num_args = 0..=1, default_missing_value = "0.0.0.0")]
     pub host: Option<String>,
 
-    /// Directory to serve the previously built artifacts from. In adapter
-    /// mode this is only an existence pre-check — `wrangler dev` serves the
-    /// directories named in the project's wrangler config, and a non-default
-    /// value here triggers a warning to that effect.
-    #[arg(long, default_value = "dist")]
-    pub outdir: PathBuf,
+    /// Directory to serve the previously built artifacts from. Falls back to
+    /// `outDir` from `zfb.config.*`, then to `dist`. In adapter mode this is
+    /// only an existence pre-check — `wrangler dev` serves the directories
+    /// named in the project's wrangler config, and a non-default selected
+    /// value triggers a warning to that effect.
+    #[arg(long)]
+    pub outdir: Option<PathBuf>,
 }
 
 /// Arguments for `zfb check`.
@@ -230,6 +230,20 @@ mod tests {
     fn preview_host(argv: &[&str]) -> Option<String> {
         match Cli::try_parse_from(argv).expect("parse").command {
             Command::Preview(args) => args.host,
+            other => panic!("expected preview subcommand, got {other:?}"),
+        }
+    }
+
+    fn build_outdir(argv: &[&str]) -> Option<PathBuf> {
+        match Cli::try_parse_from(argv).expect("parse").command {
+            Command::Build(args) => args.outdir,
+            other => panic!("expected build subcommand, got {other:?}"),
+        }
+    }
+
+    fn preview_outdir(argv: &[&str]) -> Option<PathBuf> {
+        match Cli::try_parse_from(argv).expect("parse").command {
+            Command::Preview(args) => args.outdir,
             other => panic!("expected preview subcommand, got {other:?}"),
         }
     }
@@ -280,6 +294,32 @@ mod tests {
         assert_eq!(
             preview_host(&["zfb", "preview", "--host", "10.0.0.1"]),
             Some("10.0.0.1".into())
+        );
+    }
+
+    #[test]
+    fn build_outdir_absent_is_none() {
+        assert_eq!(build_outdir(&["zfb", "build"]), None);
+    }
+
+    #[test]
+    fn build_outdir_explicit_value_is_preserved() {
+        assert_eq!(
+            build_outdir(&["zfb", "build", "--outdir", "custom"]),
+            Some(PathBuf::from("custom"))
+        );
+    }
+
+    #[test]
+    fn preview_outdir_absent_is_none() {
+        assert_eq!(preview_outdir(&["zfb", "preview"]), None);
+    }
+
+    #[test]
+    fn preview_outdir_explicit_value_is_preserved() {
+        assert_eq!(
+            preview_outdir(&["zfb", "preview", "--outdir", "custom"]),
+            Some(PathBuf::from("custom"))
         );
     }
 

--- a/crates/zfb/src/commands/build.rs
+++ b/crates/zfb/src/commands/build.rs
@@ -3,8 +3,9 @@
 //! Contract:
 //!   pub async fn run(args: &crate::cli::BuildArgs) -> anyhow::Result<()>
 //!
-//! `args.outdir` is the production output directory (default `dist`).
-//! Resolved relative to the current working directory if not absolute.
+//! The production output directory resolves with CLI `--outdir` > config
+//! `outDir` > default `dist` precedence, relative to the current working
+//! directory when it is not absolute.
 //!
 //! ## Pipeline overview
 //!
@@ -32,10 +33,10 @@
 //! statically resolvable (e.g. it `await`s an `import` or queries a
 //! content collection at runtime) are surfaced via
 //! [`crate::output::warn`] with the per-page reason and skipped from
-//! `dist/`; a follow-up sub-task adds runtime evaluation for those.
+//! `<outdir>/`; a follow-up sub-task adds runtime evaluation for those.
 //!
-//! The contract for callers (project-root sanity check, `outdir`
-//! handling, `✓ N pages built in X.XXs` summary) is unchanged.
+//! The other caller contracts (project-root sanity check and
+//! `✓ N pages built in X.XXs` summary) are unchanged.
 
 // V8-off (issue #371, sub-task 4.1a): on the `!feature = "embed_v8"`
 // path the `pub async fn run` body and `DefaultRunner` are compiled
@@ -74,7 +75,9 @@ use zfb_router::Router;
 use zfb_render::paths::PathsCache;
 
 use crate::cli::{BuildArgs, BuildMinifyHtml};
-use crate::commands::resolve::{resolve_outdir, validate_outdir_safety, wipe_outdir_contents};
+use crate::commands::resolve::{
+    resolve_outdir, resolve_outdir_arg, validate_outdir_safety, wipe_outdir_contents,
+};
 use crate::config::{Config, OutputMode};
 use crate::output;
 use crate::render_pipeline::{
@@ -106,7 +109,8 @@ pub async fn run(args: &BuildArgs) -> Result<()> {
         .context("failed to load project configuration")?;
     let minify_html = resolve_minify_html(args.minify_html(), &config);
 
-    let outdir = resolve_outdir(&project_root, &args.outdir);
+    let selected_outdir = resolve_outdir_arg(args.outdir.clone(), &config.out_dir);
+    let outdir = resolve_outdir(&project_root, &selected_outdir);
 
     // Sub 3 / #108 — plugin lifecycle. Spawn the host before any heavy
     // work so `preBuild` can prepare files the bundler will see (e.g.

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -269,6 +269,8 @@ pub async fn run(args: &DevArgs) -> Result<()> {
         .await
         .context("failed to load project configuration")?;
 
+    // Configured `outDir` is dev's read-only production seed; live dev HTML
+    // and assets use the isolated scratch roots established below.
     let dist_root = resolve_under_root(&project_root, &cfg.out_dir);
     let public_root = resolve_under_root(&project_root, &cfg.public_dir);
 
@@ -392,8 +394,9 @@ pub async fn run(args: &DevArgs) -> Result<()> {
     .await?;
 
     // preBuild runs before devMiddleware registration and the bundler.
-    // Dev-mode difference: out_dir is `dist_root` (the dev scratch dir),
-    // not the final `outdir` that build.rs uses.
+    // Dev exposes the configured production root to plugin hooks for API
+    // parity, while zfb's own live render outputs use isolated scratch roots
+    // and treat `dist_root` only as a prebuilt seed.
     if let Some(h) = plugin_host.as_ref() {
         let ctx = zfb_build::BuildHookContext {
             project_root: project_root.clone(),

--- a/crates/zfb/src/commands/preview.rs
+++ b/crates/zfb/src/commands/preview.rs
@@ -6,22 +6,23 @@
 //!
 //! ## Static-only mode (`adapter: "none"` or omitted)
 //!
-//! Serves files from `<project>/dist/` over HTTP at `args.port`.
+//! Serves files from the selected output directory (`<project>/dist/` by
+//! default) over HTTP at the selected port.
 //!
 //! Trailing-slash semantics match Workers Static Assets'
 //! `html_handling = "auto-trailing-slash"`:
 //!
-//! - `GET /` → serve `dist/index.html`.
+//! - `GET /` → serve `<outdir>/index.html`.
 //! - `GET /foo` →
-//!   - if `dist/foo` is a regular file, serve it;
-//!   - else if `dist/foo/index.html` exists, **301 redirect** to `/foo/`;
+//!   - if `<outdir>/foo` is a regular file, serve it;
+//!   - else if `<outdir>/foo/index.html` exists, **301 redirect** to `/foo/`;
 //!   - else 404.
 //! - `GET /foo/` →
-//!   - if `dist/foo/index.html` exists, serve it;
+//!   - if `<outdir>/foo/index.html` exists, serve it;
 //!   - else 404.
 //!
 //! Naked directories (no `index.html`) always 404 — never a directory
-//! listing. The 404 body is `dist/404.html` if it exists, otherwise a
+//! listing. The 404 body is `<outdir>/404.html` if it exists, otherwise a
 //! plain `404 Not Found` text response.
 //!
 //! Cache-Control is `no-store` for v0 — preview is local only and we
@@ -46,10 +47,9 @@
 //!
 //! Loads `zfb.config.json` (or surfaces a clear "ts not yet supported"
 //! error for `zfb.config.ts`) via [`crate::config::load_from_dir`].
-//! Port resolution layers as "CLI flag > config > built-in default
-//! (`4321`)" — same rule used by `zfb dev`. `--outdir` keeps a clap
-//! default because the preview command does not consult config for it
-//! today.
+//! Port and output-directory resolution layer as "CLI flag > config >
+//! built-in default" — the same rule used by `zfb dev`. The preview port
+//! defaults to `4321`; `outDir` defaults to `dist`.
 
 use std::net::SocketAddr;
 use std::path::{Component, Path, PathBuf};
@@ -63,7 +63,9 @@ use axum::Router;
 use zfb_build::AdapterChoice;
 
 use crate::cli::PreviewArgs;
-use crate::commands::resolve::{resolve_addr, resolve_host, resolve_port, resolve_under_root};
+use crate::commands::resolve::{
+    resolve_addr, resolve_host, resolve_outdir_arg, resolve_port, resolve_under_root,
+};
 use crate::config;
 use crate::output;
 
@@ -104,11 +106,11 @@ pub async fn run(args: &PreviewArgs) -> Result<()> {
         .await
         .context("failed to load project configuration")?;
 
-    // 2. Resolve `args.outdir` against the project root so the
-    //    existence check (and the static handler) operate on an
-    //    unambiguous path. CLI wins over config unconditionally — see
-    //    the precedence note in the module doc comment.
-    let outdir = resolve_under_root(&project_root, &args.outdir);
+    // 2. Select CLI > config/default before resolving against the project
+    //    root. Keep the selected value for adapter-warning logic so merely
+    //    rooting `dist` does not look like a non-default choice.
+    let selected_outdir = resolve_outdir_arg(args.outdir.clone(), &cfg.out_dir);
+    let outdir = resolve_under_root(&project_root, &selected_outdir);
     let port = resolve_port(args.port, cfg.port, DEFAULT_PREVIEW_PORT);
     let host = resolve_host(
         args.host.as_deref(),
@@ -133,14 +135,15 @@ pub async fn run(args: &PreviewArgs) -> Result<()> {
         AdapterChoice::Package(pkg) if pkg == CLOUDFLARE_ADAPTER => {
             // `wrangler dev` serves whatever the project's wrangler config
             // names (`main` + `[assets].directory`) — unlike the old
-            // `wrangler pages dev <outdir>`, the CLI outdir cannot override
-            // it. Parsing the wrangler config to verify agreement would need
-            // a TOML/JSONC parser we don't ship, so for a non-default outdir
-            // we warn loudly instead of silently previewing the wrong build.
-            if adapter_outdir_diverges_from_default(&args.outdir) {
+            // `wrangler pages dev <outdir>`, zfb's selected outdir cannot
+            // override it. Parsing the wrangler config to verify agreement
+            // would need a TOML/JSONC parser we don't ship, so for a
+            // non-default selected outdir we warn loudly instead of silently
+            // previewing the wrong build.
+            if adapter_outdir_diverges_from_default(&selected_outdir) {
                 output::warn(format!(
-                    "preview: adapter mode is driven by your wrangler config (`main` + `[assets].directory`) — `--outdir {}` only pre-checks that the directory exists and does NOT change what wrangler dev serves. Make sure your wrangler config points at the same directory.",
-                    args.outdir.display()
+                    "preview: adapter mode is driven by your wrangler config (`main` + `[assets].directory`) — zfb's selected output directory `{}` only pre-checks that the directory exists and does NOT change what wrangler dev serves. Make sure your wrangler config points at the same directory.",
+                    selected_outdir.display()
                 ));
             }
             run_via_wrangler(&project_root, &host, port).await
@@ -363,11 +366,11 @@ fn is_safe_path(url_path: &str) -> bool {
 /// path so a vanished file behaves like a missing one.
 ///
 /// Before reading, we canonicalize `path` and verify it still lives
-/// inside `dist_root` — a symlink planted inside dist that points
-/// outside the root would otherwise be followed silently. Canonicalize
-/// errors (broken symlink, missing file) are treated as not-found. The
-/// read and content-type derivation use the canonical path so a symlink
-/// swap between check and read cannot escape the root.
+/// inside `dist_root` — a symlink planted inside the selected output
+/// directory that points outside the root would otherwise be followed
+/// silently. Canonicalize errors (broken symlink, missing file) are treated
+/// as not-found. The read and content-type derivation use the canonical path
+/// so a symlink swap between check and read cannot escape the root.
 async fn serve_file(path: &Path, dist_root: &Path) -> Response {
     let Some(resolved) = resolve_within_root(path, dist_root) else {
         return not_found_response(dist_root).await;
@@ -398,7 +401,7 @@ fn redirect_response(target: &str) -> Response {
         .unwrap_or_else(|_| StatusCode::INTERNAL_SERVER_ERROR.into_response())
 }
 
-/// Serve `dist/404.html` if present, else a plain text 404 body.
+/// Serve `<outdir>/404.html` if present, else a plain text 404 body.
 async fn not_found_response(dist_root: &Path) -> Response {
     let candidate = dist_root.join("404.html");
     if candidate.is_file() {
@@ -439,11 +442,11 @@ fn content_type_for_path(path: &Path) -> String {
 /// preference (TOML, then JSONC, then plain JSON).
 const WRANGLER_CONFIG_FILENAMES: [&str; 3] = ["wrangler.toml", "wrangler.jsonc", "wrangler.json"];
 
-/// True when the user asked adapter-mode preview to serve a directory other
-/// than the clap default `dist`. `wrangler dev` cannot honor that request
-/// (the wrangler config decides what is served), so the caller warns. An
-/// explicit `--outdir dist` is indistinguishable from the default and stays
-/// silent — in practice the wrangler config points at `dist` there anyway.
+/// True when CLI/config precedence selected an adapter-mode preview directory
+/// other than the built-in default `dist`. `wrangler dev` cannot honor that
+/// selection (the wrangler config decides what is served), so the caller
+/// warns. An explicit `--outdir dist` can override a custom config value and
+/// stays silent — in practice the wrangler config points at `dist` there.
 fn adapter_outdir_diverges_from_default(outdir: &Path) -> bool {
     outdir != Path::new("dist")
 }
@@ -1229,13 +1232,27 @@ mod tests {
 
     #[test]
     fn adapter_outdir_default_dist_stays_silent() {
-        assert!(!adapter_outdir_diverges_from_default(Path::new("dist")));
+        let selected = resolve_outdir_arg(None, Path::new("dist"));
+        assert!(!adapter_outdir_diverges_from_default(&selected));
     }
 
     #[test]
-    fn adapter_outdir_non_default_triggers_warning() {
-        assert!(adapter_outdir_diverges_from_default(Path::new("build")));
-        assert!(adapter_outdir_diverges_from_default(Path::new("out/dist")));
+    fn adapter_outdir_custom_config_triggers_warning() {
+        let selected = resolve_outdir_arg(None, Path::new("configured-out"));
+        assert!(adapter_outdir_diverges_from_default(&selected));
+    }
+
+    #[test]
+    fn adapter_outdir_custom_cli_triggers_warning() {
+        let selected =
+            resolve_outdir_arg(Some(PathBuf::from("cli-out")), Path::new("configured-out"));
+        assert!(adapter_outdir_diverges_from_default(&selected));
+    }
+
+    #[test]
+    fn adapter_outdir_explicit_cli_dist_over_custom_config_stays_silent() {
+        let selected = resolve_outdir_arg(Some(PathBuf::from("dist")), Path::new("configured-out"));
+        assert!(!adapter_outdir_diverges_from_default(&selected));
     }
 
     // ---- wrangler config preflight ------------------------------------

--- a/crates/zfb/src/commands/resolve.rs
+++ b/crates/zfb/src/commands/resolve.rs
@@ -24,8 +24,10 @@ pub fn resolve_under_root(root: &Path, path: &Path) -> PathBuf {
     }
 }
 
-/// Alias of [`resolve_under_root`] for the `build` command context where
-/// the resolved value is specifically the output directory.
+/// Alias of [`resolve_under_root`] for command contexts where the selected
+/// value is specifically the output directory. Selection precedence is kept
+/// separate in [`resolve_outdir_arg`] so callers can inspect the pre-root
+/// value when needed (for example, preview's adapter warning).
 pub fn resolve_outdir(root: &Path, path: &Path) -> PathBuf {
     resolve_under_root(root, path)
 }
@@ -153,6 +155,16 @@ pub fn wipe_outdir_contents(outdir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// CLI override > configured `outDir` precedence for build and preview.
+///
+/// `Config::out_dir` already contains the built-in `dist` default, so the
+/// caller only needs this two-way fold. Returning an owned path keeps the
+/// selected value independent of either input and avoids borrowed-lifetime
+/// coupling before it is resolved against the project root.
+pub fn resolve_outdir_arg(cli: Option<PathBuf>, cfg_outdir: &Path) -> PathBuf {
+    cli.unwrap_or_else(|| cfg_outdir.to_path_buf())
+}
+
 /// CLI override > config value > built-in default precedence rule.
 ///
 /// `default_port` is the caller's built-in constant (e.g. `DEFAULT_DEV_PORT`
@@ -258,6 +270,40 @@ mod tests {
         assert_eq!(
             resolve_outdir(root, Path::new("/tmp/zfb-out")),
             PathBuf::from("/tmp/zfb-out")
+        );
+    }
+
+    // ---- resolve_outdir_arg -------------------------------------------------
+
+    #[test]
+    fn resolve_outdir_arg_uses_config_default_when_cli_absent() {
+        assert_eq!(
+            resolve_outdir_arg(None, Path::new("dist")),
+            PathBuf::from("dist")
+        );
+    }
+
+    #[test]
+    fn resolve_outdir_arg_uses_custom_config_when_cli_absent() {
+        assert_eq!(
+            resolve_outdir_arg(None, Path::new("configured-out")),
+            PathBuf::from("configured-out")
+        );
+    }
+
+    #[test]
+    fn resolve_outdir_arg_prefers_custom_cli_over_config() {
+        assert_eq!(
+            resolve_outdir_arg(Some(PathBuf::from("cli-out")), Path::new("configured-out")),
+            PathBuf::from("cli-out")
+        );
+    }
+
+    #[test]
+    fn resolve_outdir_arg_preserves_explicit_cli_dist_over_custom_config() {
+        assert_eq!(
+            resolve_outdir_arg(Some(PathBuf::from("dist")), Path::new("configured-out")),
+            PathBuf::from("dist")
         );
     }
 

--- a/crates/zfb/tests/build_cleans_outdir.rs
+++ b/crates/zfb/tests/build_cleans_outdir.rs
@@ -19,6 +19,8 @@
 //! 5. **Safety rejection** — passing `outdir == project_root` (or an ancestor
 //!    thereof) causes `zfb build` to exit non-zero before touching the
 //!    filesystem.
+//! 6. **Output-directory precedence** — config-only `outDir` is honored and
+//!    an explicit CLI `--outdir` wins over it.
 //!
 //! All tests drive the real `zfb` binary via `Command::new(zfb_binary!())` so
 //! the full async `pub async fn run()` path — including the new
@@ -39,13 +41,8 @@ use zfb_test_utils::{locate_esbuild, zfb_binary};
 
 /// Write the minimal project fixture: `zfb.config.json` + `pages/index.tsx`
 /// (no prerender export → defaults to SSG, no V8 / adapter needed).
-fn write_minimal_fixture(root: &Path) {
-    fs::write(
-        root.join("zfb.config.json"),
-        r#"{ "framework": "preact" }
-"#,
-    )
-    .unwrap();
+fn write_minimal_fixture_with_config(root: &Path, config: &str) {
+    fs::write(root.join("zfb.config.json"), config).unwrap();
 
     fs::create_dir_all(root.join("pages")).unwrap();
     fs::write(
@@ -61,6 +58,14 @@ fn write_minimal_fixture(root: &Path) {
 "#,
     )
     .unwrap();
+}
+
+fn write_minimal_fixture(root: &Path) {
+    write_minimal_fixture_with_config(
+        root,
+        r#"{ "framework": "preact" }
+"#,
+    );
 }
 
 /// Run `zfb build` in `root` with the supplied esbuild path.
@@ -98,6 +103,80 @@ fn dump(output: &std::process::Output) -> String {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
     )
+}
+
+// ---------------------------------------------------------------------------
+// Output-directory precedence regressions (#1495)
+// ---------------------------------------------------------------------------
+
+/// With no CLI override, `zfb build` writes to the configured `outDir`.
+#[test]
+fn config_outdir_is_used_when_cli_flag_is_absent() {
+    let Some(esbuild) = locate_esbuild() else {
+        eprintln!(
+            "[build_cleans_outdir] no esbuild binary available; skipping. \
+             Set ZFB_ESBUILD_BIN or install esbuild on PATH."
+        );
+        return;
+    };
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+    write_minimal_fixture_with_config(
+        root,
+        r#"{ "framework": "preact", "outDir": "configured-out" }
+"#,
+    );
+
+    let out = run_zfb_build(root, &esbuild);
+    assert!(
+        out.status.success(),
+        "build with configured outDir failed\n{}",
+        dump(&out)
+    );
+    assert!(
+        root.join("configured-out/index.html").is_file(),
+        "config-only outDir must receive the build output"
+    );
+    assert!(
+        !root.join("dist").exists(),
+        "the default dist/ must not be created when config selects another outDir"
+    );
+}
+
+/// An explicit CLI `--outdir` wins over a different configured `outDir`.
+#[test]
+fn cli_outdir_overrides_config_outdir() {
+    let Some(esbuild) = locate_esbuild() else {
+        eprintln!(
+            "[build_cleans_outdir] no esbuild binary available; skipping. \
+             Set ZFB_ESBUILD_BIN or install esbuild on PATH."
+        );
+        return;
+    };
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+    write_minimal_fixture_with_config(
+        root,
+        r#"{ "framework": "preact", "outDir": "configured-out" }
+"#,
+    );
+
+    let out = run_zfb_build_with_outdir(root, &esbuild, "cli-out");
+    assert!(
+        out.status.success(),
+        "build with CLI outdir override failed\n{}",
+        dump(&out)
+    );
+    assert!(
+        root.join("cli-out/index.html").is_file(),
+        "CLI outdir must receive the build output"
+    );
+    assert!(
+        !root.join("configured-out").exists(),
+        "configured outDir must not be created when the CLI overrides it"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/docs/src/content/docs-ja/api/cli.mdx
+++ b/docs/src/content/docs-ja/api/cli.mdx
@@ -109,7 +109,7 @@ zfb build [--outdir <dir>] [--minify-html | --no-minify-html]
 
 | フラグ | 型 | デフォルト | 説明 |
 |---|---|---|---|
-| `--outdir` | path | `dist` | プロダクションビルドの出力ディレクトリ。 |
+| `--outdir` | path | config / `dist` | プロダクションビルドの出力ディレクトリ。config の `outDir` より優先され、どちらもない場合は `dist` を使います。 |
 | `--minify-html` | boolean flag | config/default | このビルドでプロダクション HTML ミニファイを有効にします。`minifyHtml: false` または設定の省略より優先されます。 |
 | `--no-minify-html` | boolean flag | config/default | このビルドでプロダクション HTML ミニファイを無効にします。config や preset の `minifyHtml: true` より優先されます。 |
 
@@ -132,7 +132,7 @@ zfb build --no-minify-html
 zfb preview [--port <port>] [--host [<host>]] [--outdir <dir>]
 ```
 
-`zfb.config.json` の `adapter` フィールドがサポート対象のアダプタ（例: `@takazudo/zfb-adapter-cloudflare`）を指定している場合、`zfb preview` は zfb 自身の静的サーバーではなく `wrangler dev` に処理を引き渡します。この場合 `--outdir` はディレクトリが存在するかを事前確認するだけになります。実際に何を配信するかは wrangler 自身の設定が制御するためです。[SSR と Cloudflare バインディング](../guides/ssr-and-cloudflare-bindings.mdx) を参照してください。
+`zfb.config.json` の `adapter` フィールドがサポート対象のアダプタ（例: `@takazudo/zfb-adapter-cloudflare`）を指定している場合、`zfb preview` は zfb 自身の静的サーバーではなく `wrangler dev` に処理を引き渡します。この場合、`--outdir` または config の `outDir` から選ばれた出力ディレクトリは、存在するかを事前確認するだけになります。実際に何を配信するかは wrangler 自身の設定が制御するためです。[SSR と Cloudflare バインディング](../guides/ssr-and-cloudflare-bindings.mdx) を参照してください。
 
 アダプタの preview は、処理を引き渡す前に `pnpm exec wrangler --version` の事前チェックを実行します。その pin を更新している間の一時的な escape hatch としてのみ、`ZFB_SKIP_WRANGLER_VERSION_CHECK=1` を設定してください。
 
@@ -142,9 +142,11 @@ zfb preview [--port <port>] [--host [<host>]] [--outdir <dir>]
 |---|---|---|---|
 | `--port` | u16 | `4321`* | preview サーバーがバインドするポート。 |
 | `--host` | string | `localhost`* | バインドするホストインターフェース。値なしの `--host` は `0.0.0.0` のショートカットです。 |
-| `--outdir` | path | `dist` | ビルド済み成果物を配信するディレクトリ。 |
+| `--outdir` | path | config / `dist` | ビルド済み成果物を配信するディレクトリ。config の `outDir` より優先され、どちらもない場合は `dist` を使います。 |
 
 \* 次の順にフォールバックします: CLI フラグ → `zfb.config.json` の `port`/`host` → 組み込みのデフォルト。
+
+出力ディレクトリも同様に、CLI の `--outdir` → config の `outDir` → 組み込みの `dist` の順でフォールバックします。
 
 ### 例
 

--- a/docs/src/content/docs-ja/api/define-config.mdx
+++ b/docs/src/content/docs-ja/api/define-config.mdx
@@ -31,7 +31,7 @@ declare module "zfb/config" {
 
 すべてのキーは camelCase です。形状は Rust の serde デシリアライザ（`crates/zfb/src/config.rs`）によって強制されます。`packages/zfb/src/config.ts` の TypeScript 型は、エディタの IntelliSense のためにそれを反映しています。
 
-- `outDir?: string` — 出力ディレクトリ。デフォルト: `"dist"`。
+- `outDir?: string` — dev、build、preview が使う出力ディレクトリ。デフォルト: `"dist"`。build と preview では、明示的な `--outdir` がこの設定より優先されます。
 - `publicDir?: string` — 静的アセットのディレクトリ。そのままコピーされます。デフォルト: `"public"`。
 - `host?: string` — dev / preview サーバーがバインドするホスト。
 - `port?: number` — dev / preview サーバーのポート。

--- a/docs/src/content/docs-ja/api/define-config.mdx
+++ b/docs/src/content/docs-ja/api/define-config.mdx
@@ -31,7 +31,7 @@ declare module "zfb/config" {
 
 すべてのキーは camelCase です。形状は Rust の serde デシリアライザ（`crates/zfb/src/config.rs`）によって強制されます。`packages/zfb/src/config.ts` の TypeScript 型は、エディタの IntelliSense のためにそれを反映しています。
 
-- `outDir?: string` — dev、build、preview が使う出力ディレクトリ。デフォルト: `"dist"`。build と preview では、明示的な `--outdir` がこの設定より優先されます。
+- `outDir?: string` — build と preview が使う出力ディレクトリです。dev ではライブ出力先ではなく、読み取り専用の事前ビルド済みシードとして扱われます。デフォルト: `"dist"`。build と preview では、明示的な `--outdir` がこの設定より優先されます。
 - `publicDir?: string` — 静的アセットのディレクトリ。そのままコピーされます。デフォルト: `"public"`。
 - `host?: string` — dev / preview サーバーがバインドするホスト。
 - `port?: number` — dev / preview サーバーのポート。

--- a/docs/src/content/docs-ja/getting-started/project-structure.mdx
+++ b/docs/src/content/docs-ja/getting-started/project-structure.mdx
@@ -90,7 +90,7 @@ my-site/
 
 設定ファイルは camelCase スキーマを使います。主なキーには次のものがあります。`outDir`（デフォルト `"dist"`）、`publicDir`（デフォルト `"public"`）、`host`（デフォルト `"localhost"`）、`port`（デフォルト `3000`）、`framework`（`"preact"` または `"react"`、デフォルト `"preact"`）、`collections`、`tailwind`、`plugins`。これは網羅的な一覧ではありません。完全なスキーマのリファレンスは [defineConfig](../api/define-config.mdx) を参照してください。
 
-`outDir` は現時点では `zfb dev` でのみ尊重されます。`zfb build` と `zfb preview` は `--outdir` フラグから出力ディレクトリを選び、省略時は `dist/` になります。
+`outDir` は `zfb dev`、`zfb build`、`zfb preview` のすべてで尊重されます。build と preview では CLI の `--outdir` が config の `outDir` より優先され、組み込みのフォールバックは `dist/` です。
 
 テンプレートは `zfb.config.json` をスキャフォールドします。これを `zfb.config.ts` にリネームすると、zfb は同梱の esbuild バイナリ経由でロードし、完全な TypeScript 型と IDE 補完が得られます。スキーマはどちらの形式でも同一です。
 

--- a/docs/src/content/docs-ja/getting-started/your-first-site.mdx
+++ b/docs/src/content/docs-ja/getting-started/your-first-site.mdx
@@ -68,11 +68,11 @@ npx zfb build
 npx zfb preview
 ```
 
-`zfb build` は CLI の `--outdir` 値（デフォルトは `dist/`）へ書き出し、ファイルシステムルーターでルートを列挙し、静的ルートごとに 1 つの HTML ファイルを書き出します。build コマンドはサーバーを起動しないため、`--port` フラグはありません。
+`zfb build` は CLI の `--outdir` → config の `outDir` → 組み込みデフォルトの `dist/` という順で選んだディレクトリへ書き出し、ファイルシステムルーターでルートを列挙し、静的ルートごとに 1 つの HTML ファイルを書き出します。build コマンドはサーバーを起動しないため、`--port` フラグはありません。
 
-`zfb preview` は自身の CLI `--outdir` 値（こちらもデフォルトは `dist/`）を、デフォルトでポート `4321` の HTTP で配信します。preview の `--port` フラグは設定の `port` より優先されます。どちらも設定されていない場合、preview は組み込みデフォルトを使います。
+`zfb preview` も同じ出力ディレクトリの優先順位を使い、選択されたディレクトリを HTTP で配信します。preview の `--port` フラグは設定の `port` より優先されます。どちらも設定されていない場合、preview は組み込みデフォルトの `4321` を使います。
 
-現時点で `zfb.config.*` の `outDir` は `zfb dev` では尊重されますが、`zfb build` と `zfb preview` は読み取りません。デフォルト以外のディレクトリをビルドまたは配信する場合は、それらのコマンドに `--outdir` を渡してください。この分割に関する独立した判断は [issue #1473](https://github.com/Takazudo/zudo-front-builder/issues/1473) で追跡されています。
+3 つのコマンドはすべて `zfb.config.*` の `outDir` を尊重します。build と preview では、明示的な `--outdir` が常に設定値より優先されます。
 
 ## 動作するサンプル
 

--- a/docs/src/content/docs/api/cli.mdx
+++ b/docs/src/content/docs/api/cli.mdx
@@ -109,7 +109,7 @@ zfb build [--outdir <dir>] [--minify-html | --no-minify-html]
 
 | Flag | Type | Default | Description |
 |---|---|---|---|
-| `--outdir` | path | `dist` | Output directory for the production build. |
+| `--outdir` | path | config / `dist` | Output directory for the production build. Overrides config `outDir`; when both are absent, uses `dist`. |
 | `--minify-html` | boolean flag | config/default | Enable production HTML minification for this build. Overrides `minifyHtml: false` or an omitted config value. |
 | `--no-minify-html` | boolean flag | config/default | Disable production HTML minification for this build. Overrides `minifyHtml: true` from config or presets. |
 
@@ -132,7 +132,7 @@ Serve a previously built site locally. Run `zfb build` first.
 zfb preview [--port <port>] [--host [<host>]] [--outdir <dir>]
 ```
 
-When `zfb.config.json`'s `adapter` field names a supported adapter (e.g. `@takazudo/zfb-adapter-cloudflare`), `zfb preview` hands off to `wrangler dev` instead of zfb's own static server — `--outdir` then only pre-checks that the directory exists, since wrangler's own config controls what it actually serves. See [SSR and Cloudflare Bindings](../guides/ssr-and-cloudflare-bindings.mdx).
+When `zfb.config.json`'s `adapter` field names a supported adapter (e.g. `@takazudo/zfb-adapter-cloudflare`), `zfb preview` hands off to `wrangler dev` instead of zfb's own static server — the output directory selected from `--outdir` or config `outDir` then only pre-checks that the directory exists, since wrangler's own config controls what it actually serves. See [SSR and Cloudflare Bindings](../guides/ssr-and-cloudflare-bindings.mdx).
 
 Adapter preview runs a pre-flight `pnpm exec wrangler --version` check before handing off. Set `ZFB_SKIP_WRANGLER_VERSION_CHECK=1` only as a temporary escape hatch when that pin is being updated.
 
@@ -142,9 +142,11 @@ Adapter preview runs a pre-flight `pnpm exec wrangler --version` check before ha
 |---|---|---|---|
 | `--port` | u16 | `4321`* | Port to bind the preview server to. |
 | `--host` | string | `localhost`* | Host interface to bind to. Bare `--host` (no value) is a shortcut for `0.0.0.0`. |
-| `--outdir` | path | `dist` | Directory to serve the built artifacts from. |
+| `--outdir` | path | config / `dist` | Directory to serve the built artifacts from. Overrides config `outDir`; when both are absent, uses `dist`. |
 
 \* Falls back through: CLI flag → `port`/`host` in `zfb.config.json` → built-in default.
+
+Output-directory precedence is likewise CLI `--outdir` → config `outDir` → built-in `dist`.
 
 ### Example
 

--- a/docs/src/content/docs/api/define-config.mdx
+++ b/docs/src/content/docs/api/define-config.mdx
@@ -31,7 +31,7 @@ Re-export — do **not** hand-copy the `ZfbConfig` shape into the shim. A hand-m
 
 All keys are camelCase. The shape is enforced by the Rust serde deserializer (`crates/zfb/src/config.rs`) — the TypeScript type in `packages/zfb/src/config.ts` mirrors it for editor IntelliSense.
 
-- `outDir?: string` — output directory. Default: `"dist"`.
+- `outDir?: string` — output directory used by dev, build, and preview. Default: `"dist"`. An explicit `--outdir` overrides it for build and preview.
 - `publicDir?: string` — static assets directory, copied verbatim. Default: `"public"`.
 - `host?: string` — dev/preview server bind host.
 - `port?: number` — dev/preview server port.

--- a/docs/src/content/docs/api/define-config.mdx
+++ b/docs/src/content/docs/api/define-config.mdx
@@ -31,7 +31,7 @@ Re-export — do **not** hand-copy the `ZfbConfig` shape into the shim. A hand-m
 
 All keys are camelCase. The shape is enforced by the Rust serde deserializer (`crates/zfb/src/config.rs`) — the TypeScript type in `packages/zfb/src/config.ts` mirrors it for editor IntelliSense.
 
-- `outDir?: string` — output directory used by dev, build, and preview. Default: `"dist"`. An explicit `--outdir` overrides it for build and preview.
+- `outDir?: string` — output directory used by build and preview; dev treats it as a read-only prebuilt seed rather than a live-output directory. Default: `"dist"`. An explicit `--outdir` overrides it for build and preview.
 - `publicDir?: string` — static assets directory, copied verbatim. Default: `"public"`.
 - `host?: string` — dev/preview server bind host.
 - `port?: number` — dev/preview server port.

--- a/docs/src/content/docs/getting-started/project-structure.mdx
+++ b/docs/src/content/docs/getting-started/project-structure.mdx
@@ -90,7 +90,7 @@ See [Static Assets](../concepts/static-assets.mdx) for the full reference, inclu
 
 The config file uses a camelCase schema. Common keys include `outDir` (default `"dist"`), `publicDir` (default `"public"`), `host` (default `"localhost"`), `port` (default `3000`), `framework` (`"preact"` or `"react"`, default `"preact"`), `collections`, `tailwind`, and `plugins`. This is not an exhaustive list — see [defineConfig](../api/define-config.mdx) for the full schema reference.
 
-`outDir` is currently honored by `zfb dev` only. `zfb build` and `zfb preview` choose their output directory from the `--outdir` flag, defaulting to `dist/`.
+`outDir` is honored by `zfb dev`, `zfb build`, and `zfb preview`. For build and preview, CLI `--outdir` overrides config `outDir`; the built-in fallback is `dist/`.
 
 The template scaffolds `zfb.config.json`. If you rename it to `zfb.config.ts`, zfb loads it via the bundled esbuild binary and you get full TypeScript types and IDE completion — the schema is identical in both formats.
 

--- a/docs/src/content/docs/getting-started/your-first-site.mdx
+++ b/docs/src/content/docs/getting-started/your-first-site.mdx
@@ -67,11 +67,11 @@ npx zfb build
 npx zfb preview
 ```
 
-`zfb build` writes to its CLI `--outdir` value, defaulting to `dist/`, then enumerates routes via the file-system router and writes one HTML file per static route. The build command has no `--port` flag because it does not start a server.
+`zfb build` writes to the directory selected by CLI `--outdir` → config `outDir` → the built-in `dist/` default, then enumerates routes via the file-system router and writes one HTML file per static route. The build command has no `--port` flag because it does not start a server.
 
-`zfb preview` serves its own CLI `--outdir` value, also defaulting to `dist/`, over HTTP on port `4321` by default. Preview's `--port` flag wins over config `port`; if neither is set, preview uses the built-in default.
+`zfb preview` uses the same output-directory precedence and serves the selected directory over HTTP. Preview's `--port` flag wins over config `port`; if neither is set, preview uses the built-in `4321` default.
 
-Today `outDir` in `zfb.config.*` is honored by `zfb dev`, but `zfb build` and `zfb preview` do not read it; pass `--outdir` to those commands when you build or serve a non-default directory. The standalone decision about this split is tracked in [issue #1473](https://github.com/Takazudo/zudo-front-builder/issues/1473).
+All three commands honor `outDir` in `zfb.config.*`. For build and preview, an explicit `--outdir` always overrides the configured value.
 
 ## A working example
 


### PR DESCRIPTION
- issue
  - https://github.com/Takazudo/zudo-front-builder/issues/1495
- parent epic
  - https://github.com/Takazudo/zudo-front-builder/issues/1494
- root PR
  - https://github.com/Takazudo/zudo-front-builder/pull/1520

---

## Summary

- preserve whether `--outdir` was omitted for build and preview
- resolve output directories with CLI > config > `dist` precedence
- warn accurately when adapter preview cannot honor a selected non-default directory
- add CLI, precedence, warning, and real build-output regression coverage
- update English and Japanese docs, including dev's read-only prebuilt-seed semantics

## Test plan

- `cargo fmt --all -- --check`
- `cargo test -p zfb --lib`
- `cargo test -p zfb --test build_cleans_outdir -- --nocapture`
- `cargo clippy -p zfb -- -D warnings`
- stale outDir documentation grep
