### PR TITLE
Hygiene Batch 2 cleanup fixes

### DIFF
--- a/crates/zfb-build/src/bundler.rs
+++ b/crates/zfb-build/src/bundler.rs
@@ -1860,11 +1860,109 @@ pub fn bundle_with_session(
             );
         }
     }
+    let effective_virtual_context = mat_ctx
+        .worker_build_context
+        .clone()
+        .without_user_claimed_virtual_modules(&input.tsconfig_paths);
+    let mut plugin_preprocessing_files = BTreeSet::new();
+    let mut root_entry_dependency_seed_files = BTreeSet::new();
+    if mat_ctx.worker_build_context.has_plugin_resolver_inputs() {
+        let virtual_discovery = discover_registered_virtual_preprocessing_with_context(
+            &input.project_root,
+            &effective_virtual_context,
+        )
+        .context("bundler: validate registered virtual-module preprocessing syntax")?;
+        plugin_preprocessing_files.extend(virtual_discovery.files);
+        mat_ctx.raw_import_edges.borrow_mut().extend(
+            virtual_discovery
+                .raw_import_edges
+                .into_iter()
+                .map(|edge| RawImportEdge {
+                    importer: edge.importer,
+                    target: edge.target,
+                }),
+        );
+    }
+
+    // Discover preprocessing closure from every explicitly staged candidate,
+    // including user exact tsconfig targets. This catches relative imports
+    // escaping a hidden/package tree and prevents the isolated target from
+    // losing required allowed dependencies. Root-level exact entry files also
+    // seed the staged dependency view from their transitive first-party file
+    // closure; the walk root is the entry file, never the project root as a
+    // package. node_modules candidates keep the bounded containing-package copy
+    // instead of parsing vendor trees here.
+    for target in exact_target_staging_files.clone() {
+        if !target.is_file()
+            || bundle_exclude.is_excluded(&target, &project_root)
+            || node_modules_package_root(&target, &project_root).is_some()
+        {
+            continue;
+        }
+        let discovery = match discover_module_preprocessing_with_context(
+            &target,
+            &input.project_root,
+            &effective_virtual_context,
+        ) {
+            Ok(discovery) => discovery,
+            Err(error) => {
+                let message = format!("{error:#}");
+                if message.contains("zfb bundler: failed to parse ")
+                    || message.contains(" is not valid UTF-8")
+                {
+                    // A syntactically invalid plausible alternative may be
+                    // irrelevant in the actual CSS/JS/node_modules context.
+                    // Keep it raw so esbuild reports it only when selected.
+                    continue;
+                }
+                // Contract-specific preprocessing failures (unsupported
+                // SharedWorker/query forms, unsafe graph escapes, etc.) remain
+                // deterministic hard errors even for a registered alternate.
+                return Err(error).with_context(|| {
+                    format!(
+                        "bundler: discover exact-target preprocessing graph from {}",
+                        target.display()
+                    )
+                });
+            }
+        };
+        let root_level_entry = root_level_staged_entry_file(&target, &project_root).is_some();
+        let discovered_files = discovery.files;
+        plugin_preprocessing_files.insert(target.clone());
+        if root_level_entry && !bundle_exclude.is_empty() {
+            root_entry_dependency_seed_files.insert(target.clone());
+            root_entry_dependency_seed_files.extend(
+                discovered_files
+                    .iter()
+                    .filter(|path| {
+                        path.starts_with(&project_root)
+                            && path.is_file()
+                            && !project_path_is_inside_node_modules(path, &project_root)
+                            && !bundle_exclude.is_excluded(path, &project_root)
+                    })
+                    .cloned(),
+            );
+        }
+        plugin_preprocessing_files.extend(discovered_files);
+        mat_ctx
+            .raw_import_edges
+            .borrow_mut()
+            .extend(
+                discovery
+                    .raw_import_edges
+                    .into_iter()
+                    .map(|edge| RawImportEdge {
+                        importer: edge.importer,
+                        target: edge.target,
+                    }),
+            );
+    }
     extend_node_modules_dependency_staging(
         &project_root,
         input.node_modules_dir.as_deref(),
         &bundle_exclude,
         !esbuild_will_preserve_symlinks(&input),
+        &root_entry_dependency_seed_files,
         &mut exact_target_staging_dirs,
         &mut exact_target_staging_alias_dirs,
     );
