### PR TITLE
fix(dev): normalize FSEvents-coalesced Created for known content entries; deflake out-of-root e2e (#1581)

### DIFF
--- a/crates/zfb-build/src/lib.rs
+++ b/crates/zfb-build/src/lib.rs
@@ -111,8 +111,8 @@ pub use plugin_runner::{
     PluginSpec, PostBuildParamValue, PostBuildRouteEntry, PostBuildRouteManifest, SetupHookContext,
 };
 pub use policy::{
-    classify_change, classify_change_with_content_roots, GranularityPolicy, PathClass,
-    RawImportInvalidation,
+    classify_change, classify_change_with_content_roots, GranularityPolicy, KnownContentEntries,
+    PathClass, RawImportInvalidation,
 };
 pub use renderer::{
     reload, render_all, render_one, shutdown, start, Backend, EmbeddedV8Host,

--- a/crates/zfb-build/src/orchestrator.rs
+++ b/crates/zfb-build/src/orchestrator.rs
@@ -646,17 +646,55 @@ impl<P: AssetPipeline> BuildOrchestrator<P> {
         ctx: &BuildContext,
         discover: Option<&DiscoveryHook>,
     ) -> Result<Option<BuildOutcome>> {
+        // Issue #1581 — a `Removed` path is no longer a known collection
+        // entry, so forget it (and, for a removed directory, everything
+        // beneath it) BEFORE the `Created` normalization below reads the
+        // registry. Order is load-bearing: the watcher can batch a `Removed`
+        // and a `Created` into the SAME tick, and purging afterwards would
+        // let a genuine delete→recreate normalize to `Modified` and skip the
+        // discovery regime that must re-establish its routes.
+        for (path, kind) in &changes {
+            if *kind == ChangeKind::Removed {
+                self.config
+                    .policy
+                    .known_content
+                    .remove_path_and_descendants(path);
+            }
+        }
+
         // Issue #1058 — normalize a spurious `Created` for an already-known
         // content source back to `Modified`. On a loaded arm64 macOS host,
         // FSEvents coalescing can deliver an in-place edit of an EXISTING
         // file as `Created` (see `zfb_watcher::merge_kind` rule 2). Left as
         // `Created` the change routes through the discovery regime (watch-ADD)
         // instead of the in-place-edit regime, so the lazy path never
-        // eager-renders the edited entry's own route — the dropped eager
-        // render this issue tracks. A path the graph already knows as a
-        // content dependency (`consumers_of` is non-empty) cannot be
-        // genuinely new, so the `Created` flag is an artifact; a truly new
-        // file has no reverse edge yet and stays `Created` for discovery.
+        // eager-renders the edited entry's own route, and the strict #958
+        // `fan_out_safe` gate below (all-`Modified`) is poisoned — costing
+        // the whole tick its eager narrowing and re-stamping every route.
+        //
+        // "Already known" has TWO sources, and the registry is the load-
+        // bearing one (issue #1581):
+        //
+        // - The session-live collection-entry registry (`known_content`) —
+        //   seeded at boot from the collection membership walk and extended
+        //   by discovery. This is authoritative.
+        // - The dependency graph's reverse edge (`consumers_of` non-empty) —
+        //   #1058's original check, kept because a warm PERSISTED graph can
+        //   restore Content edges from a previous session. On a COLD boot it
+        //   is always empty for a pre-existing entry (the dev server's only
+        //   `DepKind::Content` writer is the discovery hook, which fires just
+        //   for newly-created files), which is why #1058 alone never fired
+        //   for the first edit of any boot-time entry.
+        //
+        // A genuinely new file is in neither, so it stays `Created` for
+        // discovery. Known-ness is read OUTSIDE the graph mutex to keep the
+        // two locks uncoupled.
+        let known_created: Vec<bool> = changes
+            .iter()
+            .map(|(path, kind)| {
+                *kind == ChangeKind::Created && self.config.policy.is_known_content_entry(path)
+            })
+            .collect();
         let changes: Vec<(PathBuf, ChangeKind)> = {
             let graph = self.graph.lock().unwrap_or_else(|p| {
                 warn!(
@@ -667,9 +705,10 @@ impl<P: AssetPipeline> BuildOrchestrator<P> {
             });
             changes
                 .into_iter()
-                .map(|(path, kind)| {
+                .zip(known_created)
+                .map(|((path, kind), known)| {
                     let spurious_created = kind == ChangeKind::Created
-                        && graph.consumers_of(&path).is_some_and(|c| !c.is_empty())
+                        && (known || graph.consumers_of(&path).is_some_and(|c| !c.is_empty()))
                         && classify_change_with_content_roots(
                             &path,
                             &self.config.project_root,
@@ -1662,6 +1701,188 @@ mod tests {
                 fan_out_safe: true,
             }),
             "a Created for a known content source is normalized to a fan-out-safe edit (#1058)"
+        );
+    }
+
+    /// Build an orchestrator whose policy carries a live known-content
+    /// registry (issue #1581), pre-seeded with `known`.
+    fn make_orch_with_known_content<P: AssetPipeline>(
+        pipeline: P,
+        known: &[&str],
+    ) -> (BuildOrchestrator<P>, crate::policy::KnownContentEntries) {
+        let registry = crate::policy::KnownContentEntries::default();
+        registry.insert_many(known.iter().map(PathBuf::from));
+        let orch = BuildOrchestrator::new(
+            OrchestratorConfig::new(
+                "/proj",
+                vec![PathBuf::from("pages"), PathBuf::from("content")],
+            )
+            .with_policy(GranularityPolicy::default().with_known_content(registry.clone())),
+            make_graph(),
+            pipeline,
+        );
+        (orch, registry)
+    }
+
+    /// #1581 — the regression this issue is about. `other.md` is a content
+    /// entry with NO graph reverse edge (`consumers_of` is `None`), which is
+    /// the state of EVERY collection entry on a cold `zfb dev` boot: the only
+    /// `DepKind::Content` writer is the discovery hook, and it fires just for
+    /// newly-created files. #1058's graph-keyed normalization therefore never
+    /// fired for a pre-existing entry, so the first macOS FSEvents-coalesced
+    /// `Created` for it lost the whole tick's #958 eager narrowing.
+    ///
+    /// With the entry in the known-content registry the `Created` is now
+    /// recognized as the artifact it is and normalized to `Modified` →
+    /// `fan_out_safe`, WITHOUT the graph needing any Content edge.
+    #[test]
+    fn edge_less_known_boot_entry_created_normalizes_to_modified() {
+        use zfb_watcher::ChangeKind;
+        let pipeline = CountingPipeline::default();
+        let applies = pipeline.applies.clone();
+        // `other.md` deliberately has no consumers in `make_graph()`.
+        let (orch, _registry) = make_orch_with_known_content(pipeline, &["/proj/content/other.md"]);
+        let dist = tempfile::tempdir().unwrap();
+
+        let boot_entry = PathBuf::from("/proj/content/other.md");
+        orch.tick_with_kinds(
+            vec![(boot_entry.clone(), ChangeKind::Created)],
+            &noop_ctx(dist.path()),
+            None,
+        )
+        .unwrap();
+
+        let plans = applies.lock().unwrap();
+        assert_eq!(plans.len(), 1);
+        assert_eq!(
+            plans[0].content_narrowing,
+            Some(crate::plan::ContentNarrowing {
+                changed_content: vec![boot_entry],
+                fan_out_safe: true,
+            }),
+            "a Created for a registry-known boot entry must normalize to a \
+             fan-out-safe edit even though the graph has no Content edge for it"
+        );
+    }
+
+    /// #1581 — the discrimination that keeps discovery working: a file the
+    /// registry does NOT know is genuinely new, so it stays `Created` and
+    /// still poisons the strict gate (routing it through the discovery
+    /// regime that must establish its routes).
+    #[test]
+    fn genuinely_new_entry_absent_from_registry_stays_created() {
+        use zfb_watcher::ChangeKind;
+        let pipeline = CountingPipeline::default();
+        let applies = pipeline.applies.clone();
+        // Registry knows `other.md`, but the tick creates `brand-new.md`.
+        let (orch, _registry) = make_orch_with_known_content(pipeline, &["/proj/content/other.md"]);
+        let dist = tempfile::tempdir().unwrap();
+
+        let brand_new = PathBuf::from("/proj/content/brand-new.md");
+        orch.tick_with_kinds(
+            vec![(brand_new.clone(), ChangeKind::Created)],
+            &noop_ctx(dist.path()),
+            None,
+        )
+        .unwrap();
+
+        let plans = applies.lock().unwrap();
+        assert_eq!(plans.len(), 1);
+        assert!(
+            !plans[0]
+                .content_narrowing
+                .as_ref()
+                .expect("content narrowing hint")
+                .fan_out_safe,
+            "a Created for a file the registry has never seen is genuinely new \
+             and must NOT be normalized — it belongs to the discovery regime"
+        );
+    }
+
+    /// #1581 — delete→recreate must still re-discover. A `Removed` purges the
+    /// path from the registry, so the NEXT tick's `Created` for it is treated
+    /// as genuinely new again rather than as an in-place-edit artifact.
+    #[test]
+    fn removed_entry_is_purged_so_a_later_recreate_still_discovers() {
+        use zfb_watcher::ChangeKind;
+        let pipeline = CountingPipeline::default();
+        let applies = pipeline.applies.clone();
+        let (orch, registry) = make_orch_with_known_content(pipeline, &["/proj/content/other.md"]);
+        let dist = tempfile::tempdir().unwrap();
+
+        let entry = PathBuf::from("/proj/content/other.md");
+        assert!(registry.contains(&entry), "precondition: seeded as known");
+
+        // Tick 1 — the file is deleted.
+        orch.tick_with_kinds(
+            vec![(entry.clone(), ChangeKind::Removed)],
+            &noop_ctx(dist.path()),
+            None,
+        )
+        .unwrap();
+        assert!(
+            !registry.contains(&entry),
+            "a Removed must purge the path from the known-content registry"
+        );
+
+        // Tick 2 — it comes back. It is new again, so it must not normalize.
+        orch.tick_with_kinds(
+            vec![(entry.clone(), ChangeKind::Created)],
+            &noop_ctx(dist.path()),
+            None,
+        )
+        .unwrap();
+
+        let plans = applies.lock().unwrap();
+        assert!(
+            !plans[1]
+                .content_narrowing
+                .as_ref()
+                .expect("content narrowing hint")
+                .fan_out_safe,
+            "after a delete, a recreate must route through discovery again — \
+             not be mistaken for a spurious FSEvents Created"
+        );
+    }
+
+    /// #1581 — the purge must run BEFORE the normalization, not after: the
+    /// watcher can batch a removed DIRECTORY and a `Created` for a file
+    /// beneath it into the SAME tick. Purging afterwards would let the child
+    /// normalize to `Modified` off a registry entry that is already dead.
+    #[test]
+    fn removed_directory_purges_descendants_before_normalizing_same_tick() {
+        use zfb_watcher::ChangeKind;
+        let pipeline = CountingPipeline::default();
+        let applies = pipeline.applies.clone();
+        let (orch, registry) =
+            make_orch_with_known_content(pipeline, &["/proj/content/nested/x.md"]);
+        let dist = tempfile::tempdir().unwrap();
+
+        let dir = PathBuf::from("/proj/content/nested");
+        let child = PathBuf::from("/proj/content/nested/x.md");
+        orch.tick_with_kinds(
+            vec![
+                (dir, ChangeKind::Removed),
+                (child.clone(), ChangeKind::Created),
+            ],
+            &noop_ctx(dist.path()),
+            None,
+        )
+        .unwrap();
+
+        assert!(
+            !registry.contains(&child),
+            "removing a directory must purge its descendants from the registry"
+        );
+        let plans = applies.lock().unwrap();
+        assert!(
+            !plans[0]
+                .content_narrowing
+                .as_ref()
+                .expect("content narrowing hint")
+                .fan_out_safe,
+            "the same-tick Created under a removed directory must NOT normalize \
+             — the purge runs first, so the child is no longer known"
         );
     }
 

--- a/crates/zfb-build/src/policy.rs
+++ b/crates/zfb-build/src/policy.rs
@@ -408,6 +408,69 @@ fn classify_by_extension(ext: Option<&str>) -> PathClass {
     }
 }
 
+/// Session-live set of content-collection entries the dev server ALREADY
+/// knows about — "every file in the last successful collection membership
+/// walk" (issue #1581).
+///
+/// Sole consumer: the #1058 spurious-`Created` normalization in
+/// [`crate::BuildOrchestrator::tick_with_kinds`]. macOS FSEvents coalesces
+/// an in-place edit of an EXISTING file into `Created` (see
+/// `zfb_watcher::merge_kind`), which poisons the strict all-`Modified`
+/// `fan_out_safe` gate and costs the whole tick its #958 eager narrowing.
+/// #1058 normalizes that artifact away, but keyed only on the dependency
+/// graph having a non-empty `consumers_of` reverse edge — and NO boot-time
+/// collection entry has one on a cold start (the dev server's only
+/// `DepKind::Content` writer is the discovery hook, which fires just for
+/// newly-CREATED files). So on a clean boot the normalization never fired
+/// and the FIRST edit of any pre-existing entry lost its narrowing.
+///
+/// This registry is the authoritative "already known" oracle the graph
+/// could not be. It deliberately does NOT feed `dirty_pages`: an unknown
+/// content path must keep tripping the planner's `PageSelection::All`
+/// fallback, which is the only thing re-rendering AGGREGATE pages (a post
+/// index listing every entry) on a content edit.
+#[derive(Debug, Clone, Default)]
+pub struct KnownContentEntries {
+    entries: Arc<RwLock<BTreeSet<PathBuf>>>,
+}
+
+impl KnownContentEntries {
+    /// Lexical `.`/`..` collapse so a configured root that could not be
+    /// canonicalised (the not-yet-created-dir fallback) still compares
+    /// equal to the canonical path `notify` delivers.
+    fn key(path: &Path) -> PathBuf {
+        zfb_types::normalize_path_lexical(path)
+    }
+
+    /// Add collection entries — the boot membership walk, and each entry a
+    /// successful discovery pass accepted.
+    pub fn insert_many(&self, paths: impl IntoIterator<Item = PathBuf>) {
+        if let Ok(mut set) = self.entries.write() {
+            set.extend(paths.into_iter().map(|p| Self::key(&p)));
+        }
+    }
+
+    /// Forget `path` and everything beneath it (a removed directory takes
+    /// its entries with it). Called for every raw `Removed` change BEFORE
+    /// the `Created` normalization runs, so a delete→recreate is not
+    /// mistaken for an in-place edit and still routes through discovery.
+    pub fn remove_path_and_descendants(&self, path: &Path) {
+        let prefix = Self::key(path);
+        if let Ok(mut set) = self.entries.write() {
+            set.retain(|known| known != &prefix && !known.starts_with(&prefix));
+        }
+    }
+
+    /// Whether this exact path is an already-known collection entry.
+    pub fn contains(&self, path: &Path) -> bool {
+        let key = Self::key(path);
+        self.entries
+            .read()
+            .map(|set| set.contains(&key))
+            .unwrap_or(false)
+    }
+}
+
 /// The granularity policy combines a [`PathClass`] with the dependency
 /// graph to decide what sub-pipelines run.
 ///
@@ -432,6 +495,12 @@ pub struct GranularityPolicy {
     /// Session-live raw-target and module-worker dependency sets. Empty by
     /// default.
     pub raw_import_invalidation: RawImportInvalidation,
+
+    /// Session-live set of already-known content-collection entries
+    /// (issue #1581). Empty by default — an empty registry simply leaves
+    /// the #1058 normalization keyed on the graph alone, i.e. exactly the
+    /// pre-#1581 behaviour.
+    pub known_content: KnownContentEntries,
 }
 
 impl Default for GranularityPolicy {
@@ -440,6 +509,7 @@ impl Default for GranularityPolicy {
             islands_roots: vec![PathBuf::from("components"), PathBuf::from("src")],
             content_roots: Vec::new(),
             raw_import_invalidation: RawImportInvalidation::default(),
+            known_content: KnownContentEntries::default(),
         }
     }
 }
@@ -471,6 +541,20 @@ impl GranularityPolicy {
     pub fn with_raw_import_invalidation(mut self, invalidation: RawImportInvalidation) -> Self {
         self.raw_import_invalidation = invalidation;
         self
+    }
+
+    /// Attach the live known-content-entry registry shared with the dev
+    /// server's boot seed and discovery hook (issue #1581).
+    pub fn with_known_content(mut self, known_content: KnownContentEntries) -> Self {
+        self.known_content = known_content;
+        self
+    }
+
+    /// Whether this changed path is a content-collection entry the dev
+    /// session already knew about (so a `Created` for it is an FSEvents
+    /// coalescing artifact, not a genuinely new file).
+    pub fn is_known_content_entry(&self, path: &Path) -> bool {
+        self.known_content.contains(path)
     }
 
     /// Whether this exact changed path is in the live islands raw/worker
@@ -1225,5 +1309,54 @@ mod tests {
         std::fs::write(&physical_candidate, r#"{"compilerOptions":{}}"#).unwrap();
         assert!(invalidation.is_client_script_worker_target(&physical_candidate));
         assert!(invalidation.is_client_script_worker_target(&logical_candidate));
+    }
+
+    /// #1581 — the registry's whole job: recognise an entry the dev session
+    /// already walked, so the orchestrator can tell a spurious FSEvents
+    /// `Created` apart from a genuinely new file.
+    #[test]
+    fn known_content_entries_recognises_seeded_paths() {
+        let known = KnownContentEntries::default();
+        known.insert_many([PathBuf::from("/proj/content/post.md")]);
+
+        assert!(known.contains(Path::new("/proj/content/post.md")));
+        assert!(!known.contains(Path::new("/proj/content/never-seen.md")));
+    }
+
+    /// #1581 — an out-of-root collection root that could not be canonicalised
+    /// keeps a literal `..` component (the `canonicalize_or_lexical` fallback
+    /// for a not-yet-created dir). The registry collapses it lexically on both
+    /// insert and lookup, so it still matches the path `notify` delivers.
+    #[test]
+    fn known_content_entries_collapses_dot_dot_on_both_sides() {
+        let known = KnownContentEntries::default();
+        known.insert_many([PathBuf::from("/proj/../shared-content/posts/alpha.mdx")]);
+
+        assert!(
+            known.contains(Path::new("/shared-content/posts/alpha.mdx")),
+            "a `..`-carrying out-of-root entry must match its collapsed form"
+        );
+    }
+
+    /// #1581 — a removed directory takes its entries with it, so a file
+    /// recreated underneath it is genuinely new again and routes through
+    /// discovery rather than normalizing to an in-place edit.
+    #[test]
+    fn known_content_entries_removes_descendants_of_a_removed_directory() {
+        let known = KnownContentEntries::default();
+        known.insert_many([
+            PathBuf::from("/proj/content/nested/x.md"),
+            PathBuf::from("/proj/content/nested/deep/y.md"),
+            PathBuf::from("/proj/content/keep.md"),
+        ]);
+
+        known.remove_path_and_descendants(Path::new("/proj/content/nested"));
+
+        assert!(!known.contains(Path::new("/proj/content/nested/x.md")));
+        assert!(!known.contains(Path::new("/proj/content/nested/deep/y.md")));
+        assert!(
+            known.contains(Path::new("/proj/content/keep.md")),
+            "a sibling outside the removed directory must survive the purge"
+        );
     }
 }

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -1003,12 +1003,28 @@ pub async fn run(args: &DevArgs) -> Result<()> {
         }
     }
     let raw_import_invalidation = zfb_build::RawImportInvalidation::default();
+
+    // #1581 — seed the session-live known-content registry from the boot
+    // collection MEMBERSHIP walk (not the frontmatter-hash map, which drops
+    // unparseable entries). This is what lets the #1058 spurious-`Created`
+    // normalization recognise a pre-existing entry on a COLD boot, where the
+    // dependency graph carries no `DepKind::Content` reverse edge for it yet.
+    // Without it, the first in-place edit of any collection entry that macOS
+    // FSEvents coalesces into `Created` loses the whole tick's #958 eager
+    // narrowing and re-stamps every route.
+    let known_content = zfb_build::KnownContentEntries::default();
+    known_content.insert_many(collect_collection_entries(
+        &cfg,
+        root_inventory.collection_roots(),
+    ));
+
     let orch_config = OrchestratorConfig::new(&project_root, watch_roots.clone())
         .with_extra_watch_paths(extra_watch_paths)
         .with_policy(
             zfb_build::GranularityPolicy::default()
                 .with_content_roots(content_roots)
-                .with_raw_import_invalidation(raw_import_invalidation.clone()),
+                .with_raw_import_invalidation(raw_import_invalidation.clone())
+                .with_known_content(known_content.clone()),
         );
     let orchestrator = BuildOrchestrator::new(orch_config, graph, pipeline);
 
@@ -1425,6 +1441,7 @@ pub async fn run(args: &DevArgs) -> Result<()> {
             // reload_renderer when the discovery refresh marked the
             // renderer fresh).
             ssr_route_set.clone(),
+            known_content.clone(),
         )
     });
 
@@ -5431,11 +5448,26 @@ fn frontmatter_hash(path: &Path) -> Option<[u8; 32]> {
 /// `project_root.join("../x")` would seed keys that never match, so the
 /// narrowing gate always tripped for out-of-root content).
 #[cfg(feature = "embed_v8")]
-fn seed_frontmatter_hashes(
-    cfg: &config::Config,
-    collection_roots: &[PathBuf],
-) -> HashMap<PathBuf, [u8; 32]> {
-    let mut hashes: HashMap<PathBuf, [u8; 32]> = HashMap::new();
+/// Walk every configured collection root and yield the path of each file
+/// that passes its collection's include/exclude filter — i.e. the session's
+/// content-collection MEMBERSHIP, independent of whether the entry's
+/// frontmatter happens to be readable.
+///
+/// Two consumers, and the distinction between them matters (issue #1581):
+///
+/// - [`seed_frontmatter_hashes`] keeps only the entries it could hash — an
+///   unparseable entry has no meaningful G4 gate hash.
+/// - The `known_content` registry takes the FULL membership. An entry whose
+///   frontmatter is missing or malformed is still a real, already-known
+///   collection entry; dropping it would let a spurious FSEvents `Created`
+///   for that file fall through to the discovery regime and cost the tick
+///   its #958 narrowing — the exact bug #1581 fixes.
+///
+/// `collection_roots` comes from the boot [`ResolvedRoots`] inventory, so
+/// out-of-root roots are already canonical and the walked paths compare
+/// equal to the canonical paths `notify` delivers (#1550).
+fn collect_collection_entries(cfg: &config::Config, collection_roots: &[PathBuf]) -> Vec<PathBuf> {
+    let mut entries: Vec<PathBuf> = Vec::new();
     for (collection, root) in cfg.collections.iter().zip(collection_roots) {
         let filter = match zfb_content::collection::CollectionFilter::new(
             collection.include.as_deref(),
@@ -5457,9 +5489,20 @@ fn seed_frontmatter_hashes(
             if zfb_content::collection::derive_slug_for_file(root, path, &filter).is_none() {
                 continue;
             }
-            if let Some(hash) = frontmatter_hash(path) {
-                hashes.insert(path.to_path_buf(), hash);
-            }
+            entries.push(path.to_path_buf());
+        }
+    }
+    entries
+}
+
+fn seed_frontmatter_hashes(
+    cfg: &config::Config,
+    collection_roots: &[PathBuf],
+) -> HashMap<PathBuf, [u8; 32]> {
+    let mut hashes: HashMap<PathBuf, [u8; 32]> = HashMap::new();
+    for path in collect_collection_entries(cfg, collection_roots) {
+        if let Some(hash) = frontmatter_hash(&path) {
+            hashes.insert(path, hash);
         }
     }
     hashes
@@ -6014,6 +6057,11 @@ fn make_discovery_hook(
     // rewrite the handle HERE or a newly-created `prerender = false` route
     // 404s until a later edit. `None` when the project has no SSR.
     ssr_routes: Option<SsrRoutesHandle>,
+    // Issue #1581 — the session-live known-content registry. A file that
+    // discovery ACCEPTS becomes an already-known entry, so a later in-place
+    // edit of it that FSEvents coalesces into `Created` normalizes back to
+    // `Modified` instead of re-entering the discovery regime.
+    known_content: zfb_build::KnownContentEntries,
 ) -> zfb_build::DiscoveryHook {
     let mut relevant_roots: Vec<PathBuf> = vec![
         session.inner.project_root.join("content"),
@@ -6043,6 +6091,14 @@ fn make_discovery_hook(
         }
 
         let (changed, vanished_rel) = session.discover_created(&relevant)?;
+
+        // #1581 — discovery succeeded, so every file it accepted is now an
+        // already-known collection entry. Registering them here (and NOT at
+        // the top of the closure) keeps the registry meaning "entries of the
+        // last SUCCESSFUL collection walk": a `discover_created` that fails
+        // returns early above and leaves the registry untouched, so the next
+        // tick still treats the file as new.
+        known_content.insert_many(relevant.iter().cloned());
 
         // Issue #807 — the discovery refresh swapped in a fresh V8 host and
         // rebuilt the route tables, but it reports `renderer_reloaded: true`,

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -5434,20 +5434,6 @@ fn frontmatter_hash(path: &Path) -> Option<[u8; 32]> {
     Some(hasher.finalize().into())
 }
 
-/// Boot-seed the frontmatter gate cache (issue #958): hash every
-/// configured collection file's frontmatter, keyed by absolute path.
-/// Membership routes through `derive_slug_for_file` so the seeded set is
-/// exactly the walker's. Unreadable / unparseable files (and collections
-/// with uncompilable filter globs) are simply not seeded — their first
-/// edit falls back to a full render (G4) and seeds the hash then.
-///
-/// `collection_roots` is the boot inventory's per-collection resolved
-/// absolute root (issue #1550), index-aligned with `cfg.collections`:
-/// canonical for out-of-root collections so the WalkDir-derived seed keys
-/// match the CANONICAL paths `notify` later delivers on an edit (a literal
-/// `project_root.join("../x")` would seed keys that never match, so the
-/// narrowing gate always tripped for out-of-root content).
-#[cfg(feature = "embed_v8")]
 /// Walk every configured collection root and yield the path of each file
 /// that passes its collection's include/exclude filter — i.e. the session's
 /// content-collection MEMBERSHIP, independent of whether the entry's
@@ -5466,6 +5452,7 @@ fn frontmatter_hash(path: &Path) -> Option<[u8; 32]> {
 /// `collection_roots` comes from the boot [`ResolvedRoots`] inventory, so
 /// out-of-root roots are already canonical and the walked paths compare
 /// equal to the canonical paths `notify` delivers (#1550).
+#[cfg(feature = "embed_v8")]
 fn collect_collection_entries(cfg: &config::Config, collection_roots: &[PathBuf]) -> Vec<PathBuf> {
     let mut entries: Vec<PathBuf> = Vec::new();
     for (collection, root) in cfg.collections.iter().zip(collection_roots) {
@@ -5495,6 +5482,25 @@ fn collect_collection_entries(cfg: &config::Config, collection_roots: &[PathBuf]
     entries
 }
 
+/// Boot-seed the frontmatter gate cache (issue #958): hash every
+/// configured collection file's frontmatter, keyed by absolute path.
+/// Membership routes through [`collect_collection_entries`] so the seeded
+/// set is exactly the walker's. Unreadable / unparseable files (and
+/// collections with uncompilable filter globs) are simply not seeded —
+/// their first edit falls back to a full render (G4) and seeds the hash
+/// then.
+///
+/// NOTE (#1581): the `known_content` registry deliberately does NOT share
+/// this map's key set — it takes the full membership walk instead, because
+/// an entry that failed to hash here is still an already-known entry.
+///
+/// `collection_roots` is the boot inventory's per-collection resolved
+/// absolute root (issue #1550), index-aligned with `cfg.collections`:
+/// canonical for out-of-root collections so the WalkDir-derived seed keys
+/// match the CANONICAL paths `notify` later delivers on an edit (a literal
+/// `project_root.join("../x")` would seed keys that never match, so the
+/// narrowing gate always tripped for out-of-root content).
+#[cfg(feature = "embed_v8")]
 fn seed_frontmatter_hashes(
     cfg: &config::Config,
     collection_roots: &[PathBuf],

--- a/crates/zfb/src/commands/dev.rs
+++ b/crates/zfb/src/commands/dev.rs
@@ -6098,13 +6098,26 @@ fn make_discovery_hook(
 
         let (changed, vanished_rel) = session.discover_created(&relevant)?;
 
-        // #1581 — discovery succeeded, so every file it accepted is now an
-        // already-known collection entry. Registering them here (and NOT at
-        // the top of the closure) keeps the registry meaning "entries of the
-        // last SUCCESSFUL collection walk": a `discover_created` that fails
-        // returns early above and leaves the registry untouched, so the next
-        // tick still treats the file as new.
-        known_content.insert_many(relevant.iter().cloned());
+        // #1581 — discovery succeeded, so re-derive the collection membership
+        // and register it. Registering here (and NOT at the top of the
+        // closure) keeps the registry meaning "entries of the last SUCCESSFUL
+        // collection walk": a `discover_created` that fails returns early
+        // above and leaves the registry untouched, so the next tick still
+        // treats the file as new.
+        //
+        // This MUST re-walk rather than insert the raw event paths in
+        // `relevant`. The watcher can report a created DIRECTORY (its children
+        // never surface as individual events), in which case `relevant` holds
+        // only the directory — registering that would leave every entry
+        // beneath it unknown, so the next FSEvents-coalesced `Created` for one
+        // of those children would be mistaken for a new file all over again.
+        // `relevant` is also broader than the collection (it admits `pages/`
+        // and `content/` paths that are not collection members at all); the
+        // membership walk is the authoritative set.
+        known_content.insert_many(collect_collection_entries(
+            &session.inner.rebuild_inputs.cfg,
+            &session.inner.collection_roots,
+        ));
 
         // Issue #807 — the discovery refresh swapped in a fresh V8 host and
         // rebuilt the route tables, but it reports `renderer_reloaded: true`,
@@ -7311,6 +7324,67 @@ mod tests {
             std::fs::create_dir_all(path.parent().unwrap()).unwrap();
             std::fs::write(&path, format!("---\n{fm}\n---\n\n{body}\n")).unwrap();
             path
+        }
+
+        /// #1581 — the `known_content` registry is seeded from this walk, and
+        /// the discovery hook RE-walks rather than registering the watcher's
+        /// raw event paths. Both rely on the walk being authoritative:
+        ///
+        /// - It must descend into NESTED directories. The watcher can report a
+        ///   created DIRECTORY whose children never surface as individual
+        ///   events; registering only the event path would leave those children
+        ///   unknown, so the next FSEvents-coalesced `Created` for one of them
+        ///   would be mistaken for a new file and lose the tick its narrowing.
+        /// - It must yield FILES only, never the directories it walks through.
+        #[test]
+        fn collect_collection_entries_descends_into_nested_dirs_and_yields_files_only() {
+            let (tmp, cfg) = scaffold(&[("top.md", "title: Top"), ("deep/nested.md", "title: N")]);
+            let collection_roots = resolve_roots(tmp.path(), &cfg).collection_roots().to_vec();
+
+            let entries = collect_collection_entries(&cfg, &collection_roots);
+
+            let blog = tmp.path().join("content/blog");
+            assert!(
+                entries.contains(&blog.join("top.md")),
+                "top-level entry must be walked; got {entries:?}"
+            );
+            assert!(
+                entries.contains(&blog.join("deep/nested.md")),
+                "an entry inside a NESTED dir must be walked — this is the case a \
+                 created-directory watcher event cannot enumerate; got {entries:?}"
+            );
+            assert!(
+                !entries.contains(&blog.join("deep")),
+                "the walk must yield files only, never the directories it descends"
+            );
+        }
+
+        /// #1581 — the registry takes the FULL membership, unlike
+        /// [`seed_frontmatter_hashes`] which keeps only what it could hash. An
+        /// entry with unparseable frontmatter is still an already-known entry:
+        /// dropping it would let a spurious FSEvents `Created` for that file
+        /// fall through to the discovery regime.
+        #[test]
+        fn collect_collection_entries_includes_entries_whose_frontmatter_is_unparseable() {
+            let (tmp, cfg) = scaffold(&[("good.md", "title: Good")]);
+            let blog = tmp.path().join("content/blog");
+            let broken = blog.join("broken.md");
+            std::fs::write(&broken, "---\n: : not: valid: yaml\n---\n\nbody\n").unwrap();
+            let collection_roots = resolve_roots(tmp.path(), &cfg).collection_roots().to_vec();
+
+            let entries = collect_collection_entries(&cfg, &collection_roots);
+            assert!(
+                entries.contains(&broken),
+                "membership does not depend on frontmatter parsing; got {entries:?}"
+            );
+
+            let hashed = seed_frontmatter_hashes(&cfg, &collection_roots);
+            assert!(
+                !hashed.contains_key(&broken),
+                "the frontmatter seed, by contrast, skips what it cannot hash — this \
+                 divergence is exactly why the registry must not be keyed off it"
+            );
+            assert!(hashed.contains_key(&blog.join("good.md")));
         }
 
         /// Stub session with boot-seeded frontmatter hashes, like

--- a/crates/zfb/tests/dev_out_of_root_collection_e2e.rs
+++ b/crates/zfb/tests/dev_out_of_root_collection_e2e.rs
@@ -63,7 +63,11 @@
 //! - `shared-content/posts/` — the out-of-root collection root, a sibling of
 //!   `project/`, seeded with two entries (`alpha.mdx`, `beta.mdx`) so there
 //!   are two independent dynamic routes to distinguish "own route" from
-//!   "sibling route".
+//!   "sibling route", plus `__warmup.mdx`, a third entry that exists ONLY so
+//!   the watcher-live handshake has a pre-existing file to EDIT. The
+//!   handshake must not CREATE entries (#1581): a genuinely-new entry
+//!   correctly forces a full fan-out, which re-stamps `beta` and races
+//!   scenario (a)'s baseline snapshot. See the Phase C comment.
 //!
 //! ## Blind spot
 //!
@@ -471,34 +475,48 @@ async fn boot_and_handshake(
         }
     }
 
-    // Phase C: watcher-live handshake. Subscribe to SSE FIRST, then write
-    // fresh-named warmup POSTS into the out-of-root collection root until the
-    // first SSE event arrives.
+    // Phase C: watcher-live handshake. Subscribe to SSE FIRST, then EDIT the
+    // pre-existing `__warmup.mdx` entry (body only, frontmatter held constant)
+    // until the first SSE event arrives.
     //
     // This MUST target `shared_content_posts`, not an arbitrary project-root
     // file: `DEFAULT_WATCH_ROOTS` in commands/dev.rs is `pages`, `content`,
     // `components`, `layouts`, `styles`, `data`, `src`, and the two config
     // files — a bare file dropped directly under the project root (this
     // fixture's `project/` has none of those as its own root) is never
-    // watched and would hang this handshake until `SSE_DEADLINE`. A real
-    // content-collection ADD is also the ONLY warmup shape guaranteed to
-    // produce an observable SSE event (an unrecognized file type could
-    // legitimately produce a no-op tick with nothing broadcast) — mirrors
-    // `dev_serve_e2e.rs`'s `content/posts/__warmup-{i}.md` choice, relocated
-    // to the out-of-root root since this fixture has no in-root collection.
+    // watched and would hang this handshake until `SSE_DEADLINE`. Touching a
+    // real collection entry also guarantees an observable SSE event (an
+    // unrecognized file type could legitimately produce a no-op tick with
+    // nothing broadcast).
+    //
+    // It must be an EDIT of an entry the fixture already ships, NOT a
+    // fresh-named `__warmup-{i}.mdx` CREATE (issue #1581). A brand-new
+    // collection entry is genuinely new, so its tick is correctly NOT
+    // `fan_out_safe` — a new entry can change aggregate pages — and it
+    // re-renders the FULL fan-out, re-stamping every route's on-disk HTML,
+    // including the `beta` sibling scenario (a) snapshots as its untouched
+    // baseline. That fan-out then races the `beta_before` snapshot: a run was
+    // captured where `alpha.mdx` narrowed perfectly and the test STILL failed,
+    // purely on a warmup tick's late write to beta. Editing a pre-existing
+    // entry keeps every handshake tick narrow (it re-renders only
+    // `/posts/__warmup/`), so no warmup tick can touch beta whenever it lands.
+    // Holding the frontmatter constant keeps the G4 gate from tripping too.
     {
+        let warmup_entry = shared_content_posts.join("__warmup.mdx");
         let sse = subscribe_sse(&client, &base).await;
         let stop = Arc::new(AtomicBool::new(false));
         let writer = {
-            let posts_root = shared_content_posts.to_path_buf();
+            let warmup_entry = warmup_entry.clone();
             let stop = Arc::clone(&stop);
             tokio::spawn(async move {
                 let mut i = 0u32;
                 while !stop.load(Ordering::SeqCst) {
-                    let warmup = posts_root.join(format!("__warmup-{i}.mdx"));
                     let _ = fs::write(
-                        &warmup,
-                        format!("---\ntitle: warmup {i}\n---\n\nwarmup body {i}\n"),
+                        &warmup_entry,
+                        format!(
+                            "---\ntitle: Warmup Out Of Root\n---\n\n\
+                             V1-MARKER-WARMUP body for the warmup post. rev {i}\n"
+                        ),
                     );
                     i += 1;
                     tokio::time::sleep(Duration::from_millis(400)).await;

--- a/crates/zfb/tests/dev_out_of_root_collection_e2e.rs
+++ b/crates/zfb/tests/dev_out_of_root_collection_e2e.rs
@@ -69,14 +69,25 @@
 //!   correctly forces a full fan-out, which re-stamps `beta` and races
 //!   scenario (a)'s baseline snapshot. See the Phase C comment.
 //!
+//! ## Where it runs
+//!
+//! CI runs it on ubuntu/inotify (`health.yml`'s `cargo nextest`, via the
+//! `e2e-heavy` test-group). It has since also been run for real on macOS
+//! arm64 / FSEvents during issue #1581 — which is where the FSEvents
+//! `Created`-coalescing bug it now guards was found and fixed. The PR gate is
+//! still ubuntu-only, so macOS parity rides the weekly `exam.yml` macOS
+//! re-exam, not the PR gate.
+//!
 //! ## Blind spot
 //!
-//! This container cannot build the V8-embedding `zfb` binary (rusty_v8
-//! download blocked), so this test is UNRUN here — it is written and proven
-//! to COMPILE (`cargo check --no-default-features -p zfb --test
-//! dev_out_of_root_collection_e2e`) and runs for real in CI (`health.yml`'s
-//! `cargo nextest`, ubuntu/inotify). macOS/FSEvents parity is NOT covered by
-//! the PR gate — only by the weekly `exam.yml` macOS re-exam.
+//! Scenario (a) proves the sibling POST route is untouched. It does NOT prove
+//! `pages/index.tsx` is untouched: a static route carries no params
+//! provenance, so it re-renders in full via the S1 fallback on every content
+//! tick regardless (the fixture's index deliberately does not read the
+//! collection, so this never confuses the sibling proof). An AGGREGATE dynamic
+//! page — a post index listing every entry — is likewise out of scope: nothing
+//! here guards the planner's unknown-path `PageSelection::All` fallback that
+//! such a page currently relies on to stay fresh (see #1581's commit message).
 
 #![cfg(unix)]
 

--- a/crates/zfb/tests/fixtures/dev-out-of-root-basic/shared-content/posts/__warmup.mdx
+++ b/crates/zfb/tests/fixtures/dev-out-of-root-basic/shared-content/posts/__warmup.mdx
@@ -1,0 +1,5 @@
+---
+title: Warmup Out Of Root
+---
+
+V1-MARKER-WARMUP body for the warmup post.


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1581

---

## Summary

Issue #1581 asked for a triage decision: is the macOS flake in `e2e_out_of_root_edit_narrows_rerender_and_discovers_new_entry` **test-harness timing** or a **real product gap**?

**It is a real product gap** — option 2, ruled IN with hard evidence. But the mechanism is *not* the directory-granularity candidate-broadening the issue hypothesised, and it is *not* out-of-root-specific. So this PR fixes the product, and does **not** quarantine the test: the test was never broken, it was correctly detecting a real bug.

## Root cause

macOS FSEvents coalesces an in-place edit of an **existing** content file into `ChangeKind::Created` (`zfb_watcher::merge_kind` keeps `Created` over a coalesced `Modified`). That poisons the strict all-`Modified` `fan_out_safe` gate, so `compute_tick_narrowing` switches the #958 eager narrowing **off** and the tick re-renders — and re-stamps — every route, including the sibling the test snapshots.

The smoking gun, from the repo's own `ZFB_DEV_TIMING=1` instrument:

```
[zfb-timing] tick(): kinds=[alpha.mdx:Created] eager_hint=true fan_out_safe=false
```

#1058 already added a `Created` → `Modified` normalization for exactly this artifact — but it keys on `graph.consumers_of(path)` being non-empty, and **no collection entry has a graph Content edge on a cold boot**:

- `seed_boot_module_edges` records only `DepKind::Module` edges.
- The dev server's only `DepKind::Content` writer is the discovery hook, which fires **only for newly-created files**.

```
[ZFB_DEBUG_NORM] path=<TMP>/shared-content/posts/alpha.mdx consumers=None class=Content spurious=false
```

So #1058's normalization was **dead code for every pre-existing entry**, and the first coalesced edit of *any* collection entry (in-root or out-of-root) silently lost its narrowing on macOS. Bytes still ended up correct — a perf-only degradation, which is why nothing caught it until a test asserted the narrowing on disk under `ZFB_DEV_EAGER=1`.

## Changes

**Product** — a session-live `KnownContentEntries` registry on `GranularityPolicy` (same shared-interior-mutability shape as the existing `RawImportInvalidation`), seeded at boot from the collection **membership** walk and extended by discovery. The normalization consults it, keeping #1058's graph check as a secondary source (a warm persisted graph can still restore Content edges).

- Seeded from membership, **not** `fm_hashes.keys()` — an entry with unparseable frontmatter is still a real known entry.
- A `Removed` purges the path **and its descendants** **before** the normalization reads the registry. Order is load-bearing: the watcher can batch a removed directory and a `Created` beneath it into one tick, so purging afterwards would let a genuine delete→recreate normalize to `Modified` and skip discovery.
- Known-ness is read **outside** the graph mutex (no lock-order coupling).

**Deliberately scoped to the normalization only.** Seeding real Content edges would narrow `dirty_pages` and **silently under-render aggregate pages** (a post index), which today stay fresh solely via the planner's unknown-path `PageSelection::All` fallback. That larger graph project is filed as #1583.

**Test** — the watcher-live handshake was CREATING `__warmup-{i}.mdx` entries *in the collection under test*. A genuinely-new entry correctly forces a full fan-out, which re-stamps `beta` and races scenario (a)'s baseline snapshot; a run was captured where `alpha.mdx` narrowed perfectly and the test **still** failed. The handshake now EDITS a pre-existing `__warmup.mdx` fixture entry (body only, frontmatter held constant), so every handshake tick is narrow and can never touch `beta`.

## Test plan

**Ablation (the honest check).** A passing test does not prove the product fix is doing the work, so I disabled **only** the registry check — product fix OFF, test fix ON:

```
run 1: PASS
run 2: FAIL   <-- flake returns, kinds=[alpha.mdx:Created] fan_out_safe=false
run 3: PASS
```

The test fix alone does **not** deflake it. The product fix is load-bearing.

- **Before:** 2/4 runs failed on macOS arm64 (baseline), matching the ~3/4 in the report.
- **After:** clean sequential burn-in on macOS arm64, green.
- **7 new unit tests:** edge-less known boot entry normalizes to `Modified`; genuinely-new entry stays `Created` (discovery still works); delete→recreate re-discovers; removed-directory purges descendants in the same tick; registry seed/lookup, `..`-collapse for out-of-root, descendant purge.

## Not tested / blind spots

- **Linux/inotify** is covered by this PR's `health.yml` run, not by me locally — the bug is macOS-only, so the risk here is regression, not the fix.
- **Aggregate dynamic pages** (post index / tag / pagination) have **no** regression test in the repo today. This PR does not change their behaviour (the `All` fallback is untouched), but #1583 must add that test *before* anyone narrows `dirty_pages`.
- The `known_content` registry is dev-server-only; `zfb build` is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)