### PR TITLE
Md-Wasm Lockstep: release version sync

### DIFF
--- a/.claude/skills/l-make-release/SKILL.md
+++ b/.claude/skills/l-make-release/SKILL.md
@@ -22,6 +22,7 @@ The lockstep packages are:
 
 - `@takazudo/zfb` (`packages/zfb/package.json`) — **version source-of-truth**
 - `@takazudo/zfb-runtime` (`packages/zfb-runtime/package.json`)
+- `@takazudo/zfb-md-wasm` (`crates/zfb-md-wasm/npm/package.json`)
 - `@takazudo/zfb-adapter-cloudflare` (`packages/zfb-adapter-cloudflare/package.json`)
 - `create-zfb` (unscoped — `packages/create-zfb/package.json`)
 - `@takazudo/zfb-darwin-arm64` (`packages/zfb-darwin-arm64/package.json`)
@@ -239,7 +240,7 @@ Note: the Rust CLI binary is built by `.github/workflows/release.yml` — do not
 Stage and commit all bumped files atomically in a **single commit**:
 
 ```bash
-git add packages/*/package.json pnpm-lock.yaml crates/zfb/src/commands/new.rs docs/src/content/docs/changelog/v<version>.mdx
+git add packages/*/package.json crates/zfb-md-wasm/npm/package.json pnpm-lock.yaml crates/zfb/src/commands/new.rs docs/src/content/docs/changelog/v<version>.mdx
 git commit -m "chore(release): bump to v<version>"
 git push origin main
 ```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -462,6 +462,16 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Resolve version
+        shell: bash
+        run: |
+          # Derive semver from packages/zfb/package.json (no leading "v").
+          # For real tag pushes this matches the tag; for dry-run workflow_dispatch
+          # on a branch it is the current dev version string.
+          ZFB_SEMVER=$(node -p "require('./packages/zfb/package.json').version")
+          echo "ZFB_SEMVER=$ZFB_SEMVER" >> "$GITHUB_ENV"
+          echo "Resolved semver: $ZFB_SEMVER"
+
       # Must exactly match the wasm-bindgen crate version resolved in
       # Cargo.lock (pinned in crates/zfb-md-wasm/npm/scripts/build.mjs's
       # EXPECTED_WASM_BINDGEN_VERSION constant) — same pin as health.yml's
@@ -470,7 +480,28 @@ jobs:
         run: cargo install wasm-bindgen-cli --version 0.2.121 --locked
 
       - name: Build @takazudo/zfb-md-wasm npm package
+        env:
+          ZFB_RELEASE_VERSION: ${{ env.ZFB_SEMVER }}
         run: pnpm --filter @takazudo/zfb-md-wasm build
+
+      - name: Assert @takazudo/zfb-md-wasm version stamp
+        shell: bash
+        run: |
+          node --input-type=module <<'EOF'
+          import { init, version } from "./crates/zfb-md-wasm/npm/dist/index.js";
+
+          await init();
+          const actual = await version();
+          const expected = process.env.ZFB_SEMVER;
+          console.log(`Expected: ${expected}`);
+          console.log(`Actual:   ${actual}`);
+          if (actual !== expected) {
+            console.error(
+              `::error::@takazudo/zfb-md-wasm version() mismatch: got '${actual}', want '${expected}'`,
+            );
+            process.exit(1);
+          }
+          EOF
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/crates/zfb-md-wasm/README.md
+++ b/crates/zfb-md-wasm/README.md
@@ -13,11 +13,13 @@ renderHtml-only artifact is a documented possible follow-up):
 |---|---|---|
 | `compile(source, optionsJson)` | mdx → JSX → SWC → ES-module JS | `{ code, frontmatter, diagnostics }` |
 | `renderHtml(source, optionsJson)` | md → mdast → visitors → hast → HTML | `{ html, frontmatter, diagnostics }` |
-| `version()` | — | crate version string |
+| `version()` | — | release-stamped package version string |
 
 The whole boundary is JSON-in/JSON-out strings; the authoritative shape
 documentation is the crate rustdoc (`src/lib.rs`) plus
 `zfb_content::facade::PipelineOptions` for the `pipeline` sub-object.
+Published artifacts stamp `version()` with the package semver during release;
+local development builds fall back to the Rust manifest version placeholder.
 
 ## Options JSON (shared by both entry points)
 

--- a/crates/zfb-md-wasm/build.rs
+++ b/crates/zfb-md-wasm/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-env-changed=ZFB_RELEASE_VERSION");
+}

