### PR TITLE
Docs & Scaffold Tidy: Tailwind temp-file gitignore + Cloudflare examples index

### DIFF
--- a/crates/zfb/src/commands/new.rs
+++ b/crates/zfb/src/commands/new.rs
@@ -925,6 +925,39 @@ mod tests {
             has_md_post,
             "scaffolded content/posts/ must contain at least one .md seed post"
         );
+
+        // The emitted .gitignore must carry the Tailwind entry temp-file glob
+        // (issue #1538) so node-free projects (Tailwind defaults to enabled
+        // when the config key is absent) don't re-discover the need for it.
+        let gitignore = fs::read_to_string(dest.join(".gitignore"))
+            .expect("scaffolded node-free site must have a .gitignore");
+        assert!(
+            gitignore.contains("**/zfb-tailwind-entry-*.css"),
+            "scaffolded node-free .gitignore must ignore the Tailwind entry temp file, got:\n{gitignore}"
+        );
+    }
+
+    #[test]
+    fn templates_gitignore_ignores_tailwind_entry_temp_file() {
+        // Drift risk: this glob is hand-derived from zfb-css's private
+        // ENTRY_TMP_PREFIX ("zfb-tailwind-entry-") / ENTRY_TMP_SUFFIX
+        // (".css") constants (crates/zfb-css/src/engine.rs). If those change,
+        // this glob and the shipped .gitignore templates must change too.
+        const EXPECTED_GLOB: &str = "**/zfb-tailwind-entry-*.css";
+        for template_name in ["basic-blog", "node-free"] {
+            let dir = TEMPLATES
+                .get_dir(template_name)
+                .unwrap_or_else(|| panic!("{template_name} template missing from registry"));
+            let gitignore_path = format!("{template_name}/.gitignore");
+            let gitignore_file = dir
+                .get_file(&gitignore_path)
+                .unwrap_or_else(|| panic!("{gitignore_path} missing from template"));
+            let contents = String::from_utf8_lossy(gitignore_file.contents());
+            assert!(
+                contents.contains(EXPECTED_GLOB),
+                "{gitignore_path} must contain '{EXPECTED_GLOB}', got:\n{contents}"
+            );
+        }
     }
 
     #[test]

--- a/crates/zfb/templates/basic-blog/.gitignore
+++ b/crates/zfb/templates/basic-blog/.gitignore
@@ -2,3 +2,7 @@ node_modules
 dist
 .zfb-build
 .DS_Store
+
+# Tailwind entry temp file synthesised by zfb-css next to the CSS entry
+# (see zfb-css's ENTRY_TMP_PREFIX/ENTRY_TMP_SUFFIX).
+**/zfb-tailwind-entry-*.css

--- a/crates/zfb/templates/node-free/.gitignore
+++ b/crates/zfb/templates/node-free/.gitignore
@@ -2,3 +2,7 @@ node_modules
 dist
 .zfb-build
 .DS_Store
+
+# Tailwind entry temp file synthesised by zfb-css next to the CSS entry
+# (see zfb-css's ENTRY_TMP_PREFIX/ENTRY_TMP_SUFFIX).
+**/zfb-tailwind-entry-*.css

--- a/docs/src/content/docs-ja/concepts/styling.mdx
+++ b/docs/src/content/docs-ja/concepts/styling.mdx
@@ -57,6 +57,8 @@ Tailwind v4 の CSS ファーストな設定は `global.css` 内の `@theme` デ
 
 `tailwind: { enabled: false }` を設定すると `AuthoredCssEngine` に切り替わり、あなたが書いた `styles/global.css` がそのまま素通りします。Tailwind の `@import` も、ユーティリティのスキャンも、preflight のリセットも、サブプロセスもありません。CSS Modules のコンパイル、クラス名のハッシュ化、アセットの出力はすべて変わらず動作し続け、Tailwind 固有のステップだけがスキップされます。
 