@@ -1915,83 +2013,6 @@ pub fn bundle_with_session(
         .map(|root| ShadowWriter::new(root.to_path_buf(), None, true, None))
         .transpose()?;
 
-    let effective_virtual_context = mat_ctx
-        .worker_build_context
-        .clone()
-        .without_user_claimed_virtual_modules(&input.tsconfig_paths);
-    let mut plugin_preprocessing_files = BTreeSet::new();
-    if mat_ctx.worker_build_context.has_plugin_resolver_inputs() {
-        let virtual_discovery = discover_registered_virtual_preprocessing_with_context(
-            &input.project_root,
-            &effective_virtual_context,
-        )
-        .context("bundler: validate registered virtual-module preprocessing syntax")?;
-        plugin_preprocessing_files.extend(virtual_discovery.files);
-        mat_ctx.raw_import_edges.borrow_mut().extend(
-            virtual_discovery
-                .raw_import_edges
-                .into_iter()
-                .map(|edge| RawImportEdge {
-                    importer: edge.importer,
-                    target: edge.target,
-                }),
-        );
-    }
-
-    // Discover preprocessing closure from every explicitly staged candidate,
-    // including user exact tsconfig targets. This catches relative imports
-    // escaping a hidden/package tree and prevents the isolated target from
-    // losing required allowed dependencies. node_modules candidates keep the
-    // bounded containing-package copy instead of parsing vendor trees here.
-    for target in exact_target_staging_files.clone() {
-        if !target.is_file()
-            || bundle_exclude.is_excluded(&target, &project_root)
-            || node_modules_package_root(&target, &project_root).is_some()
-        {
-            continue;
-        }
-        let discovery = match discover_module_preprocessing_with_context(
-            &target,
-            &input.project_root,
-            &effective_virtual_context,
-        ) {
-            Ok(discovery) => discovery,
-            Err(error) => {
-                let message = format!("{error:#}");
-                if message.contains("zfb bundler: failed to parse ")
-                    || message.contains(" is not valid UTF-8")
-                {
-                    // A syntactically invalid plausible alternative may be
-                    // irrelevant in the actual CSS/JS/node_modules context.
-                    // Keep it raw so esbuild reports it only when selected.
-                    continue;
-                }
-                // Contract-specific preprocessing failures (unsupported
-                // SharedWorker/query forms, unsafe graph escapes, etc.) remain
-                // deterministic hard errors even for a registered alternate.
-                return Err(error).with_context(|| {
-                    format!(
-                        "bundler: discover exact-target preprocessing graph from {}",
-                        target.display()
-                    )
-                });
-            }
-        };
-        plugin_preprocessing_files.insert(target);
-        plugin_preprocessing_files.extend(discovery.files);
-        mat_ctx
-            .raw_import_edges
-            .borrow_mut()
-            .extend(
-                discovery
-                    .raw_import_edges
-                    .into_iter()
-                    .map(|edge| RawImportEdge {
-                        importer: edge.importer,
-                        target: edge.target,
-                    }),
-            );
-    }
     if let Some(src) = input.mdx_components_file.as_deref() {
         if !bundle_exclude.is_excluded(src, &input.project_root) {
             preflight_raw_file(src, src, &mat_ctx);
@@ -5759,6 +5780,7 @@ fn extend_node_modules_dependency_staging(
     node_modules_dir: Option<&Path>,
     bundle_exclude: &BundleExcludeMatcher,
     resolve_from_canonical_package: bool,
+    root_entry_dependency_seed_files: &BTreeSet<PathBuf>,
     staging_dirs: &mut BTreeSet<PathBuf>,
     staging_alias_dirs: &mut BTreeMap<PathBuf, PathBuf>,
 ) {
@@ -5785,6 +5807,47 @@ fn extend_node_modules_dependency_staging(
         .map(|path| (path.clone(), path.clone()))
         .collect::<BTreeMap<_, _>>();
     let mut visited = BTreeSet::new();
+
+    for seed in root_entry_dependency_seed_files {
+        if !seed.is_file() || bundle_exclude.is_excluded(seed, project_root) {
+            continue;
+        }
+        let Ok(specifiers) = collect_runtime_import_specifiers_from_file(seed) else {
+            // An unused invalid alternate must remain esbuild-contextual.
+            continue;
+        };
+        for package_name in specifiers
+            .iter()
+            .filter_map(|specifier| bare_package_name(specifier))
+        {
+            let (logical_dependency, source_dependency) = if let Some(dependency) =
+                resolve_installed_package_dir(seed, &package_name, project_root)
+            {
+                (dependency.clone(), dependency)
+            } else if let Some(dependency) =
+                resolve_vendored_package_dir(node_modules_dir, &package_name)
+            {
+                (
+                    project_root.join("node_modules").join(&package_name),
+                    dependency,
+                )
+            } else {
+                continue;
+            };
+            if bundle_exclude.is_excluded(&logical_dependency, project_root) {
+                continue;
+            }
+            if logical_dependency == source_dependency {
+                staging_dirs.insert(logical_dependency.clone());
+            } else {
+                staging_alias_dirs.insert(logical_dependency.clone(), source_dependency.clone());
+            }
+            if !visited.contains(&logical_dependency) {
+                pending.insert(logical_dependency, source_dependency);
+            }
+        }
+    }
+
     while let Some((logical_root, source_root)) = pending.pop_first() {
         if !visited.insert(logical_root.clone()) || !source_root.is_dir() {
             continue;
@@ -5915,6 +5978,23 @@ fn first_party_staged_package_root(path: &Path, project_root: &Path) -> Option<P
     }
     let root = containing_project_package_root(path, project_root)?;
     (root != project_root).then_some(root)
+}
+
+/// A concrete exact target that is a file under the project root but not under
+/// any first-party package below the root. These root-level entry files are
+/// closure-walk roots for dependency staging, but the project root itself is
+/// still not treated as a package root.
+fn root_level_staged_entry_file(path: &Path, project_root: &Path) -> Option<PathBuf> {
+    if !path.is_file() || !path.starts_with(project_root) {
+        return None;
+    }
+    if project_path_is_inside_node_modules(path, project_root) {
+        return None;
+    }
+    match containing_project_package_root(path, project_root) {
+        Some(package_root) if package_root != project_root => None,
+        _ => Some(path.to_path_buf()),
+    }
 }
 
 /// Resolve a bare package inside the configured external vendored node_modules

--- a/crates/zfb-build/src/module_worker.rs
+++ b/crates/zfb-build/src/module_worker.rs
@@ -215,8 +215,13 @@ impl ModuleWorkerBuildContext {
         let mut virtual_modules = self.plugin_virtual_modules.clone();
         virtual_modules.sort();
         for (specifier, source) in virtual_modules {
+            let stable_source = stable_virtual_module_source(&source, project_root);
             field(aggregate, b"plugin-virtual", specifier.as_bytes());
-            field(aggregate, b"plugin-virtual-source", source.as_bytes());
+            field(
+                aggregate,
+                b"plugin-virtual-source",
+                stable_source.as_bytes(),
+            );
         }
     }
 }
@@ -303,6 +308,13 @@ enum ConstructorKind {
 #[derive(Debug, Clone)]
 struct ConstructorOccurrence {
     kind: ConstructorKind,
+    specifier: String,
+    lo: usize,
+    hi: usize,
+}
+
+#[derive(Debug, Clone)]
+struct ImportSpecifierOccurrence {
     specifier: String,
     lo: usize,
     hi: usize,
@@ -990,13 +1002,17 @@ impl ProjectGraphResolver {
                     importer_dir.display()
                 )
             })?
+        } else if Path::new(path_specifier).is_absolute() {
+            let candidate = normalize_path_lexical(Path::new(path_specifier));
+            let found = probe_graph_candidate(&candidate, raw).ok_or_else(|| {
+                anyhow!(
+                    "zfb bundler: module-worker dependency {specifier:?} in {} cannot be resolved exactly enough to produce a safe cache key (looked from {})",
+                    importer.display(),
+                    importer_dir.display()
+                )
+            })?;
+            return self.finish_absolute_file_resolution(specifier, importer, found, raw);
         } else {
-            if path_specifier.starts_with('/') {
-                bail!(
-                    "zfb bundler: absolute module-worker dependency {specifier:?} in {} is outside the project graph contract",
-                    importer.display()
-                );
-            }
             let user_claims_specifier = self.user_claims_specifier(path_specifier);
             // Plugin virtual modules are emitted through esbuild `--alias`
             // unless the user's tsconfig claims the specifier. They have no
@@ -1055,6 +1071,59 @@ impl ProjectGraphResolver {
             }
         };
         self.finish_file_resolution(found, raw)
+    }
+
+    fn finish_absolute_file_resolution(
+        &self,
+        specifier: &str,
+        importer: &Path,
+        found: PathBuf,
+        raw: bool,
+    ) -> Result<Option<GraphResolution>> {
+        if is_inside_node_modules(&found) {
+            return Ok(None);
+        }
+
+        let canonical_root = self.project_root.canonicalize().with_context(|| {
+            format!("canonicalize project root {}", self.project_root.display())
+        })?;
+        let canonical = found.canonicalize().with_context(|| {
+            format!(
+                "canonicalize absolute module-worker dependency {}",
+                found.display()
+            )
+        })?;
+        if !canonical.starts_with(&canonical_root) {
+            bail!(
+                "zfb bundler: absolute module-worker dependency {specifier:?} in {} is outside the project graph contract (canonical target {})",
+                importer.display(),
+                canonical.display()
+            );
+        }
+
+        if is_inside_node_modules(&canonical) {
+            return Ok(None);
+        }
+
+        let relative = canonical.strip_prefix(&canonical_root).with_context(|| {
+            format!(
+                "map canonical module-worker dependency {} into project root {}",
+                canonical.display(),
+                canonical_root.display()
+            )
+        })?;
+        let logical = normalize_path_lexical(&self.project_root.join(relative));
+        match validate_first_party_path(&logical, &self.project_root, "module-worker dependency") {
+            Ok(path) => Ok(Some(if raw {
+                GraphResolution::RawFile(path)
+            } else {
+                GraphResolution::File(path)
+            })),
+            Err(error) => bail!(
+                "zfb bundler: absolute module-worker dependency {specifier:?} in {} is outside the project graph contract: {error:#}",
+                importer.display()
+            ),
+        }
     }
 
     fn finish_file_resolution(&self, found: PathBuf, raw: bool) -> Result<Option<GraphResolution>> {
@@ -1323,6 +1392,148 @@ fn collect_import_specifiers(module: &Module, unresolved_ctxt: SyntaxContext) ->
     module.visit_with(&mut runtime_calls);
     specifiers.extend(runtime_calls.specifiers);
     specifiers
+}
+
+fn collect_import_specifier_occurrences(
+    module: &Module,
+    base: u32,
+    unresolved_ctxt: SyntaxContext,
+) -> Vec<ImportSpecifierOccurrence> {
+    fn occurrence(value: &swc_core::ecma::ast::Str, base: u32) -> ImportSpecifierOccurrence {
+        let span = value.span();
+        ImportSpecifierOccurrence {
+            specifier: atom_to_string(&value.value),
+            lo: (span.lo.0 - base) as usize,
+            hi: (span.hi.0 - base) as usize,
+        }
+    }
+
+    let mut specifiers = Vec::new();
+    for item in &module.body {
+        let ModuleItem::ModuleDecl(declaration) = item else {
+            continue;
+        };
+        match declaration {
+            ModuleDecl::Import(import) if !import.type_only => {
+                let runtime = import.specifiers.iter().any(|specifier| {
+                    !matches!(specifier, ImportSpecifier::Named(named) if named.is_type_only)
+                });
+                if runtime || import.specifiers.is_empty() {
+                    specifiers.push(occurrence(&import.src, base));
+                }
+            }
+            ModuleDecl::ExportNamed(export) if !export.type_only => {
+                if let Some(source) = &export.src {
+                    specifiers.push(occurrence(source, base));
+                }
+            }
+            ModuleDecl::ExportAll(export) if !export.type_only => {
+                specifiers.push(occurrence(&export.src, base));
+            }
+            ModuleDecl::TsImportEquals(import_equals) if !import_equals.is_type_only => {
+                if let swc_core::ecma::ast::TsModuleRef::TsExternalModuleRef(module_ref) =
+                    &import_equals.module_ref
+                {
+                    specifiers.push(occurrence(&module_ref.expr, base));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    struct RuntimeCalls {
+        base: u32,
+        unresolved_ctxt: SyntaxContext,
+        specifiers: Vec<ImportSpecifierOccurrence>,
+    }
+    impl Visit for RuntimeCalls {
+        fn visit_call_expr(&mut self, node: &swc_core::ecma::ast::CallExpr) {
+            let is_dynamic_import = matches!(node.callee, Callee::Import(_));
+            let is_global_require = matches!(
+                &node.callee,
+                Callee::Expr(callee)
+                    if matches!(&**callee, Expr::Ident(ident)
+                        if ident.sym == "require" && ident.ctxt == self.unresolved_ctxt)
+            );
+            if is_dynamic_import || is_global_require {
+                if let Some(argument) = node.args.first() {
+                    if argument.spread.is_none() {
+                        if let Expr::Lit(Lit::Str(value)) = &*argument.expr {
+                            self.specifiers.push(occurrence(value, self.base));
+                        }
+                    }
+                }
+            }
+            node.visit_children_with(self);
+        }
+    }
+    let mut runtime_calls = RuntimeCalls {
+        base,
+        unresolved_ctxt,
+        specifiers: Vec::new(),
+    };
+    module.visit_with(&mut runtime_calls);
+    specifiers.extend(runtime_calls.specifiers);
+    specifiers
+}
+
+fn stable_virtual_module_source(source: &str, project_root: &Path) -> String {
+    let virtual_path = project_root.join(".zfb-worker-virtual-module.mjs");
+    let Ok((module, base, unresolved_ctxt)) = parse_module(&virtual_path, source) else {
+        return source.to_string();
+    };
+    let mut replacements = collect_import_specifier_occurrences(&module, base, unresolved_ctxt)
+        .into_iter()
+        .filter_map(|occurrence| {
+            let stable = stable_project_virtual_specifier(&occurrence.specifier, project_root)
+                .unwrap_or(occurrence.specifier);
+            let replacement = serde_json::to_string(&stable).ok()?;
+            Some((occurrence.lo, occurrence.hi, replacement))
+        })
+        .collect::<Vec<_>>();
+    if replacements.is_empty() {
+        return source.to_string();
+    }
+
+    replacements.sort_by(|left, right| right.0.cmp(&left.0));
+    let mut stable = source.to_string();
+    for (lo, hi, replacement) in replacements {
+        stable.replace_range(lo..hi, &replacement);
+    }
+    stable
+}
+
+fn stable_project_virtual_specifier(specifier: &str, project_root: &Path) -> Option<String> {
+    if specifier.contains('?') || specifier.contains('#') {
+        return None;
+    }
+    let specifier_path = Path::new(specifier);
+    let candidate = if specifier_path.is_absolute() {
+        normalize_path_lexical(specifier_path)
+    } else if specifier.starts_with("./") || specifier.starts_with("../") {
+        normalize_path_lexical(&project_root.join(specifier_path))
+    } else {
+        return None;
+    };
+    if is_inside_node_modules(&candidate) {
+        return None;
+    }
+    let found = probe_graph_candidate(&candidate, false)?;
+    let canonical_root = project_root.canonicalize().ok()?;
+    let canonical = found.canonicalize().ok()?;
+    if !canonical.starts_with(&canonical_root) || is_inside_node_modules(&canonical) {
+        return None;
+    }
+    let relative = canonical.strip_prefix(&canonical_root).ok()?;
+    let relative = relative
+        .components()
+        .filter_map(|component| match component {
+            Component::Normal(value) => Some(value.to_string_lossy()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/");
+    Some(format!("./{relative}"))
 }
 
 /// Collect statically analyzable runtime import/require specifiers from one

--- a/crates/zfb-build/src/module_worker.rs
+++ b/crates/zfb-build/src/module_worker.rs
@@ -1495,7 +1495,7 @@ fn stable_virtual_module_source(source: &str, project_root: &Path) -> String {
         return source.to_string();
     }
 
-    replacements.sort_by(|left, right| right.0.cmp(&left.0));
+    replacements.sort_by_key(|replacement| std::cmp::Reverse(replacement.0));
     let mut stable = source.to_string();
     for (lo, hi, replacement) in replacements {
         stable.replace_range(lo..hi, &replacement);

--- a/crates/zfb-build/tests/bundler_exact_match_resolution.rs
+++ b/crates/zfb-build/tests/bundler_exact_match_resolution.rs
@@ -2682,6 +2682,119 @@ fn first_party_root_exact_target_cannot_climb_to_excluded_bare_dependency() {
     }
 }
 
+#[test]
+fn root_level_plugin_entry_stages_allowed_direct_bare_dependency_under_exclusions() {
+    let Some(esbuild) = locate_esbuild() else {
+        eprintln!("[bundler_exact_match_resolution] no esbuild binary available; skipping.");
+        return;
+    };
+    let esbuild = fs::canonicalize(esbuild).expect("absolute esbuild path");
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+    write_fixture_project(&root, "plugin:root-direct", "unused.tsx");
+    write_value_page(&root, "plugin:root-direct");
+    fs::write(
+        root.join(".root-direct-entry.js"),
+        "import value from 'allowed-root-direct-dependency'; export default value;\n",
+    )
+    .unwrap();
+    write_root_bare_package(
+        &root,
+        "allowed-root-direct-dependency",
+        "ALLOWED_ROOT_DIRECT_DEPENDENCY",
+    );
+    let excluded = write_root_bare_package(
+        &root,
+        "excluded-root-direct-dependency",
+        "EXCLUDED_ROOT_DIRECT_DEPENDENCY",
+    );
+    let mut input = make_input(
+        &root,
+        &esbuild,
+        "dist-root-direct-allowed",
+        BTreeMap::new(),
+        vec![(
+            "plugin:root-direct".to_string(),
+            root.join(".root-direct-entry.js")
+                .to_string_lossy()
+                .into_owned(),
+        )],
+        vec![],
+    );
+    input.node_modules_dir = Some(root.join("node_modules"));
+    input.bundle_exclude = vec![excluded
+        .join("index.js")
+        .strip_prefix(&root)
+        .unwrap()
+        .to_string_lossy()
+        .into_owned()];
+
+    bundle(input).expect("root-level plugin entry must stage its allowed direct bare dependency");
+    let body = fs::read_to_string(root.join("dist-root-direct-allowed/bundle.mjs")).unwrap();
+    assert!(body.contains("ALLOWED_ROOT_DIRECT_DEPENDENCY"), "{body}");
+    assert!(!body.contains("EXCLUDED_ROOT_DIRECT_DEPENDENCY"), "{body}");
+}
+
+#[test]
+fn root_level_tsconfig_entry_stages_allowed_transitive_bare_dependency_under_exclusions() {
+    let Some(esbuild) = locate_esbuild() else {
+        eprintln!("[bundler_exact_match_resolution] no esbuild binary available; skipping.");
+        return;
+    };
+    let esbuild = fs::canonicalize(esbuild).expect("absolute esbuild path");
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+    write_fixture_project(&root, "project:root-hop", "unused.tsx");
+    write_value_page(&root, "project:root-hop");
+    fs::write(
+        root.join(".root-hop-entry.js"),
+        "import value from './root-hop-local.js'; export default value;\n",
+    )
+    .unwrap();
+    fs::write(
+        root.join("root-hop-local.js"),
+        "import value from 'allowed-root-hop-dependency'; export default value;\n",
+    )
+    .unwrap();
+    write_root_bare_package(
+        &root,
+        "allowed-root-hop-dependency",
+        "ALLOWED_ROOT_HOP_DEPENDENCY",
+    );
+    let excluded = write_root_bare_package(
+        &root,
+        "excluded-root-hop-dependency",
+        "EXCLUDED_ROOT_HOP_DEPENDENCY",
+    );
+    let mut input = make_input(
+        &root,
+        &esbuild,
+        "dist-root-hop-allowed",
+        BTreeMap::from([(
+            "project:root-hop".to_string(),
+            vec![root
+                .join(".root-hop-entry.js")
+                .to_string_lossy()
+                .into_owned()],
+        )]),
+        vec![],
+        vec![],
+    );
+    input.node_modules_dir = Some(root.join("node_modules"));
+    input.bundle_exclude = vec![excluded
+        .join("index.js")
+        .strip_prefix(&root)
+        .unwrap()
+        .to_string_lossy()
+        .into_owned()];
+
+    bundle(input)
+        .expect("root-level tsconfig entry must stage a bare dependency imported by a local hop");
+    let body = fs::read_to_string(root.join("dist-root-hop-allowed/bundle.mjs")).unwrap();
+    assert!(body.contains("ALLOWED_ROOT_HOP_DEPENDENCY"), "{body}");
+    assert!(!body.contains("EXCLUDED_ROOT_HOP_DEPENDENCY"), "{body}");
+}
+
 // Finding 2 — a first-party package resolving an external via package `imports`
 // must use the filtered dependency view, not climb to the excluded dependency.
 #[test]

--- a/crates/zfb-build/tests/module_worker_plugin_virtual_absolute_deps.rs
+++ b/crates/zfb-build/tests/module_worker_plugin_virtual_absolute_deps.rs
@@ -1,0 +1,180 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use zfb_build::{rewrite_module_worker_urls_with_context, ModuleWorkerBuildContext};
+
+fn write(path: &Path, source: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(path, source).unwrap();
+}
+
+fn source_with_worker() -> &'static str {
+    "new Worker(new URL('./worker.ts', import.meta.url), { type: 'module' });"
+}
+
+fn write_worker_fixture(root: &Path) -> (PathBuf, PathBuf, PathBuf) {
+    let importer = root.join("src/app.ts");
+    let worker = root.join("src/worker.ts");
+    let helper = root.join("src/virtual-helper.ts");
+    write(&importer, "placeholder");
+    write(
+        &worker,
+        "import { value } from 'virtual:worker-data'; self.postMessage(value);",
+    );
+    write(&helper, "export const value = 'helper';");
+    (importer, worker, helper)
+}
+
+#[test]
+fn virtual_module_absolute_project_import_matches_relative_worker_cache_key() {
+    let project = tempfile::tempdir().unwrap();
+    let root = project.path();
+    let (importer, _, helper) = write_worker_fixture(root);
+
+    let absolute_context = ModuleWorkerBuildContext::default().with_plugins(
+        Vec::new(),
+        vec![(
+            "virtual:worker-data".into(),
+            format!(
+                "import {{ value }} from {}; export {{ value }};",
+                serde_json::to_string(&helper.to_string_lossy()).unwrap()
+            ),
+        )],
+    );
+    let relative_context = ModuleWorkerBuildContext::default().with_plugins(
+        Vec::new(),
+        vec![(
+            "virtual:worker-data".into(),
+            "import { value } from './src/virtual-helper'; export { value };".into(),
+        )],
+    );
+
+    let absolute = rewrite_module_worker_urls_with_context(
+        source_with_worker(),
+        &importer,
+        root,
+        &absolute_context,
+    )
+    .expect("absolute in-project import from plugin virtual module must resolve");
+    let relative = rewrite_module_worker_urls_with_context(
+        source_with_worker(),
+        &importer,
+        root,
+        &relative_context,
+    )
+    .expect("relative in-project import from plugin virtual module must resolve");
+
+    assert_eq!(
+        absolute.expanded_source, relative.expanded_source,
+        "absolute and relative virtual imports of the same project file must produce the same worker cache key"
+    );
+    assert!(absolute
+        .dependencies
+        .iter()
+        .any(|dependency| dependency.dependency == helper));
+}
+
+#[test]
+fn virtual_module_absolute_outside_project_import_keeps_contract_error() {
+    let workspace = tempfile::tempdir().unwrap();
+    let root = workspace.path().join("project");
+    let outside = workspace.path().join("outside/shared.ts");
+    let (importer, _, _) = write_worker_fixture(&root);
+    write(&outside, "export const value = 'outside';");
+
+    let context = ModuleWorkerBuildContext::default().with_plugins(
+        Vec::new(),
+        vec![(
+            "virtual:worker-data".into(),
+            format!(
+                "import {{ value }} from {}; export {{ value }};",
+                serde_json::to_string(&outside.to_string_lossy()).unwrap()
+            ),
+        )],
+    );
+
+    let error =
+        rewrite_module_worker_urls_with_context(source_with_worker(), &importer, &root, &context)
+            .expect_err("absolute imports outside the project root must still be rejected");
+    let message = format!("{error:#}");
+    assert!(
+        message.contains("absolute module-worker dependency"),
+        "{message}"
+    );
+    assert!(
+        message.contains("outside the project graph contract"),
+        "{message}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn virtual_module_absolute_symlink_escape_keeps_contract_error() {
+    use std::os::unix::fs::symlink;
+
+    let workspace = tempfile::tempdir().unwrap();
+    let root = workspace.path().join("project");
+    let outside = workspace.path().join("outside/shared.ts");
+    let escape = root.join("src/escape.ts");
+    let (importer, _, _) = write_worker_fixture(&root);
+    write(&outside, "export const value = 'outside';");
+    symlink(&outside, &escape).unwrap();
+
+    let context = ModuleWorkerBuildContext::default().with_plugins(
+        Vec::new(),
+        vec![(
+            "virtual:worker-data".into(),
+            format!(
+                "import {{ value }} from {}; export {{ value }};",
+                serde_json::to_string(&escape.to_string_lossy()).unwrap()
+            ),
+        )],
+    );
+
+    let error =
+        rewrite_module_worker_urls_with_context(source_with_worker(), &importer, &root, &context)
+            .expect_err("absolute imports that symlink outside the project root must be rejected");
+    let message = format!("{error:#}");
+    assert!(
+        message.contains("absolute module-worker dependency"),
+        "{message}"
+    );
+    assert!(
+        message.contains("outside the project graph contract"),
+        "{message}"
+    );
+}
+
+#[test]
+fn virtual_module_absolute_node_modules_import_is_not_project_source() {
+    let project = tempfile::tempdir().unwrap();
+    let root = project.path();
+    let (importer, _, _) = write_worker_fixture(root);
+    let dependency = root.join("node_modules/pkg/helper.ts");
+    write(&dependency, "export const value = 'dependency';");
+
+    let context = ModuleWorkerBuildContext::default().with_plugins(
+        Vec::new(),
+        vec![(
+            "virtual:worker-data".into(),
+            format!(
+                "import {{ value }} from {}; export {{ value }};",
+                serde_json::to_string(&dependency.to_string_lossy()).unwrap()
+            ),
+        )],
+    );
+
+    let rewrite =
+        rewrite_module_worker_urls_with_context(source_with_worker(), &importer, root, &context)
+            .expect("absolute node_modules imports should be left to package tooling, not treated as project files");
+
+    assert!(
+        !rewrite
+            .dependencies
+            .iter()
+            .any(|dependency_edge| dependency_edge.dependency == dependency),
+        "node_modules absolute imports must not be classified as project source dependencies"
+    );
+}

--- a/crates/zfb-content/Cargo.toml
+++ b/crates/zfb-content/Cargo.toml
@@ -20,11 +20,10 @@ default = ["syntect-onig"]
 # syntect itself fails to compile (cryptic unresolved `regex_impl` errors in
 # the syntect crate — cargo stops there, before this crate's units) — every
 # consumer must select exactly one backend, directly or via zfb-render's
-# forwarding features (zfb#1576). Note the zfb-render dev-dep below
-# depends back on this crate with default features, so `cargo test -p
-# zfb-content --no-default-features --features syntect-fancy` still unifies
-# to onig — a genuinely fancy-only build needs a graph without that
-# dev-dep cycle (`zfb-md-wasm` is exactly that consumer since zfb#1576).
+# forwarding features (zfb#1576). Keep the zfb-render dev-dep below on
+# `default-features = false`: the tests only need its SWC parse helper, and
+# inheriting zfb-render's defaults would pull `embed_v8` (`deno_core`/V8)
+# into this otherwise lightweight test graph.
 syntect-onig = ["syntect/regex-onig"]
 syntect-fancy = ["syntect/regex-fancy"]
 
@@ -72,7 +71,7 @@ swc_core = { workspace = true, features = [
 # Used by tests/mdx_jsx_emit.rs to pipe emitter output through SWC and
 # assert it parses as valid JS. Pure dev-only — keeps zfb-content's
 # runtime dependency surface minimal.
-zfb-render = { path = "../zfb-render" }
+zfb-render = { path = "../zfb-render", default-features = false }
 # Used by tests/walk_order_determinism.rs to create temp directories
 # for fake MDX file paths.
 tempfile = { workspace = true }

--- a/crates/zfb-content/src/pipeline.rs
+++ b/crates/zfb-content/src/pipeline.rs
@@ -19,6 +19,7 @@
 //! minimal hast representation here. This mirrors the
 //! `remark` (mdast) → `rehype` (hast) split in the unified ecosystem.
 
+use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -487,6 +488,13 @@ impl Default for Pipeline {
     fn default() -> Self {
         Self::new()
     }
+}
+
+#[derive(Clone, Copy)]
+enum HiEmit<'a> {
+    Single(Option<&'a str>),
+    Dual(&'a str, &'a str),
+    Class(&'a str, &'a BTreeMap<String, String>),
 }
 
 impl Pipeline {
@@ -1500,7 +1508,7 @@ impl Pipeline {
         // all — it is used by direct callers (tests, embedders), never by
         // `PipelineSpec::build_pipeline`. Class emission (zfb#1532) lives on
         // the full-config path via
-        // `with_defaults_and_full_config_class` → the `class_mode` arm in
+        // `with_defaults_and_full_config_class` → the class-emission arm in
         // `with_defaults_and_full_config_inner`. If a legacy class-mode entry
         // point is ever needed, add a `with_theme_class_mode`-style
         // constructor rather than branching here.
@@ -1614,15 +1622,6 @@ impl Pipeline {
     /// [`Pipeline::with_defaults_and_theme_and_gfm_and_themes_dir`] (and
     /// `zfb::config::resolve_hard_breaks`). Returns `Err` only when
     /// `themes_dir` is `Some` and a `.tmTheme` file fails to load.
-    ///
-    /// `dual` — when `Some((light, dark))`, constructs [`SyntectPlugin`] in
-    /// dual-theme mode via [`SyntectPlugin::with_dual_themes`] and overrides
-    /// `theme`. Both names must be SYNTECT theme names (e.g.
-    /// `"base16-ocean.light"`, `"base16-ocean.dark"`), NOT Shiki names like
-    /// `"dracula"`. When `None`, the single-theme path is used (with the
-    /// `theme` param as usual). The fingerprint encodes the mode explicitly
-    /// (`code_highlight=single(theme=…)` vs `code_highlight=dual(light=…,dark=…)`)
-    /// so single/dual configs can never alias a compile-cache entry.
     pub fn with_defaults_and_full_config(
         theme: Option<&str>,
         resolved: ResolvedGfmConstructs,
@@ -1632,23 +1631,20 @@ impl Pipeline {
         features: Option<&zfb_md_extras::MarkdownFeaturesConfig>,
     ) -> Result<Self, crate::syntect_highlight::HighlightError> {
         Self::with_defaults_and_full_config_inner(
-            theme,
+            HiEmit::Single(theme),
             resolved,
             themes_dir,
             cjk_friendly,
             hard_breaks,
             features,
-            None,
-            None,
         )
     }
 
     /// Like [`Pipeline::with_defaults_and_full_config`] but with an explicit
     /// dual-theme pair.
     ///
-    /// When `dual` is `Some((light, dark))`, the `SyntectPlugin` is constructed
-    /// in dual-theme mode (CSS custom properties `--shiki-light`/`--shiki-dark`
-    /// instead of inline `color:`). The `theme` parameter is ignored in this case.
+    /// Constructs the `SyntectPlugin` in dual-theme mode (CSS custom properties
+    /// `--shiki-light`/`--shiki-dark` instead of inline `color:`).
     ///
     /// Both theme names must be SYNTECT names — NOT Shiki names like `"dracula"`.
     pub fn with_defaults_and_full_config_dual(
@@ -1661,14 +1657,12 @@ impl Pipeline {
         theme_dark: &str,
     ) -> Result<Self, crate::syntect_highlight::HighlightError> {
         Self::with_defaults_and_full_config_inner(
-            None,
+            HiEmit::Dual(theme_light, theme_dark),
             resolved,
             themes_dir,
             cjk_friendly,
             hard_breaks,
             features,
-            Some((theme_light, theme_dark)),
-            None,
         )
     }
 
@@ -1681,7 +1675,7 @@ impl Pipeline {
     /// the `role_classes` override) with NO inline colour, and the `<pre>` is
     /// classed `{class_prefix}root`. The `class_prefix` / `role_classes` pair
     /// is also encoded into the compile-cache fingerprint segment (see the
-    /// `class_mode` arm inside [`Self::with_defaults_and_full_config_inner`])
+    /// class-emission arm inside [`Self::with_defaults_and_full_config_inner`])
     /// so a class-mode config can never alias an inline/dual entry and
     /// `classPrefix`/`roleClasses` edits correctly invalidate the cache.
     pub fn with_defaults_and_full_config_class(
@@ -1691,39 +1685,27 @@ impl Pipeline {
         hard_breaks: bool,
         features: Option<&zfb_md_extras::MarkdownFeaturesConfig>,
         class_prefix: &str,
-        role_classes: &std::collections::BTreeMap<String, String>,
+        role_classes: &BTreeMap<String, String>,
     ) -> Result<Self, crate::syntect_highlight::HighlightError> {
         Self::with_defaults_and_full_config_inner(
-            None,
+            HiEmit::Class(class_prefix, role_classes),
             resolved,
             themes_dir,
             cjk_friendly,
             hard_breaks,
             features,
-            None,
-            Some((class_prefix, role_classes)),
         )
     }
 
     /// Internal shared builder for the single / dual / class full-config
     /// constructors.
-    // Private shared impl of three public constructors; each knob is a distinct
-    // pipeline input threaded verbatim into the fingerprint, so bundling them
-    // into a params struct would only obscure the drift guard.
-    #[allow(clippy::too_many_arguments)]
     fn with_defaults_and_full_config_inner(
-        theme: Option<&str>,
+        hi_emit: HiEmit<'_>,
         resolved: ResolvedGfmConstructs,
         themes_dir: Option<&Path>,
         cjk_friendly: bool,
         hard_breaks: bool,
         features: Option<&zfb_md_extras::MarkdownFeaturesConfig>,
-        dual: Option<(&str, &str)>,
-        // Highlight Tokens epic (zfb#1528, zfb#1532):
-        // `Some((class_prefix, role_classes))` when `codeHighlight.mode` is
-        // `"class"`. Selects `SyntectPlugin::with_class_mode` in the syntect
-        // arm below and is encoded into the compile-cache fingerprint segment.
-        class_mode: Option<(&str, &std::collections::BTreeMap<String, String>)>,
     ) -> Result<Self, crate::syntect_highlight::HighlightError> {
         // `markdown.features` absent → empty feature set (post-epic opt-in
         // default, #583 / #586): the former-Core framework features
@@ -1767,9 +1749,10 @@ impl Pipeline {
         // modes. (config.rs only validates name *presence* / dual-pair
         // completeness; theme-name existence depends on `themesDir`, which is
         // not known until here.)
-        let required_themes: Vec<&str> = match dual {
-            Some((light, dark)) => vec![light, dark],
-            None => theme.into_iter().collect(),
+        let required_themes: Vec<&str> = match hi_emit {
+            HiEmit::Single(theme) => theme.into_iter().collect(),
+            HiEmit::Dual(light, dark) => vec![light, dark],
+            HiEmit::Class(_, _) => Vec::new(),
         };
         if !required_themes.is_empty() {
             let names = highlighter.theme_names();
@@ -1839,23 +1822,21 @@ impl Pipeline {
         // SyntectPlugin MUST be added AFTER register_features so pre-syntect
         // extras visitors (mermaid, …) run first.
         //
-        // Dual mode: when `dual` is `Some((light, dark))` the plugin is
-        // constructed via `with_dual_themes`; the `theme` param is ignored.
-        // Single mode: mirrors the pre-dual logic.
-        let syntect = if let Some((class_prefix, role_classes)) = class_mode {
-            // Class-emission mode (zfb#1532): every token becomes a
-            // `<span class="…">` role class (default `{prefix}{short_name}`,
-            // or the `roleClasses` override) with NO inline colour; the
-            // `<pre>` is classed `{prefix}root`. config.rs validation forbids
-            // setting `theme`/`themeLight`/`themeDark` alongside class mode,
-            // so this arm never coexists with `dual`/`theme`.
-            SyntectPlugin::new(highlighter).with_class_mode(class_prefix, role_classes.clone())
-        } else if let Some((light, dark)) = dual {
-            SyntectPlugin::new(highlighter).with_dual_themes(light, dark)
-        } else if let Some(t) = theme {
-            SyntectPlugin::new(highlighter).with_theme(t)
-        } else {
-            SyntectPlugin::new(highlighter)
+        let syntect = match hi_emit {
+            HiEmit::Class(class_prefix, role_classes) => {
+                // Class-emission mode (zfb#1532): every token becomes a
+                // `<span class="…">` role class (default `{prefix}{short_name}`,
+                // or the `roleClasses` override) with NO inline colour; the
+                // `<pre>` is classed `{prefix}root`. config.rs validation forbids
+                // setting `theme`/`themeLight`/`themeDark` alongside class mode,
+                // so this variant never coexists with single/dual theme input.
+                SyntectPlugin::new(highlighter).with_class_mode(class_prefix, role_classes.clone())
+            }
+            HiEmit::Dual(light, dark) => {
+                SyntectPlugin::new(highlighter).with_dual_themes(light, dark)
+            }
+            HiEmit::Single(Some(theme)) => SyntectPlugin::new(highlighter).with_theme(theme),
+            HiEmit::Single(None) => SyntectPlugin::new(highlighter),
         };
         p.push_config_derived_hast_visitor(Box::new(syntect));
         // Post-syntect extras visitors operate on the per-line
@@ -1888,14 +1869,18 @@ impl Pipeline {
         // stability across two constructions of an equal map.
         // IMPORTANT: the single-mode segment must be BYTE-IDENTICAL to the
         // pre-dual form so existing warm caches are not invalidated on upgrade.
-        let code_highlight_seg = if let Some((prefix, role_classes)) = class_mode {
-            format!("code_highlight=class(prefix={prefix:?},roles={role_classes:?})")
-        } else if let Some((light, dark)) = dual {
-            format!("code_highlight=dual(light={light:?},dark={dark:?})")
-        } else {
-            // Single mode: reproduce the exact pre-dual descriptor string so
-            // fingerprints are unchanged for all existing single-theme configs.
-            format!("theme={theme:?}")
+        let code_highlight_seg = match hi_emit {
+            HiEmit::Class(prefix, role_classes) => {
+                format!("code_highlight=class(prefix={prefix:?},roles={role_classes:?})")
+            }
+            HiEmit::Dual(light, dark) => {
+                format!("code_highlight=dual(light={light:?},dark={dark:?})")
+            }
+            HiEmit::Single(theme) => {
+                // Single mode: reproduce the exact pre-dual descriptor string so
+                // fingerprints are unchanged for all existing single-theme configs.
+                format!("theme={theme:?}")
+            }
         };
         let base = match (
             themes_dir_fingerprint_segment(themes_dir),

--- a/crates/zfb-md-wasm/npm/src/index.ts
+++ b/crates/zfb-md-wasm/npm/src/index.ts
@@ -42,9 +42,15 @@ function getCompiledModule(): Promise<WebAssembly.Module> {
   return compiledModulePromise;
 }
 
-let generation = 0;
+const MAX_TRAP_RECOVERIES = 16;
+
+let currentGeneration = 0;
+let trapRecoveriesStarted = 0;
+let freshInstanceStarts = 0;
+let terminalTrapRecoveryError: ZfbMdWasmTrapRecoveryLimitError | undefined;
 
 interface Instance {
+  generation: number;
   glue: WasmGlueModule;
   raw: WasmRawExports;
 }
@@ -54,16 +60,19 @@ interface Instance {
  *
  * wasm-bindgen's `--target web` output guards `init`/`initSync` with an
  * "already initialized" early return keyed on a module-scope singleton, so
- * recovering from a trapped (poisoned) instance requires a genuinely fresh
- * ES module record -- re-calling `initSync` on the existing module record is
- * a no-op. Re-importing the same specifier with a distinct query string
- * yields a new module record per the ECMAScript module spec (Node and
- * browsers agree on this); the underlying `WebAssembly.Module` (compiled
- * code) is cached and reused via `getCompiledModule`, so this only re-runs
- * cheap instantiation, never a recompile.
+ * recovering from a trapped (poisoned) instance requires a genuinely fresh ES
+ * module record -- re-calling `initSync` on the existing module record is a
+ * no-op. Re-importing the same specifier with a distinct query string yields a
+ * new module record per the ECMAScript module spec (Node and browsers agree on
+ * this); the underlying `WebAssembly.Module` (compiled code) is cached and
+ * reused via `getCompiledModule`, so this only re-runs cheap instantiation,
+ * never a recompile. Module-record growth is bounded by
+ * `MAX_TRAP_RECOVERIES`: once that many poisoned instances have been replaced,
+ * recovery stops permanently and callers receive
+ * `ZfbMdWasmTrapRecoveryLimitError` instead of minting another module record.
  */
-async function freshInstance(): Promise<Instance> {
-  generation += 1;
+async function freshInstance(generation: number): Promise<Instance> {
+  freshInstanceStarts += 1;
   const [module, glue] = await Promise.all([
     getCompiledModule(),
     import(
@@ -71,13 +80,16 @@ async function freshInstance(): Promise<Instance> {
     ) as Promise<WasmGlueModule>,
   ]);
   const raw = glue.initSync({ module });
-  return { glue, raw };
+  return { generation, glue, raw };
 }
 
 let instancePromise: Promise<Instance> | undefined;
 
 function getInstance(): Promise<Instance> {
-  instancePromise ??= freshInstance();
+  if (terminalTrapRecoveryError) {
+    return Promise.reject(terminalTrapRecoveryError);
+  }
+  instancePromise ??= freshInstance(currentGeneration);
   return instancePromise;
 }
 
@@ -90,10 +102,12 @@ function getInstance(): Promise<Instance> {
  * thrown error. See this package's README "Error / trap / re-init
  * contract" section.
  *
- * By the time this is thrown, the poisoned instance has already been
- * dropped and a replacement is being instantiated in the background (from
- * the cached compiled module, so no recompile) -- the next `compile` /
- * `renderHtml` / `version` call transparently uses the fresh instance.
+ * By the time this is thrown, the poisoned instance has already been dropped
+ * and a replacement has been instantiated (from the cached compiled module, so
+ * no recompile). Concurrent trap reporters for the same poisoned generation
+ * wait for that same replacement instead of each starting another one; the
+ * next `compile` / `renderHtml` / `version` call transparently uses the fresh
+ * instance.
  */
 export class ZfbMdWasmTrapError extends Error {
   constructor(cause: unknown) {
@@ -107,8 +121,54 @@ export class ZfbMdWasmTrapError extends Error {
   }
 }
 
+/**
+ * Thrown once this wrapper has already recovered from too many wasm traps in
+ * one module lifetime. ES module records cannot be evicted, and wasm-bindgen
+ * `--target web` glue cannot be safely re-used after initialization, so the
+ * only bounded behavior after repeated poisoning is to stop recovering and ask
+ * the host to reload/recreate the JS realm before trying again.
+ */
+export class ZfbMdWasmTrapRecoveryLimitError extends Error {
+  constructor(maxRecoveries: number, cause: unknown) {
+    super(
+      `zfb-md-wasm: wasm trap recovery limit reached after ${maxRecoveries} ` +
+        `successful re-instantiations. Further automatic recovery is disabled to avoid ` +
+        `unbounded ES module record growth. Reload the JS realm before using zfb-md-wasm ` +
+        `again, and please report the input that triggered the repeated traps.`,
+    );
+    this.name = "ZfbMdWasmTrapRecoveryLimitError";
+    this.cause = cause;
+  }
+}
+
 function isTrap(err: unknown): boolean {
   return typeof WebAssembly !== "undefined" && err instanceof WebAssembly.RuntimeError;
+}
+
+async function recoverAfterTrap(observedGeneration: number, cause: unknown): Promise<void> {
+  if (terminalTrapRecoveryError) {
+    throw terminalTrapRecoveryError;
+  }
+
+  // CAS-style single-flight: only the reporter that observed the currently
+  // active generation advances it and starts a fresh instantiation. Other
+  // concurrent reporters trapped on an older instance, so they await the
+  // already-started replacement instead of minting another module record.
+  if (observedGeneration !== currentGeneration) {
+    await getInstance();
+    return;
+  }
+
+  if (trapRecoveriesStarted >= MAX_TRAP_RECOVERIES) {
+    terminalTrapRecoveryError = new ZfbMdWasmTrapRecoveryLimitError(MAX_TRAP_RECOVERIES, cause);
+    instancePromise = undefined;
+    throw terminalTrapRecoveryError;
+  }
+
+  trapRecoveriesStarted += 1;
+  currentGeneration += 1;
+  instancePromise = freshInstance(currentGeneration);
+  await instancePromise;
 }
 
 async function callWasm<T>(fn: (instance: Instance) => T): Promise<T> {
@@ -119,10 +179,11 @@ async function callWasm<T>(fn: (instance: Instance) => T): Promise<T> {
     if (!isTrap(err)) {
       throw err;
     }
-    // Drop the poisoned instance and eagerly start re-instantiating it (from
-    // the cached compiled module) so the next call does not pay the
-    // instantiation cost synchronously.
-    instancePromise = freshInstance();
+    // Drop the poisoned instance and re-instantiate it from the cached compiled
+    // module. Concurrent trap reporters single-flight through the same
+    // generation advance, so one poisoned generation creates at most one fresh
+    // module record.
+    await recoverAfterTrap(instance.generation, err);
     throw new ZfbMdWasmTrapError(err);
   }
 }
@@ -192,6 +253,27 @@ export async function __forceTrapForTests(): Promise<void> {
   await callWasm(({ raw }) => {
     raw.compile(0xfffffff0, 0, 0, 0, 0);
   });
+}
+
+/**
+ * @internal Test-only observability for the trap recovery contract. This is a
+ * named export only so the built-package Vitest suite can assert the public
+ * wrapper's concurrency/cap behavior without mocking the wasm-bindgen glue.
+ */
+export function __getTrapRecoveryStateForTests(): {
+  currentGeneration: number;
+  freshInstanceStarts: number;
+  maxTrapRecoveries: number;
+  trapRecoveriesStarted: number;
+  terminal: boolean;
+} {
+  return {
+    currentGeneration,
+    freshInstanceStarts,
+    maxTrapRecoveries: MAX_TRAP_RECOVERIES,
+    trapRecoveriesStarted,
+    terminal: !!terminalTrapRecoveryError,
+  };
 }
 
 export type {

--- a/crates/zfb-md-wasm/npm/test/api.test.ts
+++ b/crates/zfb-md-wasm/npm/test/api.test.ts
@@ -16,6 +16,15 @@ import {
   __getTrapRecoveryStateForTests,
 } from "../dist/index.js";
 
+function nestedYamlFrontmatter(depth: number): string {
+  let yaml = "root:\n";
+  for (let i = 0; i < depth; i += 1) {
+    yaml += `${"  ".repeat(i + 1)}k${i}:\n`;
+  }
+  yaml += `${"  ".repeat(depth + 1)}leaf: ok\n`;
+  return `---\n${yaml}---\n# Body\n`;
+}
+
 describe("renderHtml (md -> HTML, no SWC)", () => {
   it("renders markdown and returns parsed frontmatter VALUES", async () => {
     const out = await renderHtml(
@@ -102,6 +111,33 @@ describe("expected failures surface as structured diagnostics (never a throw)", 
     const out = await compile("# hi\n", { filename: "p.txt" });
     expect(out.code).toBeNull();
     expect(out.diagnostics[0]?.source).toBe("options");
+  });
+
+  it("deep YAML frontmatter returns a diagnostic rather than trapping", async () => {
+    const before = __getTrapRecoveryStateForTests();
+
+    const out = await renderHtml(nestedYamlFrontmatter(512), { filename: "deep.md" });
+
+    const after = __getTrapRecoveryStateForTests();
+    expect(out.html).toBeNull();
+    expect(out.frontmatter).toBeNull();
+    expect(out.diagnostics).toHaveLength(1);
+    expect(out.diagnostics[0]?.source).toBe("frontmatter");
+    expect(out.diagnostics[0]?.message).toContain("recursion limit exceeded");
+    expect(after.trapRecoveriesStarted).toBe(before.trapRecoveriesStarted);
+  });
+
+  it("reasonable YAML frontmatter depth still parses", async () => {
+    const out = await renderHtml(nestedYamlFrontmatter(20), { filename: "reasonable.md" });
+
+    expect(out.html).toBe("<h1>Body</h1>");
+    expect(out.diagnostics).toHaveLength(0);
+    let cursor = out.frontmatter as Record<string, unknown>;
+    cursor = cursor.root as Record<string, unknown>;
+    for (let i = 0; i < 20; i += 1) {
+      cursor = cursor[`k${i}`] as Record<string, unknown>;
+    }
+    expect(cursor.leaf).toBe("ok");
   });
 });
 

--- a/crates/zfb-md-wasm/npm/test/api.test.ts
+++ b/crates/zfb-md-wasm/npm/test/api.test.ts
@@ -11,7 +11,9 @@ import {
   version,
   init,
   ZfbMdWasmTrapError,
+  ZfbMdWasmTrapRecoveryLimitError,
   __forceTrapForTests,
+  __getTrapRecoveryStateForTests,
 } from "../dist/index.js";
 
 describe("renderHtml (md -> HTML, no SWC)", () => {
@@ -123,5 +125,49 @@ describe("trap / auto-re-init contract", () => {
     const out = await renderHtml("# recovered\n");
     expect(out.html).toBe("<h1>recovered</h1>");
     expect(out.diagnostics).toHaveLength(0);
+  });
+
+  it("single-flights concurrent trap recovery to one fresh instantiation", async () => {
+    await init();
+    const before = __getTrapRecoveryStateForTests();
+
+    const trapA = __forceTrapForTests();
+    const trapB = __forceTrapForTests();
+
+    await Promise.all([
+      expect(trapA).rejects.toBeInstanceOf(ZfbMdWasmTrapError),
+      expect(trapB).rejects.toBeInstanceOf(ZfbMdWasmTrapError),
+    ]);
+
+    const after = __getTrapRecoveryStateForTests();
+    expect(after.trapRecoveriesStarted - before.trapRecoveriesStarted).toBe(1);
+    expect(after.freshInstanceStarts - before.freshInstanceStarts).toBe(1);
+
+    const out = await renderHtml("# recovered after concurrent traps\n");
+    expect(out.html).toBe("<h1>recovered after concurrent traps</h1>");
+    expect(out.diagnostics).toHaveLength(0);
+  });
+
+  it("stops recovering after the cap and mints no further module records", async () => {
+    await init();
+    const before = __getTrapRecoveryStateForTests();
+    const remainingRecoveries = before.maxTrapRecoveries - before.trapRecoveriesStarted;
+    expect(remainingRecoveries).toBeGreaterThan(0);
+
+    for (let i = 0; i < remainingRecoveries; i += 1) {
+      await expect(__forceTrapForTests()).rejects.toBeInstanceOf(ZfbMdWasmTrapError);
+    }
+
+    const atCap = __getTrapRecoveryStateForTests();
+    expect(atCap.trapRecoveriesStarted).toBe(atCap.maxTrapRecoveries);
+    const freshInstanceStartsAtCap = atCap.freshInstanceStarts;
+
+    await expect(__forceTrapForTests()).rejects.toBeInstanceOf(ZfbMdWasmTrapRecoveryLimitError);
+    const terminal = __getTrapRecoveryStateForTests();
+    expect(terminal.terminal).toBe(true);
+    expect(terminal.freshInstanceStarts).toBe(freshInstanceStartsAtCap);
+
+    await expect(__forceTrapForTests()).rejects.toBeInstanceOf(ZfbMdWasmTrapRecoveryLimitError);
+    expect(__getTrapRecoveryStateForTests().freshInstanceStarts).toBe(freshInstanceStartsAtCap);
   });
 });

--- a/crates/zfb-md-wasm/src/lib.rs
+++ b/crates/zfb-md-wasm/src/lib.rs
@@ -57,12 +57,13 @@
 //!
 //! ## Error / trap contract (correctness-critical — see README.md)
 //!
-//! Expected failures (parse errors, malformed options) come back as
+//! Expected failures (parse errors, malformed options, dependency-enforced
+//! input limits such as serde_yaml's recursion cap) come back as
 //! structured diagnostics — these functions do not intentionally panic
-//! on any input. A *bug*-level panic on `wasm32-unknown-unknown` traps
-//! and poisons the instance; the host wrapper must re-instantiate (the
-//! API is stateless per call, so re-init loses nothing). Full contract
-//! in this crate's README.
+//! on supported error paths. A *bug*-level panic on
+//! `wasm32-unknown-unknown` traps and poisons the instance; the host
+//! wrapper must re-instantiate (the API is stateless per call, so re-init
+//! loses nothing). Full contract in this crate's README.
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;

--- a/crates/zfb-server/src/routes.rs
+++ b/crates/zfb-server/src/routes.rs
@@ -908,12 +908,17 @@ async fn serve_page(
     // other methods, gate on `is_get_like` here to skip the lock and
     // path-format work for POST/PUT/etc.
     if is_get_like {
-        let path_only = format!("/{trimmed}");
+        let redirects_path = redirects_match_path(trimmed, state.base_prefix.as_deref());
         // `/_redirects` itself must never be servable — Cloudflare
         // never exposes the control file at its own URL, and it would
         // otherwise leak through the `public_root` disk leg further
         // down (the raw source file, not a servable asset).
-        if path_only == "/_redirects" {
+        if redirects_path == "/_redirects"
+            || state
+                .base_prefix
+                .as_deref()
+                .is_some_and(|prefix| redirects_path == format!("{prefix}/_redirects"))
+        {
             return page_response_bytes(
                 StatusCode::NOT_FOUND,
                 DEV_404_BODY.as_bytes().to_vec(),
@@ -932,7 +937,8 @@ async fn serve_page(
             // any I/O so the watcher's reload is never blocked by an
             // in-flight request.
             let snapshot: Redirects = handle.read().unwrap_or_else(|p| p.into_inner()).clone();
-            if let Some(outcome) = snapshot.match_request(&path_only, uri.query(), method.as_str())
+            if let Some(outcome) =
+                snapshot.match_request(&redirects_path, uri.query(), method.as_str())
             {
                 match outcome {
                     RedirectOutcome::Redirect { status, location } => {
@@ -944,8 +950,11 @@ async fn serve_page(
                         // waterfall a normal request would eventually
                         // reach, never re-consulting plugins, embed
                         // handlers, SSR, the hook, or the rule set again.
-                        let target_trimmed = target.trim_start_matches('/');
-                        return serve_from_waterfall(state, target_trimmed, lr_prefix).await;
+                        let target_trimmed = waterfall_trimmed_for_rewrite_target(
+                            &target,
+                            state.base_prefix.as_deref(),
+                        );
+                        return serve_from_waterfall(state, &target_trimmed, lr_prefix).await;
                     }
                 }
             }
@@ -1336,6 +1345,62 @@ fn redirect_response(status: u16, location: &str) -> Response {
     let location_value =
         HeaderValue::from_str(location).unwrap_or_else(|_| HeaderValue::from_static("/"));
     (status_code, [(header::LOCATION, location_value)]).into_response()
+}
+
+/// Reconstruct the full request path used by `_redirects` matching.
+///
+/// The base-prefixed dev router registers routes at `<base>/{*path}` and
+/// passes only the captured, prefix-stripped path into [`serve_page`].
+/// Static preview (and Workers Static Assets) match `_redirects` against
+/// the full request path, so dev has to put the mount prefix back before
+/// consulting the shared matcher.
+fn redirects_match_path(trimmed: &str, base_prefix: Option<&str>) -> String {
+    let local_path = if trimmed.is_empty() {
+        "/".to_string()
+    } else {
+        format!("/{trimmed}")
+    };
+    match base_prefix {
+        Some(prefix) if !prefix.is_empty() && local_path == "/" => format!("{prefix}/"),
+        Some(prefix) if !prefix.is_empty() => format!("{prefix}{local_path}"),
+        _ => local_path,
+    }
+}
+
+/// Convert a `_redirects` 200-rewrite target into the prefix-stripped
+/// path shape expected by [`serve_from_waterfall`].
+///
+/// Spec-form rules under a custom `base` use full-path targets such as
+/// `/pj/site/rewritten/?literal=1`. Dev's waterfall, however, stores and
+/// probes pages/public files without the mount prefix. Query strings are
+/// not part of filesystem/page-cache lookup; preview splits them before
+/// calling its static waterfall, and dev mirrors that here.
+fn waterfall_trimmed_for_rewrite_target(target: &str, base_prefix: Option<&str>) -> String {
+    let path = target
+        .split_once('?')
+        .map(|(path, _)| path)
+        .unwrap_or(target);
+    strip_prefix_from_path(path, base_prefix)
+        .trim_start_matches('/')
+        .to_string()
+}
+
+fn strip_prefix_from_path<'a>(path: &'a str, prefix: Option<&str>) -> &'a str {
+    let prefix = match prefix {
+        Some(p) if !p.is_empty() => p,
+        _ => return path,
+    };
+    if !path.starts_with(prefix) {
+        return path;
+    }
+    let rest = &path[prefix.len()..];
+    if rest.is_empty() {
+        return "/";
+    }
+    match rest.as_bytes()[0] {
+        b'/' => rest,
+        _ => path,
+    }
 }
 
 /// Strip the dev server's mount prefix from `uri`'s path-and-query
@@ -1979,6 +2044,7 @@ mod tests {
     };
     use axum::body::{to_bytes, Body};
     use axum::http::{Request, StatusCode};
+    use std::sync::{Arc, RwLock};
     use tokio::sync::broadcast;
     use tower::ServiceExt;
 
@@ -3574,6 +3640,129 @@ mod tests {
         assert!(
             body.contains("<script src=\"/foo/__zfb/livereload.js\"></script>"),
             "expected prefixed livereload tag in 404, got: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn base_prefix_redirects_match_full_path_and_rewrite_strips_base() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let public_root = tmp.path().to_path_buf();
+        std::fs::write(
+            public_root.join("_redirects"),
+            b"this control file must never be served",
+        )
+        .unwrap();
+
+        let mut state = test_state_with_base("/pj/site");
+        state.public_root = public_root;
+        state.redirects = Some(Arc::new(RwLock::new(Redirects::parse(
+            "\
+/pj/site/old /pj/site/new-page 302
+/pj/site/rewrite-me /pj/site/rewritten/?literal=1 200
+",
+        ))));
+        state
+            .pages
+            .insert(
+                "/rewritten",
+                "<html><body>BASE_REWRITE_TARGET_MARKER</body></html>",
+            )
+            .await;
+        state
+            .pages
+            .insert(
+                "/pass-through",
+                "<html><body>BASE_PASS_THROUGH_MARKER</body></html>",
+            )
+            .await;
+        let router = test_router_with_base(state);
+
+        let redirect_resp = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/pj/site/old")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(redirect_resp.status(), StatusCode::FOUND);
+        let location = redirect_resp
+            .headers()
+            .get(header::LOCATION)
+            .and_then(|h| h.to_str().ok())
+            .unwrap_or_default();
+        assert_eq!(
+            location, "/pj/site/new-page",
+            "redirect Location must be the rule target exactly, not double-prefixed"
+        );
+
+        let rewrite_resp = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/pj/site/rewrite-me?request=ignored")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(rewrite_resp.status(), StatusCode::OK);
+        let rewrite_body = body_string(rewrite_resp).await;
+        assert!(
+            rewrite_body.contains("BASE_REWRITE_TARGET_MARKER"),
+            "base-prefixed 200 rewrite with literal query must resolve through the waterfall: {rewrite_body}"
+        );
+
+        let pass_through_resp = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/pj/site/pass-through")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(pass_through_resp.status(), StatusCode::OK);
+        let pass_through_body = body_string(pass_through_resp).await;
+        assert!(
+            pass_through_body.contains("BASE_PASS_THROUGH_MARKER"),
+            "non-matching full-path request must fall through to the ordinary dev waterfall: {pass_through_body}"
+        );
+
+        let prefixed_control_resp = router
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/pj/site/_redirects")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(prefixed_control_resp.status(), StatusCode::NOT_FOUND);
+        let prefixed_control_body = body_string(prefixed_control_resp).await;
+        assert!(
+            !prefixed_control_body.contains("this control file must never be served"),
+            "base-prefixed _redirects must remain hidden"
+        );
+
+        let bare_control_resp = router
+            .oneshot(
+                Request::builder()
+                    .uri("/_redirects")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(bare_control_resp.status(), StatusCode::NOT_FOUND);
+        let bare_control_body = body_string(bare_control_resp).await;
+        assert!(
+            !bare_control_body.contains("this control file must never be served"),
+            "bare _redirects must remain hidden even when a base is configured"
         );
     }
 

--- a/crates/zfb/tests/preview_cross_mode_e2e.rs
+++ b/crates/zfb/tests/preview_cross_mode_e2e.rs
@@ -111,6 +111,39 @@ const SCENARIO_DEADLINE: Duration = Duration::from_secs(30);
 
 const POLL_INTERVAL: Duration = Duration::from_millis(100);
 
+#[derive(Clone, Copy)]
+enum CrossModeCase {
+    Default,
+    CustomBase,
+}
+
+impl CrossModeCase {
+    fn preview_readiness_path(self) -> &'static str {
+        "/"
+    }
+
+    fn dev_readiness_path(self) -> &'static str {
+        match self {
+            CrossModeCase::Default => "/",
+            CrossModeCase::CustomBase => "/pj/site/",
+        }
+    }
+
+    fn preview_label(self) -> &'static str {
+        match self {
+            CrossModeCase::Default => "preview",
+            CrossModeCase::CustomBase => "preview-custom-base",
+        }
+    }
+
+    fn dev_label(self) -> &'static str {
+        match self {
+            CrossModeCase::Default => "dev",
+            CrossModeCase::CustomBase => "dev-custom-base",
+        }
+    }
+}
+
 fn fixture_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("tests")
@@ -142,6 +175,34 @@ fn copy_dir(src: &Path, dst: &Path) -> std::io::Result<()> {
         }
     }
     Ok(())
+}
+
+fn configure_fixture_case(root: &Path, case: CrossModeCase) {
+    match case {
+        CrossModeCase::Default => {}
+        CrossModeCase::CustomBase => {
+            fs::write(
+                root.join("zfb.config.json"),
+                r#"{
+  "framework": "preact",
+  "base": "/pj/site/",
+  "plugins": [{ "name": "./preset.mjs" }]
+}
+"#,
+            )
+            .expect("write custom-base zfb.config.json");
+            fs::write(
+                root.join("public/_redirects"),
+                "\
+# Custom-base parity rules: spec-form sources include the base prefix.
+/pj/site/old-page /pj/site/new-page 301
+/pj/site/rewrite-me /rewritten/?literal=1 200
+/pj/site/blog/* /pj/site/new-page?src=:splat 301
+",
+            )
+            .expect("write custom-base _redirects");
+        }
+    }
 }
 
 /// Owns one spawned `zfb <subcommand>` process (dev OR preview). Drop
@@ -267,16 +328,18 @@ fn spawn_zfb(
     }
 }
 
-/// Wait for the ready banner and confirm `GET /` answers 200. Panics if
-/// the process exits prematurely, or the deadline is exceeded, with the
-/// captured logs attached — there is no "known-skip indicator" branch
-/// here (unlike `dev_serve_e2e.rs`): by the time this is called,
-/// `locate_esbuild()`/`node_available()` have already gated the whole
-/// test, so a premature exit is a real failure, not an environment gap.
+/// Wait for the ready banner and confirm the case's readiness URL
+/// answers 200. Panics if the process exits prematurely, or the deadline
+/// is exceeded, with the captured logs attached — there is no
+/// "known-skip indicator" branch here (unlike `dev_serve_e2e.rs`): by
+/// the time this is called, `locate_esbuild()`/`node_available()` have
+/// already gated the whole test, so a premature exit is a real failure,
+/// not an environment gap.
 async fn boot_and_get_port(
     session: &mut ServerSession,
     client: &reqwest::Client,
     boot_deadline: Duration,
+    readiness_path: &str,
 ) -> u16 {
     let boot_start = Instant::now();
     let port = loop {
@@ -312,14 +375,14 @@ async fn boot_and_get_port(
     let base = format!("http://localhost:{port}");
     let start = Instant::now();
     loop {
-        if let Ok(resp) = client.get(format!("{base}/")).send().await {
+        if let Ok(resp) = client.get(format!("{base}{readiness_path}")).send().await {
             if resp.status().as_u16() == 200 {
                 return port;
             }
         }
         assert!(
             start.elapsed() < boot_deadline,
-            "`{}` GET / never answered 200 within {}s after the ready banner.\n{}",
+            "`{}` GET {readiness_path} never answered 200 within {}s after the ready banner.\n{}",
             session.label,
             boot_deadline.as_secs(),
             session.logs(),
@@ -619,6 +682,49 @@ async fn run_shared_get_scenarios(client: &reqwest::Client, base: &str, session:
     .await;
 }
 
+/// Custom-base GET assertions for issue #1594. The rule sources are
+/// authored in Cloudflare/preview spec form, so they include `/pj/site`.
+/// Dev must reconstruct that full source path before matching, while
+/// preview naturally feeds the full request path to the same matcher.
+async fn run_custom_base_get_scenarios(
+    client: &reqwest::Client,
+    base: &str,
+    session: &ServerSession,
+) {
+    poll_get_redirect(
+        client,
+        &format!("{base}/pj/site/old-page?x=1"),
+        301,
+        "/pj/site/new-page?x=1",
+        SCENARIO_DEADLINE,
+        "custom base: redirect preserves exact base-prefixed Location + query",
+        session,
+    )
+    .await;
+
+    poll_get_contains(
+        client,
+        &format!("{base}/pj/site/rewrite-me?extra=1"),
+        200,
+        "CROSS_MODE_REWRITTEN_MARKER",
+        SCENARIO_DEADLINE,
+        "custom base: 200 rewrite matches a base-prefixed source before serving target content",
+        session,
+    )
+    .await;
+
+    poll_get_redirect(
+        client,
+        &format!("{base}/pj/site/blog/2024/07/hello?x=1"),
+        301,
+        "/pj/site/new-page?src=2024/07/hello&x=1",
+        SCENARIO_DEADLINE,
+        "custom base: splat capture + exact base-prefixed Location",
+        session,
+    )
+    .await;
+}
+
 /// POST assertions: `_redirects` bypass (no rule fires for a non-GET/HEAD
 /// method) and the shared plugin handler's POST response.
 async fn run_shared_post_scenarios(client: &reqwest::Client, base: &str, session: &ServerSession) {
@@ -660,6 +766,117 @@ async fn run_shared_post_scenarios(client: &reqwest::Client, base: &str, session
 // The test
 // ---------------------------------------------------------------------------
 
+async fn run_cross_mode_case(
+    case: CrossModeCase,
+    client: &reqwest::Client,
+    esbuild: &Path,
+) -> bool {
+    // ── Build once, for the preview half ──────────────────────────
+    let preview_tmp = tempfile::tempdir().expect("tempdir for preview root");
+    let preview_root = preview_tmp
+        .path()
+        .canonicalize()
+        .expect("canonicalize preview root");
+    copy_dir(&fixture_dir(), &preview_root).expect("copy fixture into preview root");
+    configure_fixture_case(&preview_root, case);
+
+    let build_ok = {
+        let root = preview_root.clone();
+        let esbuild = esbuild.to_path_buf();
+        tokio::task::spawn_blocking(move || run_build(&root, &esbuild))
+            .await
+            .expect("join zfb build task")
+    };
+    if !build_ok {
+        return false; // known-skip, already logged by run_build
+    }
+
+    // ── Dev gets its OWN fresh, unbuilt copy of the fixture ───────
+    let dev_tmp = tempfile::tempdir().expect("tempdir for dev root");
+    let dev_root = dev_tmp
+        .path()
+        .canonicalize()
+        .expect("canonicalize dev root");
+    copy_dir(&fixture_dir(), &dev_root).expect("copy fixture into dev root");
+    configure_fixture_case(&dev_root, case);
+
+    // ── Preview half ───────────────────────────────────────────────
+    let mut preview_session = spawn_zfb(
+        &preview_root,
+        &["preview", "--port", "0"],
+        &[],
+        case.preview_label(),
+    );
+    let preview_port = boot_and_get_port(
+        &mut preview_session,
+        client,
+        PREVIEW_BOOT_DEADLINE,
+        case.preview_readiness_path(),
+    )
+    .await;
+    let preview_base = format!("http://localhost:{preview_port}");
+
+    match case {
+        CrossModeCase::Default => {
+            run_shared_get_scenarios(client, &preview_base, &preview_session).await;
+            run_shared_post_scenarios(client, &preview_base, &preview_session).await;
+
+            // Sanity: an unmatched route 404s cleanly (not a panic/500)
+            // — cheap belt-and-suspenders check that the
+            // redirects/plugin wiring above didn't swallow the ordinary
+            // static-file waterfall.
+            poll_get_status(
+                client,
+                &format!("{preview_base}/nonexistent-route-for-404-check"),
+                404,
+                SCENARIO_DEADLINE,
+                "sanity: an unmatched route 404s (not a panic/500)",
+                &preview_session,
+            )
+            .await;
+        }
+        CrossModeCase::CustomBase => {
+            run_custom_base_get_scenarios(client, &preview_base, &preview_session).await;
+        }
+    }
+
+    // Explicitly release the preview server before booting dev — the
+    // two never need to run concurrently, and shutting one down first
+    // keeps the failure logs for whichever phase is running unambiguous.
+    drop(preview_session);
+
+    // ── Dev half — same scenarios, same expected literal values ────
+    let mut dev_session = spawn_zfb(
+        &dev_root,
+        &["dev", "--port", "0"],
+        &[(
+            "ZFB_ESBUILD_BIN",
+            esbuild.to_str().expect("esbuild path is UTF-8"),
+        )],
+        case.dev_label(),
+    );
+    let dev_port = boot_and_get_port(
+        &mut dev_session,
+        client,
+        DEV_BOOT_DEADLINE,
+        case.dev_readiness_path(),
+    )
+    .await;
+    let dev_base = format!("http://localhost:{dev_port}");
+
+    match case {
+        CrossModeCase::Default => {
+            run_shared_get_scenarios(client, &dev_base, &dev_session).await;
+            run_shared_post_scenarios(client, &dev_base, &dev_session).await;
+        }
+        CrossModeCase::CustomBase => {
+            run_custom_base_get_scenarios(client, &dev_base, &dev_session).await;
+        }
+    }
+
+    true
+}
+
 #[tokio::test(flavor = "multi_thread")]
 async fn preview_and_dev_agree_on_redirects_and_plugin_middleware() {
     // Cross-binary lock acquired BEFORE anything else (issue #1339) — see
@@ -684,33 +901,6 @@ async fn preview_and_dev_agree_on_redirects_and_plugin_middleware() {
     }
 
     let overall = async {
-        // ── Build once, for the preview half ──────────────────────────
-        let preview_tmp = tempfile::tempdir().expect("tempdir for preview root");
-        let preview_root = preview_tmp
-            .path()
-            .canonicalize()
-            .expect("canonicalize preview root");
-        copy_dir(&fixture_dir(), &preview_root).expect("copy fixture into preview root");
-
-        let build_ok = {
-            let root = preview_root.clone();
-            let esbuild = esbuild.clone();
-            tokio::task::spawn_blocking(move || run_build(&root, &esbuild))
-                .await
-                .expect("join zfb build task")
-        };
-        if !build_ok {
-            return; // known-skip, already logged by run_build
-        }
-
-        // ── Dev gets its OWN fresh, unbuilt copy of the fixture ───────
-        let dev_tmp = tempfile::tempdir().expect("tempdir for dev root");
-        let dev_root = dev_tmp
-            .path()
-            .canonicalize()
-            .expect("canonicalize dev root");
-        copy_dir(&fixture_dir(), &dev_root).expect("copy fixture into dev root");
-
         let client = reqwest::Client::builder()
             .connect_timeout(Duration::from_secs(5))
             .timeout(Duration::from_secs(10))
@@ -718,50 +908,12 @@ async fn preview_and_dev_agree_on_redirects_and_plugin_middleware() {
             .build()
             .expect("build reqwest client");
 
-        // ── Preview half ───────────────────────────────────────────────
-        let mut preview_session =
-            spawn_zfb(&preview_root, &["preview", "--port", "0"], &[], "preview");
-        let preview_port =
-            boot_and_get_port(&mut preview_session, &client, PREVIEW_BOOT_DEADLINE).await;
-        let preview_base = format!("http://localhost:{preview_port}");
-
-        run_shared_get_scenarios(&client, &preview_base, &preview_session).await;
-        run_shared_post_scenarios(&client, &preview_base, &preview_session).await;
-
-        // Sanity: an unmatched route 404s cleanly (not a panic/500) —
-        // cheap belt-and-suspenders check that the redirects/plugin wiring
-        // above didn't swallow the ordinary static-file waterfall.
-        poll_get_status(
-            &client,
-            &format!("{preview_base}/nonexistent-route-for-404-check"),
-            404,
-            SCENARIO_DEADLINE,
-            "sanity: an unmatched route 404s (not a panic/500)",
-            &preview_session,
-        )
-        .await;
-
-        // Explicitly release the preview server before booting dev — the
-        // two never need to run concurrently, and shutting one down first
-        // keeps the failure logs for whichever phase is running
-        // unambiguous.
-        drop(preview_session);
-
-        // ── Dev half — same scenarios, same expected literal values ────
-        let mut dev_session = spawn_zfb(
-            &dev_root,
-            &["dev", "--port", "0"],
-            &[(
-                "ZFB_ESBUILD_BIN",
-                esbuild.to_str().expect("esbuild path is UTF-8"),
-            )],
-            "dev",
-        );
-        let dev_port = boot_and_get_port(&mut dev_session, &client, DEV_BOOT_DEADLINE).await;
-        let dev_base = format!("http://localhost:{dev_port}");
-
-        run_shared_get_scenarios(&client, &dev_base, &dev_session).await;
-        run_shared_post_scenarios(&client, &dev_base, &dev_session).await;
+        if !run_cross_mode_case(CrossModeCase::Default, &client, &esbuild).await {
+            return;
+        }
+        if !run_cross_mode_case(CrossModeCase::CustomBase, &client, &esbuild).await {
+            return;
+        }
     };
 
     tokio::time::timeout(OVERALL_DEADLINE, overall)

--- a/crates/zfb/tests/preview_cross_mode_e2e.rs
+++ b/crates/zfb/tests/preview_cross_mode_e2e.rs
@@ -911,9 +911,7 @@ async fn preview_and_dev_agree_on_redirects_and_plugin_middleware() {
         if !run_cross_mode_case(CrossModeCase::Default, &client, &esbuild).await {
             return;
         }
-        if !run_cross_mode_case(CrossModeCase::CustomBase, &client, &esbuild).await {
-            return;
-        }
+        run_cross_mode_case(CrossModeCase::CustomBase, &client, &esbuild).await;
     };
 
     tokio::time::timeout(OVERALL_DEADLINE, overall)

--- a/docs/src/content/docs/api/cli.mdx
+++ b/docs/src/content/docs/api/cli.mdx
@@ -138,9 +138,7 @@ Only `GET`/`HEAD` requests reach the `_redirects` matcher — mirrors real Worke
 
 <Note title="_redirects and a custom `base`">
 
-Static preview serves whatever `zfb build` emitted under the selected output directory, and does not know about your project's `base` prefix — it has no prefix-stripping layer of its own. So `_redirects` rule *sources* are matched against the **full request path**, exactly as written in the file — they are never rewritten to add or strip a `base` prefix. If `zfb.config.ts` sets `base: "/pj/site/"`, a rule meant to redirect `/pj/site/old-page` must be written with the prefix included (`/pj/site/old-page /pj/site/new-page 301`), not as `/old-page /new-page 301`.
-
-This is specific to static preview. `zfb dev`'s router is mounted *under* `base` (issue #229), so it matches `_redirects` sources against the prefix-**stripped** path — the same rule would need to be written without the prefix (`/old-page /new-page 301`) to fire in dev. A project combining `base` with `_redirects` today needs mode-aware rule sources; this is a known gap, not a deliberate design choice ([#1562](https://github.com/Takazudo/zudo-front-builder/issues/1562)).
+Static preview serves whatever `zfb build` emitted under the selected output directory, and does not know about your project's `base` prefix — it has no prefix-stripping layer of its own. So `_redirects` rule *sources* are matched against the **full request path**, exactly as written in the file — they are never rewritten to add or strip a `base` prefix. `zfb dev` mirrors that matching shape even though its router is mounted under `base`. If `zfb.config.ts` sets `base: "/pj/site/"`, a rule meant to redirect `/pj/site/old-page` must be written with the prefix included (`/pj/site/old-page /pj/site/new-page 301`), not as `/old-page /new-page 301`.
 
 </Note>
 


### PR DESCRIPTION
Closes #1589.

## Summary
- fixes module-worker handling for in-project absolute plugin virtual imports while preserving outside-root/node_modules safeguards
- removes zfb-render default feature leakage from zfb-content tests and refactors highlight emit mode to a single enum
- bounds zfb-md-wasm trap recovery with single-flight reinit, plus documents deep-YAML non-repro evidence
- restores custom-base `_redirects` parity between dev and preview
- stages root-level entry bare dependency closures under `bundle.exclude`
- fixes clippy findings surfaced by CI after integration

## Integrated sub-issues
- #1590 — module-worker graph: normalize in-project absolute deps from plugin virtual modules
- #1591 — zfb-content: default-features=false on the zfb-render dev-dep
- #1592 — zfb-md-wasm npm: bound trap-recovery module records + single-flight reinit
- #1593 — zfb-content pipeline: HiEmit enum replaces theme/dual/class_mode Options
- #1594 — dev server: base-aware _redirects matching
- #1595 — bundler: closure-seed root-level entry points
- #1596 — zfb-md-wasm deep-YAML trap repro evidence; closes as non-reproducible with tests/docs

## Test plan
- `cargo fmt --check`
- `git diff --check main...HEAD`
- `cargo test -p zfb-content`
- `cargo test -p zfb-build --test module_worker_plugin_virtual_absolute_deps`
- `cargo test -p zfb-build --test bundler_exact_match_resolution root_level_ -- --nocapture`
- `cargo test -p zfb-server base_prefix_redirects_match_full_path_and_rewrite_strips_base`
- `PATH="$HOME/.cargo/bin:$PATH" pnpm -C crates/zfb-md-wasm/npm build && pnpm -C crates/zfb-md-wasm/npm test`
- `cargo test -p zfb --test preview_cross_mode_e2e`
- `cargo clippy -p zfb-build --all-targets -- -D warnings`
- `cargo clippy -p zfb --test preview_cross_mode_e2e -- -D warnings`
- GitHub CI on #1606: all checks passing, including `health`.