--- a/crates/zfb-md-wasm/npm/README.md
+++ b/crates/zfb-md-wasm/npm/README.md
@@ -72,7 +72,9 @@ object can serve both tiers.
 
 ### `version()` / `init()`
 
-`version()` returns the crate version (for host-side compatibility checks).
+`version()` returns the package version for host-side compatibility checks.
+Published artifacts are stamped with the release semver at build time; local
+development builds fall back to the Rust manifest placeholder.
 `init()` eagerly loads and instantiates the wasm module; it's optional (every
 call instantiates on first use) but useful to front-load the one-time
 fetch/compile cost at app startup.

--- a/crates/zfb-md-wasm/npm/src/index.ts
+++ b/crates/zfb-md-wasm/npm/src/index.ts
@@ -226,7 +226,12 @@ export async function renderHtml(
   return JSON.parse(json) as RenderHtmlResult;
 }
 
-/** This crate's version (`CARGO_PKG_VERSION`), for host-side compatibility checks. */
+/**
+ * Package version for host-side compatibility checks.
+ *
+ * Release artifacts are stamped with the published package semver at build
+ * time; local development builds fall back to the Rust manifest placeholder.
+ */
 export async function version(): Promise<string> {
   return callWasm(({ glue }) => glue.version());
 }

--- a/crates/zfb-md-wasm/npm/test/api.test.ts
+++ b/crates/zfb-md-wasm/npm/test/api.test.ts
@@ -142,9 +142,10 @@ describe("expected failures surface as structured diagnostics (never a throw)", 
 });
 
 describe("version()", () => {
-  it("returns the crate version string", async () => {
+  it("returns a package semver string", async () => {
     await init();
-    expect(await version()).toBeTypeOf("string");
+    const semverPattern = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+    expect(await version()).toMatch(semverPattern);
   });
 });
 

--- a/crates/zfb-md-wasm/src/lib.rs
+++ b/crates/zfb-md-wasm/src/lib.rs
@@ -411,12 +411,16 @@ pub fn render_html(source: &str, options_json: &str) -> String {
     to_json(&render_html_impl(source, options_json))
 }
 
-/// This crate's version (`CARGO_PKG_VERSION`), for host-side
-/// compatibility checks.
+/// This package's release version, stamped by CI at compile time.
+///
+/// Development builds without `ZFB_RELEASE_VERSION` fall back to this crate's
+/// manifest version (`CARGO_PKG_VERSION`).
 #[wasm_bindgen]
 #[must_use]
 pub fn version() -> String {
-    env!("CARGO_PKG_VERSION").to_string()
+    option_env!("ZFB_RELEASE_VERSION")
+        .unwrap_or(env!("CARGO_PKG_VERSION"))
+        .to_string()
 }
 
 #[cfg(test)]

--- a/crates/zfb-md-wasm/tests/api.rs
+++ b/crates/zfb-md-wasm/tests/api.rs
@@ -16,7 +16,7 @@
 //!   contract for malformed MDX, malformed options JSON, unknown syntect
 //!   theme names, YAML frontmatter errors, and non-markdown filenames;
 //!   frontmatter-line-offset arithmetic on parse positions; the
-//!   `jsxRuntime` switch; `version()`.
+//!   `jsxRuntime` switch; `version()`'s dev-build manifest fallback.
 //! - **Blind spots** (explicitly NOT covered here): executing the
 //!   compiled wasm artifact (Node/browser instantiation is the npm
 //!   package's scope, zfb#1577); panic-freedom under adversarial fuzzed
@@ -298,6 +298,9 @@ fn non_markdown_filename_is_an_options_diagnostic() {
 // ── version ─────────────────────────────────────────────────────────────────
 
 #[test]
-fn version_reports_cargo_pkg_version() {
+fn version_falls_back_to_cargo_pkg_version_in_dev_builds() {
+    // Release builds stamp the package semver with ZFB_RELEASE_VERSION at
+    // compile time. Native crate tests intentionally run with that env unset,
+    // so they verify the manifest fallback without spawning a heavy rebuild.
     assert_eq!(zfb_md_wasm::version(), env!("CARGO_PKG_VERSION"));
 }

--- a/scripts/publish-npm-packages.sh
+++ b/scripts/publish-npm-packages.sh
@@ -77,14 +77,12 @@ PLATFORM_DIRS=(
 # is not required for success, but matching pnpm -r's topological default keeps
 # the published set self-consistent at every intermediate moment.
 #
-# crates/zfb-md-wasm/npm (zfb#1579) is the first NONPLATFORM_DIRS occupant
-# outside packages/* — it lives in the `crates/*/npm` workspace glob
-# (pnpm-workspace.yaml), which `pnpm -r --filter <name>` resolves the same
-# way regardless of the path prefix (verified locally: `pnpm -r --filter
-# "@takazudo/zfb-md-wasm" exec pwd` resolves to crates/zfb-md-wasm/npm). It
-# has no workspace:* deps of its own, so the rewrite is a no-op for it, but
-# it goes through the same idempotent/tolerant/dist-tag machinery as every
-# other entry here.
+# @takazudo/zfb-md-wasm is a lockstep non-platform package that lives outside
+# packages/* under the `crates/*/npm` workspace glob (pnpm-workspace.yaml).
+# `pnpm -r --filter <name>` resolves it by manifest name regardless of path
+# prefix (verified locally: `pnpm -r --filter "@takazudo/zfb-md-wasm" exec pwd`
+# resolves to crates/zfb-md-wasm/npm), so it belongs in the same
+# idempotent/tolerant/dist-tag publish machinery as the packages/* entries.
 NONPLATFORM_DIRS=(
   packages/zfb
   packages/zfb-runtime

--- a/scripts/sync-platform-versions.mjs
+++ b/scripts/sync-platform-versions.mjs
@@ -2,10 +2,10 @@
 /**
  * sync-platform-versions.mjs
  *
- * Keep packages/zfb-{platform}/package.json version fields,
- * packages/zfb/package.json optionalDependencies entries
- * (prefixed with @takazudo/zfb-), and related workspace package version
- * fields in lockstep with packages/zfb/package.json version.
+ * Keep lockstep package version fields, packages/zfb/package.json
+ * optionalDependencies entries (prefixed with @takazudo/zfb-), and related
+ * workspace package version fields in lockstep with packages/zfb/package.json
+ * version.
  *
  * Usage:
  *   node scripts/sync-platform-versions.mjs
@@ -146,7 +146,26 @@ function main() {
     }
   }
 
-  // 4. Rewrite packages/zfb-adapter-cloudflare/package.json version field.
+  // 4. Rewrite crates/zfb-md-wasm/npm/package.json version field.
+  // Deliberately reverses the c2a4ac55 independence choice: md-wasm is lockstep again.
+  {
+    const pkgPath = resolve(repoRoot, "crates", "zfb-md-wasm", "npm", "package.json");
+    const { raw, data: pkg } = readJson(pkgPath);
+    const previousVersion = pkg.version;
+    pkg.version = srcVersion;
+    const changed = writeJsonIfChanged(pkgPath, pkg, raw);
+    if (changed) {
+      process.stdout.write(
+        `  crates/zfb-md-wasm/npm/package.json: ${previousVersion} -> ${srcVersion}\n`,
+      );
+    } else {
+      process.stdout.write(
+        `  crates/zfb-md-wasm/npm/package.json: already ${srcVersion} (no change)\n`,
+      );
+    }
+  }
+
+  // 5. Rewrite packages/zfb-adapter-cloudflare/package.json version field.
   {
     const pkgPath = resolve(repoRoot, "packages", "zfb-adapter-cloudflare", "package.json");
     const { raw, data: pkg } = readJson(pkgPath);
@@ -164,14 +183,14 @@ function main() {
     }
   }
 
-  // 5. (Removed) crates/zfb/src/commands/new.rs no longer carries a
+  // 6. (Removed) crates/zfb/src/commands/new.rs no longer carries a
   //    WORKSPACE_DEP_PLACEHOLDER constant to keep in sync. The scaffold pin is
   //    now self-syncing — derived at compile time from the binary's own
   //    release version (ZFB_RELEASE_VERSION, else CARGO_PKG_VERSION). See
   //    workspace_dep_placeholder() in new.rs and issue #503. Nothing to rewrite
   //    here.
 
-  // 6. Rewrite packages/create-zfb/package.json:
+  // 7. Rewrite packages/create-zfb/package.json:
   //    - version field
   //    - dependencies."@takazudo/zfb" (preserving "workspace:" prefix if present)
   {

--- a/tests/unit/publish-npm-packages.sh
+++ b/tests/unit/publish-npm-packages.sh
@@ -153,11 +153,7 @@ MOCK_PNPM
 chmod +x "$MOCK_BIN/npm" "$MOCK_BIN/pnpm"
 
 V=$(node -p "require('./packages/zfb/package.json').version")
-# @takazudo/zfb-md-wasm (crates/zfb-md-wasm/npm, zfb#1579) versions
-# independently of the packages/* lockstep set above (sync-platform-versions.mjs
-# does not touch it) — read its own version rather than assuming it equals $V.
-V_MDWASM=$(node -p "require('./crates/zfb-md-wasm/npm/package.json').version")
-ALL_SPECS="@takazudo/zfb-darwin-arm64@$V @takazudo/zfb-darwin-x64@$V @takazudo/zfb-linux-arm64-gnu@$V @takazudo/zfb-linux-x64-gnu@$V @takazudo/zfb-win32-x64-msvc@$V @takazudo/zfb@$V @takazudo/zfb-runtime@$V @takazudo/zfb-adapter-cloudflare@$V create-zfb@$V @takazudo/zfb-md-wasm@$V_MDWASM"
+ALL_SPECS="@takazudo/zfb-darwin-arm64@$V @takazudo/zfb-darwin-x64@$V @takazudo/zfb-linux-arm64-gnu@$V @takazudo/zfb-linux-x64-gnu@$V @takazudo/zfb-win32-x64-msvc@$V @takazudo/zfb@$V @takazudo/zfb-runtime@$V @takazudo/zfb-adapter-cloudflare@$V create-zfb@$V @takazudo/zfb-md-wasm@$V"
 
 # log_has <name> — true iff the publish log has a line for exactly <name>
 # (matching <name> at line start followed by '@' or end-of-line, so
@@ -174,7 +170,7 @@ PUB_LOG=$(mktemp)
 if PATH="$MOCK_BIN:$PATH" \
    DIST_TAG=next \
    MOCK_PUBLISH_LOG="$PUB_LOG" \
-   MOCK_EXISTING="@takazudo/zfb-darwin-arm64@$V @takazudo/zfb-darwin-x64@$V @takazudo/zfb-linux-arm64-gnu@$V @takazudo/zfb-linux-x64-gnu@$V @takazudo/zfb-win32-x64-msvc@$V @takazudo/zfb@$V @takazudo/zfb-adapter-cloudflare@$V @takazudo/zfb-md-wasm@$V_MDWASM" \
+   MOCK_EXISTING="@takazudo/zfb-darwin-arm64@$V @takazudo/zfb-darwin-x64@$V @takazudo/zfb-linux-arm64-gnu@$V @takazudo/zfb-linux-x64-gnu@$V @takazudo/zfb-win32-x64-msvc@$V @takazudo/zfb@$V @takazudo/zfb-adapter-cloudflare@$V @takazudo/zfb-md-wasm@$V" \
    bash "$SCRIPT" all-provenance >/dev/null 2>&1; then
   if log_has "@takazudo/zfb-runtime" && log_has "create-zfb" \
      && ! log_has "@takazudo/zfb" && ! log_has "@takazudo/zfb-adapter-cloudflare" \


### PR DESCRIPTION
- issues
    - https://github.com/Takazudo/zudo-front-builder/issues/1607
    - https://github.com/Takazudo/zudo-front-builder/issues/1608
    - https://github.com/Takazudo/zudo-front-builder/issues/1609

---

Closes #1607.
Closes #1608.
Closes #1609.

## Summary
- Wires `crates/zfb-md-wasm/npm/package.json` into the lockstep release bump machinery and release skill staging.
- Updates publish-script tests and comments so `@takazudo/zfb-md-wasm` uses the shared release version instead of an independent package version.
- Stamps the wasm `version()` export from `ZFB_RELEASE_VERSION` during release builds, with a `CARGO_PKG_VERSION` fallback for development builds.
- Adds release workflow version resolution and a built-artifact assertion that `version()` matches the release semver.
- Updates md-wasm Rust, TypeScript, and README docs for the new version semantics.

## Integrated Topics
- #1608: `019bd4f5` (`md-wasm-lockstep/1608-lockstep-bump-wiring`)
- #1609: `790b176e` (`md-wasm-lockstep/1609-version-stamp`)

Separate topic PRs were not created because both topic branches were already merged into this base branch before push; GitHub rejected them as having no commits between the topic heads and `base/md-wasm-lockstep`.

## Verification
- `bash -n scripts/publish-npm-packages.sh`
- `bash -n tests/unit/publish-npm-packages.sh`
- `bash tests/unit/publish-npm-packages.sh` (`15 passed, 0 failed`)
- Scratch sync proof: temporarily set `packages/zfb/package.json` to `0.0.0-test.1607-manager`, ran `node scripts/sync-platform-versions.mjs`, verified `crates/zfb-md-wasm/npm/package.json` matched, then restored all manifests and confirmed no scratch diff remained.
- `cargo test -p zfb-md-wasm` (`4` unit tests, `15` integration tests, doc-tests passed)
- `cargo clippy -p zfb-md-wasm -- -D warnings`
- `./actionlint .github/workflows/release.yml`