+Tailwind が有効な間、ビルドパイプラインは CSS エントリの隣に `zfb-tailwind-entry-*.css` という名前の一時エントリファイルを（追跡対象のソースツリー内に）生成し、ビルド完了後に削除します。新規にスキャフォールドしたプロジェクトはこれを自動的に無視します。このグロブが導入される前にスキャフォールドしたプロジェクトに Tailwind を追加する場合は、`.gitignore` に `**/zfb-tailwind-entry-*.css` を追加してください。
+
 ## コンポーネントスコープなスタイリング
 
 コンポーネントレベルのスタイリングには、十分にサポートされたパターンが 2 つあります。Tailwind ユーティリティクラスと CSS Modules です。

--- a/docs/src/content/docs-ja/getting-started/project-structure.mdx
+++ b/docs/src/content/docs-ja/getting-started/project-structure.mdx
@@ -96,4 +96,4 @@ my-site/
 
 ## package.json、tsconfig.json、.gitignore
 
-標準的なプロジェクトの配管です。`package.json` はフレームワークのランタイム依存（デフォルトでは `preact`）と、島が import する任意のライブラリを宣言します。`tsconfig.json` は `pages/`・`layouts/`・`components/` 内の TSX がクリーンに型チェックされるよう構成されています。同梱の `.gitignore` は `dist/` と `node_modules/` を除外し、ビルド出力と依存関係をバージョン管理の外に保ちます。
+標準的なプロジェクトの配管です。`package.json` はフレームワークのランタイム依存（デフォルトでは `preact`）と、島が import する任意のライブラリを宣言します。`tsconfig.json` は `pages/`・`layouts/`・`components/` 内の TSX がクリーンに型チェックされるよう構成されています。同梱の `.gitignore` は `dist/` と `node_modules/` を除外し、ビルド出力と依存関係をバージョン管理の外に保ちます。加えて `**/zfb-tailwind-entry-*.css` も除外します。これは Tailwind パイプラインが CSS エントリの隣に生成する一時エントリファイルです（[スタイリング](../concepts/styling.mdx)を参照）。

--- a/docs/src/content/docs/concepts/styling.mdx
+++ b/docs/src/content/docs/concepts/styling.mdx
@@ -61,6 +61,12 @@ scan, no preflight reset, no subprocess. CSS Modules compilation, class-name has
 and asset emission all keep working unchanged; only the Tailwind-specific steps are
 skipped.
 
+While Tailwind is enabled, the build pipeline synthesises a temp entry file named
+`zfb-tailwind-entry-*.css` next to your CSS entry (inside the tracked source tree) and
+removes it once the build finishes. New scaffolds ignore it automatically. If you are
+adding Tailwind to a project scaffolded before this glob shipped, add
+`**/zfb-tailwind-entry-*.css` to your `.gitignore`.
+
 ## Component-scoped styling
 
 There are two well-supported patterns for component-level styling: Tailwind utility classes, and CSS Modules.

--- a/docs/src/content/docs/getting-started/project-structure.mdx
+++ b/docs/src/content/docs/getting-started/project-structure.mdx
@@ -96,4 +96,4 @@ The template scaffolds `zfb.config.json`. If you rename it to `zfb.config.ts`, z
 
 ## package.json, tsconfig.json, .gitignore
 
-Standard project plumbing. `package.json` declares the framework runtime dependency (`preact` by default) and any libraries your islands import. `tsconfig.json` is configured so TSX in `pages/`, `layouts/`, and `components/` type-checks cleanly. The shipped `.gitignore` excludes `dist/` and `node_modules/` so build output and dependencies stay out of version control.
+Standard project plumbing. `package.json` declares the framework runtime dependency (`preact` by default) and any libraries your islands import. `tsconfig.json` is configured so TSX in `pages/`, `layouts/`, and `components/` type-checks cleanly. The shipped `.gitignore` excludes `dist/` and `node_modules/` so build output and dependencies stay out of version control, plus `**/zfb-tailwind-entry-*.css` — the temp entry file the Tailwind pipeline synthesises next to your CSS entry (see [Styling](../concepts/styling.mdx)).

--- a/docs/src/content/docs/guides/examples.mdx
+++ b/docs/src/content/docs/guides/examples.mdx
@@ -1,0 +1,43 @@
+---
+title: Examples
+description: An index of the standalone Cloudflare Workers and Cloudflare Pages example repositories that demonstrate zfb in real, deployable projects.
+sidebar_position: 5
+---
+
+zfb ships a set of standalone example repositories, each one a small,
+deployable project that demonstrates a single Cloudflare recipe end to end.
+Every repo is independently `pnpm install`-able and includes its own README
+with local run steps and Cloudflare provisioning commands — clone one to see
+the whole thing assembled rather than copying snippets piecemeal.
+
+<Note title="Demo URLs go live after first deploy">
+
+Each Worker demo URL below resolves once that repo's Cloudflare secrets are
+configured and it has deployed at least once. Until then, some links may
+404 — check the repo's README for its current deploy status.
+
+</Note>
+
+## Cloudflare Workers (Static Assets) — 7
+
+These deploy as a **Cloudflare Worker with Static Assets**, the pattern
+covered in [SSR and Cloudflare Bindings](./ssr-and-cloudflare-bindings.mdx).
+
+| Example                                                                       | Demo                                                                     | What it shows                                                                                                                       |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| [ai-summarizer](https://github.com/Takazudo/zfb-example-ai-summarizer)         | [Demo](https://zfb-example-ai-summarizer-ai.takazudo.workers.dev/)        | Preact island UI + a Workers AI–backed `/api/summarize` route, with a deterministic local fallback when the `AI` binding is absent. |
+| [json-api](https://github.com/Takazudo/zfb-example-json-api)                   | [Demo](https://zfb-example-json-api.takazudo.workers.dev/)                | SSR/API starter: `/api/items` (filter + paginate) and `/api/search` (lazy MiniSearch index), consumed by one island.                |
+| [kv-guestbook](https://github.com/Takazudo/zfb-example-kv-guestbook)           | [Demo](https://zfb-example-kv-guestbook.takazudo.workers.dev/)            | Workers KV guestbook: a `prerender = false` no-JS form + JSON API + admin delete, backed by a KV namespace.                         |
+| [password-gate](https://github.com/Takazudo/zfb-example-password-gate)         | [Demo](https://zfb-example-password-gate.takazudo.workers.dev/)           | Static preview site behind a hand-written Worker password gate (`run_worker_first = true`).                                        |
+| [reverse-proxy](https://github.com/Takazudo/zfb-example-reverse-proxy)         | [Demo](https://zfb-example-reverse-proxy.takazudo.workers.dev/)           | Catch-all SSR reverse proxy (`/proxy/...` → `PROXY_ORIGIN`) with hop-by-hop / cookie / security-header hygiene.                     |
+| [workers-cache](https://github.com/Takazudo/zfb-example-workers-cache)         | [Demo](https://zfb-example-workers-cache.takazudo.workers.dev/)           | SSR Workers Cache recipe: explicit cache headers + `Cache-Tag` + a token-protected purge route (`ctx.cache.purge()`).               |
+| [webshop](https://github.com/Takazudo/zfb-example-webshop)                     | [Demo](https://zfb-example-webshop.takazudo.workers.dev/)                 | SSR shop on Cloudflare (migrated Pages → Workers Static Assets) + D1 (per-preview databases, migrations in CI).                     |
+
+## Cloudflare Pages — 2
+
+These deploy as a static site to **Cloudflare Pages** and are live today.
+
+| Example                                                                              | Demo                                                    | What it shows                                                                     |
+| --------------------------------------------------------------------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| [blog](https://github.com/Takazudo/zfb-example-blog)                                    | [Demo](https://zfb-example-blog.pages.dev/)                 | Tailwind blog with content collections, pagination, tags, and a hydrated theme-toggle island. |
+| [corporate-website](https://github.com/Takazudo/zfb-example-corporate-website)          | [Demo](https://zfb-example-corporate-website.pages.dev/)    | Static corporate site using CSS Modules.                                          |

--- a/docs/src/content/docs/guides/ssr-and-cloudflare-bindings.mdx
+++ b/docs/src/content/docs/guides/ssr-and-cloudflare-bindings.mdx
@@ -361,6 +361,10 @@ is the shop's own design choice, not a zfb limitation; zfb supports
 
 </Tip>
 
+For more Cloudflare recipes beyond webshop — Workers KV, Workers AI, a
+reverse proxy, a password gate, and more — see the
+[Examples](./examples.mdx) index of every standalone example repository.
+
 There are two ways to run the app locally, and they answer different questions:
 
 - **`zfb dev`** — fast page-authoring loop. It runs the SSR **render code** for

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,12 @@
 # Examples Workspace Contract
 
+> **Looking for a full, deployable example?** This directory holds in-repo
+> scratch examples used to test published packages, not standalone projects.
+> For the 9 standalone Cloudflare Workers/Pages example repositories with
+> live demos, see the
+> [Examples](https://takazudomodular.com/pj/zudo-front-builder/docs/guides/examples/)
+> docs page.
+
 The `examples/*` workspace is for copyable, runnable examples that exercise
 published `@takazudo/*` packages the same way an external user would consume
 them. Example packages are intentionally excluded from release build and T1


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1537

---

## Summary

Epic #1537 (Docs & Scaffold Tidy) — two independent hygiene topics, implemented via `/x-wt-teams` (Claude Code on the web; the session branch is the base, topics merged into it locally).

### Topic 1 — Tailwind temp-file gitignore (#1538)

The Tailwind pipeline synthesises a short-lived `zfb-tailwind-entry-*.css` entry file inside the tracked source tree; nothing gitignored it by default, so every adopting project re-discovered the same `.gitignore` line.

- Added `**/zfb-tailwind-entry-*.css` to both embedded scaffold templates (`basic-blog`, `node-free` `.gitignore`), with a comment pointing at zfb-css's `ENTRY_TMP_PREFIX`/`ENTRY_TMP_SUFFIX` (drift risk).
- New unit test `templates_gitignore_ignores_tailwind_entry_temp_file` asserts both embedded templates carry the glob; extended `node_free_scaffold_produces_correct_file_set` to assert the emitted scaffold's `.gitignore` carries the line.
- Documented the temp file + the exact glob for pre-existing projects in `concepts/styling.mdx` and `getting-started/project-structure.mdx` (EN **and** the maintained JA mirrors).

### Topic 2 — Cloudflare examples docs index (#1539)

- New EN-only `guides/examples.mdx` (`sidebar_position: 5`) indexing all 9 extracted example repos — 7 Cloudflare Workers + 2 Cloudflare Pages — each with GitHub URL, demo URL, and a one-line recipe explanation (owner-corrected data: webshop is a Workers example; account subdomain `takazudo`; ai-summarizer's worker is `-ai`).
- Cross-link added from `guides/ssr-and-cloudflare-bindings.mdx`; pointer to the published docs route added to `examples/README.md`.

## Verification (confirm gate #1540)

- `cargo test -p zfb --lib commands::new` → **19 passed, 0 failed** (run in the no-V8 lane; V8 native build is blocked by this container's egress policy — CI's health.yml is the authoritative full-suite gate).
- `pnpm docs:build` → 248 pages built, Examples page renders (EN + JA-fallback routes).
- `pnpm format:check` → clean.
- External links: both Pages demos 200; webshop Worker 200; the other 6 Workers demos 404 (not yet deployed — secrets unset, explicitly accepted by the source issue). GitHub repo URLs are not verifiable from this container (proxy egress returns 403 for github.com HTML) — they are the canonical Takazudo example repos already referenced in existing docs.

## Sub-issues

- #1538 — Tailwind temp-file gitignore in scaffold templates + docs
- #1539 — Cloudflare examples docs index page
- #1540 — Confirm: batch gate

---
_Generated by [Claude Code](https://claude.ai/code/session_01FTLM9ZxgJWAaWVGhDCNs5j)_